### PR TITLE
Add samples for using Bootstrap class

### DIFF
--- a/ErrorReporting/README.md
+++ b/ErrorReporting/README.md
@@ -38,6 +38,34 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
+The Stackdriver Error Reporting client provides APIs allowing you to easily configure your application to send errors and exceptions automatically to Stackdriver, or to manually report and manage errors and statistics.
+
+#### Reporting errors from your application:
+
+```php
+require 'vendor/autoload.php';
+
+use Google\Cloud\ErrorReporting\Bootstrap;
+use Google\Cloud\Logging\LoggingClient;
+use Google\Cloud\Core\Report\SimpleMetadataProvider;
+
+$projectId = '[PROJECT]';
+$service = '[SERVICE_NAME]';
+$version = '[APP_VERSION]';
+
+$logging = new LoggingClient();
+$metadata = new SimpleMetadataProvider([], $projectId, $service, $version);
+$psrLogger = $logging->psrLogger('error-log', [
+    'metadataProvider' => $metadata
+]);
+
+// Register the logger as a PHP exception and error handler.
+// This will begin logging application exceptions and errors to Stackdriver.
+Bootstrap::init($psrLogger);
+```
+
+#### Using the Error Reporting API:
+
 ```php
 require 'vendor/autoload.php';
 

--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,34 @@ $ composer require google/cloud-dlp
 
 #### Preview
 
+The Stackdriver Error Reporting client provides APIs allowing you to easily configure your application to send errors and exceptions automatically to Stackdriver, or to manually report and manage errors and statistics.
+
+##### Reporting errors from your application:
+
+```php
+require 'vendor/autoload.php';
+
+use Google\Cloud\ErrorReporting\Bootstrap;
+use Google\Cloud\Logging\LoggingClient;
+use Google\Cloud\Core\Report\SimpleMetadataProvider;
+
+$projectId = '[PROJECT]';
+$service = '[SERVICE_NAME]';
+$version = '[APP_VERSION]';
+
+$logging = new LoggingClient();
+$metadata = new SimpleMetadataProvider([], $projectId, $service, $version);
+$psrLogger = $logging->psrLogger('error-log', [
+    'metadataProvider' => $metadata
+]);
+
+// Register the logger as a PHP exception and error handler.
+// This will begin logging application exceptions and errors to Stackdriver.
+Bootstrap::init($psrLogger);
+```
+
+##### Using the Error Reporting API:
+
 ```php
 require 'vendor/autoload.php';
 


### PR DESCRIPTION
Fixes #1737.

Sample is based on [`php-docs-samples` quickstart](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/83cbbeb2ee36a458db4d2dc868cd8e16812fa957/error_reporting/quickstart.php).