### PR TITLE
feat(storage): Add support for service account HMAC keys

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -198,11 +198,10 @@ class RequestWrapper
         }
 
         try {
-            $res = $backoff->execute($this->httpHandler, [
+            return $backoff->execute($this->httpHandler, [
                 $this->applyHeaders($request),
                 $this->getRequestOptions($options)
             ]);
-            return $res;
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -198,10 +198,11 @@ class RequestWrapper
         }
 
         try {
-            return $backoff->execute($this->httpHandler, [
+            $res = $backoff->execute($this->httpHandler, [
                 $this->applyHeaders($request),
                 $this->getRequestOptions($options)
             ]);
+            return $res;
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }

--- a/Storage/src/Connection/ConnectionInterface.php
+++ b/Storage/src/Connection/ConnectionInterface.php
@@ -181,5 +181,10 @@ interface ConnectionInterface
     /**
      * @param array $args
      */
+    public function updateHmacKey(array $args = []);
+
+    /**
+     * @param array $args
+     */
     public function listHmacKeys(array $args = []);
 }

--- a/Storage/src/Connection/ConnectionInterface.php
+++ b/Storage/src/Connection/ConnectionInterface.php
@@ -162,4 +162,24 @@ interface ConnectionInterface
      * @param array $args
      */
     public function lockRetentionPolicy(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function createHmacKey(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function deleteHmacKey(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function getHmacKey(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function listHmacKeys(array $args = []);
 }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -405,6 +405,38 @@ class Rest implements ConnectionInterface
 
     /**
      * @param array $args
+     */
+    public function createHmacKey(array $args = [])
+    {
+        return $this->send('projects.resources.hmacKeys', 'create', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteHmacKey(array $args = [])
+    {
+        return $this->send('projects.resources.hmacKeys', 'delete', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getHmacKey(array $args = [])
+    {
+        return $this->send('projects.resources.hmacKeys', 'get', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listHmacKeys(array $args = [])
+    {
+        return $this->send('projects.resources.hmacKeys', 'list', $args);
+    }
+
+    /**
+     * @param array $args
      * @return array
      */
     private function buildDownloadObjectParams(array $args)

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -430,6 +430,14 @@ class Rest implements ConnectionInterface
     /**
      * @param array $args
      */
+    public function updateHmacKey(array $args = [])
+    {
+        return $this->send('projects.resources.hmacKeys', 'update', $args);
+    }
+
+    /**
+     * @param array $args
+     */
     public function listHmacKeys(array $args = [])
     {
         return $this->send('projects.resources.hmacKeys', 'list', $args);

--- a/Storage/src/Connection/ServiceDefinition/storage-v1.json
+++ b/Storage/src/Connection/ServiceDefinition/storage-v1.json
@@ -1,11 +1,11 @@
 {
   "kind": "discovery#restDescription",
-  "etag": "\"J3WqvAcMk4eQjJXvfSI4Yr8VouA/DmyEBWot3HQKPyHnL5ZWMvY99pg\"",
+  "etag": "\"VPK3KBfpaEgZ16pozGOoMYfKc0U/p_spPkWHsRi33PRBHlYtU2G_uKg\"",
   "discoveryVersion": "v1",
   "id": "storage:v1",
   "name": "storage",
   "version": "v1",
-  "revision": "20181217",
+  "revision": "20190426",
   "title": "Cloud Storage JSON API",
   "description": "Stores and retrieves potentially large, immutable data objects.",
   "ownerDomain": "google.com",
@@ -184,6 +184,7 @@
           "properties": {
             "bucketPolicyOnly": {
               "type": "object",
+              "description": "The bucket's Bucket Policy Only configuration.",
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -283,6 +284,10 @@
         "location": {
           "type": "string",
           "description": "The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list."
+        },
+        "locationType": {
+          "type": "string",
+          "description": "The type of the bucket location."
         },
         "logging": {
           "type": "object",
@@ -614,6 +619,127 @@
               "storage.objects.compose"
             ]
           }
+        }
+      }
+    },
+    "Expr": {
+      "id": "Expr",
+      "type": "object",
+      "description": "Represents an expression text. Example: title: \"User account presence\" description: \"Determines whether the request has a user account\" expression: \"size(request.user) \u003e 0\"",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
+        },
+        "expression": {
+          "type": "string",
+          "description": "Textual representation of an expression in Common Expression Language syntax. The application context of the containing message determines which well-known feature set of CEL is supported."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of item this is. For storage, this is always storage#expr. This field is ignored on input.",
+          "default": "storage#expr"
+        },
+        "location": {
+          "type": "string",
+          "description": "An optional string indicating the location of the expression for error reporting, e.g. a file name and a position in the file."
+        },
+        "title": {
+          "type": "string",
+          "description": "An optional title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
+        }
+      }
+    },
+    "HmacKey": {
+      "id": "HmacKey",
+      "type": "object",
+      "description": "JSON template to produce a JSON-style HMAC Key resource for Create responses.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind of item this is. For HMAC keys, this is always storage#hmacKey.",
+          "default": "storage#hmacKey"
+        },
+        "metadata": {
+          "$ref": "HmacKeyMetadata",
+          "description": "Key metadata."
+        },
+        "secret": {
+          "type": "string",
+          "description": "HMAC secret key material."
+        }
+      }
+    },
+    "HmacKeyMetadata": {
+      "id": "HmacKeyMetadata",
+      "type": "object",
+      "description": "JSON template to produce a JSON-style HMAC Key metadata resource.",
+      "properties": {
+        "accessId": {
+          "type": "string",
+          "description": "The ID of the HMAC Key."
+        },
+        "etag": {
+          "type": "string",
+          "description": "HTTP 1.1 Entity tag for the HMAC key."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the HMAC key, including the Project ID and the Access ID."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of item this is. For HMAC Key metadata, this is always storage#hmacKeyMetadata.",
+          "default": "storage#hmacKeyMetadata"
+        },
+        "projectId": {
+          "type": "string",
+          "description": "Project ID owning the service account to which the key authenticates."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "The link to this resource."
+        },
+        "serviceAccountEmail": {
+          "type": "string",
+          "description": "The email address of the key's associated service account."
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the key. Can be one of ACTIVE, INACTIVE, or DELETED."
+        },
+        "timeCreated": {
+          "type": "string",
+          "description": "The creation time of the HMAC key in RFC 3339 format.",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "description": "The last modification time of the HMAC key metadata in RFC 3339 format.",
+          "format": "date-time"
+        }
+      }
+    },
+    "HmacKeysMetadata": {
+      "id": "HmacKeysMetadata",
+      "type": "object",
+      "description": "A list of hmacKeys.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "The list of items.",
+          "items": {
+            "$ref": "HmacKeyMetadata"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of item this is. For lists of hmacKeys, this is always storage#hmacKeysMetadata.",
+          "default": "storage#hmacKeysMetadata"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The continuation token, used to page through large result sets. Provide this value in a subsequent request to return the next page of results."
         }
       }
     },
@@ -1014,7 +1140,8 @@
             "type": "object",
             "properties": {
               "condition": {
-                "type": "any"
+                "$ref": "Expr",
+                "description": "The condition that is associated with this binding. NOTE: an unsatisfied condition will not allow user access via current binding. Different bindings, including their conditions, are examined independently."
               },
               "members": {
                 "type": "array",
@@ -1155,6 +1282,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1188,6 +1320,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1217,6 +1354,11 @@
               "description": "Name of a bucket.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -1249,6 +1391,11 @@
               "description": "Name of a bucket.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -1284,6 +1431,11 @@
               "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -1323,6 +1475,11 @@
               "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -1371,6 +1528,11 @@
               "type": "string",
               "description": "If set, only deletes the bucket if its metageneration does not match this value.",
               "format": "int64",
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -1425,6 +1587,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1457,6 +1624,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1471,10 +1643,7 @@
           },
           "scopes": [
             "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only",
-            "https://www.googleapis.com/auth/devstorage.full_control",
-            "https://www.googleapis.com/auth/devstorage.read_only",
-            "https://www.googleapis.com/auth/devstorage.read_write"
+            "https://www.googleapis.com/auth/devstorage.full_control"
           ]
         },
         "insert": {
@@ -1542,6 +1711,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request.",
@@ -1606,6 +1780,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request.",
@@ -1643,6 +1822,11 @@
               "description": "Makes the operation conditional on whether bucket's current metageneration matches the given value.",
               "required": true,
               "format": "int64",
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -1741,6 +1925,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1773,6 +1962,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1790,8 +1984,7 @@
           },
           "scopes": [
             "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/devstorage.full_control",
-            "https://www.googleapis.com/auth/devstorage.read_write"
+            "https://www.googleapis.com/auth/devstorage.full_control"
           ]
         },
         "testIamPermissions": {
@@ -1811,6 +2004,11 @@
               "description": "Permissions to test.",
               "required": true,
               "repeated": true,
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -1911,6 +2109,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -1974,6 +2177,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2007,6 +2215,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2036,6 +2249,11 @@
               "description": "Name of a bucket.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2081,6 +2299,11 @@
               "format": "int64",
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2115,6 +2338,11 @@
               "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2154,6 +2382,11 @@
               "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2198,6 +2431,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2232,6 +2470,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2265,6 +2508,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2297,6 +2545,11 @@
               "description": "Name of a Google Cloud Storage bucket.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2352,6 +2605,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2398,6 +2656,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2440,6 +2703,11 @@
               "description": "Name of the object. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2485,6 +2753,11 @@
               "description": "Name of the object. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2533,6 +2806,11 @@
               "description": "Name of the object. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2585,6 +2863,11 @@
               "description": "Name of the object. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -2666,6 +2949,11 @@
             "kmsKeyName": {
               "type": "string",
               "description": "Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's kms_key_name value, if any.",
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -2790,6 +3078,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "sourceBucket": {
               "type": "string",
               "description": "Name of the bucket in which to find the source object.",
@@ -2880,6 +3173,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -2957,6 +3255,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -3003,6 +3306,11 @@
               "description": "Name of the object. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.",
               "required": true,
               "location": "path"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
             },
             "userProject": {
               "type": "string",
@@ -3110,6 +3418,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -3198,6 +3511,11 @@
                 "Include all properties.",
                 "Omit the owner, acl property."
               ],
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -3306,6 +3624,11 @@
                 "Include all properties.",
                 "Omit the owner, acl property."
               ],
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -3440,6 +3763,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "rewriteToken": {
               "type": "string",
               "description": "Include this field (from the previous rewrite response) on each rewrite request after the first one, until the rewrite response 'done' flag is true. Calls that provide a rewriteToken can omit all other request fields, but if included those fields must match the values provided in the first rewrite request.",
@@ -3511,6 +3839,11 @@
               "required": true,
               "location": "path"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -3562,6 +3895,11 @@
               "description": "Permissions to test.",
               "required": true,
               "repeated": true,
+              "location": "query"
+            },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
               "location": "query"
             },
             "userProject": {
@@ -3668,6 +4006,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -3742,6 +4085,11 @@
               ],
               "location": "query"
             },
+            "provisionalUserProject": {
+              "type": "string",
+              "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+              "location": "query"
+            },
             "userProject": {
               "type": "string",
               "description": "The project to be billed for this request. Required for Requester Pays buckets.",
@@ -3776,6 +4124,210 @@
     },
     "projects": {
       "resources": {
+        "hmacKeys": {
+          "methods": {
+            "create": {
+              "id": "storage.projects.hmacKeys.create",
+              "path": "projects/{projectId}/hmacKeys",
+              "httpMethod": "POST",
+              "description": "Creates a new HMAC key for the specified service account.",
+              "parameters": {
+                "projectId": {
+                  "type": "string",
+                  "description": "Project ID owning the service account.",
+                  "required": true,
+                  "location": "path"
+                },
+                "serviceAccountEmail": {
+                  "type": "string",
+                  "description": "Email address of the service account.",
+                  "required": true,
+                  "location": "query"
+                },
+                "userProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request.",
+                  "location": "query"
+                }
+              },
+              "parameterOrder": [
+                "projectId",
+                "serviceAccountEmail"
+              ],
+              "response": {
+                "$ref": "HmacKey"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/devstorage.full_control"
+              ]
+            },
+            "delete": {
+              "id": "storage.projects.hmacKeys.delete",
+              "path": "projects/{projectId}/hmacKeys/{accessId}",
+              "httpMethod": "DELETE",
+              "description": "Deletes an HMAC key.",
+              "parameters": {
+                "accessId": {
+                  "type": "string",
+                  "description": "Name of the HMAC key to be deleted.",
+                  "required": true,
+                  "location": "path"
+                },
+                "projectId": {
+                  "type": "string",
+                  "description": "Project ID owning the requested key",
+                  "required": true,
+                  "location": "path"
+                },
+                "userProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request.",
+                  "location": "query"
+                }
+              },
+              "parameterOrder": [
+                "projectId",
+                "accessId"
+              ],
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/devstorage.full_control",
+                "https://www.googleapis.com/auth/devstorage.read_write"
+              ]
+            },
+            "get": {
+              "id": "storage.projects.hmacKeys.get",
+              "path": "projects/{projectId}/hmacKeys/{accessId}",
+              "httpMethod": "GET",
+              "description": "Retrieves an HMAC key's metadata",
+              "parameters": {
+                "accessId": {
+                  "type": "string",
+                  "description": "Name of the HMAC key.",
+                  "required": true,
+                  "location": "path"
+                },
+                "projectId": {
+                  "type": "string",
+                  "description": "Project ID owning the service account of the requested key.",
+                  "required": true,
+                  "location": "path"
+                },
+                "userProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request.",
+                  "location": "query"
+                }
+              },
+              "parameterOrder": [
+                "projectId",
+                "accessId"
+              ],
+              "response": {
+                "$ref": "HmacKeyMetadata"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/devstorage.read_only"
+              ]
+            },
+            "list": {
+              "id": "storage.projects.hmacKeys.list",
+              "path": "projects/{projectId}/hmacKeys",
+              "httpMethod": "GET",
+              "description": "Retrieves a list of HMAC keys matching the criteria.",
+              "parameters": {
+                "maxResults": {
+                  "type": "integer",
+                  "description": "Maximum number of items to return in a single page of responses. The service uses this parameter or 250 items, whichever is smaller. The max number of items per page will also be limited by the number of distinct service accounts in the response. If the number of service accounts in a single response is too high, the page will truncated and a next page token will be returned.",
+                  "default": "250",
+                  "format": "uint32",
+                  "minimum": "0",
+                  "location": "query"
+                },
+                "pageToken": {
+                  "type": "string",
+                  "description": "A previously-returned page token representing part of the larger set of results to view.",
+                  "location": "query"
+                },
+                "projectId": {
+                  "type": "string",
+                  "description": "Name of the project in which to look for HMAC keys.",
+                  "required": true,
+                  "location": "path"
+                },
+                "serviceAccountEmail": {
+                  "type": "string",
+                  "description": "If present, only keys for the given service account are returned.",
+                  "location": "query"
+                },
+                "showDeletedKeys": {
+                  "type": "boolean",
+                  "description": "Whether or not to show keys in the DELETED state.",
+                  "location": "query"
+                },
+                "userProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request.",
+                  "location": "query"
+                }
+              },
+              "parameterOrder": [
+                "projectId"
+              ],
+              "response": {
+                "$ref": "HmacKeysMetadata"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/devstorage.full_control",
+                "https://www.googleapis.com/auth/devstorage.read_only"
+              ]
+            },
+            "update": {
+              "id": "storage.projects.hmacKeys.update",
+              "path": "projects/{projectId}/hmacKeys/{accessId}",
+              "httpMethod": "PUT",
+              "description": "Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.",
+              "parameters": {
+                "accessId": {
+                  "type": "string",
+                  "description": "Name of the HMAC key being updated.",
+                  "required": true,
+                  "location": "path"
+                },
+                "projectId": {
+                  "type": "string",
+                  "description": "Project ID owning the service account of the updated key.",
+                  "required": true,
+                  "location": "path"
+                },
+                "userProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request.",
+                  "location": "query"
+                }
+              },
+              "parameterOrder": [
+                "projectId",
+                "accessId"
+              ],
+              "request": {
+                "$ref": "HmacKeyMetadata"
+              },
+              "response": {
+                "$ref": "HmacKeyMetadata"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/devstorage.full_control"
+              ]
+            }
+          }
+        },
         "serviceAccount": {
           "methods": {
             "get": {
@@ -3789,6 +4341,11 @@
                   "description": "Project ID",
                   "required": true,
                   "location": "path"
+                },
+                "provisionalUserProject": {
+                  "type": "string",
+                  "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
+                  "location": "query"
                 },
                 "userProject": {
                   "type": "string",

--- a/Storage/src/CreatedHmacKey.php
+++ b/Storage/src/CreatedHmacKey.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+/**
+ * Represents a newly created HMAC key. Provides access to the key metadata and
+ * secret.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\Storage\StorageClient;
+ *
+ * $storage = new StorageClient();
+ * $response = $storage->createHmacKey($serviceAccountEmail);
+ * ```
+ */
+class CreatedHmacKey
+{
+    /**
+     * @var HmacKey
+     */
+    private $hmacKey;
+
+    /**
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * @param HmacKey $hmacKey The HMAC Key object.
+     * @param string $secret The HMAC key secret.
+     */
+    public function __construct(HmacKey $hmacKey, $secret)
+    {
+        $this->hmacKey = $hmacKey;
+        $this->secret = $secret;
+    }
+
+    /**
+     * Get the HMAC key object.
+     *
+     * Example:
+     * ```
+     * $key = $response->hmacKey();
+     * ```
+     *
+     * @return HmacKey
+     */
+    public function hmacKey()
+    {
+        return $this->hmacKey;
+    }
+
+    /**
+     * Get the HMAC key secret.
+     *
+     * This value will never be returned from the API after first creation. Make
+     * sure to record it for later use immediately upon key creation.
+     *
+     * Example:
+     * ```
+     * $secret = $response->secret();
+     * ```
+     *
+     * @return string
+     */
+    public function secret()
+    {
+        return $this->secret;
+    }
+}

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -50,7 +50,7 @@ class HmacKey
     /**
      * @var array|null
      */
-    private $metadata;
+    private $info;
 
     /**
      * @var string|null
@@ -61,20 +61,20 @@ class HmacKey
      * @param ConnectionInterface $connection A connection to Cloud Storage.
      * @param string $projectId The current project ID.
      * @param string $accessId The key identifier.
-     * @param array|null $metadata The key metadata.
+     * @param array|null $info The key metadata.
      * @param string|null $secret The key secret.
      */
     public function __construct(
         ConnectionInterface $connection,
         $projectId,
         $accessId,
-        array $metadata = [],
+        array $info = [],
         $secret = null
     ) {
         $this->connection = $connection;
         $this->projectId = $projectId;
         $this->accessId = $accessId;
-        $this->metadata = $metadata;
+        $this->info = $info;
         $this->secret = $secret;
     }
 
@@ -111,12 +111,12 @@ class HmacKey
      */
     public function reload(array $options = [])
     {
-        $this->metadata = $this->connection->getHmacKey([
+        $this->info = $this->connection->getHmacKey([
             'projectId' => $this->projectId,
             'accessId' => $this->accessId
         ] + $options);
 
-        return $this->metadata;
+        return $this->info;
     }
 
     /**
@@ -140,7 +140,7 @@ class HmacKey
      */
     public function info(array $options = [])
     {
-        return $this->metadata ?: $this->reload($options);
+        return $this->info ?: $this->reload($options);
     }
 
     /**
@@ -179,13 +179,13 @@ class HmacKey
      */
     public function update($state, array $options = [])
     {
-        $this->metadata = $this->connection->updateHmacKey([
+        $this->info = $this->connection->updateHmacKey([
             'accessId' => $this->accessId,
             'projectId' => $this->projectId,
             'state' => $state
         ] + $options);
 
-        return $this->metadata;
+        return $this->info;
     }
 
     /**

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -127,7 +127,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $keyMetadata = $hmacKey->metadata();
+     * $keyMetadata = $hmacKey->info();
      * ```
      *
      * @param array $options {
@@ -138,7 +138,7 @@ class HmacKey
      * }
      * @return array
      */
-    public function metadata(array $options = [])
+    public function info(array $options = [])
     {
         return $this->metadata ?: $this->reload($options);
     }

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -27,7 +27,7 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
  * use Google\Cloud\Storage\StorageClient;
  *
  * $storage = new StorageClient();
- * $key = $storage->hmacKey($accessId);
+ * $hmacKey = $storage->hmacKey($accessId);
  * ```
  */
 class HmacKey
@@ -83,7 +83,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $accessId = $key->accessId();
+     * $accessId = $hmacKey->accessId();
      * ```
      *
      * @return string
@@ -98,7 +98,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $keyMetadata = $key->reload();
+     * $keyMetadata = $hmacKey->reload();
      * ```
      *
      * @param array $options {
@@ -127,7 +127,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $keyMetadata = $key->metadata();
+     * $keyMetadata = $hmacKey->metadata();
      * ```
      *
      * @param array $options {
@@ -150,7 +150,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $secret = $key->secret();
+     * $secret = $hmacKey->secret();
      * ```
      *
      * @return string|null
@@ -165,7 +165,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $key->update('INACTIVE');
+     * $hmacKey->update('INACTIVE');
      * ```
      *
      * @param string $state The key state. Either `ACTIVE` or `INACTIVE`.
@@ -196,7 +196,7 @@ class HmacKey
      *
      * Example:
      * ```
-     * $key->delete();
+     * $hmacKey->delete();
      * ```
      *
      * @param array $options {

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -72,13 +72,29 @@ class HmacKey
         $secret = null
     ) {
         $this->connection = $connection;
-        $this->acessId = $accessId;
+        $this->projectId = $projectId;
+        $this->accessId = $accessId;
         $this->metadata = $metadata;
         $this->secret = $secret;
     }
 
     /**
-     * Fetch the key metadata from Cloud Storage
+     * Get the HMAC Key Access ID.
+     *
+     * Example:
+     * ```
+     * $accessId = $key->accessId();
+     * ```
+     *
+     * @return string
+     */
+    public function accessId()
+    {
+        return $this->accessId;
+    }
+
+    /**
+     * Fetch the key metadata from Cloud Storage.
      *
      * Example:
      * ```
@@ -141,11 +157,42 @@ class HmacKey
      */
     public function secret()
     {
-        return $this->hmacKey['secret'];
+        return $this->secret;
+    }
+
+    /**
+     * Update the HMAC Key state.
+     *
+     * Example:
+     * ```
+     * $key->update('INACTIVE');
+     * ```
+     *
+     * @param string $state The key state. Either `ACTIVE` or `INACTIVE`.
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $userProject If set, this is the ID of the project which
+     *           will be billed for the request.
+     * }
+     * @return array
+     */
+    public function update($state, array $options = [])
+    {
+        $this->metadata = $this->connection->updateHmacKey([
+            'accessId' => $this->accessId,
+            'projectId' => $this->projectId,
+            'state' => $state
+        ] + $options);
+
+        return $this->metadata;
     }
 
     /**
      * Delete the HMAC Key.
+     *
+     * Key state must be set to `INACTIVE` prior to deletion. See
+     * {@see Google\Cloud\Storage\HmacKey::update()} for details.
      *
      * Example:
      * ```
@@ -163,7 +210,8 @@ class HmacKey
     public function delete(array $options = [])
     {
         $this->connection->deleteHmacKey([
-            'accessId' => $this->accessId
+            'accessId' => $this->accessId,
+            'projectId' => $this->projectId,
         ] + $options);
     }
 }

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -53,29 +53,21 @@ class HmacKey
     private $info;
 
     /**
-     * @var string|null
-     */
-    private $secret;
-
-    /**
      * @param ConnectionInterface $connection A connection to Cloud Storage.
      * @param string $projectId The current project ID.
      * @param string $accessId The key identifier.
      * @param array|null $info The key metadata.
-     * @param string|null $secret The key secret.
      */
     public function __construct(
         ConnectionInterface $connection,
         $projectId,
         $accessId,
-        array $info = [],
-        $secret = null
+        array $info = []
     ) {
         $this->connection = $connection;
         $this->projectId = $projectId;
         $this->accessId = $accessId;
         $this->info = $info;
-        $this->secret = $secret;
     }
 
     /**
@@ -105,7 +97,8 @@ class HmacKey
      *     Configuration Options
      *
      *     @type string $userProject If set, this is the ID of the project which
-     *           will be billed for the request.
+     *           will be billed for the request. **NOTE**: This option is
+     *           currently ignored by Cloud Storage.
      * }
      * @return array
      */
@@ -134,30 +127,14 @@ class HmacKey
      *     Configuration Options
      *
      *     @type string $userProject If set, this is the ID of the project which
-     *           will be billed for the request.
+     *           will be billed for the request. **NOTE**: This option is
+     *           currently ignored by Cloud Storage.
      * }
      * @return array
      */
     public function info(array $options = [])
     {
         return $this->info ?: $this->reload($options);
-    }
-
-    /**
-     * Get the HMAC Key Secret.
-     *
-     * Only populated immediately after key creation.
-     *
-     * Example:
-     * ```
-     * $secret = $hmacKey->secret();
-     * ```
-     *
-     * @return string|null
-     */
-    public function secret()
-    {
-        return $this->secret;
     }
 
     /**
@@ -173,7 +150,8 @@ class HmacKey
      *     Configuration Options
      *
      *     @type string $userProject If set, this is the ID of the project which
-     *           will be billed for the request.
+     *           will be billed for the request. **NOTE**: This option is
+     *           currently ignored by Cloud Storage.
      * }
      * @return array
      */
@@ -203,7 +181,8 @@ class HmacKey
      *     Configuration Options
      *
      *     @type string $userProject If set, this is the ID of the project which
-     *           will be billed for the request.
+     *           will be billed for the request. **NOTE**: This option is
+     *           currently ignored by Cloud Storage.
      * }
      * @return void
      */

--- a/Storage/src/HmacKey.php
+++ b/Storage/src/HmacKey.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use Google\Cloud\Storage\Connection\ConnectionInterface;
+
+/**
+ * Represents a Service Account HMAC key.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\Storage\StorageClient;
+ *
+ * $storage = new StorageClient();
+ * $key = $storage->hmacKey($accessId);
+ * ```
+ */
+class HmacKey
+{
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $projectId;
+
+    /**
+     * @var string
+     */
+    private $accessId;
+
+    /**
+     * @var array|null
+     */
+    private $metadata;
+
+    /**
+     * @var string|null
+     */
+    private $secret;
+
+    /**
+     * @param ConnectionInterface $connection A connection to Cloud Storage.
+     * @param string $projectId The current project ID.
+     * @param string $accessId The key identifier.
+     * @param array|null $metadata The key metadata.
+     * @param string|null $secret The key secret.
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        $projectId,
+        $accessId,
+        array $metadata = [],
+        $secret = null
+    ) {
+        $this->connection = $connection;
+        $this->acessId = $accessId;
+        $this->metadata = $metadata;
+        $this->secret = $secret;
+    }
+
+    /**
+     * Fetch the key metadata from Cloud Storage
+     *
+     * Example:
+     * ```
+     * $keyMetadata = $key->reload();
+     * ```
+     *
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $userProject If set, this is the ID of the project which
+     *           will be billed for the request.
+     * }
+     * @return array
+     */
+    public function reload(array $options = [])
+    {
+        $this->metadata = $this->connection->getHmacKey([
+            'projectId' => $this->projectId,
+            'accessId' => $this->accessId
+        ] + $options);
+
+        return $this->metadata;
+    }
+
+    /**
+     * Get the HMAC Key Metadata.
+     *
+     * If the metadata is not already available, it will be requested from Cloud
+     * Storage.
+     *
+     * Example:
+     * ```
+     * $keyMetadata = $key->metadata();
+     * ```
+     *
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $userProject If set, this is the ID of the project which
+     *           will be billed for the request.
+     * }
+     * @return array
+     */
+    public function metadata(array $options = [])
+    {
+        return $this->metadata ?: $this->reload($options);
+    }
+
+    /**
+     * Get the HMAC Key Secret.
+     *
+     * Only populated immediately after key creation.
+     *
+     * Example:
+     * ```
+     * $secret = $key->secret();
+     * ```
+     *
+     * @return string|null
+     */
+    public function secret()
+    {
+        return $this->hmacKey['secret'];
+    }
+
+    /**
+     * Delete the HMAC Key.
+     *
+     * Example:
+     * ```
+     * $key->delete();
+     * ```
+     *
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $userProject If set, this is the ID of the project which
+     *           will be billed for the request.
+     * }
+     * @return void
+     */
+    public function delete(array $options = [])
+    {
+        $this->connection->deleteHmacKey([
+            'accessId' => $this->accessId
+        ] + $options);
+    }
+}

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -491,8 +491,8 @@ class StorageClient
      *
      * Example:
      * ```
-     * $hmacKey = $storage->createHmacKey('account@myProject.iam.gserviceaccount.com');
-     * $secret = $hmacKey->secret();
+     * $response = $storage->createHmacKey('account@myProject.iam.gserviceaccount.com');
+     * $secret = $response->secret();
      * ```
      *
      * @param string $serviceAccountEmail Email address of the service account.
@@ -500,9 +500,10 @@ class StorageClient
      *     Configuration Options
      *
      *     @type string $userProject If set, this is the ID of the project which
-     *           will be billed for the request.
+     *           will be billed for the request. **NOTE**: This option is
+     *           currently ignored by Cloud Storage.
      * }
-     * @return HmacKey
+     * @return CreatedHmacKey
      */
     public function createHmacKey($serviceAccountEmail, array $options = [])
     {
@@ -513,13 +514,14 @@ class StorageClient
             'serviceAccountEmail' => $serviceAccountEmail
         ] + $options);
 
-        return new HmacKey(
+        $key = new HmacKey(
             $this->connection,
             $this->projectId,
             $res['metadata']['accessId'],
-            $res['metadata'],
-            $res['secret']
+            $res['metadata']
         );
+
+        return new CreatedHmacKey($key, $res['secret']);
     }
 
     /**

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -428,7 +428,7 @@ class StorageClient
      * ```
      * // Get the HMAC keys associated with a Service Account email
      * $hmacKeys = $storage->hmacKeys([
-     *     'serviceAccountEmail' => 'account@myProject.iam.gserviceaccount.com'
+     *     'serviceAccountEmail' => $serviceAccountEmail
      * ]);
      * ```
      *

--- a/Storage/tests/Snippet/CreatedHmacKeyTest.php
+++ b/Storage/tests/Snippet/CreatedHmacKeyTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\Snippet;
+
+use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Storage\Connection\ConnectionInterface;
+use Google\Cloud\Storage\CreatedHmacKey;
+use Google\Cloud\Storage\HmacKey;
+use Google\Cloud\Storage\StorageClient;
+use Prophecy\Argument;
+
+/**
+ * @group storage
+ * @group storage-hmackey
+ */
+class CreatedHmacKeyTest extends SnippetTestCase
+{
+    const ACCESS_ID = 'aid';
+    const SECRET = 'secrettttt';
+
+    private $connection;
+    private $createdKey;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+
+        $this->createdKey = new CreatedHmacKey(
+            $this->prophesize(HmacKey::class)->reveal(),
+            self::SECRET
+        );
+    }
+
+    public function testClass()
+    {
+        $this->connection->createHmacKey(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'metadata' => [
+                    'foo' => 'bar',
+                    'accessId' => self::ACCESS_ID
+                ],
+                'secret' => self::SECRET
+            ]);
+
+        $client = TestHelpers::stub(StorageClient::class);
+        $client->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromClass(CreatedHmacKey::class);
+        $snippet->addLocal('serviceAccountEmail', 'foo@bar.com');
+        $snippet->replace('$storage = new StorageClient();', '');
+        $snippet->addLocal('storage', $client);
+
+        $res = $snippet->invoke('response');
+        $this->assertInstanceOf(CreatedHmacKey::class, $res->returnVal());
+    }
+
+    public function testHmacKey()
+    {
+        $snippet = $this->snippetFromMethod(CreatedHmacKey::class, 'hmacKey');
+        $snippet->addLocal('response', $this->createdKey);
+
+        $this->assertInstanceOf(
+            HmacKey::class,
+            $snippet->invoke('key')->returnVal()
+        );
+    }
+
+    public function testSecret()
+    {
+        $snippet = $this->snippetFromMethod(CreatedHmacKey::class, 'secret');
+        $snippet->addLocal('response', $this->createdKey);
+
+        $this->assertEquals(
+            self::SECRET,
+            $snippet->invoke('secret')->returnVal()
+        );
+    }
+}

--- a/Storage/tests/Snippet/HmacKeyTest.php
+++ b/Storage/tests/Snippet/HmacKeyTest.php
@@ -41,8 +41,6 @@ class HmacKeyTest extends SnippetTestCase
 
     private $secret = 'bar';
 
-
-
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
@@ -85,9 +83,9 @@ class HmacKeyTest extends SnippetTestCase
         $this->assertEquals($newMetadata, $res->returnVal());
     }
 
-    public function testMetadata()
+    public function testInfo()
     {
-        $snippet = $this->snippetFromMethod(HmacKey::class, 'metadata');
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'info');
         $snippet->addLocal('hmacKey', $this->key);
 
         $this->assertEquals($this->metadata, $snippet->invoke('keyMetadata')->returnVal());

--- a/Storage/tests/Snippet/HmacKeyTest.php
+++ b/Storage/tests/Snippet/HmacKeyTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\Snippet;
+
+use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Storage\Connection\ConnectionInterface;
+use Google\Cloud\Storage\HmacKey;
+use Prophecy\Argument;
+
+/**
+ * @group storage
+ * @group storage-hmackey
+ */
+class HmacKeyTest extends SnippetTestCase
+{
+    const PROJECT = 'project';
+
+    private $connection;
+
+    private $key;
+
+    private $metadata = [
+        'accessId' => 'foo'
+    ];
+
+    private $secret = 'bar';
+
+
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+
+        $this->key = TestHelpers::stub(HmacKey::class, [
+            $this->connection->reveal(),
+            self::PROJECT,
+            $this->metadata['accessId'],
+            $this->metadata,
+            $this->secret
+        ]);
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(HmacKey::class);
+        $snippet->addLocal('accessId', 'foo');
+        $res = $snippet->invoke('hmacKey');
+        $this->assertInstanceOf(HmacKey::class, $res->returnVal());
+    }
+
+    public function testAccessId()
+    {
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'accessId');
+        $snippet->addLocal('hmacKey', $this->key);
+
+        $res = $snippet->invoke('accessId');
+        $this->assertEquals($this->metadata['accessId'], $res->returnVal());
+    }
+
+    public function testReload()
+    {
+        $newMetadata = array_merge($this->metadata, ['foo' => 'bar']);
+        $this->connection->getHmacKey(Argument::any())->willReturn($newMetadata);
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'reload');
+        $snippet->addLocal('hmacKey', $this->key);
+        $res = $snippet->invoke('keyMetadata');
+        $this->assertEquals($newMetadata, $res->returnVal());
+    }
+
+    public function testMetadata()
+    {
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'metadata');
+        $snippet->addLocal('hmacKey', $this->key);
+
+        $this->assertEquals($this->metadata, $snippet->invoke('keyMetadata')->returnVal());
+    }
+
+    public function testSecret()
+    {
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'secret');
+        $snippet->addLocal('hmacKey', $this->key);
+
+        $this->assertEquals($this->secret, $snippet->invoke('secret')->returnVal());
+    }
+
+    public function testUpdate()
+    {
+        $this->connection->updateHmacKey(Argument::withEntry('state', 'INACTIVE'))
+            ->willReturn($this->metadata);
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'update');
+        $snippet->addLocal('hmacKey', $this->key);
+
+        $snippet->invoke();
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteHmacKey(Argument::any())
+            ->willReturn(null);
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(HmacKey::class, 'delete');
+        $snippet->addLocal('hmacKey', $this->key);
+
+        $snippet->invoke();
+    }
+}

