### PR TITLE
Fix flaky test

### DIFF
--- a/Storage/tests/Unit/SigningHelperTest.php
+++ b/Storage/tests/Unit/SigningHelperTest.php
@@ -193,7 +193,9 @@ class SigningHelperTest extends TestCase
             $expires,
             $resource,
             self::GENERATION,
-            []
+            [
+                'timestamp' => $now
+            ]
         );
 
         $parts = parse_url($url);
@@ -275,7 +277,8 @@ class SigningHelperTest extends TestCase
                 'contentMd5' => $contentMd5,
                 'responseType' => $responseType,
                 'responseDisposition' => $responseDisposition,
-                'cname' => $cname
+                'cname' => $cname,
+                'timestamp' => $now
             ]
         );
 


### PR DESCRIPTION
Following #1829 and #1843. The previous attempt at fixing this didn't do the trick. This change manually sets the URL signing method timestamp to match the expected timestamp, eliminating the possibility of failures based on when the test is executed.