### PR TITLE
feat(storage): Add CRC32 Checksums to Cloud Storage uploads.

### DIFF
--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -176,9 +176,15 @@ class ResumableUploader extends AbstractUploader
             try {
                 $response = $this->requestWrapper->send($request, $this->requestOptions);
             } catch (GoogleException $ex) {
+                $msg = json_decode($ex->getMessage, true) ?: $ex->getMessage();
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $msg['resumeUri'] = $this->resumeUri;
+                    $msg = json_encode($msg);
+                }
                 throw new GoogleException(
-                    "Upload failed. Please use this URI to resume your upload: $this->resumeUri",
-                    $ex->getCode()
+                    $msg,
+                    $ex->getCode(),
+                    $ex
                 );
             }
 

--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Core\Upload;
 
 use Google\Cloud\Core\Exception\GoogleException;
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Core\Exception\UploadException;
 use Google\Cloud\Core\JsonTrait;
 use Google\Cloud\Core\RequestWrapper;
 use GuzzleHttp\Psr7;
@@ -139,8 +141,11 @@ class ResumableUploader extends AbstractUploader
     /**
      * Triggers the upload process.
      *
+     * Errors are of form [`google.rpc.Status`](https://cloud.google.com/apis/design/errors#error_model),
+     * and may be obtained via {@see Google\Cloud\Core\Exception\ServiceException::getMetadata()}.
+     *
      * @return array
-     * @throws GoogleException
+     * @throws ServiceException
      */
     public function upload()
     {
@@ -176,15 +181,11 @@ class ResumableUploader extends AbstractUploader
             try {
                 $response = $this->requestWrapper->send($request, $this->requestOptions);
             } catch (GoogleException $ex) {
-                $msg = json_decode($ex->getMessage, true) ?: $ex->getMessage();
-                if (json_last_error() === JSON_ERROR_NONE) {
-                    $msg['resumeUri'] = $this->resumeUri;
-                    $msg = json_encode($msg);
-                }
-                throw new GoogleException(
-                    $msg,
+                throw new ServiceException(
+                    "Upload failed. Please use this URI to resume your upload: $this->resumeUri",
                     $ex->getCode(),
-                    $ex
+                    null,
+                    json_decode($ex->getMessage(), true)
                 );
             }
 

--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -185,7 +185,7 @@ class ResumableUploader extends AbstractUploader
                     "Upload failed. Please use this URI to resume your upload: $this->resumeUri",
                     $ex->getCode(),
                     null,
-                    json_decode($ex->getMessage(), true)
+                    json_decode($ex->getMessage(), true) ?: []
                 );
             }
 

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -4,7 +4,8 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.28"
+        "google/cloud-core": "^1.28",
+        "google/crc32": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.28",
-        "google/crc32": "dev-master"
+        "google/crc32": "^0.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -222,6 +222,7 @@ class Bucket
      * uploads.
      * @see https://cloud.google.com/storage/docs/json_api/v1/objects/insert Objects insert API documentation.
      * @see https://cloud.google.com/storage/docs/encryption#customer-supplied Customer-supplied encryption keys.
