### PR TITLE
Add Firestore FieldValue::increment().

### DIFF
--- a/Firestore/src/FieldValue.php
+++ b/Firestore/src/FieldValue.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore;
 use Google\Cloud\Firestore\FieldValue\ArrayRemoveValue;
 use Google\Cloud\Firestore\FieldValue\ArrayUnionValue;
 use Google\Cloud\Firestore\FieldValue\DeleteFieldValue;
+use Google\Cloud\Firestore\FieldValue\IncrementValue;
 use Google\Cloud\Firestore\FieldValue\ServerTimestampValue;
 
 /**
@@ -157,5 +158,42 @@ class FieldValue
     public static function arrayRemove(array $elements)
     {
         return new ArrayRemoveValue($elements);
+    }
+
+    /**
+     * Returns a special value that can be used with set() or update() that
+     * tells the server to add the given value to the field's current value.
+     *
+     * Given value must be an integer or a double value. If the field is not an
+     * integer or double, or if the field does not yet exist, the
+     * transformation will set the field to the given value. If either of the
+     * given value or the current field value are doubles, both values will be
+     * interpreted as doubles. Double arithmetic and representation of double
+     * values follow IEEE 754 semantics. If there is positive/negative integer
+     * overflow, the field is resolved to the largest magnitude
+     * positive/negative integer.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\Firestore\FieldValue;
+     * use Google\Cloud\Firestore\FirestoreClient;
+     *
+     * $firestore = new FirestoreClient;
+     * $document = $firestore->document('users/dave');
+     *
+     * $document->update([
+     *     [
+     *         'path' => 'loginCount',
+     *         'value' => FieldValue::increment(1)
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param mixed $value
+     * @return IncrementValue
+     */
+    public static function increment($value)
+    {
+        return new IncrementValue($value);
     }
 }

