### PR TITLE
Remove quotes from signed URL

### DIFF
--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -926,7 +926,7 @@ class StorageObject
         if ($options['responseDisposition']) {
             $query[] = 'response-content-disposition=' . urlencode($options['responseDisposition']);
         } elseif ($options['saveAsName']) {
-            $query[] = 'response-content-disposition=attachment;filename="' . urlencode($options['saveAsName']) . '"';
+            $query[] = 'response-content-disposition=attachment;filename=' . urlencode($options['saveAsName']);
         }
 
         if ($options['responseType']) {

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -926,7 +926,7 @@ class StorageObject
         if ($options['responseDisposition']) {
             $query[] = 'response-content-disposition=' . urlencode($options['responseDisposition']);
         } elseif ($options['saveAsName']) {
-            $query[] = 'response-content-disposition=attachment;filename=' . urlencode($options['saveAsName']);
+            $query[] = 'response-content-disposition=attachment;filename=' . urlencode('"'.$options['saveAsName'].'"');
         }
 
         if ($options['responseType']) {


### PR DESCRIPTION
These quotes don't seem necessary, and do not get encoded with the rest of $options['saveAsName'] causing issues when output into HTML.