+     * @see https://github.com/google/php-crc32 crc32c PHP extension for hardware-accelerated validation hashes.
      *
      * @param string|resource|StreamInterface|null $data The data to be uploaded.
      * @param array $options [optional] {

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -233,16 +233,16 @@ class Bucket
      *     @type bool $resumable Indicates whether or not the upload will be
      *           performed in a resumable fashion.
      *     @type bool|string $validate Indicates whether or not validation will
-     *           be applied using md5 or crc32 hashing functionality. If
+     *           be applied using md5 or crc32c hashing functionality. If
      *           enabled, and the calculated hash does not match that of the
      *           upstream server, the upload will be rejected. Available options
      *           are `true`, `false`, `md5` and `crc32`. If true, either md5 or
-     *           crc32 will be chosen based on your platform. If false, no
+     *           crc32c will be chosen based on your platform. If false, no
      *           validation hash will be sent. Choose either `md5` or `crc32` to
      *           force a hash method regardless of performance implications. In
      *           PHP versions earlier than 7.4, performance will be very
-     *           adversely impacted by using crc32 unless you install the `crc32c`
-     *           PHP extension. **Defaults to** `true`.
+     *           adversely impacted by using crc32c unless you install the
+     *           `crc32c` PHP extension. **Defaults to** `true`.
      *     @type int $chunkSize If provided the upload will be done in chunks.
      *           The size must be in multiples of 262144 bytes. With chunking
      *           you have increased reliability at the risk of higher overhead.

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -231,10 +231,15 @@ class Bucket
      *           of type string or null.
      *     @type bool $resumable Indicates whether or not the upload will be
      *           performed in a resumable fashion.
-     *     @type bool $validate Indicates whether or not validation will be
-     *           applied using md5 and crc32 hashing functionality. If true and
-     *           the calculated hash does not match that of the upstream server
-     *           the upload will be rejected.
+     *     @type bool|string $validate Indicates whether or not validation will
+     *           be applied using md5 or crc32 hashing functionality. If
+     *           enabled, and the calculated hash does not match that of the
+     *           upstream server, the upload will be rejected. Provide `true` or
+     *           `md5` for md5 hashing, `crc32` for crc32 hashing, or `false` to
+     *           disable. Please note that crc32 may have negative performance
+     *           implications in older versions of PHP. Installation of the
+     *           `crc32c` PHP extension is strongly advised for best
+     *           performance. **Defaults to** `true` (md5).
      *     @type int $chunkSize If provided the upload will be done in chunks.
      *           The size must be in multiples of 262144 bytes. With chunking
      *           you have increased reliability at the risk of higher overhead.

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -234,12 +234,14 @@ class Bucket
      *     @type bool|string $validate Indicates whether or not validation will
      *           be applied using md5 or crc32 hashing functionality. If
      *           enabled, and the calculated hash does not match that of the
-     *           upstream server, the upload will be rejected. Provide `true` or
-     *           `md5` for md5 hashing, `crc32` for crc32 hashing, or `false` to
-     *           disable. Please note that crc32 may have negative performance
-     *           implications in older versions of PHP. Installation of the
-     *           `crc32c` PHP extension is strongly advised for best
-     *           performance. **Defaults to** `true` (md5).
+     *           upstream server, the upload will be rejected. Available options
+     *           are `true`, `false`, `md5` and `crc32`. If true, either md5 or
+     *           crc32 will be chosen based on your platform. If false, no
+     *           validation hash will be sent. Choose either `md5` or `crc32` to
+     *           force a hash method regardless of performance implications. In
+     *           PHP versions earlier than 7.4, performance will be very
+     *           adversely impacted by using crc32 unless you install the `crc32c`
+     *           PHP extension. **Defaults to** `true`.
      *     @type int $chunkSize If provided the upload will be done in chunks.
      *           The size must be in multiples of 262144 bytes. With chunking
      *           you have increased reliability at the risk of higher overhead.

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -232,9 +232,9 @@ class Bucket
      *     @type bool $resumable Indicates whether or not the upload will be
      *           performed in a resumable fashion.
      *     @type bool $validate Indicates whether or not validation will be
-     *           applied using md5 hashing functionality. If true and the
-     *           calculated hash does not match that of the upstream server the
-     *           upload will be rejected.
+     *           applied using md5 and crc32 hashing functionality. If true and
+     *           the calculated hash does not match that of the upstream server
+     *           the upload will be rejected.
      *     @type int $chunkSize If provided the upload will be done in chunks.
      *           The size must be in multiples of 262144 bytes. With chunking
      *           you have increased reliability at the risk of higher overhead.

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -475,7 +475,7 @@ class Rest implements ConnectionInterface
         }
 
         // is crc32c available in `hash()`?
-        if ($this->supportsBuiltinCrc32()) {
+        if ($this->supportsBuiltinCrc32c()) {
             return 'crc32';
         }
 
@@ -517,7 +517,7 @@ class Rest implements ConnectionInterface
      */
     protected function crc32cExtensionLoaded()
     {
-        return function_exists('crc32c');
+        return extension_loaded('crc32c');
     }
 
     /**
@@ -527,7 +527,7 @@ class Rest implements ConnectionInterface
      *
      * @return bool
      */
-    protected function supportsBuiltinCrc32()
+    protected function supportsBuiltinCrc32c()
     {
         return Builtin::supports(CRC32::CASTAGNOLI);
     }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -460,7 +460,7 @@ class Rest implements ConnectionInterface
         }
 
         $validate = $args['validate'];
-        if (in_array($validate, [false, 'crc32', 'cd5'])) {
+        if (in_array($validate, [false, 'crc32', 'md5'], true)) {
             return $validate;
         }
 
@@ -470,12 +470,12 @@ class Rest implements ConnectionInterface
         }
 
         // is the extension loaded?
