### PR TITLE
Require ProductSearchParams on productSearch helper

### DIFF
--- a/Vision/src/V1/ImageAnnotatorClient.php
+++ b/Vision/src/V1/ImageAnnotatorClient.php
@@ -515,11 +515,24 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      *
      * Example:
      * ```
+     * use Google\Cloud\Vision\V1\ProductSearchClient;
+     * use Google\Cloud\Vision\V1\ProductSearchParams;
+     *
      * $imageContent = file_get_contents('path/to/image.jpg');
-     * $response = $imageAnnotatorClient->productSearch($imageContent);
+     * $productSetName = ProductSearchClient::productSetName('PROJECT_ID', 'LOC_ID', 'PRODUCT_SET_ID');
+     * $productSearchParams = (new ProductSearchParams)
+     *     ->setProductSet($productSetName);
+     * $response = $imageAnnotatorClient->productSearch(
+     *     $imageContent,
+     *     $productSearchParams
+     * );
      * ```
      *
      * @param resource|string|Image $image The image to be processed.
+     * @param ProductSearchParams   $productSearchParams Parameters for a product search request. Please note, if the
+     *                              optional image context argument is provided this value will take precedent over
+     *                              any product search parameters already set on the
+     *                              {@see Google\Cloud\Vision\V1\ImageContext} instance.
      * @param array $optionalArgs   {
      *     Configuration Options.
      *
@@ -536,8 +549,15 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function productSearch($image, $optionalArgs = [])
+    public function productSearch($image, ProductSearchParams $productSearchParams, $optionalArgs = [])
     {
+        if (isset($optionalArgs['imageContext']) && $optionalArgs['imageContext'] instanceof ImageContext) {
+            $optionalArgs['imageContext']->setProductSearchParams($productSearchParams);
+        } else {
+            $optionalArgs['imageContext'] = (new ImageContext)
+                ->setProductSearchParams($productSearchParams);
+        }
+
         return $this->annotateSingleFeature(
             $image,
             Type::PRODUCT_SEARCH,

--- a/Vision/tests/Snippet/V1/ImageAnnotatorClientTest.php
+++ b/Vision/tests/Snippet/V1/ImageAnnotatorClientTest.php
@@ -24,6 +24,8 @@ use Google\Cloud\Vision\V1\AnnotateImageResponse;
 use Google\Cloud\Vision\V1\BatchAnnotateImagesResponse;
 use Google\Cloud\Vision\V1\Image;
 use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+use Google\Cloud\Vision\V1\ImageContext;
+use Google\Cloud\Vision\V1\ProductSearchParams;
 use GuzzleHttp\Promise\FulfilledPromise;
 use Prophecy\Argument;
 
@@ -110,7 +112,6 @@ class ImageAnnotatorClientTest extends SnippetTestCase
             "path/to/image.jpg",
             "php://temp"
         );
-
 
         $this->transport->startUnaryCall(Argument::type(Call::class), Argument::type('array'))
             ->shouldBeCalledTimes(1)


### PR DESCRIPTION
Since the product set name is required to run a product search annotation request, we wanted to require users provide `Google\Cloud\Vision\V1\ProductSearchParams` as an avenue to help guide them to the correct usage.