### PR TITLE
Firestore list documents

### DIFF
--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -235,7 +235,20 @@ class CollectionReference extends Query
      * }
      * ```
      *
-     * @param array $options Configuration options
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/firestore/docs/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.ListDocumentsRequest ListDocumentsRequest
+     * @codingStandardsIgnoreEnd
+     *
+     * @param array $options {
+     *     Configuration options
+     *
+     *     @type int $pageSize The maximum number of results to return per
+     *           request.
+     *     @type int $resultLimit Limit the number of results returned in total.
+     *           **Defaults to** `0` (return all results).
+     *     @type string $pageToken A previously-returned page token used to
+     *           resume the loading of results from a specific point.
+     * }
      * @return ItemIterator<DocumentReference>
      */
     public function listDocuments(array $options = [])

--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -241,17 +241,21 @@ class CollectionReference extends Query
     public function listDocuments(array $options = [])
     {
         $resultLimit = $this->pluck('resultLimit', $options, false);
+
+        $options += [
+            'parent' => $this->parentPath($this->name),
+            'collectionId' => $this->pathId($this->name),
+            'mask' => []
+        ];
+
         return new ItemIterator(
             new PageIterator(
                 function ($document) {
                     return $this->documentFactory($document['name']);
                 },
                 [$this->connection, 'listDocuments'],
-                $options + [
-                    'parent' => $this->parentPath($this->name),
-                    'collectionId' => $this->pathId($this->name),
-                    'mask' => []
-                ], [
+                $options,
+                [
                     'itemsKey' => 'documents',
                     'resultLimit' => $resultLimit
                 ]

--- a/Firestore/src/Connection/ConnectionInterface.php
+++ b/Firestore/src/Connection/ConnectionInterface.php
@@ -45,6 +45,11 @@ interface ConnectionInterface
     /**
      * @param array $args
      */
+    public function listDocuments(array $args);
+
+    /**
+     * @param array $args
+     */
     public function rollback(array $args);
 
     /**

--- a/Firestore/tests/System/DocumentAndCollectionTest.php
+++ b/Firestore/tests/System/DocumentAndCollectionTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Firestore\Tests\System;
 
 use Google\Cloud\Firestore\CollectionReference;
+use Google\Cloud\Firestore\DocumentReference;
 
 /**
  * @group firestore
@@ -106,6 +107,17 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         $collection = $this->document->collections()->current();
 
         $this->assertEquals($childName, $collection->id());
+    }
+
+    public function testListDocuments()
+    {
+        $collection = self::$client->collection(uniqid(self::COLLECTION_NAME));
+        self::$localDeletionQueue->add($collection);
+        $doc = $collection->add(['a' => 'b']);
+
+        $list = $collection->listDocuments();
+        $this->assertCount(1, iterator_to_array($list));
+        $this->assertContainsOnlyInstancesOf(DocumentReference::class, $list);
     }
 
     public function testNonAlphaNumericFieldPaths()

--- a/Firestore/tests/Unit/Connection/GrpcTest.php
+++ b/Firestore/tests/Unit/Connection/GrpcTest.php
@@ -166,12 +166,32 @@ class GrpcTest extends TestCase
     public function testListCollectionIds()
     {
         $args = [
-            'parent' => sprintf('projects/%s/databases/%s', self::PROJECT, self::DATABASE)
+            'parent' => sprintf('projects/%s/databases/%s/documents', self::PROJECT, self::DATABASE)
         ];
 
         $expected = [$args['parent'], $this->header()];
 
         $this->sendAndAssert('listCollectionIds', $args, $expected);
+    }
+
+    public function testListDocuments()
+    {
+        $args = [
+            'parent' => sprintf('projects/%s/databases/%s/documents', self::PROJECT, self::DATABASE),
+            'collectionId' => 'coll1',
+            'mask' => [],
+        ];
+
+        $expected = [
+            $args['parent'],
+            $args['collectionId'],
+            [
+                'showMissing' => true,
+                'mask' => new DocumentMask(['field_paths' => []]),
+            ] + $this->header()
+        ];
+
+        $this->sendAndAssert('listDocuments', $args, $expected);
     }
 
     public function testRollback()


### PR DESCRIPTION
Adds `CollectionReference::listDocuments()` and implements the `ListDocuments` RPC.