### PR TITLE
Add more in-depth support for object lifecycle management

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -779,7 +779,7 @@ class Bucket
      *           configuration.
      *     @type array $defaultObjectAcl Default access controls to apply to new
      *           objects when no ACL is provided.
-     *     @type array $lifecycle The bucket's lifecycle configuration.
+     *     @type array|Lifecycle $lifecycle The bucket's lifecycle configuration.
      *     @type array $logging The bucket's logging configuration, which
      *           defines the destination bucket and optional name prefix for the
      *           current bucket's logs.
@@ -810,6 +810,10 @@ class Bucket
      */
     public function update(array $options = [])
     {
+        if (isset($options['lifecycle']) && $options['lifecycle'] instanceof Lifecycle) {
+            $options['lifecycle'] = $options['lifecycle']->toArray();
+        }
+
         return $this->info = $this->connection->patchBucket($options + $this->identity);
     }
 
@@ -986,6 +990,80 @@ class Bucket
     public function name()
     {
         return $this->identity['bucket'];
+    }
+
+    /**
+     * Retrieves a fresh lifecycle builder. If a lifecyle configuration already
+     * exists on the target bucket and this builder is used, it will fully
+     * replace the configuration with the rules provided by this builder.
+     *
+     * This builder is intended to be used in tandem with
+     * {@see Google\Cloud\Storage\StorageClient::createBucket()} and
+     * {@see Google\Cloud\Storage\Bucket::update()}.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\Storage\Bucket;
+     *
+     * $lifecycle = Bucket::lifecycle()
+     *     ->addDeleteRule([
+     *         'age' => 50,
+     *         'isLive' => true
+     *     ]);
+     * $bucket->update([
+     *     'lifecycle' => $lifecycle
+     * ]);
+     * ```
+     *
+     * @see https://cloud.google.com/storage/docs/lifecycle Object Lifecycle Management API Documentation
+     *
+     * @param array $lifecycle [optional] A lifecycle configuration. Please see
+     *        [here](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle)
+     *        for the expected structure.
+     * @return Lifecycle
+     */
+    public static function lifecycle(array $lifecycle = [])
+    {
+        return new Lifecycle($lifecycle);
+    }
+
+    /**
+     * Retrieves a lifecycle builder preconfigured with the lifecycle rules that
+     * already exists on the bucket. Use this if you want to make updates to an
+     * existing configuration without removing existing rules, as would be the
+     * case when using {@see Google\Cloud\Storage\Bucket::lifecycle()}.
+     *
+     * This builder is intended to be used in tandem with
+     * {@see Google\Cloud\Storage\StorageClient::createBucket()} and
+     * {@see Google\Cloud\Storage\Bucket::update()}.
+     *
+     * Please note, this method may trigger a network request in order to fetch
+     * the existing lifecycle rules from the server.
+     *
+     * Example:
+     * ```
+     * $lifecycle = $bucket->currentLifecycle()
+     *     ->addDeleteRule([
+     *         'age' => 50,
+     *         'isLive' => true
+     *     ]);
+     * $bucket->update([
+     *     'lifecycle' => $lifecycle
+     * ]);
+     * ```
+     *
+     * @see https://cloud.google.com/storage/docs/lifecycle Object Lifecycle Management API Documentation
+     *
+     * @param array $options [optional] Configuration options.
+     * @return Lifecycle
+     */
+    public function currentLifecycle(array $options = [])
+    {
+        return self::lifecycle(
+            isset($this->info($options)['lifecycle'])
+                ? $this->info['lifecycle']
+                : []
+        );
     }
 
     /**

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1052,6 +1052,15 @@ class Bucket
      * ]);
      * ```
      *
+     * ```
+     * // Iterate over existing rules.
+     * $lifecycle = $bucket->currentLifecycle();
+     *
+     * foreach ($lifecycle as $rule) {
+     *     print_r($rule);
+     * }
+     * ```
+     *
      * @see https://cloud.google.com/storage/docs/lifecycle Object Lifecycle Management API Documentation
      *
      * @param array $options [optional] Configuration options.

--- a/Storage/src/Lifecycle.php
+++ b/Storage/src/Lifecycle.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+/**
+ * Object Lifecycle Management supports common use cases like setting a Time to
+ * Live (TTL) for objects, archiving older versions of objects, or "downgrading"
+ * storage classes of objects to help manage costs.
+ *
+ * This builder does not execute any network requests and is intended to be used
+ * in combination with either
+ * {@see Google\Cloud\Storage\StorageClient::createBucket()}
+ * or {@see Google\Cloud\Storage\Bucket::update()}.
+ *
+ * Example:
+ * ```
+ * // Access a builder preconfigured with rules already existing on a given
+ * // bucket.
+ * use Google\Cloud\Storage\StorageClient;
+ *
+ * $storage = new StorageClient();
+ * $bucket = $storage->bucket('my-bucket');
+ * $lifecycle = $bucket->currentLifecycle();
+ * ```
+ *
+ * ```
+ * // Or get a fresh builder by using the static factory method.
+ * use Google\Cloud\Storage\Bucket;
+ *
+ * $lifecycle = Bucket::lifecycle();
+ * ```
+ *
+ * @see https://cloud.google.com/storage/docs/lifecycle Object Lifecycle Management API Documentation
+ */
+class Lifecycle
+{
+    /**
+     * @var array
+     */
+    private $lifecycle;
+
+    /**
+     * @param array $lifecycle [optional] A lifecycle configuration. Please see
+     *        [here](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle)
+     *        for the expected structure.
+     */
+    public function __construct(array $lifecycle = [])
+    {
+        $this->lifecycle = $lifecycle;
+    }
+
+    /**
+     * Adds a delete rule.
+     *
+     * Example:
+     * ```
+     * $lifecycle->addDeleteRule([
+     *     'age' => 50,
+     *     'isLive' => true
+     * ]);
+     * ```
+     *
+     * @param array $condition {
+     *     The condition(s) where the rule will apply.
+     *
+     *     @type int $age Age of an object (in days). This condition is
+     *           satisfied when an object reaches the specified age.
+     *     @type string $createdBefore A date in RFC 3339 format with only the
+     *           date part (for instance, "2013-01-15"). This condition is
+     *           satisfied when an object is created before midnight of the
+     *           specified date in UTC.
+     *     @type bool $isLive Relevant only for versioned objects. If the value
+     *           is `true`, this condition matches live objects; if the value is
+     *           `false`, it matches archived objects.
+     *     @type string[] $matchesStorageClass Objects having any of the storage
+     *           classes specified by this condition will be matched. Values
+     *           include `"MULTI_REGIONAL"`, `"REGIONAL"`, `"NEARLINE"`,
+     *           `"COLDLINE"`, `"STANDARD"`, and `"DURABLE_REDUCED_AVAILABILITY"`.
+     *     @type int $numNewerVersions Relevant only for versioned objects. If
+     *           the value is N, this condition is satisfied when there are at
+     *           least N versions (including the live version) newer than this
+     *           version of the object.
+     * }
+     * @return Lifecycle
+     */
+    public function addDeleteRule(array $condition)
+    {
+        $this->lifecycle['rule'][] = [
+            'action' => [
+                'type' => 'Delete'
+            ],
+            'condition' => $condition
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Adds a set storage class rule.
+     *
+     * Example:
+     * ```
+     * $lifecycle->addSetStorageClassRule('COLDLINE', [
+     *     'age' => 50,
+     *     'isLive' => true
+     * ]);
+     * ```
+     *
+     * @param string $storageClass The target storage class. Values include
+     *        `"MULTI_REGIONAL"`, `"REGIONAL"`, `"NEARLINE"`, `"COLDLINE"`,
+     *        `"STANDARD"`, and `"DURABLE_REDUCED_AVAILABILITY"`.
+     * @param array $condition {
+     *     The condition(s) where the rule will apply.
+     *
+     *     @type int $age Age of an object (in days). This condition is
+     *           satisfied when an object reaches the specified age.
+     *     @type string $createdBefore A date in RFC 3339 format with only the
+     *           date part (for instance, "2013-01-15"). This condition is
+     *           satisfied when an object is created before midnight of the
+     *           specified date in UTC.
+     *     @type bool $isLive Relevant only for versioned objects. If the value
+     *           is `true`, this condition matches live objects; if the value is
+     *           `false`, it matches archived objects.
+     *     @type string[] $matchesStorageClass Objects having any of the storage
+     *           classes specified by this condition will be matched. Values
+     *           include `"MULTI_REGIONAL"`, `"REGIONAL"`, `"NEARLINE"`,
+     *           `"COLDLINE"`, `"STANDARD"`, and `"DURABLE_REDUCED_AVAILABILITY"`.
+     *     @type int $numNewerVersions Relevant only for versioned objects. If
+     *           the value is N, this condition is satisfied when there are at
+     *           least N versions (including the live version) newer than this
+     *           version of the object.
+     * }
+     * @return Lifecycle
+     */
+    public function addSetStorageClassRule($storageClass, array $condition)
+    {
+        $this->lifecycle['rule'][] = [
+            'action' => [
+                'type' => 'SetStorageClass',
+                'storageClass' => $storageClass
+            ],
+            'condition' => $condition
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Clears out rules based on the provided condition.
+     *
+     * Example:
+     * ```
+     * // Remove all rules.
+     * $lifecycle->clearRules();
+     * ```
+     *
+     * ```
+     * // Remove all "Delete" based rules.
+     * $lifecycle->clearRules('Delete');
+     * ```
+     *
+     * @param string|callable $condition [optional] If a string is provided, it
+     *        must be the name of the type of rule to remove (`SetStorageClass`
+     *        or `Delete`). All rules of this type will then be cleared. When
+     *        providing a callable you may define a custom route for how you
+     *        would like to remove rules. The provided callable will be run
+     *        through
+     *        [array_filter](http://php.net/manual/en/function.array-filter.php).
+     *        **Defaults to** `null`, clearing all assigned rules.
+     * @return Lifecycle
+     * @throws \InvalidArgumentException If a type other than a string or
+     *         callabe is provided.
+     */
+    public function clearRules($condition = null)
+    {
+        if (!$condition) {
+            $this->lifecycle = [];
+            return $this;
+        }
+
+        if (!is_string($condition) && !is_callable($condition)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected either a string or callable, instead got \'%s\'.',
+                    gettype($condition)
+                )
+            );
+        }
+
+        if (isset($this->lifecycle['rule'])) {
+            if (is_string($condition)) {
+                $condition = function ($rule) use ($condition) {
+                    return $rule['action']['type'] !== $condition;
+                };
+            }
+
+            $this->lifecycle['rule'] = array_filter(
+                $this->lifecycle['rule'],
+                $condition
+            );
+
+            if (!$this->lifecycle['rule']) {
+                $this->lifecycle = [];
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @access private
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->lifecycle;
+    }
+}

--- a/Storage/src/Lifecycle.php
+++ b/Storage/src/Lifecycle.php
@@ -65,7 +65,7 @@ class Lifecycle
     }
 
     /**
-     * Adds a delete rule.
+     * Adds an Object Lifecycle Delete Rule.
      *
      * Example:
      * ```
@@ -111,7 +111,7 @@ class Lifecycle
     }
 
     /**
-     * Adds a set storage class rule.
+     * Adds an Object Lifecycle Set Storage Class Rule.
      *
      * Example:
      * ```
@@ -161,7 +161,7 @@ class Lifecycle
     }
 
     /**
-     * Clears out rules based on the provided condition.
+     * Clear all Object Lifecycle rules or rules of a certain action type.
      *
      * Example:
      * ```
@@ -174,7 +174,16 @@ class Lifecycle
      * $lifecycle->clearRules('Delete');
      * ```
      *
-     * @param string|callable $condition [optional] If a string is provided, it
+     * ```
+     * // Clear any rules which have an age equal to 50.
+     * $lifecycle->clearRules(function (array $rule) {
+     *     return $rule['condition']['age'] === 50
+     *         ? false
+     *         : true;
+     * });
+     * ```
+     *
+     * @param string|callable $action [optional] If a string is provided, it
      *        must be the name of the type of rule to remove (`SetStorageClass`
      *        or `Delete`). All rules of this type will then be cleared. When
      *        providing a callable you may define a custom route for how you
@@ -189,32 +198,32 @@ class Lifecycle
      * @throws \InvalidArgumentException If a type other than a string or
      *         callabe is provided.
      */
-    public function clearRules($condition = null)
+    public function clearRules($action = null)
     {
-        if (!$condition) {
+        if (!$action) {
             $this->lifecycle = [];
             return $this;
         }
 
-        if (!is_string($condition) && !is_callable($condition)) {
+        if (!is_string($action) && !is_callable($action)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     'Expected either a string or callable, instead got \'%s\'.',
-                    gettype($condition)
+                    gettype($action)
                 )
             );
         }
 
         if (isset($this->lifecycle['rule'])) {
-            if (is_string($condition)) {
-                $condition = function ($rule) use ($condition) {
-                    return $rule['action']['type'] !== $condition;
+            if (is_string($action)) {
+                $action = function ($rule) use ($action) {
+                    return $rule['action']['type'] !== $action;
                 };
             }
 
             $this->lifecycle['rule'] = array_filter(
                 $this->lifecycle['rule'],
-                $condition
+                $action
             );
 
             if (!$this->lifecycle['rule']) {

--- a/Storage/src/Lifecycle.php
+++ b/Storage/src/Lifecycle.php
@@ -181,6 +181,9 @@ class Lifecycle
      *        would like to remove rules. The provided callable will be run
      *        through
      *        [array_filter](http://php.net/manual/en/function.array-filter.php).
+     *        The callable's argument will be a single lifecycle rule as an
+     *        associative array. When returning true from the callable the rule
+     *        will be preserved, and if false it will be removed.
      *        **Defaults to** `null`, clearing all assigned rules.
      * @return Lifecycle
      * @throws \InvalidArgumentException If a type other than a string or

--- a/Storage/src/Lifecycle.php
+++ b/Storage/src/Lifecycle.php
@@ -47,7 +47,7 @@ namespace Google\Cloud\Storage;
  *
  * @see https://cloud.google.com/storage/docs/lifecycle Object Lifecycle Management API Documentation
  */
-class Lifecycle
+class Lifecycle implements \ArrayAccess, \IteratorAggregate
 {
     /**
      * @var array
@@ -236,10 +236,66 @@ class Lifecycle
 
     /**
      * @access private
+     * @return \Generator
+     */
+    public function getIterator()
+    {
+        if (!isset($this->lifecycle['rule'])) {
+            return;
+        }
+
+        foreach ($this->lifecycle['rule'] as $rule) {
+            yield $rule;
+        }
+    }
+
+    /**
+     * @access private
      * @return array
      */
     public function toArray()
     {
         return $this->lifecycle;
+    }
+
+    /**
+     * @access private
+     * @param string $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->lifecycle['rule'][$offset] = $value;
+    }
+
+    /**
+     * @access private
+     * @param string $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->lifecycle['rule'][$offset]);
+    }
+
+    /**
+     * @access private
+     * @param string $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->lifecycle['rule'][$offset]);
+    }
+
+    /**
+     * @access private
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->lifecycle['rule'][$offset])
+            ? $this->lifecycle['rule'][$offset]
+            : null;
     }
 }

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -258,7 +258,7 @@ class StorageClient
      *           configuration.
      *     @type array $defaultObjectAcl Default access controls to apply to new
      *           objects when no ACL is provided.
-     *     @type array $lifecycle The bucket's lifecycle configuration.
+     *     @type array|Lifecycle $lifecycle The bucket's lifecycle configuration.
      *     @type string $location The location of the bucket. **Defaults to**
      *           `"US"`.
      *     @type array $logging The bucket's logging configuration, which
@@ -305,6 +305,9 @@ class StorageClient
                 'No project ID was provided, ' .
                 'and we were unable to detect a default project ID.'
             );
+        }
+        if (isset($options['lifecycle']) && $options['lifecycle'] instanceof Lifecycle) {
+            $options['lifecycle'] = $options['lifecycle']->toArray();
         }
 
         $bucketUserProject = $this->pluck('bucketUserProject', $options, false);

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -531,6 +531,23 @@ class BucketTest extends SnippetTestCase
         $res = $snippet->invoke();
     }
 
+    public function testCurrentLifecycleIterate()
+    {
+        $snippet = $this->snippetFromMethod(Bucket::class, 'currentLifecycle', 1);
+        $snippet->addLocal('bucket', $this->bucket);
+        $this->connection->getBucket(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(self::$expectedLifecycleData);
+        $this->bucket->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke();
+
+        $this->assertEquals(
+            print_r(self::$expectedLifecycleData['lifecycle']['rule'][0], true),
+            $res->output()
+        );
+    }
+
     public function testIam()
     {
         $snippet = $this->snippetFromMethod(Bucket::class, 'iam');

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -46,6 +46,23 @@ class BucketTest extends SnippetTestCase
 
     private $connection;
     private $bucket;
+    private static $expectedLifecycleData = [
+        'userProject' => null,
+        'bucket' => self::BUCKET,
+        'lifecycle' => [
+            'rule' => [
+                [
+                    'action' => [
+                        'type' => 'Delete'
+                    ],
+                    'condition' => [
+                        'age' => 50,
+                        'isLive' => true
+                    ]
+                ]
+            ]
+        ]
+    ];
 
     public function setUp()
     {
@@ -487,6 +504,31 @@ class BucketTest extends SnippetTestCase
 
         $res = $snippet->invoke();
         $this->assertEquals(self::BUCKET, $res->output());
+    }
+
+    public function testLifecycle()
+    {
+        $snippet = $this->snippetFromMethod(Bucket::class, 'lifecycle');
+        $snippet->addLocal('bucket', $this->bucket);
+        $this->connection->patchBucket(self::$expectedLifecycleData)
+            ->shouldBeCalled();
+        $this->bucket->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke();
+    }
+
+    public function testCurrentLifecycle()
+    {
+        $snippet = $this->snippetFromMethod(Bucket::class, 'currentLifecycle');
+        $snippet->addLocal('bucket', $this->bucket);
+        $this->connection->getBucket(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([]);
+        $this->connection->patchBucket(self::$expectedLifecycleData)
+            ->shouldBeCalled();
+        $this->bucket->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke();
     }
 
     public function testIam()

--- a/Storage/tests/Snippet/LifecycleTest.php
+++ b/Storage/tests/Snippet/LifecycleTest.php
@@ -146,4 +146,18 @@ class LifecycleTest extends SnippetTestCase
         $this->assertInstanceOf(Lifecycle::class, $returnVal);
         $this->assertEmpty($returnVal->toArray());
     }
+
+    public function testClearRulesWithCallable()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition);
+        $snippet = $this->snippetFromMethod(Lifecycle::class, 'clearRules', 2);
+        $snippet->addLocal('lifecycle', $this->lifecycle);
+
+        $returnVal = $snippet->invoke('lifecycle')
+            ->returnVal();
+
+        $this->assertInstanceOf(Lifecycle::class, $returnVal);
+        $this->assertEmpty($returnVal->toArray());
+    }
 }

--- a/Storage/tests/Snippet/LifecycleTest.php
+++ b/Storage/tests/Snippet/LifecycleTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\Snippet;
+
+use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Storage\Connection\Rest;
+use Google\Cloud\Storage\Lifecycle;
+use Google\Cloud\Storage\StorageClient;
+use Prophecy\Argument;
+
+/**
+ * @group storage
+ */
+class LifecycleTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'project';
+
+    private $lifecycle;
+    private static $condition = [
+        'age' => 50,
+        'isLive' => true
+    ];
+
+    public function setUp()
+    {
+        $this->lifecycle = new Lifecycle;
+    }
+
+    public function testClass()
+    {
+        $connection = $this->prophesize(Rest::class);
+        $connection->projectId()
+            ->willReturn(self::PROJECT_ID);
+        $connection->getBucket(Argument::any())
+            ->willReturn([
+                'lifecycle' => ['test' => 'test']
+            ]);
+        $client = TestHelpers::stub(StorageClient::class);
+        $client->___setProperty('connection', $connection->reveal());
+
+        $snippet = $this->snippetFromClass(Lifecycle::class);
+        $snippet->setLine(4, '');
+        $snippet->addLocal('storage', $client);
+        $res = $snippet->invoke('lifecycle');
+
+        $this->assertInstanceOf(Lifecycle::class, $res->returnVal());
+    }
+
+    public function testClassStatic()
+    {
+        $snippet = $this->snippetFromClass(Lifecycle::class, 1);
+        $res = $snippet->invoke('lifecycle');
+
+        $this->assertInstanceOf(Lifecycle::class, $res->returnVal());
+    }
+
+    public function testAddDeleteRule()
+    {
+        $snippet = $this->snippetFromMethod(Lifecycle::class, 'addDeleteRule');
+        $snippet->addLocal('lifecycle', $this->lifecycle);
+
+        $returnVal = $snippet->invoke('lifecycle')
+            ->returnVal();
+
+        $this->assertInstanceOf(Lifecycle::class, $returnVal);
+        $this->assertEquals(
+            [
+                'rule' => [
+                    [
+                        'action' => [
+                            'type' => 'Delete'
+                        ],
+                        'condition' => self::$condition
+                    ]
+                ]
+            ],
+            $returnVal->toArray()
+        );
+    }
+
+    public function testAddSetStorageClassRule()
+    {
+        $snippet = $this->snippetFromMethod(Lifecycle::class, 'addSetStorageClassRule');
+        $snippet->addLocal('lifecycle', $this->lifecycle);
+
+        $returnVal = $snippet->invoke('lifecycle')
+            ->returnVal();
+
+        $this->assertInstanceOf(Lifecycle::class, $returnVal);
+        $this->assertEquals(
+            [
+                'rule' => [
+                    [
+                        'action' => [
+                            'type' => 'SetStorageClass',
+                            'storageClass' => 'COLDLINE'
+                        ],
+                        'condition' => self::$condition
+                    ]
+                ]
+            ],
+            $returnVal->toArray()
+        );
+    }
+
+    public function testClearRules()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition);
+        $snippet = $this->snippetFromMethod(Lifecycle::class, 'clearRules');
+        $snippet->addLocal('lifecycle', $this->lifecycle);
+
+        $returnVal = $snippet->invoke('lifecycle')
+            ->returnVal();
+
+        $this->assertInstanceOf(Lifecycle::class, $returnVal);
+        $this->assertEmpty($returnVal->toArray());
+    }
+
+    public function testClearRulesWithString()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition);
+        $snippet = $this->snippetFromMethod(Lifecycle::class, 'clearRules', 1);
+        $snippet->addLocal('lifecycle', $this->lifecycle);
+
+        $returnVal = $snippet->invoke('lifecycle')
+            ->returnVal();
+
+        $this->assertInstanceOf(Lifecycle::class, $returnVal);
+        $this->assertEmpty($returnVal->toArray());
+    }
+}

--- a/Storage/tests/Unit/LifecycleTest.php
+++ b/Storage/tests/Unit/LifecycleTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Storage;
+
+use Google\Cloud\Storage\Lifecycle;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group storage
+ */
+class LifecycleTest extends TestCase
+{
+    private $lifecycle;
+    private static $condition = [
+        'age' => 50
+    ];
+
+    public function setUp()
+    {
+        $this->lifecycle = new Lifecycle;
+    }
+
+    public function testAddDeleteRule()
+    {
+        $expected = [
+            'rule' => [
+                [
+                    'action' => [
+                        'type' => 'Delete'
+                    ],
+                    'condition' => self::$condition
+                ]
+            ]
+        ];
+
+        $this->assertInstanceOf(
+            Lifecycle::class,
+            $this->lifecycle->addDeleteRule(self::$condition)
+        );
+        $this->assertEquals($expected, $this->lifecycle->toArray());
+    }
+
+    public function testAddStorageClassRule()
+    {
+        $storageClass = 'NEARLINE';
+        $expected = [
+            'rule' => [
+                [
+                    'action' => [
+                        'type' => 'SetStorageClass',
+                        'storageClass' => $storageClass
+                    ],
+                    'condition' => self::$condition
+                ]
+            ]
+        ];
+
+        $this->assertInstanceOf(
+            Lifecycle::class,
+            $this->lifecycle->addSetStorageClassRule($storageClass, self::$condition)
+        );
+        $this->assertEquals($expected, $this->lifecycle->toArray());
+    }
+
+    public function testClearRules()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition)
+            ->addDeleteRule(self::$condition);
+
+        $this->assertCount(
+            2,
+            $this->lifecycle->toArray()['rule']
+        );
+
+        $this->assertInstanceOf(
+            Lifecycle::class,
+            $this->lifecycle->clearRules()
+        );
+        $this->assertEmpty(
+            $this->lifecycle->toArray()
+        );
+    }
+
+    public function testClearRulesWithString()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition)
+            ->addSetStorageClassRule('NEARLINE', self::$condition);
+
+        $this->assertInstanceOf(
+            Lifecycle::class,
+            $this->lifecycle->clearRules('Delete')
+        );
+
+        $result = $this->lifecycle
+            ->toArray();
+
+        $this->assertCount(1, $result['rule']);
+        $this->assertEquals(
+            'SetStorageClass',
+            current($result['rule'])['action']['type']
+        );
+    }
+
+    public function testClearRulesWithCallable()
+    {
+        $this->lifecycle
+            ->addDeleteRule(self::$condition);
+
+        $this->assertInstanceOf(
+            Lifecycle::class,
+            $this->lifecycle
+                ->clearRules(function ($rule) {
+                    return $rule['condition']['age'] > 70;
+                })
+        );
+        $this->assertEmpty(
+            $this->lifecycle->toArray()
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testClearRulesThrowsExceptionWithInvalidType()
+    {
+        $this->lifecycle
+            ->clearRules(123);
+    }
+}

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\Rest;
+use Google\Cloud\Storage\Lifecycle;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StreamWrapper;
 use GuzzleHttp\Psr7;
@@ -130,6 +131,33 @@ class StorageClientTest extends TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
 
         $this->assertInstanceOf(Bucket::class, $this->client->createBucket('bucket'));
+    }
+
+    public function testCreatesBucketWithLifecycleBuilder()
+    {
+        $bucket = 'bucket';
+        $lifecycleArr = ['test' => 'test'];
+        $lifecycle = $this->prophesize(Lifecycle::class);
+        $lifecycle->toArray()
+            ->willReturn($lifecycleArr);
+        $this->connection->projectId()
+            ->willReturn(self::PROJECT);
+        $this->connection
+            ->insertBucket([
+                'project' => self::PROJECT,
+                'lifecycle' => $lifecycleArr,
+                'name' => $bucket
+            ])
+            ->willReturn(['name' => $bucket]);
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertInstanceOf(
+            Bucket::class,
+            $this->client->createBucket(
+                $bucket,
+                ['lifecycle' => $lifecycle->reveal()]
+            )
+        );
     }
 
     public function testRegisteringStreamWrapper()


### PR DESCRIPTION
With this change set `Google\Cloud\Storage\StorageClient::createBucket()` and `Google\Cloud\Storage\Bucket::update()` can now both accept an instance of `Google\Cloud\Storage\Lifecycle` as opposed to a raw array.

Sample usage:

```php
use Google\Cloud\Storage\Bucket;
use Google\Cloud\Storage\StorageClient;

$storage = new StorageClient;
$bucket = $storage->createBucket('myBeautifulBucket', [
    'lifecycle' => Bucket::lifecycle()
        ->addDeleteRule([
            'age' => 50
        ])
]);
```
/cc @frankyn