### PR TITLE
[Core] Do not export Testing tooling

### DIFF
--- a/Core/.gitattributes
+++ b/Core/.gitattributes
@@ -1,3 +1,4 @@
 /*.xml.dist export-ignore
 /tests export-ignore
+/src/Testing export-ignore
 /.github export-ignore


### PR DESCRIPTION
Right now the /tests/ directory is being excluded from the builds, but not the supporting classes which are located at src/Testing. Without the tests those classes are pretty useless.