### PR TITLE
Automatically paginate GQL Queries

### DIFF
--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -22,6 +22,7 @@ use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Connection\Rest;
 use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
+use Google\Cloud\Datastore\V1\QueryResultBatch\MoreResultsType;
 
 /**
  * Run lookups and queries and commit changes.
@@ -437,7 +438,13 @@ class Operation
             'nextResultTokenKey' => 'batch.endCursor',
             'setNextResultTokenCondition' => function ($res) use ($query) {
                 if (isset($res['batch']['moreResults'])) {
-                    return $query->canPaginate() && $res['batch']['moreResults'] === 'NOT_FINISHED';
+                    $moreResultsType = $res['batch']['moreResults'];
+                    // Transform gRPC enum to string
+                    if (is_numeric($moreResultsType)) {
+                        $moreResultsType = MoreResultsType::name($moreResultsType);
+                    }
+
+                    return $query->canPaginate() && $moreResultsType === 'NOT_FINISHED';
                 }
 
                 return false;

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Datastore;
 use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Connection\Rest;
+use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
 
 /**
@@ -429,11 +430,7 @@ class Operation
             'className' => Entity::class,
             'namespaceId' => $this->namespaceId
         ];
-        $request = $options + $this->readOptions($options) + [
-            'projectId' => $this->projectId,
-            'partitionId' => $this->partitionId($this->projectId, $options['namespaceId']),
-            $query->queryKey() => $query->queryObject()
-        ];
+
         $iteratorConfig = [
             'itemsKey' => 'batch.entityResults',
             'resultTokenKey' => 'query.startCursor',
@@ -447,13 +444,42 @@ class Operation
             }
         ];
 
+        $runQueryObj = clone $query;
+        $runQueryFn = function (array $args = []) use (&$runQueryObj, $options) {
+            $args += [
+                'query' => []
+            ];
+
+            // The iterator provides the startCursor for subsequent pages as an argument.
+            $requestQueryArr = $args['query'] + $runQueryObj->queryObject();
+            $request = [
+                'projectId' => $this->projectId,
+                'partitionId' => $this->partitionId($this->projectId, $options['namespaceId']),
+                $runQueryObj->queryKey() => $requestQueryArr
+            ] + $this->readOptions($options) + $options;
+
+            $res = $this->connection->runQuery($request);
+
+            // When executing a GQL Query, the server will compute a query object
+            // and return it with the first response batch.
+            // Automatic pagination with GQL is accomplished by requesting
+            // subsequent pages with this query object, and discarding the GQL
+            // query. This is done by replacing the GQL object with a Query
+            // instance prior to the next iteration of the page.
+            if (isset($res['query'])) {
+                $runQueryObj = new Query($this->entityMapper, $res['query']);
+            }
+
+            return $res;
+        };
+
         return new EntityIterator(
             new EntityPageIterator(
                 function (array $entityResult) use ($options) {
                     return $this->mapEntityResult($entityResult, $options['className']);
                 },
-                [$this->connection, 'runQuery'],
-                $request,
+                $runQueryFn,
+                [],
                 $iteratorConfig
             )
         );

--- a/Datastore/src/Query/GqlQuery.php
+++ b/Datastore/src/Query/GqlQuery.php
@@ -192,7 +192,7 @@ class GqlQuery implements QueryInterface
      */
     public function canPaginate()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/Datastore/tests/Snippet/DatastoreClientTest.php
+++ b/Datastore/tests/Snippet/DatastoreClientTest.php
@@ -625,7 +625,11 @@ class DatastoreClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(DatastoreClient::class, 'runQuery');
         $snippet->addLocal('datastore', $this->client);
-        $snippet->addLocal('query', $this->prophesize(QueryInterface::class)->reveal());
+
+        $query = $this->prophesize(QueryInterface::class);
+        $query->queryObject()->willReturn([]);
+        $query->queryKey()->willReturn('query');
+        $snippet->addLocal('query', $query->reveal());
 
         $this->connection->runQuery(Argument::any())
             ->shouldBeCalled()

--- a/Datastore/tests/Snippet/ReadOnlyTransactionTest.php
+++ b/Datastore/tests/Snippet/ReadOnlyTransactionTest.php
@@ -210,7 +210,11 @@ class ReadOnlyTransactionTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(ReadOnlyTransaction::class, 'runQuery');
         $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
-        $snippet->addLocal('query', $this->prophesize(QueryInterface::class)->reveal());
+
+        $query = $this->prophesize(QueryInterface::class);
+        $query->queryObject()->willReturn([]);
+        $query->queryKey()->willReturn('query');
+        $snippet->addLocal('query', $query->reveal());
 
         $this->connection->runQuery(Argument::withEntry('transaction', self::TRANSACTION))
             ->shouldBeCalled()

--- a/Datastore/tests/Snippet/TransactionTest.php
+++ b/Datastore/tests/Snippet/TransactionTest.php
@@ -372,7 +372,11 @@ class TransactionTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Transaction::class, 'runQuery');
         $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
