### PR TITLE
Handle pubsub deleted topics

### DIFF
--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -546,11 +546,15 @@ class PubSubClient
      */
     private function subscriptionFactory($name, $topicName = null, array $info = [])
     {
+        $topic = $topicName ?
+            $this->topicFactory($topicName)
+            : null;
+
         return new Subscription(
             $this->connection,
             $this->projectId,
             $name,
-            $topicName,
+            $topic,
             $this->encode,
             $info
         );

--- a/PubSub/src/Subscription.php
+++ b/PubSub/src/Subscription.php
@@ -131,9 +131,7 @@ class Subscription
             $this->name = $this->formatName('subscription', $name, $projectId);
         }
 
-        if ($topic instanceof Topic) {
-            $topic = clone $topic;
-        } else {
+        if (!($topic instanceof Topic)) {
             // Accept either a simple name or a fully-qualified name.
             // If the topic is null, use the topic name in the subscription info.
             // If there's no subscription info, set the topic to null.

--- a/PubSub/src/Topic.php
+++ b/PubSub/src/Topic.php
@@ -186,6 +186,10 @@ class Topic
      * a boolean value. If you want to check for errors, use
      * {@see Google\Cloud\PubSub\Topic::info()}.
      *
+     * If a topic has been deleted, this method will return `false`. To
+     * differentiate between a deleted topic and non-existent topic, use
+     * {@see Google\Cloud\PubSub\Topic::deleted()}.
+     *
      * Example:
      * ```
      * if ($topic->exists()) {
@@ -198,12 +202,35 @@ class Topic
      */
     public function exists(array $options = [])
     {
+        if ($this->isDeleted()) {
+            return false;
+        }
+
         try {
             $this->info($options);
             return true;
         } catch (NotFoundException $e) {
             return false;
         }
+    }
+
+    /**
+     * Check if a topic was deleted.
+     *
+     * To check if a topic exists, use {@see Google\Cloud\PubSub\Topic::exists()}.
+     *
+     * You may encounter a deleted topic if you fetch the topic from a subscription.
+     *
+     * Example:
+     * ```
+     * $deleted = $topic->isDeleted();
+     * ```
+     *
+     * @return bool
+     */
+    public function isDeleted()
+    {
+        return $this->pluckName('topic', $this->name) === '_deleted-topic_';
     }
 
     /**
@@ -578,7 +605,7 @@ class Topic
             $this->connection,
             $this->projectId,
             $name,
-            $this->name,
+            $this,
             $this->encode,
             $info
         );

--- a/PubSub/tests/Snippet/SubscriptionTest.php
+++ b/PubSub/tests/Snippet/SubscriptionTest.php
@@ -24,6 +24,7 @@ use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Topic;
 use Prophecy\Argument;
 
 /**
@@ -77,6 +78,15 @@ class SubscriptionTest extends SnippetTestCase
         $snippet->addLocal('subscription', $this->subscription);
         $res = $snippet->invoke();
         $this->assertEquals(self::SUBSCRIPTION, $res->output());
+    }
+
+    public function testTopic()
+    {
+        $snippet = $this->snippetFromMethod(Subscription::class, 'topic');
+        $snippet->addLocal('subscription', $this->subscription);
+
+        $res = $snippet->invoke('topic');
+        $this->assertInstanceOf(Topic::class, $res->returnVal());
     }
 
     public function testCreate()
@@ -142,7 +152,7 @@ class SubscriptionTest extends SnippetTestCase
 
         $this->connection->getSubscription(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(['name' => self::SUBSCRIPTION]);
+            ->willReturn(['name' => self::SUBSCRIPTION, 'topic' => self::TOPIC]);
 
         $this->subscription->___setProperty('connection', $this->connection->reveal());
 
@@ -157,7 +167,7 @@ class SubscriptionTest extends SnippetTestCase
 
         $this->connection->getSubscription(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(['name' => self::SUBSCRIPTION]);
+            ->willReturn(['name' => self::SUBSCRIPTION, 'topic' => self::TOPIC]);
 
         $this->subscription->___setProperty('connection', $this->connection->reveal());
 

--- a/PubSub/tests/Snippet/TopicTest.php
+++ b/PubSub/tests/Snippet/TopicTest.php
@@ -34,6 +34,7 @@ use Prophecy\Argument;
 class TopicTest extends SnippetTestCase
 {
     const TOPIC = 'projects/my-awesome-project/topics/my-new-topic';
+    const DELETED = 'projects/my-awesome-project/topics/_deleted-topic_';
     const SUBSCRIPTION = 'projects/my-awesome-project/subscriptions/my-new-subscription';
 
     private $connection;
@@ -49,7 +50,7 @@ class TopicTest extends SnippetTestCase
             'my-awesome-project',
             self::TOPIC,
             false
-        ]);
+        ], ['connection', 'name']);
     }
 
     public function testClass()
@@ -122,6 +123,17 @@ class TopicTest extends SnippetTestCase
 
         $res = $snippet->invoke();
         $this->assertEquals('Topic exists', $res->output());
+    }
+
+    public function testIsDeleted()
+    {
+        $snippet = $this->snippetFromMethod(Topic::class, 'isDeleted');
+        $snippet->addLocal('topic', $this->topic);
+
+        $this->topic->___setProperty('name', self::DELETED);
+
+        $res = $snippet->invoke('deleted');
+        $this->assertTrue($res->returnVal());
     }
 
     public function testInfo()

--- a/PubSub/tests/Unit/PubSubClientTest.php
+++ b/PubSub/tests/Unit/PubSubClientTest.php
@@ -40,6 +40,8 @@ class PubSubClientTest extends TestCase
 {
     use GrpcTestTrait;
 
+    const TOPIC = 'projects/project/topics/topic-a';
+
     private $connection;
 
     private $client;
@@ -113,7 +115,7 @@ class PubSubClientTest extends TestCase
     {
         $topicResult = [
             [
-                'name' => 'projects/project/topics/topic-a'
+                'name' => self::TOPIC
             ], [
                 'name' => 'projects/project/topics/topic-b'
             ], [
@@ -145,7 +147,7 @@ class PubSubClientTest extends TestCase
     {
         $topicResult = [
             [
-                'name' => 'projects/project/topics/topic-a'
+                'name' => self::TOPIC
             ], [
                 'name' => 'projects/project/topics/topic-b'
             ], [
@@ -210,7 +212,10 @@ class PubSubClientTest extends TestCase
     {
         $this->connection->getSubscription(Argument::any())
             ->shouldBeCalledTimes(1)
-            ->willReturn(['foo' => 'bar']);
+            ->willReturn([
+                'foo' => 'bar',
+                'topic' => self::TOPIC
+            ]);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
 
@@ -228,13 +233,13 @@ class PubSubClientTest extends TestCase
         $subscriptionResult = [
             [
                 'name' => 'projects/project/subscriptions/subscription-a',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ], [
                 'name' => 'projects/project/subscriptions/subscription-b',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ], [
                 'name' => 'projects/project/subscriptions/subscription-c',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ]
         ];
 
@@ -263,13 +268,13 @@ class PubSubClientTest extends TestCase
         $subscriptionResult = [
             [
                 'name' => 'projects/project/subscriptions/subscription-a',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ], [
                 'name' => 'projects/project/subscriptions/subscription-b',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ], [
                 'name' => 'projects/project/subscriptions/subscription-c',
-                'topic' => 'projects/project/topics/topic-a'
+                'topic' => self::TOPIC
             ]
         ];
 


### PR DESCRIPTION
In Pubsub, subscriptions are related to a topic, but are not direct descendants of it. So when a topic is deleted, the subscriptions are not deleted, but rather the representation of them will be modified, so that the topic they are attached to is `_deleted-topic_`.

This can cause issues when attempting to use a subscription attached to a deleted topic. This change improves somewhat the way Subscriptions represent their attached topics, and exposes a new method `isDeleted()` on `Google\Cloud\PubSub\Topic`.

I chose the name `isDeleted()`, which is somewhat outside our normal convention because I was concerned that `bool deleted()` would be too close to `delete()`, and typos could cause accidental topic deletion.