--- a/Storage/tests/Snippet/HmacKeyTest.php
+++ b/Storage/tests/Snippet/HmacKeyTest.php
@@ -39,8 +39,6 @@ class HmacKeyTest extends SnippetTestCase
         'accessId' => 'foo'
     ];
 
-    private $secret = 'bar';
-
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
@@ -49,8 +47,7 @@ class HmacKeyTest extends SnippetTestCase
             $this->connection->reveal(),
             self::PROJECT,
             $this->metadata['accessId'],
-            $this->metadata,
-            $this->secret
+            $this->metadata
         ]);
     }
 
@@ -89,14 +86,6 @@ class HmacKeyTest extends SnippetTestCase
         $snippet->addLocal('hmacKey', $this->key);
 
         $this->assertEquals($this->metadata, $snippet->invoke('keyMetadata')->returnVal());
-    }
-
-    public function testSecret()
-    {
-        $snippet = $this->snippetFromMethod(HmacKey::class, 'secret');
-        $snippet->addLocal('hmacKey', $this->key);
-
-        $this->assertEquals($this->secret, $snippet->invoke('secret')->returnVal());
     }
 
     public function testUpdate()

--- a/Storage/tests/System/HmacKeyTest.php
+++ b/Storage/tests/System/HmacKeyTest.php
@@ -40,15 +40,15 @@ class HmacKeyTest extends StorageTestCase
 
     public function testKeyLifecycle()
     {
-        $key = $this->createHmacKey(self::$serviceAccountEmail);
-        $this->assertEquals('ACTIVE', $key->info()['state']);
-        $this->assertNotNull($key->secret());
+        $res = $this->createHmacKey(self::$serviceAccountEmail);
+        $this->assertEquals('ACTIVE', $res->hmacKey()->info()['state']);
+        $this->assertNotNull($res->secret());
 
-        $this->assertHasKey($key->accessId());
+        $this->assertHasKey($res->hmacKey()->accessId());
 
-        $this->deleteKey($key);
+        $this->deleteKey($res->hmacKey());
 
-        $this->assertNotHasKey($key->accessId());
+        $this->assertNotHasKey($res->hmacKey()->accessId());
     }
 
     public function testListWithServiceAccountEmail()
