### PR TITLE
Update readme/projectID detection

### DIFF
--- a/Bigtable/README.md
+++ b/Bigtable/README.md
@@ -31,6 +31,17 @@ $ composer require google/cloud
 This component supports both REST over HTTP/1.1 and gRPC. In order to take advantage of the benefits offered by gRPC (such as streaming methods)
 please see our [gRPC installation guide](https://cloud.google.com/php/grpc).
 
+### Notable Client Differences
+
+The handwritten client offered by this package differs from the others in `google-cloud-php` in that it more directly wraps our generated clients.
+This means some of the idioms and configuration options you are used to may differ slightly. The most notable differences are outlined below:
+
+- There is now more granular control over retry logic. Please see [the `bigtable_client_config.json` file](https://github.com/googleapis/google-cloud-php/blob/master/Bigtable/src/V2/resources/bigtable_client_config.json)
+  for an example of the configuration which can be passed into the client at construction time.
+- Exceptions triggered at the network level utilize the base class `Google\ApiCore\ApiException` as opposed to `Google\Cloud\Core\ServiceException`.
+- The `authHttpHandler` and `httpHandler` client configuration options are now provided through `$credentialsConfig['authHttpHandler']`
+  and `$transportConfig['httpHandler']`, respectively. Additionally, please note the `httpHandler` should now return an implementation of [Guzzle's `PromiseInterface`](https://github.com/guzzle/promises/blob/master/src/PromiseInterface.php).
+
 ### Authentication
 
 Please see our [Authentication guide](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/AUTHENTICATION.md) for more information

--- a/Bigtable/README.md
+++ b/Bigtable/README.md
@@ -36,6 +36,7 @@ please see our [gRPC installation guide](https://cloud.google.com/php/grpc).
 The handwritten client offered by this package differs from the others in `google-cloud-php` in that it more directly wraps our generated clients.
 This means some of the idioms and configuration options you are used to may differ slightly. The most notable differences are outlined below:
 
+- A key file is now provided through the `credentials` configuration option as opposed to either `keyFile` or `keyFilePath`.
 - There is now more granular control over retry logic. Please see [the `bigtable_client_config.json` file](https://github.com/googleapis/google-cloud-php/blob/master/Bigtable/src/V2/resources/bigtable_client_config.json)
   for an example of the configuration which can be passed into the client at construction time.
 - Exceptions triggered at the network level utilize the base class `Google\ApiCore\ApiException` as opposed to `Google\Cloud\Core\ServiceException`.

--- a/Bigtable/README.md
+++ b/Bigtable/README.md
@@ -48,6 +48,9 @@ This means some of the idioms and configuration options you are used to may diff
 Please see our [Authentication guide](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/AUTHENTICATION.md) for more information
 on authenticating your client. Once authenticated, you'll be ready to start making requests.
 
+When going through the authentication guide, please take note that the handwritten client for this package will more closely follow the conventions
+outlined for the generated clients.
+
 ### Sample
 
 ```php

--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -22,6 +22,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Bigtable\V2\BigtableClient as GapicClient;
+use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ClientTrait;
 
 /**
@@ -38,6 +39,7 @@ use Google\Cloud\Core\ClientTrait;
  */
 class BigtableClient
 {
+    use ArrayTrait;
     use ClientTrait;
 
     const VERSION = '0.5.3';
@@ -93,23 +95,26 @@ class BigtableClient
      *               'grpc' => [...],
      *               'rest' => [...]
      *           ];
-     *           See {@see Google\ApiCore\Transport\GrpcTransport} and
-     *           {@see Google\ApiCore\Transport\RestTransport} for
-     *           the supported options.
+     *           See the `build` method on {@see Google\ApiCore\Transport\GrpcTransport}
+     *           and {@see Google\ApiCore\Transport\RestTransport} for the
+     *           supported options.
      * }
      * @throws ValidationException
      */
     public function __construct(array $config = [])
     {
         if (!isset($config['transportConfig']['grpc']['stubOpts'])) {
-            // Workaround for large messages.
-            $config['transportConfig']['grpc']['stubOpts'] = [
-                'grpc.max_send_message_length' => -1,
-                'grpc.max_receive_message_length' => -1
-            ];
+            $config['transportConfig']['grpc']['stubOpts'] = [];
         }
 
-        $this->projectId = $this->detectProjectId($config);
+        // Workaround for large messages.
+        $config['transportConfig']['grpc']['stubOpts'] += [
+            'grpc.max_send_message_length' => -1,
+            'grpc.max_receive_message_length' => -1
+        ];
+
+        $this->projectId = $this->pluck('projectId', $config, false)
+            ?: $this->detectProjectId();
         $this->gapicClient = new GapicClient($config);
     }
 
@@ -139,6 +144,29 @@ class BigtableClient
             $this->gapicClient,
             GapicClient::tableName($this->projectId, $instanceId, $tableId),
             $options
+        );
+    }
+
+    /**
+     * Attempts to detect the project ID.
+     *
+     * @todo Add better support for detecting the project ID (check keyFile/GCE metadata server).
+     * @return string
+     * @throws ValidationException If a project ID cannot be detected.
+     */
+    private function detectProjectId()
+    {
+        if (getenv('GOOGLE_CLOUD_PROJECT')) {
+            return getenv('GOOGLE_CLOUD_PROJECT');
+        }
+
+        if (getenv('GCLOUD_PROJECT')) {
+            return getenv('GCLOUD_PROJECT');
+        }
+
+        throw new ValidationException(
+            'No project ID was provided, ' .
+            'and we were unable to detect a default project ID.'
         );
     }
 }

--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -23,7 +23,6 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Bigtable\V2\BigtableClient as GapicClient;
 use Google\Cloud\Core\ArrayTrait;
-use Google\Cloud\Core\ClientTrait;
 
 /**
  * Google Cloud Bigtable is Google's NoSQL Big Data database service.
@@ -40,7 +39,6 @@ use Google\Cloud\Core\ClientTrait;
 class BigtableClient
 {
     use ArrayTrait;
-    use ClientTrait;
 
     const VERSION = '0.5.3';
 
@@ -48,6 +46,11 @@ class BigtableClient
      * @var GapicClient
      */
     private $gapicClient;
+
+    /**
+     * @var string
+     */
+    private $projectId;
 
     /**
      * Create a Bigtable client.


### PR DESCRIPTION
The README updates intend to help clarify the differences we are introducing by updating our client constructor options to more closely match the generated clients.

The `ClientTrait` is intended to be used with our "older" style of handwritten clients. We'll need to do a little refactoring to get back to the same functionality. We can follow up with this work shortly.