### PR TITLE
Add 64 or 32 bit test

### DIFF
--- a/Bigtable/src/DataUtil.php
+++ b/Bigtable/src/DataUtil.php
@@ -49,7 +49,7 @@ class DataUtil
     public static function isSupported()
     {
         if (self::$isSupported === null) {
-            self::$isSupported = PHP_VERSION_ID >= 50600;
+            self::$isSupported = PHP_VERSION_ID >= 50600 && PHP_INT_SIZE > 4;
         }
         return self::$isSupported;
     }

--- a/Bigtable/tests/Unit/DataUtilTest.php
+++ b/Bigtable/tests/Unit/DataUtilTest.php
@@ -23,10 +23,16 @@ use PHPUnit\Framework\TestCase;
 /**
  * @group bigtable
  * @group bigtabledata
- * @requires PHP 5.6.0
  */
 class DataUtilTest extends TestCase
 {
+    public function setUp()
+    {
+        if (!DataUtil::isSupported()) {
+            $this->markTestSkipped('Tested functionality is not supported in the current version of PHP.');
+        }
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Expected argument to be of type int, instead got
@@ -38,20 +44,12 @@ class DataUtilTest extends TestCase
 
     public function testIntToByteString()
     {
-        if (!DataUtil::isSupported()) {
-            $this->markTestSkipped('Tested functionality is not supported in the current version of PHP.');
-        }
-
         $expected = hex2bin("0000000000000002");
         $this->assertEquals($expected, DataUtil::intToByteString(2));
     }
 
     public function testByteStringToInt()
     {
-        if (!DataUtil::isSupported()) {
-            $this->markTestSkipped('Tested functionality is not supported in the current version of PHP.');
-        }
-
         $value = DataUtil::byteStringToInt(DataUtil::intToByteString(-52));
         $this->assertEquals(-52, $value);
     }

--- a/Bigtable/tests/Unit/DataUtilTest.php
+++ b/Bigtable/tests/Unit/DataUtilTest.php
@@ -38,12 +38,20 @@ class DataUtilTest extends TestCase
 
     public function testIntToByteString()
     {
+        if (!DataUtil::isSupported()) {
+            $this->markTestSkipped('Tested functionality is not supported in the current version of PHP.');
+        }
+
         $expected = hex2bin("0000000000000002");
         $this->assertEquals($expected, DataUtil::intToByteString(2));
     }
 
     public function testByteStringToInt()
     {
+        if (!DataUtil::isSupported()) {
+            $this->markTestSkipped('Tested functionality is not supported in the current version of PHP.');
+        }
+
         $value = DataUtil::byteStringToInt(DataUtil::intToByteString(-52));
         $this->assertEquals(-52, $value);
     }


### PR DESCRIPTION
Since the DataUtil methods in Bigtable require a 64-bit build of PHP 5.6 or greater, this change adds a check to verify that the PHP version supports 64-bit ints and skips tests if it does not. This should fix the build failure in the other PR.

@ajaaym @dwsupplee 