### PR TITLE
Marks Vision classes as deprecated in favor of gapic

### DIFF
--- a/Vision/src/Annotation.php
+++ b/Vision/src/Annotation.php
@@ -42,6 +42,9 @@ use Google\Cloud\Vision\Annotation\Web;
  *
  * $annotation = $vision->annotate($image);
  * ```
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Annotation
 {
@@ -185,6 +188,10 @@ class Annotation
         if (isset($info['error'])) {
             $this->error = $info['error'];
         }
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Annotation/AbstractFeature.php
+++ b/Vision/src/Annotation/AbstractFeature.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Vision\Annotation;
 
 /**
  * Provide shared functionality for features
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 abstract class AbstractFeature implements FeatureInterface
 {

--- a/Vision/src/Annotation/CropHint.php
+++ b/Vision/src/Annotation/CropHint.php
@@ -69,6 +69,8 @@ use Google\Cloud\Core\CallTrait;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#CropHint CropHint
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class CropHint extends AbstractFeature
 {
@@ -80,5 +82,9 @@ class CropHint extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 }

--- a/Vision/src/Annotation/Document.php
+++ b/Vision/src/Annotation/Document.php
@@ -67,6 +67,8 @@ use Google\Cloud\Core\CallTrait;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#TextAnnotation TextAnnotation
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Document extends AbstractFeature
 {
@@ -78,5 +80,9 @@ class Document extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 }

--- a/Vision/src/Annotation/Entity.php
+++ b/Vision/src/Annotation/Entity.php
@@ -171,6 +171,8 @@ use Google\Cloud\Core\CallTrait;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/vision/reference/rest/v1/images/annotate#entityannotation EntityAnnotation
  * @codingStandardsIgnoreEnd
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Entity extends AbstractFeature
 {
@@ -194,5 +196,9 @@ class Entity extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 }

--- a/Vision/src/Annotation/Face.php
+++ b/Vision/src/Annotation/Face.php
@@ -206,6 +206,9 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/vision/reference/rest/v1/images/annotate#faceannotation FaceAnnotation
  * @codingStandardsIgnoreEnd
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Face extends AbstractFeature
 {
@@ -230,6 +233,10 @@ class Face extends AbstractFeature
     {
         $this->info = $info;
         $this->landmarks = new Landmarks($info['landmarks']);
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Annotation/Face/Landmarks.php
+++ b/Vision/src/Annotation/Face/Landmarks.php
@@ -50,6 +50,9 @@ use Google\Cloud\Vision\Annotation\AbstractFeature;
  *
  *     @return array
  * }
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Landmarks extends AbstractFeature
 {

--- a/Vision/src/Annotation/FeatureInterface.php
+++ b/Vision/src/Annotation/FeatureInterface.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Vision\Annotation;
 
 /**
  * Define shared functionality for annotation features.
+ * @deprecated This interface is no longer supported and will be removed in a future
+ * release.
  */
 interface FeatureInterface
 {

--- a/Vision/src/Annotation/ImageProperties.php
+++ b/Vision/src/Annotation/ImageProperties.php
@@ -45,6 +45,8 @@ namespace Google\Cloud\Vision\Annotation;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#ImageProperties ImageProperties
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class ImageProperties extends AbstractFeature
 {
@@ -60,6 +62,10 @@ class ImageProperties extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Annotation/LikelihoodTrait.php
+++ b/Vision/src/Annotation/LikelihoodTrait.php
@@ -21,6 +21,8 @@ use InvalidArgumentException;
 
 /**
  * Provide likelihood functionality to annotation features.
+ * @deprecated This trait is no longer supported and will be removed in a future
+ * release.
  */
 trait LikelihoodTrait
 {

--- a/Vision/src/Annotation/SafeSearch.php
+++ b/Vision/src/Annotation/SafeSearch.php
@@ -98,6 +98,8 @@ use Google\Cloud\Core\CallTrait;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#SafeSearchAnnotation SafeSearchAnnotation
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class SafeSearch extends AbstractFeature
 {
@@ -116,6 +118,10 @@ class SafeSearch extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Annotation/Web.php
+++ b/Vision/src/Annotation/Web.php
@@ -38,6 +38,8 @@ use Google\Cloud\Vision\Annotation\Web\WebPage;
  * ```
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#WebDetection WebDetection
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Web extends AbstractFeature
 {
@@ -101,6 +103,10 @@ class Web extends AbstractFeature
                 $this->pages[] = new WebPage($page);
             }
         }
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Annotation/Web/WebEntity.php
+++ b/Vision/src/Annotation/Web/WebEntity.php
@@ -71,6 +71,8 @@ use Google\Cloud\Vision\Annotation\AbstractFeature;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#WebEntity WebEntity
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class WebEntity extends AbstractFeature
 {

--- a/Vision/src/Annotation/Web/WebImage.php
+++ b/Vision/src/Annotation/Web/WebImage.php
@@ -61,6 +61,8 @@ use Google\Cloud\Vision\Annotation\AbstractFeature;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#WebImage WebImage
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class WebImage extends AbstractFeature
 {

--- a/Vision/src/Annotation/Web/WebPage.php
+++ b/Vision/src/Annotation/Web/WebPage.php
@@ -61,6 +61,8 @@ use Google\Cloud\Vision\Annotation\AbstractFeature;
  * }
  *
  * @see https://cloud.google.com/vision/docs/reference/rest/v1/images/annotate#WebPage WebPage
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class WebPage extends AbstractFeature
 {
@@ -72,5 +74,9 @@ class WebPage extends AbstractFeature
     public function __construct(array $info)
     {
         $this->info = $info;
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 }

--- a/Vision/src/Connection/Rest.php
+++ b/Vision/src/Connection/Rest.php
@@ -26,6 +26,9 @@ use Google\Cloud\Vision\VisionClient;
 /**
  * Implementation of the
  * [Google Cloud Vision JSON API](https://cloud.google.com/vision/reference/rest/).
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Rest implements ConnectionInterface
 {
@@ -49,6 +52,10 @@ class Rest implements ConnectionInterface
             $config['serviceDefinitionPath'],
             self::BASE_URI
         ));
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/Image.php
+++ b/Vision/src/Image.php
@@ -140,6 +140,9 @@ use InvalidArgumentException;
  *
  * @see https://cloud.google.com/vision/docs/best-practices Best Practices
  * @see https://cloud.google.com/vision/docs/pricing Pricing
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class Image
 {
@@ -253,6 +256,10 @@ class Image
                 'Image must be a string of bytes, a google storage object, a valid image URI, or a resource.'
             );
         }
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**

--- a/Vision/src/VisionClient.php
+++ b/Vision/src/VisionClient.php
@@ -31,12 +31,19 @@ use Psr\Cache\CacheItemPoolInterface;
  * more information at the
  * [Google Cloud Vision docs](https://cloud.google.com/vision/docs/).
  *
+ * Please note this client will be deprecated in our next release. In order
+ * to receive the latest features and updates, please take
+ * the time to familiarize yourself with {@see Google\Cloud\Vision\V1\ImageAnnotatorClient}.
+ *
  * Example:
  * ```
  * use Google\Cloud\Vision\VisionClient;
  *
  * $vision = new VisionClient();
  * ```
+ *
+ * @deprecated This class is no longer supported and will be removed in a future
+ * release.
  */
 class VisionClient
 {
@@ -92,6 +99,10 @@ class VisionClient
         }
 
         $this->connection = new Rest($this->configureAuthentication($config));
+
+        $class = get_class($this);
+        $err = "The class {$class} is no longer supported";
+        @trigger_error($err, E_USER_DEPRECATED);
     }
 
     /**


### PR DESCRIPTION
  * Marks handwritten vision classes as deprecated
  * Adds runtime notices for constructed classes with custom error handlers
  * VisionClient references ImageAnnotatorClience for new usage.