### PR TITLE
Storage async object downloads

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -8,6 +8,7 @@
         "rize/uri-template": "~0.3",
         "google/auth": "^1.2",
         "guzzlehttp/guzzle": "^5.3|^6.0",
+        "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",
         "psr/http-message": "1.0.*"

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -103,10 +103,10 @@ class ExponentialBackoff
     /**
      * Calculates exponential delay.
      *
-     * @param int $attempt
+     * @param int $attempt The attempt number used to calculate the delay.
      * @return int
      */
-    private function calculateDelay($attempt)
+    public static function calculateDelay($attempt)
     {
         return min(
             mt_rand(0, 1000000) + (pow(2, $attempt) * 1000000),

--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -96,7 +96,7 @@ trait RequestWrapperTrait
             'credentialsFetcher' => null,
             'keyFile' => null,
             'requestTimeout' => null,
-            'retries' => null,
+            'retries' => 3,
             'scopes' => null
         ];
 

--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -412,7 +412,7 @@ class ServiceBuilder
     private function createClient($class, $packageName, array $config = [])
     {
         if (class_exists($class)) {
-            return new $class($this->resolveConfig($config));
+            return new $class($this->resolveConfig($config + $this->config));
         }
         throw new \Exception(sprintf(
             'The google/cloud-%s package is missing and must be installed.',
@@ -430,6 +430,14 @@ class ServiceBuilder
     {
         if (!isset($config['httpHandler'])) {
             $config['httpHandler'] = HttpHandlerFactory::build();
+        }
+
+        if (!isset($config['asyncHttpHandler'])) {
+            $isGuzzleHandler = $config['httpHandler'] instanceof Guzzle6HttpHandler
+                || $config['httpHandler'] instanceof Guzzle5HttpHandler;
+            $config['asyncHttpHandler'] = $isGuzzleHandler
+                ? [$config['httpHandler'], 'async']
+                : [HttpHandlerFactory::build(), 'async'];
         }
 
         return array_merge($this->config, $config);

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -111,4 +111,28 @@ class ExponentialBackoffTest extends TestCase
 
         $this->assertEquals(1, $actualAttempts);
     }
+
+    /**
+     * @dataProvider delayProvider
+     */
+    public function testCalculatesDelay($attempt, $expectedDelayLowerBound, $expectedDelayUpperBound)
+    {
+        $this->assertThat(
+            ExponentialBackoff::calculateDelay($attempt),
+            $this->logicalAnd(
+                $this->greaterThanOrEqual($expectedDelayLowerBound),
+                $this->lessThanOrEqual($expectedDelayUpperBound)
+            )
+        );
+    }
+
+    public function delayProvider()
+    {
+        return [
+            [0, 1000000, 2000000],
+            [2, 4000000, 5000000],
+            [5, 32000000, 33000000],
+            [10, 60000000, 60000000]
+        ];
+    }
 }

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -4,8 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.23",
-        "guzzlehttp/promises": "^1.3"
+        "google/cloud-core": "^1.25"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -4,7 +4,8 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.23"
+        "google/cloud-core": "^1.23",
+        "guzzlehttp/promises": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
 

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -642,6 +642,69 @@ class StorageObject
     }
 
     /**
+     * Asynchronously download an object as a stream.
+     *
+     * Example:
+     * ```
+     * use Psr\Http\Message\StreamInterface;
+     *
+     * $promise = $object->downloadAsStreamAsync()
+     *     ->then(function (StreamInterface $data) {
+     *         echo $data->getContents();
+     *     });
+     *
+     * $promise->wait();
+     * ```
+     *
+     * ```
+     * // Download all objects in a bucket asynchronously.
+     * use GuzzleHttp\Promise;
+     * use Psr\Http\Message\StreamInterface;
+     *
+     * $promises = [];
+     *
+     * foreach ($bucket->objects() as $object) {
+     *     $promises[] = $object->downloadAsStreamAsync()
+     *         ->then(function (StreamInterface $data) {
+     *             echo $data->getContents();
+     *         });
+     * }
+     *
+     * Promise\unwrap($promises);
+     * ```
+     *
+     * @see https://github.com/guzzle/promises Learn more about Guzzle Promises
+     *
+     * @param array $options [optional] {
+     *     Configuration Options.
+     *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     * }
+     * @return PromiseInterface<StreamInterface>
+     * @experimental The experimental flag means that while we believe this method
+     *      or class is ready for use, it may change before release in backwards-
+     *      incompatible ways. Please use with caution, and test thoroughly when
+     *      upgrading.
+     */
+    public function downloadAsStreamAsync(array $options = [])
+    {
+        return $this->connection->downloadObjectAsync(
+            $this->formatEncryptionHeaders(
+                $options
+                + $this->encryptionData
+                + array_filter($this->identity)
+            )
+        );
+    }
+
+    /**
      * Create a Signed URL for this object.
      *
      * Signed URLs can be complex, and it is strongly recommended you read and

--- a/Storage/tests/Snippet/StorageObjectTest.php
+++ b/Storage/tests/Snippet/StorageObjectTest.php
@@ -27,7 +27,10 @@ use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\Rest;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -259,7 +262,7 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(\GuzzleHttp\Psr7\stream_for('test'));
+            ->willReturn(Psr7\stream_for('test'));
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 
@@ -275,7 +278,7 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(\GuzzleHttp\Psr7\stream_for('test'));
+            ->willReturn(Psr7\stream_for('test'));
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 
@@ -291,7 +294,47 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(\GuzzleHttp\Psr7\stream_for('test'));
+            ->willReturn(Psr7\stream_for('test'));
+
+        $this->object->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke();
+
+        $this->assertEquals('test', $res->output());
+    }
+
+    public function testDownloadAsStreamAsync()
+    {
+        $snippet = $this->snippetFromMethod(StorageObject::class, 'downloadAsStreamAsync');
+        $snippet->addLocal('object', $this->object);
+
+        $this->connection->downloadObjectAsync(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(
+                Promise\promise_for(Psr7\stream_for('test'))
+            );
+
+        $this->object->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke();
+
+        $this->assertEquals('test', $res->output());
+    }
+
+    public function testDownloadAsStreamAsyncWithUnwrap()
+    {
+        $snippet = $this->snippetFromMethod(StorageObject::class, 'downloadAsStreamAsync', 1);
+        $bucket = $this->prophesize(Bucket::class);
+        $bucket->objects()
+            ->willReturn([$this->object]);
+        $snippet->addLocal('bucket', $bucket->reveal());
+        $snippet->addLocal('object', $this->object);
+
+        $this->connection->downloadObjectAsync(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(
+                Promise\promise_for(Psr7\stream_for('test'))
+            );
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 

--- a/Storage/tests/System/ManageObjectsTest.php
+++ b/Storage/tests/System/ManageObjectsTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\System;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -149,6 +150,14 @@ class ManageObjectsTest extends StorageTestCase
         $content = self::$object->downloadAsStream();
 
         $this->assertInstanceOf(StreamInterface::class, $content);
+    }
+
+    public function testDownloadsAsStreamAsync()
+    {
+        $promise = self::$object->downloadAsStreamAsync();
+
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+        $this->assertInstanceOf(StreamInterface::class, $promise->wait());
     }
 
     public function testDownloadsToFile()


### PR DESCRIPTION
With this changeset users can now download objects asynchronously by utilizing [Guzzle Promises](https://github.com/guzzle/promises).

```php
use Google\Cloud\Storage\StorageClient;
use GuzzleHttp\Promise;
use Psr\Http\Message\StreamInterface;

$storage = new StorageClient;
$bucket->storage('my-bucket');
$promises = [];

foreach ($bucket->objects() as $object) {
    $promises[] = $object->downloadAsStreamAsync()
        ->then(function (StreamInterface $data) {
            echo $data->getContents();
        });
}

Promise\unwrap($promises);
```