@@ -64,17 +64,17 @@ class HmacKeyTest extends StorageTestCase
             true
         )['client_email'];
 
-        $key1 = $this->createHmacKey(self::$serviceAccountEmail);
-        $key2 = $this->createHmacKey($altServiceAccountEmail);
+        $res1 = $this->createHmacKey(self::$serviceAccountEmail);
+        $res2 = $this->createHmacKey($altServiceAccountEmail);
 
-        $this->assertHasKey($key1->accessId());
-        $this->assertHasKey($key2->accessId());
+        $this->assertHasKey($res1->hmacKey()->accessId());
+        $this->assertHasKey($res2->hmacKey()->accessId());
 
-        $this->assertNotHasKey($key1->accessId(), $altServiceAccountEmail);
-        $this->assertHasKey($key2->accessId(), $altServiceAccountEmail);
+        $this->assertNotHasKey($res1->hmacKey()->accessId(), $altServiceAccountEmail);
+        $this->assertHasKey($res2->hmacKey()->accessId(), $altServiceAccountEmail);
 
-        $this->deleteKey($key1);
-        $this->deleteKey($key2);
+        $this->deleteKey($res1->hmacKey());
+        $this->deleteKey($res2->hmacKey());
     }
 
     public function testListMaxResultsAndPage()
