### PR TITLE
Add Collection Group Query support

### DIFF
--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -57,6 +57,7 @@ class Grpc implements ConnectionInterface
      */
     public function __construct(array $config = [])
     {
+        //@codeCoverageIgnoreStart
         $this->serializer = new Serializer([], [
             'google.protobuf.Value' => function ($v) {
                 return $this->flattenValue($v);
@@ -71,16 +72,19 @@ class Grpc implements ConnectionInterface
                 return $this->formatTimestampFromApi($v);
             },
         ]);
+        //@codeCoverageIgnoreEnd
 
         $config['serializer'] = $this->serializer;
         $this->setRequestWrapper(new GrpcRequestWrapper($config));
 
+        //@codeCoverageIgnoreStart
         $grpcConfig = $this->getGaxConfig(
             ManualFirestoreClient::VERSION,
             isset($config['authHttpHandler'])
                 ? $config['authHttpHandler']
                 : null
         );
+        //@codeCoverageIgnoreEnd
 
         //@codeCoverageIgnoreStart
         $config += ['emulatorHost' => null];

--- a/Firestore/src/FieldPath.php
+++ b/Firestore/src/FieldPath.php
@@ -58,6 +58,23 @@ class FieldPath
     }
 
     /**
+     * Create a field path indicating the document ID.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\Firestore\FieldPath;
+     *
+     * $path = FieldPath::documentId();
+     * ```
+     *
+     * @return FieldPath
+     */
+    public static function documentId()
+    {
+        return new self(['__name__']);
+    }
+
+    /**
      * Create a FieldPath from a string path.
      *
      * Example:

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -326,6 +326,50 @@ class FirestoreClient
     }
 
     /**
+     * Creates a new Query which includes all documents that are contained in
+     * a collection or subcollection with the given collection ID.
+     *
+     * A collection group query with a collection ID of `foo` will return
+     * documents from `/foo` and `/abc/dce/foo`, but not `/foo/bar`.
+     *
+     * Example:
+     * ```
+     * $query = $firestore->collectionGroup('users');
+     * $querySnapshot = $query->documents();
+     *
+     * echo sprintf('Found %d documents!', $querySnapshot->size());
+     * ```
+     *
+     * @param string $collectionId Identifies the collection to query over.
+     *        Every collection or subcollection with this ID as the last segment
+     *        of its path will be included. May not contain a slash.
+     * @return Query
+     * @throws InvalidArgumentException If the collection ID is not well-formed.
+     */
+    public function collectionGroup($collectionId)
+    {
+        if (strpos($collectionId, '/') !== false) {
+            throw new \InvalidArgumentException(
+                'Collection ID may not contain a slash.'
+            );
+        }
+
+        return new Query(
+            $this->connection,
+            $this->valueMapper,
+            $this->fullName($this->projectId, $this->database),
+            [
+                'from' => [
+                    [
+                        'collectionId' => $collectionId,
+                        'allDescendants' => true
+                    ]
+                ]
+            ]
+        );
+    }
+
+    /**
      * Executes a function in a Firestore transaction.
      *
      * Transactions offer atomic operations, guaranteeing that either all

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -340,15 +340,15 @@ class FirestoreClient
      * echo sprintf('Found %d documents!', $querySnapshot->size());
      * ```
      *
-     * @param string $collectionId Identifies the collection to query over.
-     *        Every collection or subcollection with this ID as the last segment
-     *        of its path will be included. May not contain a slash.
+     * @param string $id Identifies the collection to query over. Every
+     *        collection or subcollection with this ID as the last segment of
+     *        its path will be included. May not contain a slash.
      * @return Query
      * @throws InvalidArgumentException If the collection ID is not well-formed.
      */
