### PR TITLE
move google/cloud-core package from a development dependency to a production dependency in google/cloud-bigtable package

### DIFF
--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -4,11 +4,11 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/gax": "^0.37"
+        "google/gax": "^0.37",
+        "google/cloud-core": "^1.23"
     },
     "require-dev": {
         "erusev/parsedown": "^1.6",
-        "google/cloud-core": "^1.23",
         "phpdocumentor/reflection": "^3.0",
         "phpunit/phpunit": "^4.8|^5.0"
     },


### PR DESCRIPTION
when using the [google/cloud-bigtable](https://packagist.org/packages/google/cloud-bigtable) package with composer version `1.8.0` i am unable to construct the client successfully without installing a package under the [`"require-dev"`](https://github.com/googleapis/google-cloud-php-bigtable/blob/2cbfb55f928a17d1a86d05564033c15da280f7ac/composer.json#L9-L11) key
```shell session
$ cat test.php
<?php
require __DIR__ . '/vendor/autoload.php';
use Google\Cloud\Bigtable\BigtableClient;
$bigtable = new BigtableClient(['projectId' => 'my-project']);

$ php ./test.php

Fatal error: Trait 'Google\Cloud\Core\ArrayTrait' not found in /home/mstarr/nextgenaz/vendor/google/cloud-bigtable/src/BigtableClient.php on line 41

$ php -d extension=phar.so composer.phar require google/cloud-core:1.23

$ php ./test.php # exit without error
```
[ArrayTrait](https://github.com/googleapis/google-cloud-php/blob/1bf05936f5816a3066b21b3f21660ff09aba8b0f/Core/src/ArrayTrait.php) is defined in the `google/cloud-core` package and should be considered a production dependency if it is invoked in the construction of the client.