@@ -128,7 +128,7 @@ class HmacKeyTest extends StorageTestCase
      * try again.
      *
      * @param string $serviceAccountEmail
-     * @return HmacKey
+     * @return CreatedHmacKey
      */
     private function createHmacKey($serviceAccountEmail)
     {

--- a/Storage/tests/System/HmacKeyTest.php
+++ b/Storage/tests/System/HmacKeyTest.php
@@ -41,7 +41,7 @@ class HmacKeyTest extends StorageTestCase
     public function testKeyLifecycle()
     {
         $key = $this->createHmacKey(self::$serviceAccountEmail);
-        $this->assertEquals('ACTIVE', $key->metadata()['state']);
+        $this->assertEquals('ACTIVE', $key->info()['state']);
         $this->assertNotNull($key->secret());
 
         $this->assertHasKey($key->accessId());

--- a/Storage/tests/System/HmacKeyTest.php
+++ b/Storage/tests/System/HmacKeyTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\System;
+
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Storage\HmacKey;
+
+/**
+ * @group storage
+ * @group storage-hmac
+ */
+class HmacKeyTest extends StorageTestCase
+{
+    private static $serviceAccountEmail;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        self::$serviceAccountEmail = json_decode(
+            file_get_contents(getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH')),
+            true
+        )['client_email'];
+    }
+
+    public function testKeyLifecycle()
+    {
+        $key = $this->createHmacKey(self::$serviceAccountEmail);
+        $this->assertEquals('ACTIVE', $key->metadata()['state']);
+        $this->assertNotNull($key->secret());
+
+        $this->assertHasKey($key->accessId());
+
+        $this->deleteKey($key);
+
+        $this->assertNotHasKey($key->accessId());
+    }
+
+    public function testListWithServiceAccountEmail()
+    {
+        $altServiceAccount = getenv('GOOGLE_CLOUD_PHP_TESTS_ALT_KEY_PATH');
+        if (!$altServiceAccount) {
+            $this->markTestSkipped('Must provide `GOOGLE_CLOUD_PHP_TESTS_ALT_KEY_PATH` to run this test.');
+            return;
+        }
+
+        $altServiceAccountEmail = json_decode(
+            file_get_contents($altServiceAccount),
+            true
+        )['client_email'];
+
+        $key1 = $this->createHmacKey(self::$serviceAccountEmail);
+        $key2 = $this->createHmacKey($altServiceAccountEmail);
+
+        $this->assertHasKey($key1->accessId());
+        $this->assertHasKey($key2->accessId());
+
+        $this->assertNotHasKey($key1->accessId(), $altServiceAccountEmail);
+        $this->assertHasKey($key2->accessId(), $altServiceAccountEmail);
+
+        $this->deleteKey($key1);
+        $this->deleteKey($key2);
+    }
+
+    public function testListMaxResultsAndPage()
+    {
+        $this->flushKeys(self::$serviceAccountEmail);
+
+        for ($i = 0; $i < 5; $i++) {
+            self::$client->createHmacKey(self::$serviceAccountEmail);
+        }
+
+        $keys = self::$client->hmacKeys(['maxResults' => 2]);
+        $pages = $keys->iterateByPage();
+        $currentPage = $pages->current();
+        $this->assertCount(2, $currentPage);
+        $this->assertNotNull($pages->nextResultToken());
+    }
+
+    private function assertNotHasKey($accessId, $serviceAccountEmail = null)
+    {
+        return $this->runAssertHasKey('assertEmpty', $accessId, $serviceAccountEmail);
+    }
+
+    private function assertHasKey($accessId, $serviceAccountEmail = null)
+    {
+        return $this->runAssertHasKey('assertNotEmpty', $accessId, $serviceAccountEmail);
+    }
+
+    private function runAssertHasKey($assertion, $accessId, $serviceAccountEmail)
+    {
+        $opts = $serviceAccountEmail
+            ? ['serviceAccountEmail' => $serviceAccountEmail]
+            : [];
+
+        $allKeys = iterator_to_array(self::$client->hmacKeys($opts));
+        $this->$assertion(array_filter($allKeys, function ($key) use ($accessId) {
+            return $key->accessId() === $accessId;
+        }));
+    }
+
+    private function deleteKey(HmacKey $key)
+    {
+        $key->update('INACTIVE');
+        $key->delete();
+    }
+
+    /**
+     * Create HMAC key with flush and retry if quotas are exceeded.
+     *
+     * Quotas for each service account are low, and thus the test is subject to
+     * quickly exceeding these limits. If the limits are hit, clear the keys and
+     * try again.
+     *
+     * @param string $serviceAccountEmail
+     * @return HmacKey
+     */
+    private function createHmacKey($serviceAccountEmail)
+    {
+        try {
+            return self::$client->createHmacKey($serviceAccountEmail);
+        } catch (ServiceException $e) {
+            $this->flushKeys($serviceAccountEmail);
+
+            return $this->createHmacKey($serviceAccountEmail);
+        }
+    }
+
+    private function flushKeys($serviceAccountEmail)
+    {
+        foreach (self::$client->hmacKeys(['serviceAccountEmail' => $serviceAccountEmail]) as $key) {
+            $key->update('INACTIVE');
+            $key->delete();
+        }
+    }
+}

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -118,7 +118,12 @@ class RestTest extends TestCase
             ['insertNotification'],
             ['listNotifications'],
             ['getServiceAccount'],
-            ['lockRetentionPolicy']
+            ['lockRetentionPolicy'],
+            ['createHmacKey'],
+            ['deleteHmacKey'],
+            ['getHmacKey'],
+            ['updateHmacKey'],
+            ['listHmacKeys'],
         ];
     }
 

