### PR TITLE
Retry fixes

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -46,8 +46,10 @@ use Psr\Http\Message\StreamInterface;
 class BigQueryClient
 {
     use ArrayTrait;
-    use ClientTrait;
-    use RetryDeciderTrait;
+    use ClientTrait, RetryDeciderTrait {
+        ClientTrait::jsonEncode insteadof RetryDeciderTrait;
+        ClientTrait::jsonDecode insteadof RetryDeciderTrait;
+    }
 
     const VERSION = '1.5.0';
 
@@ -124,7 +126,7 @@ class BigQueryClient
             'projectIdRequired' => true,
             'returnInt64AsObject' => false,
             'restRetryFunction' => $this->getRetryFunction(),
-            'restDelayFunction' => function ($attempt) {
+            'restCalcDelayFunction' => function ($attempt) {
                 return min(
                     mt_rand(0, 1000000) + (pow(2, $attempt) * 1000000),
                     self::MAX_DELAY_MICROSECONDS

--- a/Core/src/Logger/AppEngineFlexFormatter.php
+++ b/Core/src/Logger/AppEngineFlexFormatter.php
@@ -24,8 +24,6 @@ use Monolog\Formatter\LineFormatter;
  */
 class AppEngineFlexFormatter extends LineFormatter
 {
-    use JsonTrait;
-
     /**
      * @param string $format [optional] The format of the message
      * @param string $dateFormat [optional] The format of the timestamp
@@ -62,6 +60,6 @@ class AppEngineFlexFormatter extends LineFormatter
                 $_SERVER['HTTP_X_CLOUD_TRACE_CONTEXT']
             )[0];
         }
-        return "\n" . $this->jsonEncode($payload);
+        return "\n" . json_encode($payload);
     }
 }

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -112,6 +112,31 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals(1, $actualAttempts);
     }
 
+    public function testSetsCalculateDelayFunction()
+    {
+        $backoff = new ExponentialBackoff();
+        $hasTriggeredException = false;
+        $actualDelayAmount = 0;
+        $expectedDelayAmount = 100;
+        $backoff->setDelayFunction(function ($delay) use (&$actualDelayAmount) {
+            $actualDelayAmount = $delay;
+        });
+        $backoff->setCalcDelayFunction(function () use ($expectedDelayAmount) {
+            return $expectedDelayAmount;
+        });
+
+        try {
+            $backoff->execute(function () {
+                throw new \Exception();
+            });
+        } catch (\Exception $ex) {
+            $hasTriggeredException = true;
+        }
+
+        $this->assertTrue($hasTriggeredException);
+        $this->assertEquals($expectedDelayAmount, $actualDelayAmount);
+    }
+
     /**
      * @dataProvider delayProvider
      */

--- a/Core/tests/Unit/RetryDeciderTraitTest.php
+++ b/Core/tests/Unit/RetryDeciderTraitTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\Cloud\Core\RetryDeciderTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -60,8 +63,21 @@ class RetryDeciderTraitTest extends TestCase
         $rateLimitExceededMessage = '{"error": {"errors": [{"reason": "rateLimitExceeded"}]}}';
         $userRateLimitExceededMessage = '{"error": {"errors": [{"reason": "userRateLimitExceeded"}]}}';
         $notAGoodMessage = '{"error": {"errors": [{"reason": "notAGoodReason"}]}}';
+        $rateLimitExceededResponse = new Response(400, [], $rateLimitExceededMessage);
+        $notAGoodMessageResponse = new Response(400, [], $notAGoodMessage);
+        $request = new Request('GET', 'https://www.example.com');
 
         return [
+            [
+                RequestException::create($request, $rateLimitExceededResponse),
+                true,
+                true
+            ],
+            [
+                RequestException::create($request, $notAGoodMessageResponse),
+                true,
+                false
+            ],
             [new \Exception('', 400), true, false],
             [new \Exception('', 500), true, true],
             [new \Exception('', 502), true, true],

--- a/Language/src/LanguageClient.php
+++ b/Language/src/LanguageClient.php
@@ -41,8 +41,10 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class LanguageClient
 {
-    use ClientTrait;
-    use RetryDeciderTrait;
+    use ClientTrait, RetryDeciderTrait {
+        ClientTrait::jsonEncode insteadof RetryDeciderTrait;
+        ClientTrait::jsonDecode insteadof RetryDeciderTrait;
+    }
 
     const VERSION = '0.18.0';
 

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -421,6 +421,7 @@ class Rest implements ConnectionInterface
             'restOptions' => null,
             'retries' => null,
             'restRetryFunction' => null,
+            'restCalcDelayFunction' => null,
             'restDelayFunction' => null
         ]);
 


### PR DESCRIPTION
Closes: https://github.com/googleapis/google-cloud-php/issues/1813, https://github.com/googleapis/google-cloud-php/issues/1809

Big thanks to @paslandau for the reports! The `BigQueryClient` was incorrectly using the `restDelayFunction` to attempt to override the exponential delay calculation. This exposes a new option (`restCalcDelayFunction`) which allows this behavior to work as expected. Additionally, this addresses an issue when attempting to retry error messages sourced from guzzle exceptions.