-    public function collectionGroup($collectionId)
+    public function collectionGroup($id)
     {
-        if (strpos($collectionId, '/') !== false) {
+        if (strpos($id, '/') !== false) {
             throw new \InvalidArgumentException(
                 'Collection ID may not contain a slash.'
             );
@@ -361,7 +361,7 @@ class FirestoreClient
             [
                 'from' => [
                     [
-                        'collectionId' => $collectionId,
+                        'collectionId' => $id,
                         'allDescendants' => true
                     ]
                 ]

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -330,7 +330,7 @@ class FirestoreClient
      * a collection or subcollection with the given collection ID.
      *
      * A collection group query with a collection ID of `foo` will return
-     * documents from `/foo` and `/abc/dce/foo`, but not `/foo/bar`.
+     * documents from `/foo` and `/abc/dce/foo`, but not `/foo/abc/dce`.
      *
      * Example:
      * ```

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -317,12 +317,6 @@ class Query
 
         if ($escapedPathString === self::DOCUMENT_ID) {
             $value = $this->createDocumentReference($basePath, $value);
-
-            if (!$value) {
-                throw new \InvalidArgumentException(
-                    'When filtering on document ID, value must be a document reference or valid document name.'
-                );
-            }
         }
 
         if ((is_float($value) && is_nan($value)) || is_null($value)) {
@@ -653,12 +647,6 @@ class Query
             if ($orderBy[$i]['field']['fieldPath'] === self::DOCUMENT_ID) {
                 if (is_string($value)) {
                     $value = $this->createDocumentReference($basePath, $value);
-
-                    if ($value === false) {
-                        throw new \InvalidArgumentException(
-                            'When ordering by document ID, value must be a document reference or valid document name.'
-                        );
-                    }
                 } else {
                     if ($value instanceof DocumentReference) {
                         $name = $value->name();
@@ -846,7 +834,8 @@ class Query
      *
      * @param string $basePath The relative base of the document reference.
      * @param mixed $document The document.
-     * @return DocumentReference|bool
+     * @return DocumentReference
+     * @throws InvalidArgumentException If $document is not a valid document.
      */
     private function createDocumentReference($basePath, $document)
     {
@@ -854,13 +843,16 @@ class Query
             return $document;
         }
 
+        $exceptionMessage = 'When ordering or filtering by document ID, ' .
+            'value must be a document reference or valid document name.';
+
         if (!is_string($document)) {
-            return false;
+            throw new \InvalidArgumentException($exceptionMessage);
         }
 
         $childPath = $this->childPath($basePath, $document);
         if (!$this->isDocument($childPath)) {
-            return false;
+            throw new \InvalidArgumentException($exceptionMessage);
         }
 
         $parent = new CollectionReference(

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -230,24 +230,7 @@ trait SnapshotTrait
         $name
     ) {
         if ($this->isRelative($name)) {
-            try {
-                $name = $this->fullName($projectId, $database, $name);
-            } catch (ValidationException $e) {
-                // The GAPIC parser does not support special characters in paths,
-                // but Firestore does. If an exception is raised by the parser,
-                // we'll check for special characters. If they exist, we'll
-                // manually construct a document path.
-                $hasSpecialChars = preg_match('/[!@#$%^&*(),.?":{}|<>]/', $name) === 1;
-
-                //@codeCoverageIgnoreStart
-                if (!$hasSpecialChars) {
-                    throw $e;
-                }
-                //@codeCoverageIgnoreEnd
-
-                $base = $this->databaseName($projectId, $database);
-                $name = $base .'/documents/'. $name;
-            }
+            $name = $this->fullName($projectId, $database, $name);
         }
 
         if (!$this->isDocument($name)) {

--- a/Firestore/tests/Snippet/CollectionReferenceTest.php
+++ b/Firestore/tests/Snippet/CollectionReferenceTest.php
@@ -37,7 +37,6 @@ class CollectionReferenceTest extends SnippetTestCase
 
     const PROJECT = 'example_project';
     const DATABASE = '(default)';
-    const PARENT = 'projects/example_project/databases/(default)/documents';
     const NAME = 'projects/example_project/databases/(default)/documents/users';
 
     private $connection;

--- a/Firestore/tests/Snippet/FieldPathTest.php
+++ b/Firestore/tests/Snippet/FieldPathTest.php
@@ -45,6 +45,14 @@ class FieldPathTest extends SnippetTestCase
         $this->assertInstanceOf(FieldPath::class, $res->returnVal());
     }
 
+    public function testDocumentId()
+    {
+        $snippet = $this->snippetFromMethod(FieldPath::class, 'documentId');
+        $res = $snippet->invoke('path');
+        $this->assertInstanceOf(FieldPath::class, $res->returnVal());
+        $this->assertEquals('__name__', $res->returnVal()->pathString());
+    }
+
     public function testFromString()
     {
         $snippet = $this->snippetFromMethod(FieldPath::class, 'fromString');

--- a/Firestore/tests/Snippet/QueryTest.php
+++ b/Firestore/tests/Snippet/QueryTest.php
@@ -36,7 +36,7 @@ class QueryTest extends SnippetTestCase
 {
     use GrpcTestTrait;
 
-    const PARENT = 'projects/example_project/databases/(default)/documents';
+    const QUERY_PARENT = 'projects/example_project/databases/(default)/documents';
     const COLLECTION = 'a';
     const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
@@ -61,7 +61,7 @@ class QueryTest extends SnippetTestCase
         $query = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
             new ValueMapper($this->connection->reveal(), false),
-            self::PARENT,
+            self::QUERY_PARENT,
             [
                 'from' => [
                     [
@@ -225,14 +225,14 @@ class QueryTest extends SnippetTestCase
         $q = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
             new ValueMapper($this->connection->reveal(), false),
-            self::PARENT,
+            self::QUERY_PARENT,
             [
                 'from' => $from
             ]
         ]);
 
         $this->connection->runQuery(new ArrayHasSameValuesToken([
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'retries' => 0,
             'structuredQuery' => [
                 'from' => $from

--- a/Firestore/tests/Snippet/QueryTest.php
+++ b/Firestore/tests/Snippet/QueryTest.php
@@ -36,20 +36,15 @@ class QueryTest extends SnippetTestCase
 {
     use GrpcTestTrait;
 
+    const PARENT = 'projects/example_project/databases/(default)/documents';
+    const COLLECTION = 'a';
     const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
-    private $query;
 
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->query = TestHelpers::stub(Query::class, [
-            $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
-            self::NAME,
-            ['from' => self::NAME]
-        ]);
     }
 
     public function testClass()
@@ -63,14 +58,27 @@ class QueryTest extends SnippetTestCase
 
     public function testDocuments()
     {
+        $query = TestHelpers::stub(Query::class, [
+            $this->connection->reveal(),
+            new ValueMapper($this->connection->reveal(), false),
+            self::PARENT,
+            [
+                'from' => [
+                    [
+                        'collectionId' => self::COLLECTION,
+                    ]
+                ]
+            ]
+        ]);
+
         $this->connection->runQuery(Argument::any())
             ->shouldBeCalled()
             ->willReturn(new \ArrayIterator([]));
 
-        $this->query->___setProperty('connection', $this->connection->reveal());
+        $query->___setProperty('connection', $this->connection->reveal());
 
         $snippet = $this->snippetFromMethod(Query::class, 'documents');
-        $snippet->addLocal('query', $this->query);
+        $snippet->addLocal('query', $query);
         $res = $snippet->invoke('result');
         $this->assertInstanceOf(QuerySnapshot::class, $res->returnVal());
     }
@@ -205,21 +213,37 @@ class QueryTest extends SnippetTestCase
         return $this->runAndAssertArray($snippet, [$key => $argument]);
     }
 
-    private function runAndAssertArray(Snippet $snippet, array $query)
+    private function runAndAssertArray(Snippet $snippet, array $query, $allDescendants = false)
     {
+        $from = [
+            [
+                'collectionId' => self::COLLECTION,
+                'allDescendants' => $allDescendants
+            ]
+        ];
+
+        $q = TestHelpers::stub(Query::class, [
+            $this->connection->reveal(),
+            new ValueMapper($this->connection->reveal(), false),
+            self::PARENT,
+            [
+                'from' => $from
+            ]
+        ]);
+
         $this->connection->runQuery(new ArrayHasSameValuesToken([
-            'parent' => self::NAME,
+            'parent' => self::PARENT,
             'retries' => 0,
-            'structuredQuery' => array_filter([
-                'from' => self::NAME,
-            ]) + $query + [
+            'structuredQuery' => [
+                'from' => $from
+            ] + $query + [
                 'offset' => 0,
                 'orderBy' => []
             ]
         ]))->shouldBeCalled()->willReturn(new \ArrayIterator([[]]));
 
-        $this->query->___setProperty('connection', $this->connection->reveal());
-        $snippet->addLocal('query', $this->query);
+        $q->___setProperty('connection', $this->connection->reveal());
+        $snippet->addLocal('query', $q);
 
         $res = $snippet->invoke('query');
         $res->returnVal()->documents(['maxRetries' => 0]);

--- a/Firestore/tests/System/CollectionGroupTest.php
+++ b/Firestore/tests/System/CollectionGroupTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\Tests\System;
+
+use Google\Cloud\Firestore\FieldPath;
+use Google\Cloud\Firestore\Query;
+
+/**
+ * @group firestore
+ * @group firestore-collectiongroup
+ */
+class CollectionGroupTest extends FirestoreTestCase
+{
+    private function createDocuments(array $paths)
+    {
+        // Create a random collection name, but make sure
+        // it starts with 'b' for predictable ordering.
+        $collectionGroup = 'b' . uniqid(self::COLLECTION_NAME);
+        $query = self::$client->collectionGroup($collectionGroup);
+
+        foreach ($paths as &$path) {
+            $path = sprintf($path, $collectionGroup);
+        }
+
+        $batch = self::$client->batch();
+        foreach ($paths as $path) {
+            $doc = self::$client->document($path);
+            self::$deletionQueue->add($doc);
+            $batch->set($doc, [
+                'x' => 1
+            ]);
+        }
+
+        $batch->commit();
+
+        return [$query, $paths, $collectionGroup];
+    }
+
+    private function getIds(Query $query)
+    {
+        $documents = $query->documents()->rows();
+        $ids = [];
+        foreach ($documents as $document) {
+            $ids[] = $document->id();
+        }
+        sort($ids);
+
+        return $ids;
+    }
+
+    public function testCollectionGroup()
+    {
+        list ($query) = $this->createDocuments([
+            'abc/123/%s/cg-doc1',
+            'abc/123/%s/cg-doc2',
+            '%s/cg-doc3',
+            '%s/cg-doc4',
+            'def/456/%s/cg-doc5',
+            '%s/virtual-doc/nested-coll/not-cg-doc',
+            'x%s/not-cg-doc',
+            '%sx/not-cg-doc',
+            'abc/123/%sx/not-cg-doc',
+            'abc/123/x%s/not-cg-doc',
+            'abc/%s',
+        ]);
+
+        $this->assertEquals(
+            ['cg-doc1', 'cg-doc2', 'cg-doc3', 'cg-doc4', 'cg-doc5'],
+            $this->getIds($query)
+        );
+    }
+
+    public function testCollectionGroupStartAtEndAt()
+    {
+        list ($query) = $this->createDocuments([
+            'a/a/%s/cg-doc1',
+            'a/b/a/b/%s/cg-doc2',
+            'a/b/%s/cg-doc3',
+            'a/b/c/d/%s/cg-doc4',
+            'a/c/%s/cg-doc5',
+            '%s/cg-doc6',
+            'a/b/nope/nope'
+        ]);
+
+        $query = $query->orderBy(FieldPath::documentId())
+            ->startAt(['a/b'])
+            ->endAt(['a/b0']);
+
+        $this->assertEquals(
+            ['cg-doc2', 'cg-doc3', 'cg-doc4'],
+            $this->getIds($query)
+        );
+    }
+
+    public function testCollectionGroupStartAfterEndBefore()
+    {
+        list ($query, $paths, $group) = $this->createDocuments([
+            'a/a/%s/cg-doc1',
+            'a/b/a/b/%s/cg-doc2',
+            'a/b/%s/cg-doc3',
+            'a/b/c/d/%s/cg-doc4',
+            'a/c/%s/cg-doc5',
+            '%s/cg-doc6',
+            'a/b/nope/nope'
+        ]);
+
+        $query = $query->orderBy(FieldPath::documentId())
+            ->startAfter(['a/b'])
+            ->endBefore([sprintf('a/b/%s/cg-doc3', $group)]);
+
+        $this->assertEquals(
+            ['cg-doc2'],
+            $this->getIds($query)
+        );
+    }
+
+    public function testCollectionGroupWhere()
+    {
+        list ($query, $paths, $group) = $this->createDocuments([
+            'a/a/%s/cg-doc1',
+            'a/b/a/b/%s/cg-doc2',
+            'a/b/%s/cg-doc3',
+            'a/b/c/d/%s/cg-doc4',
+            'a/c/%s/cg-doc5',
+            '%s/cg-doc6',
+            'a/b/nope/nope'
+        ]);
+
+        $query = $query->where(FieldPath::documentId(), '>', 'a/b')
+            ->where(FieldPath::documentId(), '<', sprintf(
+                'a/b/%s/cg-doc3',
+                $group
+            ));
+
+        $this->assertEquals(
+            ['cg-doc2'],
+            $this->getIds($query)
+        );
+    }
+
+    public function testCollectionGroupWhereMultipleFilters()
+    {
+        list ($query, $paths, $group) = $this->createDocuments([
+            'a/a/%s/cg-doc1',
+            'a/b/a/b/%s/cg-doc2',
+            'a/b/%s/cg-doc3',
+            'a/b/c/d/%s/cg-doc4',
+            'a/c/%s/cg-doc5',
+            '%s/cg-doc6',
+            'a/b/nope/nope'
+        ]);
+
+        $query = $query->where(FieldPath::documentId(), '>=', 'a/b')
+            ->where(FieldPath::documentId(), '<=', 'a/b0');
+
+        $this->assertEquals(
+            ['cg-doc2', 'cg-doc3', 'cg-doc4'],
+            $this->getIds($query)
+        );
+    }
+}

--- a/Firestore/tests/System/CollectionGroupTest.php
+++ b/Firestore/tests/System/CollectionGroupTest.php
@@ -26,43 +26,6 @@ use Google\Cloud\Firestore\Query;
  */
 class CollectionGroupTest extends FirestoreTestCase
 {
-    private function createDocuments(array $paths)
-    {
-        // Create a random collection name, but make sure
-        // it starts with 'b' for predictable ordering.
-        $collectionGroup = 'b' . uniqid(self::COLLECTION_NAME);
-        $query = self::$client->collectionGroup($collectionGroup);
-
-        foreach ($paths as &$path) {
-            $path = sprintf($path, $collectionGroup);
-        }
-
-        $batch = self::$client->batch();
-        foreach ($paths as $path) {
-            $doc = self::$client->document($path);
-            self::$deletionQueue->add($doc);
-            $batch->set($doc, [
-                'x' => 1
-            ]);
-        }
-
-        $batch->commit();
-
-        return [$query, $paths, $collectionGroup];
-    }
-
-    private function getIds(Query $query)
-    {
-        $documents = $query->documents()->rows();
-        $ids = [];
-        foreach ($documents as $document) {
-            $ids[] = $document->id();
-        }
-        sort($ids);
-
-        return $ids;
-    }
-
     public function testCollectionGroup()
     {
         list ($query) = $this->createDocuments([
@@ -172,5 +135,42 @@ class CollectionGroupTest extends FirestoreTestCase
             ['cg-doc2', 'cg-doc3', 'cg-doc4'],
             $this->getIds($query)
         );
+    }
+
+    private function createDocuments(array $paths)
+    {
+        // Create a random collection name, but make sure
+        // it starts with 'b' for predictable ordering.
+        $collectionGroup = 'b' . uniqid(self::COLLECTION_NAME);
+        $query = self::$client->collectionGroup($collectionGroup);
+
+        foreach ($paths as &$path) {
+            $path = sprintf($path, $collectionGroup);
+        }
+
+        $batch = self::$client->batch();
+        foreach ($paths as $path) {
+            $doc = self::$client->document($path);
+            self::$deletionQueue->add($doc);
+            $batch->set($doc, [
+                'x' => 1
+            ]);
+        }
+
+        $batch->commit();
+
+        return [$query, $paths, $collectionGroup];
+    }
+
+    private function getIds(Query $query)
+    {
+        $documents = $query->documents()->rows();
+        $ids = [];
+        foreach ($documents as $document) {
+            $ids[] = $document->id();
+        }
+        sort($ids);
+
+        return $ids;
     }
 }

--- a/Firestore/tests/System/FirestoreTestCase.php
+++ b/Firestore/tests/System/FirestoreTestCase.php
@@ -59,10 +59,16 @@ class FirestoreTestCase extends SystemTestCase
         $backoff = new ExponentialBackoff(8);
 
         self::$localDeletionQueue->process(function ($items) use ($backoff) {
-            foreach ($items as $collection) {
-                $backoff->execute(function () use ($collection) {
-                    foreach ($collection->documents() as $document) {
-                        $document->reference()->delete();
+            foreach ($items as $item) {
+                $backoff->execute(function () use ($item) {
+                    if ($item instanceof CollectionReference) {
+                        foreach ($item->documents() as $document) {
+                            $document->reference()->delete();
+                        }
+                    } elseif ($item instanceof DocumentReference) {
+                        $item->delete();
+                    } elseif ($item instanceof DocumentSnapshot) {
+                        $item->reference()->delete();
                     }
                 });
             }

--- a/Firestore/tests/Unit/CollectionReferenceTest.php
+++ b/Firestore/tests/Unit/CollectionReferenceTest.php
@@ -35,7 +35,7 @@ class CollectionReferenceTest extends TestCase
 {
     const PROJECT = 'example_project';
     const DATABASE = '(default)';
-    const PARENT = 'projects/example_project/databases/(default)/documents/a';
+    const COLLECTION_PARENT = 'projects/example_project/databases/(default)/documents/a';
     const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
@@ -123,7 +123,7 @@ class CollectionReferenceTest extends TestCase
         $docName = self::NAME . '/foo';
 
         $this->connection->listDocuments(Argument::allOf(
-            Argument::withEntry('parent', self::PARENT),
+            Argument::withEntry('parent', self::COLLECTION_PARENT),
             Argument::withEntry('collectionId', $id),
             Argument::withEntry('mask', [])
         ))->shouldBeCalled()->willReturn([

--- a/Firestore/tests/Unit/FieldPathTest.php
+++ b/Firestore/tests/Unit/FieldPathTest.php
@@ -42,6 +42,12 @@ class FieldPathTest extends TestCase
         new FieldPath(['']);
     }
 
+    public function testDocumentId()
+    {
+        $path = FieldPath::documentId();
+        $this->assertEquals('__name__', $path->pathString());
+    }
+
     public function testFromString()
     {
         $fieldPath = FieldPath::fromString(implode('.', $this->pieces));

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -43,7 +43,7 @@ class QueryTest extends TestCase
 {
     const PROJECT = 'example_project';
     const DATABASE = '(default)';
-    const PARENT = 'projects/example_project/databases/(default)/documents';
+    const QUERY_PARENT = 'projects/example_project/databases/(default)/documents';
     const COLLECTION = 'foo';
 
     private $queryObj = [
@@ -61,7 +61,7 @@ class QueryTest extends TestCase
         $this->query = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
             new ValueMapper($this->connection->reveal(), false),
-            self::PARENT,
+            self::QUERY_PARENT,
             $this->queryObj
         ], ['connection', 'query', 'transaction']);
 
@@ -70,7 +70,7 @@ class QueryTest extends TestCase
         $this->collectionGroupQuery = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
             new ValueMapper($this->connection->reveal(), false),
-            self::PARENT,
+            self::QUERY_PARENT,
             $allDescendants
         ], ['connection', 'query', 'transaction']);
     }
@@ -83,14 +83,14 @@ class QueryTest extends TestCase
         new Query(
             $this->connection->reveal(),
             new ValueMapper($this->connection->reveal(), false),
-            self::PARENT,
+            self::QUERY_PARENT,
             []
         );
     }
 
     public function testDocuments()
     {
-        $name = self::PARENT .'/foo';
+        $name = self::QUERY_PARENT .'/foo';
 
         $this->connection->runQuery(Argument::any())
             ->shouldBeCalled()
@@ -122,7 +122,7 @@ class QueryTest extends TestCase
 
     public function testDocumentsMetadata()
     {
-        $name = self::PARENT .'/foo';
+        $name = self::QUERY_PARENT .'/foo';
 
         $ts = (new \DateTime)->format(Timestamp::FORMAT);
         $this->connection->runQuery(Argument::any())
@@ -162,7 +162,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) use ($paths) {
             return $q->select($paths);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'select' => [
@@ -187,7 +187,7 @@ class QueryTest extends TestCase
             $res = $res->select(['users.dan']);
             return $res;
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'select' => [
@@ -204,7 +204,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) {
             return $q->select([]);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'select' => [
@@ -226,7 +226,7 @@ class QueryTest extends TestCase
 
             return $res;
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'where' => [
@@ -352,7 +352,7 @@ class QueryTest extends TestCase
 
             return $res;
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'where' => [
@@ -414,7 +414,7 @@ class QueryTest extends TestCase
 
             return $res;
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -485,7 +485,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) use ($limit) {
             return $q->limit($limit);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'limit' => ['value' => $limit]
@@ -500,7 +500,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) use ($offset) {
             return $q->offset($offset);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'offset' => $offset
@@ -513,7 +513,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) {
             return $q->orderBy('name', Query::DIR_DESCENDING)->startAt(['john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -541,7 +541,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) {
             return $q->orderBy('name', Query::DIR_DESCENDING)->startAfter(['john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -569,7 +569,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) {
             return $q->orderBy('name', Query::DIR_DESCENDING)->endBefore(['john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -597,7 +597,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) {
             return $q->orderBy('name', Query::DIR_DESCENDING)->endAt(['john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -627,7 +627,7 @@ class QueryTest extends TestCase
         $this->runAndAssert(function (Query $q) use ($documentPath) {
             return $q->orderBy(Query::DOCUMENT_ID, Query::DIR_DESCENDING)->endAt(['john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -642,7 +642,7 @@ class QueryTest extends TestCase
                     'before' => false,
                     'values' => [
                         [
-                            'referenceValue' => self::PARENT .'/'. $documentPath
+                            'referenceValue' => self::QUERY_PARENT .'/'. $documentPath
                         ]
                     ]
                 ]
@@ -653,16 +653,16 @@ class QueryTest extends TestCase
     public function testBuildPositionWithDocumentReference()
     {
         $c = $this->prophesize(CollectionReference::class);
-        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $c->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId']);
 
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
 
         $this->runAndAssert(function (Query $q) use ($ref) {
             return $q->orderBy(Query::DOCUMENT_ID, Query::DIR_DESCENDING)->endAt([$ref->reveal()]);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -677,7 +677,7 @@ class QueryTest extends TestCase
                     'before' => false,
                     'values' => [
                         [
-                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                            'referenceValue' => self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
                         ]
                     ]
                 ]
@@ -688,20 +688,20 @@ class QueryTest extends TestCase
     public function testPositionWithDocumentSnapshot()
     {
         $c = $this->prophesize(CollectionReference::class);
-        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $c->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId']);
 
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
 
         $snapshot = $this->prophesize(DocumentSnapshot::class);
-        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
 
         $this->runAndAssert(function (Query $q) use ($snapshot) {
             return $this->query->startAt($snapshot->reveal());
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -716,7 +716,7 @@ class QueryTest extends TestCase
                     'before' => true,
                     'values' => [
                         [
-                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                            'referenceValue' => self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
                         ]
                     ]
                 ]
@@ -744,14 +744,14 @@ class QueryTest extends TestCase
     public function testPositionSnapshotOrderBy()
     {
         $c = $this->prophesize(CollectionReference::class);
-        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $c->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId']);
 
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
 
         $snapshot = $this->prophesize(DocumentSnapshot::class);
-        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
         $snapshot->get('a')->willReturn('b');
         $snapshot->get('c')->willReturn('d');
@@ -760,7 +760,7 @@ class QueryTest extends TestCase
             $query = $this->query->orderBy('a')->orderBy('c')->orderBy(FieldPath::documentId());
             return $query->startAt($snapshot->reveal());
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -787,7 +787,7 @@ class QueryTest extends TestCase
                         ['stringValue' => 'b'],
                         ['stringValue' => 'd'],
                         [
-                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                            'referenceValue' => self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
                         ]
                     ]
                 ]
@@ -798,14 +798,14 @@ class QueryTest extends TestCase
     public function testPositionInequalityFilter()
     {
         $c = $this->prophesize(CollectionReference::class);
-        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $c->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId']);
 
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
 
         $snapshot = $this->prophesize(DocumentSnapshot::class);
-        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
         $snapshot->get('foo')->willReturn('bar');
 
@@ -813,7 +813,7 @@ class QueryTest extends TestCase
             $query = $this->query->where('foo', '>', 'bar');
             return $query->startAt($snapshot->reveal());
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(),
                 'orderBy' => [
@@ -835,7 +835,7 @@ class QueryTest extends TestCase
                         [
                             'stringValue' => 'bar'
                         ], [
-                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                            'referenceValue' => self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
                         ]
                     ]
                 ],
@@ -868,10 +868,10 @@ class QueryTest extends TestCase
     public function testBuildPositionOutOfBounds()
     {
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/whatev/john');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/whatev/john');
 
         $col = $this->prophesize(CollectionReference::class);
-        $col->name()->willReturn(self::PARENT .'/whatev/john');
+        $col->name()->willReturn(self::QUERY_PARENT .'/whatev/john');
         $ref->parent()->willReturn($col->reveal());
 
         $this->query->orderBy(Query::DOCUMENT_ID)->startAt([$ref->reveal()]);
@@ -908,10 +908,10 @@ class QueryTest extends TestCase
     public function testBuildPositionNestedChild()
     {
         $c = $this->prophesize(CollectionReference::class);
-        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $c->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
 
         $ref = $this->prophesize(DocumentReference::class);
-        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john/bar/bat/baz');
+        $ref->name()->willReturn(self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john/bar/bat/baz');
         $ref->parent()->willReturn($c->reveal());
 
         $this->query->orderBy(Query::DOCUMENT_ID)->startAt([$ref->reveal()]);
@@ -923,7 +923,7 @@ class QueryTest extends TestCase
             $query = $q->orderBy(FieldPath::documentId());
             return $query->startAt([$this->queryFrom()[0]['collectionId'] .'/john']);
         }, [
-            'parent' => self::PARENT,
+            'parent' => self::QUERY_PARENT,
             'structuredQuery' => [
                 'from' => $this->queryFrom(true),
                 'orderBy' => [
@@ -938,7 +938,7 @@ class QueryTest extends TestCase
                     'before' => true,
                     'values' => [
                         [
-                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                            'referenceValue' => self::QUERY_PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
                         ]
                     ]
                 ]


### PR DESCRIPTION
Adds support for Collection Group Queries to Cloud Firestore.

Also fixes a couple other issues:

* Add support for documents as strings in `where()` when the FieldPath is `__name__`. ([precedent](https://github.com/googleapis/nodejs-firestore/pull/136))
* Added `FieldPath::documentId()` to conform with other language APIs and better surface the available functionality.
* Removed the special character workaround added in #1122, as the GAPIC parser now has improved support. (https://github.com/googleapis/gax-php/issues/197)

cc @schmidt-sebastian @crwilcox 