### PR TITLE
Prefer emulator project when pub/sub emulator is detected

### DIFF
--- a/Core/src/ClientTrait.php
+++ b/Core/src/ClientTrait.php
@@ -157,14 +157,14 @@ trait ClientTrait
      *
      * Process:
      * 1. If $config['projectId'] is set, use that.
-     * 2. If $config['keyFile'] is set, attempt to retrieve a project ID from
+     * 2. If an emulator is enabled, return a dummy value.
+     * 3. If $config['keyFile'] is set, attempt to retrieve a project ID from
      *    that.
-     * 3. Check `GOOGLE_CLOUD_PROJECT` environment variable.
-     * 4. Check `GCLOUD_PROJECT` environment variable.
-     * 5. If code is running on compute engine, try to get the project ID from
+     * 4. Check `GOOGLE_CLOUD_PROJECT` environment variable.
+     * 5. Check `GCLOUD_PROJECT` environment variable.
+     * 6. If code is running on compute engine, try to get the project ID from
      *    the metadata store.
-     * 6. If an emulator is enabled, return a dummy value.
-     * 4. Throw exception.
+     * 7. Throw exception.
      *
      * @param  array $config
      * @return string
@@ -183,6 +183,10 @@ trait ClientTrait
 
         if ($config['projectId']) {
             return $config['projectId'];
+        }
+
+        if ($config['hasEmulator']) {
+            return 'emulator-project';
         }
 
         if (isset($config['keyFile'])) {
@@ -224,10 +228,6 @@ trait ClientTrait
             if ($projectId) {
                 return $projectId;
             }
-        }
-
-        if ($config['hasEmulator']) {
-            return 'emulator-project';
         }
 
         if ($config['projectIdRequired']) {

--- a/Core/tests/Unit/ClientTraitTest.php
+++ b/Core/tests/Unit/ClientTraitTest.php
@@ -303,26 +303,26 @@ class ClientTraitTest extends TestCase
         ]]);
     }
 
+    public function testDetectProjectIdEmulatorWithProjectId()
+    {
+        $projectId = 'emulator-project';
+
+        $res = $this->impl->call('detectProjectId', [[
+            'hasEmulator' => true,
+            'projectId' => $projectId,
+        ]]);
+
+        $this->assertEquals($projectId, $res);
+    }
+
+
     public function testDetectProjectIdEmulator()
     {
         $projectId = 'emulator-project';
 
-        $originalEnv = getenv('GCLOUD_PROJECT');
-        putenv('GCLOUD_PROJECT');
-
-        $m = $this->prophesize(Metadata::class);
-        $m->getProjectId()->willReturn(false)->shouldBeCalled();
-
-        $trait = TestHelpers::impl(ClientTraitStubOnGce::class, ['metadata']);
-        $trait->___setProperty('metadata', $m);
-
-        $res = $trait->call('detectProjectId', [[
+        $res = $this->impl->call('detectProjectId', [[
             'hasEmulator' => true
         ]]);
-
-        if ($originalEnv) {
-            putenv('GCLOUD_PROJECT='. $originalEnv);
-        }
 
         $this->assertEquals($projectId, $res);
     }

--- a/PubSub/tests/Snippet/PubSubClientTest.php
+++ b/PubSub/tests/Snippet/PubSubClientTest.php
@@ -63,6 +63,8 @@ class PubSubClientTest extends SnippetTestCase
         $res = $snippet->invoke('pubsub');
 
         $this->assertInstanceOf(PubSubClient::class, $res->returnVal());
+
+        putenv('PUBSUB_EMULATOR_HOST');
     }
 
     public function testCreateTopic()


### PR DESCRIPTION
Since the emulator is always used when the *_EMULATOR_HOST environment
variable is set, there should not be any case where the ADC credentials
are needed.

Using the ADC credentials may cause confusion when they are set on the
CLI but not in the webserver, leading to different projectIds for the
same code.

Also see https://github.com/googleapis/google-cloud-php/issues/1739