--- a/Storage/tests/Unit/CreatedHmacKeyTest.php
+++ b/Storage/tests/Unit/CreatedHmacKeyTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\Unit;
+
+use Google\Cloud\Storage\CreatedHmacKey;
+use Google\Cloud\Storage\HmacKey;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group storage
+ * @group storage-hmackey
+ */
+class CreatedHmacKeyTest extends TestCase
+{
+    const ACCESS_ID = 'aid';
+    const SECRET = 'secrettttt';
+
+    private $createdKey;
+
+    public function setUp()
+    {
+        $this->createdKey = new CreatedHmacKey(
+            $this->prophesize(HmacKey::class)->reveal(),
+            self::SECRET
+        );
+    }
+
+    public function testHmacKey()
+    {
+        $this->assertInstanceOf(HmacKey::class, $this->createdKey->hmacKey());
+    }
+
+    public function testSecret()
+    {
+        $this->assertEquals(self::SECRET, $this->createdKey->secret());
+    }
+}

--- a/Storage/tests/Unit/HmacKeyTest.php
+++ b/Storage/tests/Unit/HmacKeyTest.php
@@ -73,7 +73,7 @@ class HmacKeyTest extends TestCase
         $this->key->reload();
     }
 
-    public function testMetadata()
+    public function testInfo()
     {
         $this->connection->getHmacKey([
             'projectId' => self::PROJECT,
@@ -83,19 +83,19 @@ class HmacKeyTest extends TestCase
         $this->key->___setProperty('connection', $this->connection->reveal());
         $this->key->___setProperty('metadata', []);
 
-        $this->assertEquals($this->metadata, $this->key->metadata());
+        $this->assertEquals($this->metadata, $this->key->info());
 
         // Test that the 2nd call uses cached result.
-        $this->assertEquals($this->metadata, $this->key->metadata());
+        $this->assertEquals($this->metadata, $this->key->info());
     }
 
-    public function testMetadataCached()
+    public function testInfoCached()
     {
         $this->connection->getHmacKey(Argument::any())
             ->shouldNotBeCalled();
 
         $this->key->___setProperty('connection', $this->connection->reveal());
-        $this->assertEquals($this->metadata, $this->key->metadata());
+        $this->assertEquals($this->metadata, $this->key->info());
     }
 
     public function testGetSecret()
@@ -123,7 +123,7 @@ class HmacKeyTest extends TestCase
 
         $res = $this->key->update($state);
         $this->assertEquals($newMetadata, $res);
-        $this->assertEquals($newMetadata, $this->key->metadata());
+        $this->assertEquals($newMetadata, $this->key->info());
     }
 
     public function testDelete()

--- a/Storage/tests/Unit/HmacKeyTest.php
+++ b/Storage/tests/Unit/HmacKeyTest.php
@@ -50,7 +50,7 @@ class HmacKeyTest extends TestCase
             $this->metadata['accessId'],
             $this->metadata,
             $this->secret
-        ], ['connection', 'metadata', 'secret']);
+        ], ['connection', 'info', 'secret']);
     }
 
     public function testAccessId()