--- a/Firestore/src/FieldValue.php
+++ b/Firestore/src/FieldValue.php
@@ -189,7 +189,7 @@ class FieldValue
      * ]);
      * ```
      *
-     * @param mixed $value
+     * @param int|float $value
      * @return IncrementValue
      */
     public static function increment($value)

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Firestore\FieldValue;
  *
  * This class is not intended to be used directly. See
  * {@see Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
+ *
+ * @internal
  */
 class ArrayRemoveValue implements DocumentTransformInterface
 {

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -44,4 +44,13 @@ class ArrayRemoveValue implements DocumentTransformInterface
     {
         return false;
     }
+
+    /**
+     * @access private
+     * @return bool
+     */
+    public function sendRaw()
+    {
+        return false;
+    }
 }

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -44,4 +44,13 @@ class ArrayUnionValue implements DocumentTransformInterface
     {
         return false;
     }
+
+    /**
+     * @access private
+     * @return bool
+     */
+    public function sendRaw()
+    {
+        return false;
+    }
 }

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Firestore\FieldValue;
  *
  * This class is not intended to be used directly. See
  * {@see Google\Cloud\Firestore\FieldValue::arrayUnion()} for usage.
+ *
+ * @internal
  */
 class ArrayUnionValue implements DocumentTransformInterface
 {

--- a/Firestore/src/FieldValue/DeleteFieldValue.php
+++ b/Firestore/src/FieldValue/DeleteFieldValue.php
@@ -22,6 +22,8 @@ namespace Google\Cloud\Firestore\FieldValue;
  *
  * This class is not intended to be used directly. See
  * {@see Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
+ *
+ * @internal
  */
 class DeleteFieldValue implements FieldValueInterface
 {

--- a/Firestore/src/FieldValue/DocumentTransformInterface.php
+++ b/Firestore/src/FieldValue/DocumentTransformInterface.php
@@ -40,4 +40,11 @@ interface DocumentTransformInterface extends FieldValueInterface
      * @return mixed
      */
     public function args();
+
+    /**
+     * Whether the argument should be mapped or sent as given.
+     *
+     * @return bool
+     */
+    public function sendRaw();
 }

--- a/Firestore/src/FieldValue/DocumentTransformTrait.php
+++ b/Firestore/src/FieldValue/DocumentTransformTrait.php
@@ -25,7 +25,7 @@ trait DocumentTransformTrait
     use FieldValueTrait;
 
     /**
-     * @var array
+     * @var mixed
      */
     private $args;
 

--- a/Firestore/src/FieldValue/DocumentTransformTrait.php
+++ b/Firestore/src/FieldValue/DocumentTransformTrait.php
@@ -30,9 +30,9 @@ trait DocumentTransformTrait
     private $args;
 
     /**
-     * @param array $args
+     * @param mixed $args
      */
-    public function __construct(array $args = [])
+    public function __construct($args = [])
     {
         $this->args = $args;
     }

--- a/Firestore/src/FieldValue/DocumentTransformTrait.php
+++ b/Firestore/src/FieldValue/DocumentTransformTrait.php
@@ -41,7 +41,7 @@ trait DocumentTransformTrait
      * Get the field value arguments.
      *
      * @access private
-     * @return array
+     * @return mixed
      */
     public function args()
     {

--- a/Firestore/src/FieldValue/IncrementValue.php
+++ b/Firestore/src/FieldValue/IncrementValue.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ namespace Google\Cloud\Firestore\FieldValue;
  *
  * This class is not intended to be used directly. See
  * {@see Google\Cloud\Firestore\FieldValue::increment()} for usage.
+ *
+ * @internal
  */
 class IncrementValue implements DocumentTransformInterface
 {

--- a/Firestore/src/FieldValue/IncrementValue.php
+++ b/Firestore/src/FieldValue/IncrementValue.php
@@ -17,19 +17,15 @@
 
 namespace Google\Cloud\Firestore\FieldValue;
 
-use Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform\ServerValue;
-
 /**
- * Represents a ServerTimestamp DocumentTransform.
+ * Represents an increment DocumentTransform.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
+ * {@see Google\Cloud\Firestore\FieldValue::increment()} for usage.
  */
-class ServerTimestampValue implements DocumentTransformInterface
+class IncrementValue implements DocumentTransformInterface
 {
     use DocumentTransformTrait;
-
-    const REQUEST_TIME = ServerValue::REQUEST_TIME;
 
     /**
      * @access private
@@ -37,16 +33,7 @@ class ServerTimestampValue implements DocumentTransformInterface
      */
     public function key()
     {
-        return 'setToServerValue';
-    }
-
-    /**
-     * @access private
-     * @return int
-     */
-    public function args()
-    {
-        return self::REQUEST_TIME;
+        return 'increment';
     }
 
     /**
@@ -64,6 +51,6 @@ class ServerTimestampValue implements DocumentTransformInterface
      */
     public function sendRaw()
     {
-        return true;
+        return false;
     }
 }

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -24,6 +24,8 @@ use Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform\ServerValue;
  *
  * This class is not intended to be used directly. See
  * {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
+ *
+ * @internal
  */
 class ServerTimestampValue implements DocumentTransformInterface
 {

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -509,8 +509,12 @@ class WriteBatch
             }
 
             $args = $transform->args();
-            if (is_array($args) && !$this->isAssoc($args)) {
-                $args = $this->valueMapper->encodeArrayValue($args);
+            if (!$transform->sendRaw()) {
+                if (is_array($args) && !$this->isAssoc($args)) {
+                    $args = $this->valueMapper->encodeArrayValue($args);
+                } else {
+                    $args = $this->valueMapper->encodeValue($args);
+                }
             }
 
             $operations[] = [

--- a/Firestore/tests/Snippet/FieldValueTest.php
+++ b/Firestore/tests/Snippet/FieldValueTest.php
@@ -179,4 +179,37 @@ class FieldValueTest extends SnippetTestCase
 
         $snippet->invoke();
     }
+
+    public function testIncrement()
+    {
+        $this->connection->commit([
+            "database" => "projects/my-awesome-project/databases/(default)",
+            "writes" => [
+                [
+                    "transform" => [
+                        "document" => "projects/my-awesome-project/databases/(default)/documents/users/dave",
+                        "fieldTransforms" => [
+                            [
+                                "fieldPath" => "loginCount",
+                                'increment' => [
+                                    'integerValue' => 1
+                                ]
+                            ]
+                        ]
+                    ],
+                    "currentDocument" => [
+                        "exists" => true
+                    ]
+                ]
+            ]
+        ])->willReturn([[]]);
+
+        $this->firestore->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(FieldValue::class, 'increment');
+        $snippet->setLine(3, '');
+        $snippet->addLocal('firestore', $this->firestore);
+
+        $snippet->invoke();
+    }
 }

--- a/Firestore/tests/Unit/FieldValueTest.php
+++ b/Firestore/tests/Unit/FieldValueTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore\Tests\Unit;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FieldValue\ArrayRemoveValue;
 use Google\Cloud\Firestore\FieldValue\ArrayUnionValue;
+use Google\Cloud\Firestore\FieldValue\IncrementValue;
 use Google\Cloud\Firestore\FieldValue\ServerTimestampValue;
 use Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform\ServerValue;
 use PHPUnit\Framework\TestCase;
@@ -46,7 +47,8 @@ class FieldValueTest extends TestCase
         return [
             ['serverTimestamp', ServerTimestampValue::class, ServerValue::REQUEST_TIME],
             ['arrayUnion', ArrayUnionValue::class, ['a']],
-            ['arrayRemove', ArrayRemoveValue::class, ['b']]
+            ['arrayRemove', ArrayRemoveValue::class, ['b']],
+            ['increment', IncrementValue::class, 1],
         ];
     }
 }

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -154,6 +154,7 @@ class WriteBatchTest extends TestCase
             ['path' => 'world', 'value' =>  FieldValue::serverTimestamp()],
             ['path' => 'arr', 'value' => FieldValue::arrayUnion(['a'])],
             ['path' => 'arr2', 'value' => FieldValue::arrayRemove(['b'])],
+            ['path' => 'int', 'value' => FieldValue::increment(2)],
         ]);
 
         $this->commitAndAssert([
@@ -192,6 +193,11 @@ class WriteBatchTest extends TestCase
                                             'stringValue' => 'b'
                                         ]
                                     ]
+                                ]
+                            ], [
+                                'fieldPath' => 'int',
+                                'increment' => [
+                                    'integerValue' => 2
                                 ]
                             ]
                         ]


### PR DESCRIPTION
This pull request adds support for the increment DocumentTransform.

```php
use Google\Cloud\Firestore\FieldValue;

$document->update([
    ['path' => 'loginCount', 'value' => FieldValue::increment(1)]
]);
```