### PR TITLE
Fix transaction configuration for single-use transactions

### DIFF
--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -1347,17 +1347,16 @@ class Database
      */
     public function execute($sql, array $options = [])
     {
-        $session = $this->pluck('session', $options, false);
-        if (!$session) {
-            $session = $this->selectSession(
+        $session = $this->pluck('session', $options, false)
+            ?: $this->selectSession(
                 SessionPoolInterface::CONTEXT_READ,
                 $this->pluck('sessionOptions', $options, false) ?: []
             );
-        }
 
-        list($transactionOptions, $context) = $this->transactionSelector($options);
-        $options['transaction'] = $transactionOptions;
-        $options['transactionContext'] = $context;
+        list(
+            $options['transaction'],
+            $options['transactionContext']
+        ) = $this->transactionSelector($options);
 
         try {
             return $this->operation->execute($session, $sql, $options);

--- a/Spanner/src/TransactionConfigurationTrait.php
+++ b/Spanner/src/TransactionConfigurationTrait.php
@@ -83,7 +83,17 @@ trait TransactionConfigurationTrait
         $context = $this->pluck('transactionType', $options);
         $id = $this->pluck('transactionId', $options);
 
-        if (!is_null($id)) {
+        $begin = $this->pluck('begin', $options);
+        if ($id === null) {
+            if ($begin) {
+                $type = 'begin';
+            } else {
+                $type = 'singleUseTransaction';
+                $options['singleUse'] = true;
+            }
+        }
+
+        if ($id !== null) {
             $type = 'transactionId';
             $transactionOptions = $id;
         } elseif ($context === SessionPoolInterface::CONTEXT_READ) {
@@ -95,11 +105,6 @@ trait TransactionConfigurationTrait
                 'Invalid transaction context %s',
                 $context
             ));
-        }
-
-        $begin = $this->pluck('begin', $options);
-        if (is_null($type)) {
-            $type = ($begin) ? 'begin' : 'singleUseTransaction';
         }
 
         return [$transactionOptions, $type, $context];


### PR DESCRIPTION
`Database::execute()` runs operations within a single-use transaction, but due to the order in which the transaction was configured, single-use configuration options (`maxStaleness` and `minReadTimestamp`) were not available to that method.

Fixes #1830.