@@ -81,7 +81,7 @@ class HmacKeyTest extends TestCase
         ])->shouldBeCalledTimes(1)->willReturn($this->metadata);
 
         $this->key->___setProperty('connection', $this->connection->reveal());
-        $this->key->___setProperty('metadata', []);
+        $this->key->___setProperty('info', []);
 
         $this->assertEquals($this->metadata, $this->key->info());
 

--- a/Storage/tests/Unit/HmacKeyTest.php
+++ b/Storage/tests/Unit/HmacKeyTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\Unit;
+
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Storage\Connection\ConnectionInterface;
+use Google\Cloud\Storage\HmacKey;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+/**
+ * @group storage
+ * @group storage-hmackey
+ */
+class HmacKeyTest extends TestCase
+{
+    const PROJECT = 'project';
+
+    private $connection;
+
+    private $key;
+
+    private $metadata = [
+        'accessId' => 'foo'
+    ];
+
+    private $secret = 'bar';
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->key = TestHelpers::stub(HmacKey::class, [
+            $this->connection->reveal(),
+            self::PROJECT,
+            $this->metadata['accessId'],
+            $this->metadata,
+            $this->secret
+        ], ['connection', 'metadata', 'secret']);
+    }
+
+    public function testAccessId()
+    {
+        $this->assertEquals($this->metadata['accessId'], $this->key->accessId());
+    }
+
+    public function testReload()
+    {
+        $this->connection->getHmacKey([
+            'projectId' => self::PROJECT,
+            'accessId' => $this->metadata['accessId']
+        ])->shouldBeCalledTimes(2)->willReturn($this->metadata);
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertEquals($this->metadata, $this->key->reload());
+
+        // Make sure reload() always runs a service call.
+        $this->key->reload();
+    }
+
+    public function testMetadata()
+    {
+        $this->connection->getHmacKey([
+            'projectId' => self::PROJECT,
+            'accessId' => $this->metadata['accessId']
+        ])->shouldBeCalledTimes(1)->willReturn($this->metadata);
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+        $this->key->___setProperty('metadata', []);
+
+        $this->assertEquals($this->metadata, $this->key->metadata());
+
+        // Test that the 2nd call uses cached result.
+        $this->assertEquals($this->metadata, $this->key->metadata());
+    }
+
+    public function testMetadataCached()
+    {
+        $this->connection->getHmacKey(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+        $this->assertEquals($this->metadata, $this->key->metadata());
+    }
+
+    public function testGetSecret()
+    {
+        $this->assertEquals($this->secret, $this->key->secret());
+    }
+
+    public function testGetSecretNull()
+    {
+        $this->key->___setProperty('secret', null);
+        $this->assertNull($this->key->secret());
+    }
+
+    public function testUpdate()
+    {
+        $state = 'INACTIVE';
+        $newMetadata = array_merge($this->metadata, ['state' => $state]);
+        $this->connection->updateHmacKey([
+            'accessId' => $this->metadata['accessId'],
+            'projectId' => self::PROJECT,
+            'state' => $state
+        ])->shouldBeCalled()->willReturn($newMetadata);
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->key->update($state);
+        $this->assertEquals($newMetadata, $res);
+        $this->assertEquals($newMetadata, $this->key->metadata());
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteHmacKey([
+            'accessId' => $this->metadata['accessId'],
+            'projectId' => self::PROJECT
+        ])->shouldBeCalled();
+
+        $this->key->___setProperty('connection', $this->connection->reveal());
+
+        $this->key->delete();
+    }
+}

