### PR TITLE
Fix Firestore array offset exists check

### DIFF
--- a/Firestore/src/DocumentSnapshot.php
+++ b/Firestore/src/DocumentSnapshot.php
@@ -320,7 +320,7 @@ class DocumentSnapshot implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset($this->data[$offset]);
+        return array_key_exists($offset, $this->data);
     }
 
     /**

--- a/Firestore/tests/System/ValueMapperTest.php
+++ b/Firestore/tests/System/ValueMapperTest.php
@@ -28,14 +28,18 @@ use Google\Cloud\Core\Timestamp;
 class ValueMapperTest extends FirestoreTestCase
 {
     private static $document;
+    private static $isSetup = false;
 
-    const FIELD = 'value';
+    const FIELD = 'testedField';
 
     public static function setUpBeforeClass()
     {
         parent::setupBeforeClass();
 
-        self::$document = self::$collection->add([]);
+        if (!self::$isSetup) {
+            self::$document = self::$collection->add([]);
+            self::$isSetup = true;
+        }
     }
 
     /**
@@ -59,6 +63,8 @@ class ValueMapperTest extends FirestoreTestCase
 
     public function values()
     {
+        self::setupBeforeClass();
+
         return [
             [null],
             [true],


### PR DESCRIPTION
The fix in #1377 exposed another issue, that `DocumentSnapshot::offsetExists()` uses an `isset()` check, which [according to the documentation](http://php.net/isset), returns `false` if the tested value is set to `null`. As `null` is a valid value, the `offsetExists()` test has been updated to use `array_key_exists()`.