### PR TITLE
include the HTTP request context with error reports

### DIFF
--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -131,6 +131,7 @@ class Bootstrap
             $version = self::$psrLogger->getMetadataProvider()->versionId();
             self::$psrLogger->error($message, [
                 'context' => [
+                    'httpRequest' => self::getHttpRequest(),
                     'reportLocation' => [
                         'filePath' => $ex->getFile(),
                         'lineNumber' => $ex->getLine(),
@@ -173,6 +174,7 @@ class Bootstrap
         $version = self::$psrLogger->getMetadataProvider()->versionId();
         $context = [
             'context' => [
+                'httpRequest' => self::getHttpRequest(),
                 'reportLocation' => [
                     'filePath' => $file,
                     'lineNumber' => $line,
@@ -241,6 +243,25 @@ class Bootstrap
                     break;
             }
         }
+    }
+
+    /**
+     * Get the HTTP request context.
+     */
+    private static function getHttpRequest()
+    {
+        // https://stackoverflow.com/a/6768831/358804
+        $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
+        $url = $protocol . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+
+        return [
+            'method' => $_SERVER['REQUEST_METHOD'],
+            'url' => $url,
+            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+            'referrer' => $_SERVER['HTTP_REFERER'],
+            'responseStatusCode' => http_response_code(),
+            'remoteIp' => $_SERVER['REMOTE_ADDR'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Hello! I get error reporting working in our app based on [the Stackdriver Error Reporting quickstart](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/83cbbeb2ee36a458db4d2dc868cd8e16812fa957/error_reporting/quickstart.php). Unfortunately, I learned that setting it up this way doesn't include any HTTP request information with a given error.

This pull request has the `Bootstrap` methods derive the HTTP request information, and include it with the error reports.

![Screen Shot 2019-03-20 at 1 42 00 AM](https://user-images.githubusercontent.com/86842/54661642-6a06ad00-4ab1-11e9-9f8e-00822de5f64b.png)

My main question: **Is there interest in this addition, and should I run with it?** If so, the outstanding TODOs:

* [ ] Pull ideas from [BugSnag](https://github.com/bugsnag/bugsnag-php/blob/master/src/Request/PhpRequest.php) and [RayGun](https://github.com/MindscapeHQ/raygun4php/blob/master/src/Raygun4php/RaygunRequestMessage.php) client libraries
* [ ] Allow the [`user`](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ErrorContext) to be specified - maybe as a follow-up
* [ ] Allow the [`sourceReferences`](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ErrorContext#SourceReference) to be specified - maybe as a follow-up
* [ ] Don't include HTTP information if it's not an HTTP request - what should be checked?
* [ ] Add tests

Note I don't have a ton of PHP experience, so any suggestions are welcome.