### PR TITLE
Handle error/exception types outside of ServiceExceptions more gracefully

### DIFF
--- a/Spanner/src/Result.php
+++ b/Spanner/src/Result.php
@@ -178,8 +178,12 @@ class Result implements \IteratorAggregate
         $call = $this->call;
         $generator = null;
         $shouldRetry = false;
-        $backoff = new ExponentialBackoff($this->retries, function (ServiceException $ex) {
-            return $ex->getCode() === Grpc\STATUS_UNAVAILABLE;
+        $backoff = new ExponentialBackoff($this->retries, function ($ex) {
+            if ($ex instanceof ServiceException) {
+                return $ex->getCode() === Grpc\STATUS_UNAVAILABLE;
+            }
+
+            return false;
         });
 
         $valid = $backoff->execute(function () use ($call, &$generator) {

--- a/Spanner/tests/Unit/ResultTest.php
+++ b/Spanner/tests/Unit/ResultTest.php
@@ -68,6 +68,23 @@ class ResultTest extends TestCase
         $this->assertEquals($fixture['result']['value'], $result);
     }
 
+    /**
+     * @expectedException \Exception
+     */
+    public function testFailsWhenStreamThrowsUnrecoverableException()
+    {
+        $result = $this->getResultClass(
+            null,
+            'r',
+            null,
+            function () {
+                throw new \Exception;
+            }
+        );
+
+        iterator_to_array($result->rows());
+    }
+
     public function testResumesBrokenStream()
     {
         $timesCalled = 0;


### PR DESCRIPTION
Towards: https://github.com/googleapis/google-cloud-php/issues/1717