### PR TITLE
Improve modify message and release type flow

### DIFF
--- a/dev/src/QuestionTrait.php
+++ b/dev/src/QuestionTrait.php
@@ -78,7 +78,7 @@ trait QuestionTrait
 
     private function removeDefaultFromChoice($answer)
     {
-        return rtrim($answer, $this->choiceDefaultText);
+        return explode($this->choiceDefaultText, $answer)[0];
     }
 
     private function confirm($question, $defaultToYes = true)


### PR DESCRIPTION
This change eliminates a question in the workflow for modifying the commit message or release type of a commit. It also allows changes to the message and release type to be applied to all components affected by a commit.