### PR TITLE
storage: use correct path with signed url cname

### DIFF
--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -874,6 +874,12 @@ class StorageObject
         }
 
         $options['cname'] = trim($options['cname'], '/');
+
+        // If a custom cname is used, then the resource is simply the objectName
+        if ($options['cname'] !== self::DEFAULT_DOWNLOAD_URL) {
+            $resource = '/' . $objectName;
+        }
+
         return $options['cname'] . $resource . '?' . implode('&', $query);
     }
 


### PR DESCRIPTION
When getting a signed URL from a storage object and passing the cname option the resource path should not include the bucket name, as that's implied by the cname.

This removes the bucket name from the resource path if a cname option is provided.