-        $snippet->addLocal('query', $this->prophesize(QueryInterface::class)->reveal());
+
+        $query = $this->prophesize(QueryInterface::class);
+        $query->queryObject()->willReturn([]);
+        $query->queryKey()->willReturn('query');
+        $snippet->addLocal('query', $query->reveal());
 
         $this->connection->runQuery(Argument::withEntry('transaction', self::TRANSACTION))
             ->shouldBeCalled()

--- a/Datastore/tests/System/DatastoreTestCase.php
+++ b/Datastore/tests/System/DatastoreTestCase.php
@@ -83,8 +83,8 @@ class DatastoreTestCase extends TestCase
         self::setupBeforeClass();
 
         return [
-            [self::$restClient],
-            [self::$grpcClient]
+            'restClient' => [self::$restClient],
+            'grpcClient' => [self::$grpcClient]
         ];
     }
 }

--- a/Datastore/tests/System/QueryResultPaginationTest.php
+++ b/Datastore/tests/System/QueryResultPaginationTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Datastore\Tests\System;
+
+use Google\Cloud\Datastore\DatastoreClient;
+
+/**
+ * @group datastore
+ * @group datastore-query-pagination
+ */
+class QueryResultPaginationTest extends DatastoreTestCase
+{
+    private static $expectedTotal = 610;
+    private static $kind;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        self::$kind = uniqid(self::TESTING_PREFIX);
+
+        $client = self::$restClient;
+        // seed a large set.
+        $set = [];
+        for ($i = 0; $i < self::$expectedTotal; $i++) {
+            $set[] = $client->entity(self::$kind, [
+                'a' => rand(1, 10)
+            ]);
+
+            if (count($set) === 100) {
+                $client->insertBatch($set);
+                $set = [];
+            }
+        }
+
+        if ($set) {
+            $client->insertBatch($set);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $client = self::$restClient;
+        $query = $client->query()->kind(self::$kind);
+        $set = [];
+        foreach ($client->runQuery($query) as $entity) {
+            $set[] = $entity->key();
+
+            if (count($set) === 100) {
+                $client->deleteBatch($set);
+                $set = [];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider clientProvider
+     */
+    public function testGqlQueryPagination(DatastoreClient $client)
+    {
+        $q = $client->gqlQuery('SELECT * FROM ' . self::$kind);
+
+        $res = $client->runQuery($q);
+
+        $count = count(iterator_to_array($res));
+
+        $this->assertEquals(self::$expectedTotal, $count);
+    }
+
+    /**
+     * @dataProvider clientProvider
+     */
+    public function testQueryPagination(DatastoreClient $client)
+    {
+        $q = $client->query()->kind(self::$kind);
+
+        $res = $client->runQuery($q);
+
+        $count = count(iterator_to_array($res));
+
+        $this->assertEquals(self::$expectedTotal, $count);
+    }
+
+    /**
+     * @dataProvider clientProvider
+     */
+    public function testGqlQueryPaginationByPage(DatastoreClient $client)
+    {
+        $q = $client->gqlQuery('SELECT * FROM ' . self::$kind);
+
+        $res = $client->runQuery($q);
+
+        $count = count(iterator_to_array($res->iterateByPage()));
+
+        $this->assertGreaterThan(1, $count);
+    }
+
+    /**
+     * @dataProvider clientProvider
+     */
+    public function testQueryPaginationByPage(DatastoreClient $client)
+    {
+        $q = $client->query()->kind(self::$kind);
+
+        $res = $client->runQuery($q);
+
+        $count = count(iterator_to_array($res->iterateByPage()));
+
+        $this->assertGreaterThan(1, $count);
+    }
+}

--- a/Datastore/tests/Unit/Query/GqlQueryTest.php
+++ b/Datastore/tests/Unit/Query/GqlQueryTest.php
@@ -82,10 +82,10 @@ class GqlQueryTest extends TestCase
         $this->assertTrue($res['allowLiterals']);
     }
 
-    public function testCanPaginateReturnsFalse()
+    public function testCanPaginateReturnsTrue()
     {
         $query = new GqlQuery($this->mapper, 'SELECT * FROM foo');
-        $this->assertFalse($query->canPaginate());
+        $this->assertTrue($query->canPaginate());
     }
 
     public function testQueryKeyIsCorrect()

--- a/Datastore/tests/Unit/fixtures/query-results.json
+++ b/Datastore/tests/Unit/fixtures/query-results.json
@@ -47,6 +47,9 @@
   },
   "paged": [
     {
+      "query": {
+        "kind": ["Person"]
+      },
       "batch": {
         "entityResults": [
           {


### PR DESCRIPTION
Fixes #1696.

This change adds support for automatic pagination with GQL queries.

Since GQL query positions are determined by query string binding values (i.e. `offset` and `limit`), programmatically paging is difficult using GQL. However, the server returns the computed value of the query in the first result batch when a GQL query is executed.

By dispatching subsequent requests using the computed query and discarding the GQL query, we can page through results in the same manner as with a query object.