### PR TITLE
add ability to use filters with #readRow()

### DIFF
--- a/Bigtable/src/Table.php
+++ b/Bigtable/src/Table.php
@@ -325,8 +325,7 @@ class Table
     public function readRow($rowKey, array $options = [])
     {
         return $this->readRows(
-            ['rowKeys' => [$rowKey]],
-            $options + $this->options
+            ['rowKeys' => [$rowKey]] + $options + $this->options
         )
             ->readAll()
             ->current();

--- a/Bigtable/tests/Unit/TableTest.php
+++ b/Bigtable/tests/Unit/TableTest.php
@@ -345,6 +345,32 @@ class TableTest extends TestCase
         $this->assertNull($row);
     }
 
+    public function testReadRowWithFilter()
+    {
+        $rowSet = new RowSet();
+        $rowSet->setRowKeys(['rk1']);
+        $rowFilter = Filter::pass();
+        $expectedArgs = $this->options + [
+            'rows' => $rowSet,
+            'filter' => $rowFilter->toProto()
+        ];
+        $this->serverStream->readAll()
+            ->shouldBeCalled()
+            ->willReturn(
+                $this->arrayAsGenerator([])
+            );
+        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+            ->shouldBeCalled()
+            ->willReturn(
+                $this->serverStream->reveal()
+            );
+        $args = [
+            'filter' => $rowFilter
+        ];
+        $row = $this->table->readRow('rk1', $args);
+        $this->assertNull($row);
+    }
+
     public function testReadRowsWithMultipleRowKeys()
     {
         $rowSet = new RowSet();


### PR DESCRIPTION
previously `readRow` passed two arguments to `readRows` which accepts one argument preventing the ability to use filters with `readRow`