### PR TITLE
Link to installed dependency version in generated docs

### DIFF
--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -808,6 +808,8 @@ class CodeParser implements ParserInterface
         $lockFilePath = $this->projectRoot . '/composer.lock';
         if (!self::$lockFile && file_exists($lockFilePath)) {
             self::$lockFile = json_decode(file_get_contents($lockFilePath), true)['packages'];
+        } elseif (!file_exists($lockFilePath)) {
+            throw new \RuntimeException('composer.lock file does not exist. Run `composer install` first.');
         }
 
         $dep = array_values(array_filter(self::$lockFile, function ($package) use ($depName) {

--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -20,15 +20,14 @@ namespace Google\Cloud\Dev\DocGenerator\Parser;
 use Google\Cloud\Core\Testing\DocBlockStripSpaces;
 use Google\Cloud\Dev\DocGenerator\ReflectorRegister;
 use Google\Cloud\Dev\GetComponentsTrait;
-use Symfony\Component\Console\Output\OutputInterface;
 use phpDocumentor\Reflection\ClassReflector;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
 use phpDocumentor\Reflection\DocBlock\Type\Collection;
-use phpDocumentor\Reflection\FileReflector;
 use phpDocumentor\Reflection\InterfaceReflector;
-use phpDocumentor\Reflection\TraitReflector;
+use Rize\UriTemplate;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class CodeParser implements ParserInterface
 {
@@ -38,6 +37,7 @@ class CodeParser implements ParserInterface
     const SNIPPET_NAME_REGEX = '/\/\/\s?\[snippet\=(\w{0,})\]/';
 
     private static $composerFiles = [];
+    private static $lockFile;
 
     private $path;
     private $register;
@@ -764,19 +764,52 @@ class CodeParser implements ParserInterface
         }));
 
         $external = $types[0];
-        $href = sprintf(
-            $external['uri'],
-            str_replace(
-                $external['name'],
-                '',
-                str_replace('[]', '', $type)
-            )
+
+        $type = str_replace('\\', '/', $type);
+        $type = str_replace(
+            $external['name'],
+            '',
+            str_replace('[]', '', $type)
         );
+        $placeholders = [
+            'type' => explode('/', $type)
+        ];
+
+        if (isset($external['depName'])) {
+            $placeholders['depVersion'] = $this->getExternalDepVersion($external);
+        }
+
+        $uri = new UriTemplate;
+        $href = $uri->expand($external['uri'], $placeholders);
+
         return sprintf(
             '<a href="%s" target="_blank">%s</a>',
             $href,
             $type
         );
+    }
+
+    private function getExternalDepVersion($external)
+    {
+        $depName = $external['depName'];
+
+        $lockFilePath = $this->projectRoot . '/composer.lock';
+        if (!self::$lockFile && file_exists($lockFilePath)) {
+            self::$lockFile = json_decode(file_get_contents($lockFilePath), true)['packages'];
+        }
+
+        $dep = array_values(array_filter(self::$lockFile, function ($package) use ($depName) {
+            return $package['name'] === $depName;
+        }));
+
+        if (!$dep) {
+            throw new \RuntimeException(sprintf(
+                'Could not find installed package %s. Check `docs/external-classes.json` to verify.',
+                $depName
+            ));
+        }
+
+        return $dep[0]['version'];
     }
 
     private function buildInternalLink($content)

--- a/dev/src/ReleaseBuilder/ReleaseBuilder.php
+++ b/dev/src/ReleaseBuilder/ReleaseBuilder.php
@@ -432,8 +432,7 @@ class ReleaseBuilder extends GoogleCloudCommand
                         $noMoreChanges = true;
                     }
 
-                    continue;
-                    break;
+                    continue 2;
             }
         } while (!$noMoreChanges);
 

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -96,5 +96,10 @@
   "name": "Google\\Protobuf",
   "uri": "https://github.com/protocolbuffers/protobuf/tree/{depVersion}/php/src{/type*}.php",
   "depName": "google/protobuf"
