### PR TITLE
Skip Content-Length if stream size is unknown

### DIFF
--- a/Core/src/Upload/MultipartUploader.php
+++ b/Core/src/Upload/MultipartUploader.php
@@ -50,8 +50,12 @@ class MultipartUploader extends AbstractUploader
 
         $headers = [
             'Content-Type' => 'multipart/related; boundary=boundary',
-            'Content-Length' => $multipartStream->getSize()
         ];
+
+        $size = $multipartStream->getSize();
+        if ($size !== null) {
+            $headers['Content-Length'] = $size;
+        }
 
         return $this->jsonDecode(
             $this->requestWrapper->send(


### PR DESCRIPTION
PSR-7 allows a stream to indicate its size is unknown by returning null. This is really useful if the stream is being transformed as it's uploaded, for example.

Currently, the `MultiPartUploader` always adds a `Content-Length` header, even if the `Stream` returns null. Adding this invalid null value triggers a chain of assumptions in Guzzle and other API code that tries to resolve the size in ways that can cause unwanted side effects like trying to load the entire stream into memory, etc.

However, by detecting if the size is known or not, we can avoid all the issues and everything works great.

I haven't updated the other Uploader classes because the size does seem very relevant for their usecases (and also because I'm not using them :sweat_smile:)