### PR TITLE
Update Trace README

### DIFF
--- a/Trace/README.md
+++ b/Trace/README.md
@@ -6,7 +6,7 @@
 
 * [API documentation][api-docs]
 
-**NOTE:** This repository is part of [Google Cloud PHP][github-home]. Any
+**NOTE:** This repository is part of [Google Cloud PHP][homepage]. Any
 support requests, bug reports, or development contributions should be directed to
 that project.
 
@@ -16,7 +16,8 @@ Google Cloud Platform Console.
 
 ### Installation
 
-To begin, install the preferred dependency manager for PHP, [Composer](https://getcomposer.org/).
+To begin, install the preferred dependency manager for PHP,
+[Composer](https://getcomposer.org/).
 
 Now to install just this component:
 
@@ -30,13 +31,15 @@ Or to install the entire suite of components at once:
 $ composer require google/cloud
 ```
 
-This component supports both REST over HTTP/1.1 and gRPC. In order to take advantage of the benefits offered by gRPC (such as streaming methods)
+This component supports both REST over HTTP/1.1 and gRPC. In order to take
+advantage of the benefits offered by gRPC (such as streaming methods)
 please see our [gRPC installation guide](https://cloud.google.com/php/grpc).
 
 ### Authentication
 
-Please see our [Authentication guide](https://github.com/googleapis/google-cloud-php/blob/master/AUTHENTICATION.md) for more information
-on authenticating your client. Once authenticated, you'll be ready to start making requests.
+Please see our [Authentication guide](https://github.com/googleapis/google-cloud-php/blob/master/AUTHENTICATION.md)
+for more information on authenticating your client. Once authenticated, you'll
+be ready to start making requests.
 
 ### Sample
 
@@ -89,10 +92,12 @@ out the [migration guide to OpenCensus][opencensus-migration].
 Install with `composer` or add to your `composer.json`.
 
 ```sh
-$ composer require opencensus/opencensus
+$ composer require opencensus/opencensus opencensus/opencensus-exporter-stackdriver
 ```
 
-Use the provided `StackdriverExporter` when configuring your tracer.
+`opencensus/opencensus` provides a service-agnostic implementation. Be sure to
+also require `opencensus/opencensus-exporter-stackdriver` to enable exporting of
+traces to Stackdriver Trace.
 
 ```php
 use OpenCensus\Trace\Exporter\StackdriverExporter;
@@ -106,7 +111,8 @@ options and features.
 
 ### Version
 
-This component is considered alpha. As such, it is still a work-in-progress and is more likely to get backwards-incompatible updates.
+This component is considered alpha. As such, it is still a work-in-progress and
+is more likely to get backwards-incompatible updates.
 
 ### Next Steps
 


### PR DESCRIPTION
The Trace README has fallen out of date and contained some errors. This change provides up-to-date installation information and fixes the errors.