### PR TITLE
Fix incorrect sample code in Trace/README.md

### DIFF
--- a/Trace/README.md
+++ b/Trace/README.md
@@ -55,8 +55,9 @@ $trace = $traceClient->trace();
 $span = $trace->span([
     'name' => 'main'
 ]);
-$span->setStart();
-$span->setEnd();
+$span->setStartTime();
+// some expensive operation
+$span->setEndTime();
 
 $trace->setSpans([$span]);
 $traceClient->insert($trace);


### PR DESCRIPTION
the sample code in Trace/README.md is incorrectly.
it should be 
`setStartTime` and `setEndTime`
also check:
https://github.com/googleapis/google-cloud-php/blob/master/Trace/src/Span.php#L215
https://github.com/googleapis/google-cloud-php/blob/master/Trace/src/Span.php#L253