--- a/Storage/tests/Unit/HmacKeyTest.php
+++ b/Storage/tests/Unit/HmacKeyTest.php
@@ -39,8 +39,6 @@ class HmacKeyTest extends TestCase
         'accessId' => 'foo'
     ];
 
-    private $secret = 'bar';
-
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
@@ -48,9 +46,8 @@ class HmacKeyTest extends TestCase
             $this->connection->reveal(),
             self::PROJECT,
             $this->metadata['accessId'],
-            $this->metadata,
-            $this->secret
-        ], ['connection', 'info', 'secret']);
+            $this->metadata
+        ], ['connection', 'info']);
     }
 
     public function testAccessId()
@@ -96,17 +93,6 @@ class HmacKeyTest extends TestCase
 
         $this->key->___setProperty('connection', $this->connection->reveal());
         $this->assertEquals($this->metadata, $this->key->info());
-    }
-
-    public function testGetSecret()
-    {
-        $this->assertEquals($this->secret, $this->key->secret());
-    }
-
-    public function testGetSecretNull()
-    {
-        $this->key->___setProperty('secret', null);
-        $this->assertNull($this->key->secret());
     }
 
     public function testUpdate()

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\Rest;
+use Google\Cloud\Storage\HmacKey;
 use Google\Cloud\Storage\Lifecycle;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StreamWrapper;