-        if (function_exists('crc32c')) {
+        if ($this->crc32cExtensionLoaded()) {
             return 'crc32';
         }
 
         // is crc32c available in `hash()`?
-        if (Builtin::supports(CRC32::CASTAGNOLI)) {
+        if ($this->supportsBuiltinCrc32()) {
             return 'crc32';
         }
 
@@ -506,5 +506,29 @@ class Rest implements ConnectionInterface
         $data->seek($pos);
 
         return base64_encode($crc32c->hash(true));
+    }
+
+    /**
+     * Check if the crc32c extension is available.
+     *
+     * Protected access for unit testing.
+     *
+     * @return bool
+     */
+    protected function crc32cExtensionLoaded()
+    {
+        return function_exists('crc32c');
+    }
+
+    /**
+     * Check if hash() supports crc32c.
+     *
+     * Protected access for unit testing.
+     *
+     * @return bool
+     */
+    protected function supportsBuiltinCrc32()
+    {
+        return Builtin::supports(CRC32::CASTAGNOLI);
     }
 }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -307,11 +307,9 @@ class Rest implements ConnectionInterface
         }
 
         // @todo add support for rolling hash
-        if ($args['validate'] && !isset($args['metadata']['md5Hash'])) {
+        if (($args['validate'] === true || $args['validate'] === 'md5') && !isset($args['metadata']['md5Hash'])) {
             $args['metadata']['md5Hash'] = base64_encode(Psr7\hash($args['data'], 'md5', true));
-        }
-
-        if ($args['validate'] && !isset($args['metadata']['crc32c'])) {
+        } elseif ($args['validate'] === 'crc32' && !isset($args['metadata']['crc32c'])) {
             $args['metadata']['crc32c'] = $this->crcFromStream($args['data']);
         }
 

--- a/Storage/tests/System/UploadObjectsTest.php
+++ b/Storage/tests/System/UploadObjectsTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\System;
 
+use Google\CRC32\CRC32;
 use GuzzleHttp\Psr7;
 
 /**
@@ -123,5 +124,24 @@ class UploadObjectsTest extends StorageTestCase
         if ($this->testFileSize == $this->totalStoredBytes) {
             $this->assertEquals(filesize(__DIR__ . '/data/5mb.txt'), $this->totalStoredBytes);
         }
+    }
+
+    /**
+     * @expectedException Google\Cloud\Core\Exception\BadRequestException
+     */
+    public function testCrc32ChecksumFails()
+    {
+        $path = __DIR__ . '/data/5mb.txt';
+
+        $crc32 = CRC32::create(CRC32::CASTAGNOLI);
+        $crc32->update('foobar');
+        $badChecksum = base64_encode($crc32->hash(true));
+
+        self::$bucket->upload($path, [
+            'name' => uniqid(),
+            'metadata' => [
+                'crc32c' => $badChecksum
+            ]
+        ]);
     }
 }

--- a/Storage/tests/System/UploadObjectsTest.php
+++ b/Storage/tests/System/UploadObjectsTest.php
@@ -129,13 +129,13 @@ class UploadObjectsTest extends StorageTestCase
     /**
      * @expectedException Google\Cloud\Core\Exception\BadRequestException
      */