+}, {
+  "name": "GuzzleHttp\\Promise",
+  "uri": "https://github.com/guzzle/promises/tree/{depVersion}/src{/type*}.php",
+  "depName": "guzzlehttp/promises",
+  "strip": true
 }]
 

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -52,19 +52,22 @@
 }, {
   "name": "Psr\\Cache\\",
   "uri": "https://github.com/php-fig/cache/tree/{depVersion}/src{/type*}.php",
-  "depName": "psr/cache"
+  "depName": "psr/cache",
+  "strip": true
 }, {
   "name": "Psr\\Log\\",
-  "uri": "https://github.com/php-fig/log/tree/{depVersion}/Psr/Log{/type*}.php",
+  "uri": "https://github.com/php-fig/log/tree/{depVersion}{/type*}.php",
   "depName": "psr/log"
 }, {
   "name": "Psr\\Http\\Message\\",
   "uri": "https://github.com/php-fig/http-message/tree/{depVersion}/src{/type*}.php",
-  "depName": "psr/http-message"
+  "depName": "psr/http-message",
+  "strip": true
 }, {
   "name": "Google\\Auth\\",
   "uri": "https://github.com/googleapis/google-auth-library-php/tree/{depVersion}/src{/type*}.php",
-  "depName": "google/auth"
+  "depName": "google/auth",
+  "strip": true
 }, {
   "name": "Google\\ApiCore\\",
   "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
@@ -75,10 +78,6 @@
   "depName": "google/gax"
 }, {
   "name": "Google\\Cloud\\",
-  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
-  "depName": "google/gax"
-}, {
-  "name": "Google\\Iam\\V1\\",
   "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
   "depName": "google/gax"
 }, {
@@ -93,5 +92,9 @@
   "name": "Google\\Type\\",
   "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
   "depName": "google/gax"
+}, {
+  "name": "Google\\Protobuf",
+  "uri": "https://github.com/protocolbuffers/protobuf/tree/{depVersion}/php/src{/type*}.php",
+  "depName": "google/protobuf"
 }]
 

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -51,36 +51,47 @@
   "uri": "http://php.net/manual/en/class.jsonserializable.php"
 }, {
   "name": "Psr\\Cache\\",
-  "uri": "https://github.com/php-fig/cache/blob/master/src/%s.php"
+  "uri": "https://github.com/php-fig/cache/tree/{depVersion}/src{/type*}.php",
+  "depName": "psr/cache"
 }, {
   "name": "Psr\\Log\\",
-  "uri": "https://github.com/php-fig/log/blob/master/Psr/Log/%s.php"
+  "uri": "https://github.com/php-fig/log/tree/{depVersion}/Psr/Log{/type*}.php",
+  "depName": "psr/log"
 }, {
   "name": "Psr\\Http\\Message\\",
-  "uri": "https://github.com/php-fig/http-message/blob/master/src/%s.php"
+  "uri": "https://github.com/php-fig/http-message/tree/{depVersion}/src{/type*}.php",
+  "depName": "psr/http-message"
 }, {
   "name": "Google\\Auth\\",
-  "uri": "https://github.com/google/google-auth-library-php/blob/master/src/%s.php"
+  "uri": "https://github.com/googleapis/google-auth-library-php/tree/{depVersion}/src{/type*}.php",
+  "depName": "google/auth"
 }, {
   "name": "Google\\ApiCore\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/ApiCore/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\Api\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/Api/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\Cloud\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/Cloud/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\Iam\\V1\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/Iam/V1/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\LongRunning\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/LongRunning/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\Rpc\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/Rpc/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }, {
   "name": "Google\\Type\\",
-  "uri": "https://googleapis.github.io/gax-php/#Google/Type/%s.html"
+  "uri": "https://googleapis.github.io/gax-php/{depVersion}{/type*}.html",
+  "depName": "google/gax"
 }]
 


### PR DESCRIPTION
This change updates the external type transformer to use the installed dependency version in the URIs.

Some examples:
* http://jdpedrie.github.io/google-cloud-php/#/docs/google-cloud/master/asset/v1beta1/assetserviceclient?method=resumeOperation
* http://jdpedrie.github.io/google-cloud-php/#/docs/google-cloud/master/bigquery/bigqueryclient?method=__construct
  * config['authCache']
  * config['credentialsFetcher']

Closes #757.