### PR TITLE
Use the new(er) getServiceAccount method instead of hard coding the storage service account

### DIFF
--- a/Storage/tests/System/ManageNotificationsTest.php
+++ b/Storage/tests/System/ManageNotificationsTest.php
@@ -27,7 +27,6 @@ class ManageNotificationsTest extends StorageTestCase
     {
         $created = [];
         $topic = self::createTopic(self::$pubsubClient, uniqid(self::TESTING_PREFIX));
-        $projectId = self::getProjectId(getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH'));
         $policy = $topic->iam()->policy();
         $policy['bindings'] = [
             [

--- a/Storage/tests/System/ManageNotificationsTest.php
+++ b/Storage/tests/System/ManageNotificationsTest.php
@@ -33,7 +33,7 @@ class ManageNotificationsTest extends StorageTestCase
             [
                 'role' => 'roles/pubsub.publisher',
                 'members' => [
-                    "serviceAccount:$projectId@gs-project-accounts.iam.gserviceaccount.com"
+                    'serviceAccount:' . self::$client->getServiceAccount()
                 ]
             ]
         ];

--- a/Storage/tests/System/RequesterPaysTest.php
+++ b/Storage/tests/System/RequesterPaysTest.php
@@ -111,7 +111,7 @@ class RequesterPaysTest extends StorageTestCase
         $p['bindings'][] = [
             'role' => 'roles/pubsub.publisher',
             'members' => [
-                'serviceAccount:'. self::$ownerProject .'@gs-project-accounts.iam.gserviceaccount.com',
+                'serviceAccount:'. $client->getServiceAccount()
             ]
         ];
         self::$topic->iam()->setPolicy($p);

--- a/Storage/tests/System/RequesterPaysTest.php
+++ b/Storage/tests/System/RequesterPaysTest.php
@@ -53,17 +53,12 @@ class RequesterPaysTest extends StorageTestCase
 
         $requesterKeyFilePath = getenv('GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH');
         $ownerKeyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-
         self::$requesterKeyFile = json_decode(file_get_contents($requesterKeyFilePath), true);
         self::$requesterEmail = self::$requesterKeyFile['client_email'];
         self::$requesterProject = self::$requesterKeyFile['project_id'];
-
         self::$ownerKeyFile = json_decode(file_get_contents($ownerKeyFilePath), true);
         self::$ownerEmail = self::$ownerKeyFile['client_email'];
-        self::$ownerProject = self::$ownerKeyFile['project_id'];
-
         self::$bucketName = uniqid(self::TESTING_PREFIX);
-
         $client = self::$client;
 
         // Owner bucket instance is a bucket class with requester pays turned on

--- a/Storage/tests/System/RequesterPaysTest.php
+++ b/Storage/tests/System/RequesterPaysTest.php
@@ -111,7 +111,7 @@ class RequesterPaysTest extends StorageTestCase
         $p['bindings'][] = [
             'role' => 'roles/pubsub.publisher',
             'members' => [
-                'serviceAccount:'. $client->getServiceAccount()
+                'serviceAccount:' . $client->getServiceAccount()
             ]
         ];
         self::$topic->iam()->setPolicy($p);


### PR DESCRIPTION
The `{projectId}@gs-project-accounts.iam.gserviceaccount.com` format has been deprecated, utilizing the `getServiceAccount` request will make sure we are always using the correct format.