@@ -31,6 +32,7 @@ use Prophecy\Argument;
 
 /**
  * @group storage
+ * @group storage-client
  */
 class StorageClientTest extends TestCase
 {
@@ -56,19 +58,6 @@ class StorageClientTest extends TestCase
         $bucket = $this->client->bucket('myBucket', true);
 
         $bucket->reload();
-    }
-
-    /**
-     * @expectedException \Google\Cloud\Core\Exception\GoogleException
-     */
-    public function testGetsBucketsThrowsExceptionWithoutProjectId()
-    {
-        $project = getenv('GCLOUD_PROJECT');
-        putenv('GCLOUD_PROJECT');
-        $keyFilePath = __DIR__ . '/../fixtures/empty-json-key-fixture.json';
-        $client = new StorageClientStub(['keyFilePath' => $keyFilePath]);
-        $client->buckets();
-        putenv("GCLOUD_PROJECT=$project");
     }
 
     public function testGetsBucketsWithoutToken()
@@ -108,19 +97,6 @@ class StorageClientTest extends TestCase
         $bucket = iterator_to_array($this->client->buckets());
 
         $this->assertEquals('bucket2', $bucket[1]->name());
-    }
-
-    /**
-     * @expectedException \Google\Cloud\Core\Exception\GoogleException
-     */
-    public function testCreateBucketThrowsExceptionWithoutProjectId()
-    {
-        $project = getenv('GCLOUD_PROJECT');
-        putenv('GCLOUD_PROJECT');
-        $keyFilePath = __DIR__ . '/../fixtures/empty-json-key-fixture.json';
-        $client = new StorageClientStub(['keyFilePath' => $keyFilePath]);
-        $client->createBucket('bucket');
-        putenv("GCLOUD_PROJECT=$project");
     }
 
     public function testCreatesBucket()
@@ -201,6 +177,87 @@ class StorageClientTest extends TestCase
             $this->client->getServiceAccount(['userProject' => self::PROJECT]),
             $expectedServiceAccount
         );
+    }
+
+    public function testHmacKeys()
+    {
+        $accessId = 'foo';
+        $email = 'foo@bar.com';
+
+        $this->connection->listHmacKeys([
+            'projectId' => self::PROJECT,
+            'serviceAccountEmail' => $email
+        ])->shouldBeCalled()->willReturn([
+            'items' => [
+                [
+                    'accessId' => $accessId
+                ]
+            ]
+        ]);
+
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $key = iterator_to_array($this->client->hmacKeys([
+            'serviceAccountEmail' => $email
+        ]))[0];
+
+        $this->assertEquals($accessId, $key->accessId());
+        $this->assertEquals(['accessId' => $accessId], $key->metadata());
+        $this->assertNull($key->secret());
+    }
+
+    public function testHmacKey()
+    {
+        $res = $this->client->hmacKey('foo');
+        $this->assertInstanceOf(HmacKey::class, $res);
+        $this->assertEquals('foo', $res->accessId());
+    }
+
+    public function testCreateHmacKey()
+    {
+        $email = 'foo@bar.com';
+        $secret = 'foo';
+        $accessId = 'bar';
+        $this->connection->createHmacKey([
+            'projectId' => self::PROJECT,
+            'serviceAccountEmail' => $email
+        ])->shouldBeCalled()->willReturn([
+            'secret' => $secret,
+            'metadata' => [
+                'accessId' => $accessId
+            ]
+        ]);
+
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->client->createHmacKey($email);
+        $this->assertInstanceOf(HmacKey::class, $res);
+        $this->assertEquals($secret, $res->secret());
+        $this->assertEquals($accessId, $res->accessId());
+        $this->assertEquals(['accessId' => $accessId], $res->metadata());
+    }
+
+    /**
+     * @expectedException Google\Cloud\Core\Exception\GoogleException
+     * @dataProvider requiresProjectIdMethods
+     */
+    public function testMethodsFailWithoutProjectId($method, array $args = [])
+    {
+        $client = TestHelpers::stub(StorageClientStub::class, [], ['projectId']);
+        $client->___setProperty('projectId', null);
+
+        call_user_func_array([$client, $method], $args);
+    }
+
+    public function requiresProjectIdMethods()
+    {
+        return [
+            ['buckets'],
+            ['createBucket', ['foo']],
+            ['hmacKeys'],
+            ['hmacKey', ['foo']],
+            ['createHmacKey', ['foo']]
+        ];
     }
 }
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\Rest;
+use Google\Cloud\Storage\CreatedHmacKey;
 use Google\Cloud\Storage\HmacKey;
 use Google\Cloud\Storage\Lifecycle;
 use Google\Cloud\Storage\StorageClient;
@@ -203,7 +204,6 @@ class StorageClientTest extends TestCase
 
         $this->assertEquals($accessId, $key->accessId());
         $this->assertEquals(['accessId' => $accessId], $key->info());
-        $this->assertNull($key->secret());
     }
 
     public function testHmacKey()
@@ -231,10 +231,10 @@ class StorageClientTest extends TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
 
         $res = $this->client->createHmacKey($email);
-        $this->assertInstanceOf(HmacKey::class, $res);
+        $this->assertInstanceOf(CreatedHmacKey::class, $res);
         $this->assertEquals($secret, $res->secret());
-        $this->assertEquals($accessId, $res->accessId());
-        $this->assertEquals(['accessId' => $accessId], $res->info());
+        $this->assertEquals($accessId, $res->hmacKey()->accessId());
+        $this->assertEquals(['accessId' => $accessId], $res->hmacKey()->info());
     }
 
     /**

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -202,7 +202,7 @@ class StorageClientTest extends TestCase
         ]))[0];
 
         $this->assertEquals($accessId, $key->accessId());
-        $this->assertEquals(['accessId' => $accessId], $key->metadata());
+        $this->assertEquals(['accessId' => $accessId], $key->info());
         $this->assertNull($key->secret());
     }
 
@@ -234,7 +234,7 @@ class StorageClientTest extends TestCase
         $this->assertInstanceOf(HmacKey::class, $res);
         $this->assertEquals($secret, $res->secret());
         $this->assertEquals($accessId, $res->accessId());
-        $this->assertEquals(['accessId' => $accessId], $res->metadata());
+        $this->assertEquals(['accessId' => $accessId], $res->info());
     }
 
     /**


### PR DESCRIPTION
Closes #1868.

This change adds support for service account HMAC keys.

The change adds a new `Google\Cloud\Storage\HmacKey` class, which represents a single HMAC key. It also adds list, create and instantiate methods for HMAC keys to `Google\Cloud\Storage\StorageClient`.