### PR TITLE
Fix continue switch targeting warning in PHP 7.3

### DIFF
--- a/Debugger/src/Agent.php
+++ b/Debugger/src/Agent.php
@@ -19,7 +19,6 @@ namespace Google\Cloud\Debugger;
 
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Batch\BatchDaemonTrait;
-use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\BatchTrait;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Core\Exception\ServiceException;
@@ -207,7 +206,7 @@ class Agent
                     );
                     break;
                 default:
-                    continue;
+                    continue 2;
             }
         }
     }


### PR DESCRIPTION
Fixes error in PHP 7.3:

```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /path/to/google-cloud-php/Debugger/src/Agent.php on line 210
```