-    public function testCrc32ChecksumFails()
+    public function testCrc32cChecksumFails()
     {
         $path = __DIR__ . '/data/5mb.txt';
 
-        $crc32 = CRC32::create(CRC32::CASTAGNOLI);
-        $crc32->update('foobar');
-        $badChecksum = base64_encode($crc32->hash(true));
+        $crc32c = CRC32::create(CRC32::CASTAGNOLI);
+        $crc32c->update('foobar');
+        $badChecksum = base64_encode($crc32c->hash(true));
 
         self::$bucket->upload($path, [
             'name' => uniqid(),

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -234,7 +234,6 @@ class RestTest extends TestCase
         $this->assertEquals($expectedContentType, $contentType);
 
         foreach ($expectedMetadata as $key => $value) {
-
             $this->assertEquals($value, $metadata[$key]);
         }
     }

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -23,7 +23,6 @@ use Google\Cloud\Core\Upload\MultipartUploader;
 use Google\Cloud\Core\Upload\ResumableUploader;
 use Google\Cloud\Core\Upload\StreamableUploader;
 use Google\Cloud\Storage\Connection\Rest;
-use Google\Cloud\Storage\StorageClient;
 use Google\CRC32\CRC32;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -34,7 +33,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
-use Rize\UriTemplate;
 
 /**
  * @group storage
@@ -206,7 +204,7 @@ class RestTest extends TestCase
         $expectedUploaderType,
         $expectedContentType,
         array $expectedMetadata,
-        array $metadataDoesNotHave = []
+        array $metadataKeysWhichShouldNotBeSet = []
     ) {
         $actualRequest = null;
         $response = new Response(200, ['Location' => 'http://www.mordor.com'], $this->successBody);
@@ -238,9 +236,9 @@ class RestTest extends TestCase
             $this->assertEquals($value, $metadata[$key]);
         }
 
-        if ($metadataDoesNotHave) {
+        if ($metadataKeysWhichShouldNotBeSet) {
             $metadataKeys = array_keys($metadata);
-            foreach ($metadataDoesNotHave as $key) {
+            foreach ($metadataKeysWhichShouldNotBeSet as $key) {
                 $this->assertArrayNotHasKey($key, $metadataKeys);
             }
         }
@@ -368,7 +366,7 @@ class RestTest extends TestCase
      */
     public function testChooseValidationMethod($args, $extensionLoaded, $supportsBuiltin, $expected)
     {
-        $rest = new RestCrc32Stub;
+        $rest = new RestCrc32cStub;
         $rest->extensionLoaded = $extensionLoaded;
         $rest->supportsBuiltin = $supportsBuiltin;
 
@@ -447,7 +445,7 @@ class RestTest extends TestCase
 }
 
 //@codingStandardsIgnoreStart
-class RestCrc32Stub extends Rest
+class RestCrc32cStub extends Rest
 {
     public $extensionLoaded = false;
     public $supportsBuiltin = false;
@@ -457,7 +455,7 @@ class RestCrc32Stub extends Rest
         return $this->extensionLoaded;
     }
 
-    protected function supportsBuiltinCrc32()
+    protected function supportsBuiltinCrc32c()
     {
         return $this->supportsBuiltin;
     }

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -205,7 +205,8 @@ class RestTest extends TestCase
         array $options,
         $expectedUploaderType,
         $expectedContentType,
-        array $expectedMetadata
+        array $expectedMetadata,
+        array $metadataDoesNotHave = []
     ) {
         $actualRequest = null;
         $response = new Response(200, ['Location' => 'http://www.mordor.com'], $this->successBody);
@@ -236,6 +237,13 @@ class RestTest extends TestCase
         foreach ($expectedMetadata as $key => $value) {
             $this->assertEquals($value, $metadata[$key]);
         }
+
+        if ($metadataDoesNotHave) {
+            $metadataKeys = array_keys($metadata);
+            foreach ($metadataDoesNotHave as $key) {
+                $this->assertArrayNotHasKey($key, $metadataKeys);
+            }
+        }
     }
 
     public function insertObjectProvider()
@@ -261,7 +269,8 @@ class RestTest extends TestCase
                 [
                     'md5Hash' => base64_encode(Psr7\hash($tempFile, 'md5', true)),
                     'name' => 'file.txt'
-                ]
+                ],
+                ['crc32c']
             ],
             [
                 [
@@ -272,7 +281,8 @@ class RestTest extends TestCase
                 'image/svg+xml',
                 [
                     'name' => 'logo.svg'
-                ]
+                ],
+                ['md5Hash', 'crc32c']
             ],
             [
                 [
@@ -294,7 +304,8 @@ class RestTest extends TestCase
                     'metadata' => [
                         'here' => 'wego'
                     ]
-                ]
+                ],
+                ['md5Hash', 'crc32c']
             ],
             [
                 [
@@ -316,32 +327,37 @@ class RestTest extends TestCase
                     'metadata' => [
                         'here' => 'wego'
                     ]
-                ]
+                ],
+                ['md5Hash', 'crc32c']
             ],
             [
                 [
                     'data' => $logoFile,
                     'name' => 'logo.svg',
+                    'validate' => 'crc32'
                 ],
                 MultipartUploader::class,
                 'image/svg+xml',
                 [
                     'name' => 'logo.svg',
                     'crc32c' => $crcHash
-                ]
+                ],
+                ['md5Hash']
             ],
             [
                 [
                     'data' => $logoFile,
                     'name' => 'logo.svg',
-                    'resumable' => true
+                    'resumable' => true,
+                    'validate' => 'crc32'
                 ],
                 ResumableUploader::class,
                 'image/svg+xml',
                 [
                     'name' => 'logo.svg',
                     'crc32c' => $crcHash
-                ]
+                ],
+                ['md5Hash']
             ]
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "ramsey/uuid": "~3",
         "google/gax": "^1.0",
         "google/common-protos": "^1.0",
-        "google/auth": "^1.5.1"
+        "google/auth": "^1.5.1",
+        "google/crc32": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "google/gax": "^1.0",
         "google/common-protos": "^1.0",
         "google/auth": "^1.5.1",
-        "google/crc32": "dev-master"
+        "google/crc32": "^0.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
This cannot be merged until [`google/crc32`](https://github.com/google/php-crc32) has a stable release.

cc @frankyn.