### PR TITLE
Remove debug information from build

### DIFF
--- a/dev/sh/build-docs
+++ b/dev/sh/build-docs
@@ -3,17 +3,11 @@
 set -ev
 
 function buildDocs () {
-  echo "doc dir before generation:"
-  find docs
-
   if [ -z "$TRAVIS_TAG" ]; then
     ./dev/google-cloud docs
   else
     ./dev/google-cloud docs -r
   fi
-
-  echo "doc dir after generation:"
-  find docs
 }
 
 


### PR DESCRIPTION
This was used as debug information quite some time ago, and isn't really necessary anymore. Removing it should help make parsing the build logs a little easier.