### PR TITLE
Component integration: Skip tests if folder does not exist

### DIFF
--- a/dev/src/ComponentIntegration/Command/ComponentIntegration.php
+++ b/dev/src/ComponentIntegration/Command/ComponentIntegration.php
@@ -93,7 +93,7 @@ class ComponentIntegration extends GoogleCloudCommand
             // use semver to normalize both versions.
             $isUpdated = version::gt($localLatestVersion, $remoteLatestVersion);
             $component['useLocalPath'] = $isUpdated;
-            $component['tmpDir'] = $tmpDir;
+            $component['tmpDir'] = realpath($tmpDir);
         }
 
         $components = $this->updateComposerFiles($dest, $components);
@@ -272,11 +272,37 @@ class ComponentIntegration extends GoogleCloudCommand
         $commands = [
             "cd {$component['tmpDir']}",
             "composer update --no-suggest",
-            "echo \"\\nRUNNING UNIT TESTS\\n\"",
-            "vendor/bin/phpunit",
-            "echo \"\\nRUNNING SNIPPET TESTS\\n\"",
-            "vendor/bin/phpunit -c phpunit-snippets.xml.dist"
         ];
+
+        if (file_exists($component['tmpDir'] . '/tests/Unit')) {
+            if (!file_exists($component['tmpDir'] . '/phpunit.xml.dist')) {
+                throw new \RuntimeException(sprintf(
+                    'Test folder %s exists, but no relevant PHPUnit configuration was found at %s.',
+                    $component['tmpDir'] . '/tests/Unit',
+                    $component['tmpDir'] . '/phpunit.xml.dist'
+                ));
+            }
+
+            $commands = array_merge($commands, [
+                "echo \"\\nRUNNING UNIT TESTS\\n\"",
+                "vendor/bin/phpunit",
+            ]);
+        }
+
+        if (file_exists($component['tmpDir'] . '/tests/Snippet')) {
+            if (!file_exists($component['tmpDir'] . '/phpunit-snippets.xml.dist')) {
+                throw new \RuntimeException(sprintf(
+                    'Test folder %s exists, but no relevant PHPUnit configuration was found at %s.',
+                    $component['tmpDir'] . '/tests/Snippet',
+                    $component['tmpDir'] . '/phpunit-snippets.xml.dist'
+                ));
+            }
+
+            $commands = array_merge($commands, [
+                "echo \"\\nRUNNING SNIPPET TESTS\\n\"",
+                "vendor/bin/phpunit -c phpunit-snippets.xml.dist"
+            ]);
+        }
 
         passthru(implode(" && ", $commands), $exitCode);
 

--- a/dev/src/ComponentIntegration/Command/ComponentIntegration.php
+++ b/dev/src/ComponentIntegration/Command/ComponentIntegration.php
@@ -274,30 +274,14 @@ class ComponentIntegration extends GoogleCloudCommand
             "composer update --no-suggest",
         ];
 
-        if (file_exists($component['tmpDir'] . '/tests/Unit')) {
-            if (!file_exists($component['tmpDir'] . '/phpunit.xml.dist')) {
-                throw new \RuntimeException(sprintf(
-                    'Test folder %s exists, but no relevant PHPUnit configuration was found at %s.',
-                    $component['tmpDir'] . '/tests/Unit',
-                    $component['tmpDir'] . '/phpunit.xml.dist'
-                ));
-            }
-
+        if ($this->hasTests($component, 'Unit', 'phpunit.xml.dist')) {
             $commands = array_merge($commands, [
                 "echo \"\\nRUNNING UNIT TESTS\\n\"",
                 "vendor/bin/phpunit",
             ]);
         }
 
-        if (file_exists($component['tmpDir'] . '/tests/Snippet')) {
-            if (!file_exists($component['tmpDir'] . '/phpunit-snippets.xml.dist')) {
-                throw new \RuntimeException(sprintf(
-                    'Test folder %s exists, but no relevant PHPUnit configuration was found at %s.',
-                    $component['tmpDir'] . '/tests/Snippet',
-                    $component['tmpDir'] . '/phpunit-snippets.xml.dist'
-                ));
-            }
-
+        if ($this->hasTests($component, 'Snippet', 'phpunit-snippets.xml.dist')) {
             $commands = array_merge($commands, [
                 "echo \"\\nRUNNING SNIPPET TESTS\\n\"",
                 "vendor/bin/phpunit -c phpunit-snippets.xml.dist"
@@ -337,5 +321,25 @@ class ComponentIntegration extends GoogleCloudCommand
         $composer['repositories'] = array_merge($oldRepositories, $repositories);
 
         file_put_contents($composerFile, json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+    }
+
+    private function hasTests(array $component, $folderName, $configFile)
+    {
+        $folderPath = $component['tmpDir'] . '/tests/' . $folderName;
+        $configFilePath = $component['tmpDir'] . '/' . $configFile;
+
+        if (file_exists($folderPath)) {
+            if (!file_exists($configFilePath)) {
+                throw new \RuntimeException(sprintf(
+                    'Test folder %s exists, but no relevant PHPUnit configuration was found at %s.',
+                    $folderPath,
+                    $configFilePath
+                ));
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This should fix the kokoro continuous error.

If a component is missing a test folder (`tests/Unit` or `tests/Snippet`), the commands for running those tests will be omitted.

If a component contains a test folder (`tests/Unit` or `tests/Snippet`), but is missing the PHPUnit configuration (`phpunit.xml.dist` or `phpunit-snippets.xml.dist` respectively), the test will fail.

If the configuration file exists but no test folder exists (as is the case for several gapic-only components), the test will proceed without error.