### PR TITLE
Cleanup minor issues in Core

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -19,7 +19,8 @@
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",
         "google/gax": "^1.0",
-        "opis/closure": "^3"
+        "opis/closure": "^3",
+        "google/common-protos": "^1.0"
     },
     "suggest": {
         "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",

--- a/Core/src/ArrayTrait.php
+++ b/Core/src/ArrayTrait.php
@@ -51,7 +51,7 @@ trait ArrayTrait
     /**
      * Pluck a subset of an array.
      *
-     * @param string $keys
+     * @param string[] $keys
      * @param array $arr
      * @return array
      */

--- a/Core/src/ArrayTrait.php
+++ b/Core/src/ArrayTrait.php
@@ -28,7 +28,7 @@ trait ArrayTrait
      * @param string $key
      * @param array $arr
      * @param bool $isRequired
-     * @return string|null
+     * @return mixed
      * @throws \InvalidArgumentException
      */
     private function pluck($key, array &$arr, $isRequired = true)

--- a/Core/src/Batch/BatchRunner.php
+++ b/Core/src/Batch/BatchRunner.php
@@ -126,7 +126,7 @@ class BatchRunner
      * @param string $identifier Unique identifier of the job.
      * @param mixed $item It needs to be serializable.
      *
-     * @return bool true on success, false on failure
+     * @return void
      * @throws \RuntimeException
      */
     public function submitItem($identifier, $item)
@@ -138,7 +138,7 @@ class BatchRunner
             );
         }
         $idNum = $job->id();
-        return $this->processor->submit($item, $idNum);
+        $this->processor->submit($item, $idNum);
     }
 
     /**

--- a/Core/src/Batch/InterruptTrait.php
+++ b/Core/src/Batch/InterruptTrait.php
@@ -48,7 +48,7 @@ trait InterruptTrait
      *
      * @return void
      */
-    public function sigHandler($signo, $signinfo = null)
+    public function sigHandler($signo, $siginfo = null)
     {
         switch ($signo) {
             case SIGINT:

--- a/Core/src/Batch/JobTrait.php
+++ b/Core/src/Batch/JobTrait.php
@@ -43,7 +43,7 @@ trait JobTrait
     private $numWorkers;
 
     /**
-     * @var string An optional file that is required to run this job.
+     * @var string|null An optional file that is required to run this job.
      */
     private $bootstrapFile;
 

--- a/Core/src/Batch/SimpleJob.php
+++ b/Core/src/Batch/SimpleJob.php
@@ -17,8 +17,6 @@
 
 namespace Google\Cloud\Core\Batch;
 
-use Google\Cloud\Core\SysvTrait;
-
 /**
  * Represents a simple job that runs a single method that loops forever.
  *

--- a/Core/src/Compute/Metadata.php
+++ b/Core/src/Compute/Metadata.php
@@ -45,7 +45,7 @@ use Google\Cloud\Core\Compute\Metadata\Readers\ReaderInterface;
 class Metadata
 {
     /**
-     * @var StreamReader The metadata reader.
+     * @var ReaderInterface The metadata reader.
      */
     private $reader;
 

--- a/Core/src/DebugInfoTrait.php
+++ b/Core/src/DebugInfoTrait.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Core;
 
 /**
  * Provides easier to read debug information when dumping a class to stdout.
+ *
+ * @codeCoverageIgnore
  */
 trait DebugInfoTrait
 {

--- a/Core/src/Iterator/ItemIteratorTrait.php
+++ b/Core/src/Iterator/ItemIteratorTrait.php
@@ -54,7 +54,9 @@ trait ItemIteratorTrait
      */
     public function nextResultToken()
     {
-        return $this->pageIterator->nextResultToken();
+        return method_exists($this->pageIterator, 'nextResultToken')
+            ? $this->pageIterator->nextResultToken()
+            : null;
     }
 
     /**

--- a/Core/src/PhpArray.php
+++ b/Core/src/PhpArray.php
@@ -27,6 +27,7 @@ use google\protobuf\Struct;
  * Extend the Protobuf-PHP array codec to allow messages to match the format
  * used for REST.
  * @deprecated
+ * @codeCoverageIgnore
  */
 class PhpArray extends Protobuf\Codec\PhpArray
 {

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -373,13 +373,6 @@ class RequestWrapper
     {
         if ($ex instanceof RequestException && $ex->hasResponse()) {
             return (string) $ex->getResponse()->getBody();
-
-            try {
-                $this->jsonDecode($res);
-                return $res;
-            } catch (\InvalidArgumentException $e) {
-                // no-op
-            }
         }
 
         return $ex->getMessage();

--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -40,7 +40,7 @@ trait RequestWrapperTrait
     private $authCacheOptions;
 
     /**
-     * @var FetchAuthTokenInterface Fetches credentials.
+     * @var FetchAuthTokenInterface|null Fetches credentials.
      */
     private $credentialsFetcher;
 

--- a/Core/src/Retry.php
+++ b/Core/src/Retry.php
@@ -33,15 +33,15 @@ class Retry
     /**
      * @var callable
      */
-    private $retryFunction;
-
-    /**
-     * @var callable
-     */
     private $delayFunction;
 
     /**
-     * @param int $retries Maximum number of retries for a failed request.
+     * @var callable|null
+     */
+    private $retryFunction;
+
+    /**
+     * @param int|null $retries Maximum number of retries for a failed request.
      * @param callable $delayFunction A function returning an array of format
      *        `['seconds' => (int >= 0), 'nanos' => (int >= 0)] specifying how
      *        long an operation should pause before retrying. Should accept a

--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Core;
 
+use Google\Auth\HttpHandler\Guzzle5HttpHandler;
+use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\Datastore\DatastoreClient;

--- a/Core/src/Testing/ArrayHasSameValuesToken.php
+++ b/Core/src/Testing/ArrayHasSameValuesToken.php
@@ -19,7 +19,7 @@ class ArrayHasSameValuesToken implements TokenInterface
 
     /**
      * ArrayHasSameValuesToken constructor.
-     * @param $value
+     * @param mixed $value
      * @param StringUtil|null $util
      *
      * @experimental
@@ -32,7 +32,7 @@ class ArrayHasSameValuesToken implements TokenInterface
     }
 
     /**
-     * @param $argument
+     * @param mixed $argument
      * @return bool|int
      *
      * @experimental

--- a/Core/src/Testing/Snippet/Coverage/Coverage.php
+++ b/Core/src/Testing/Snippet/Coverage/Coverage.php
@@ -108,7 +108,7 @@ class Coverage
     }
 
     /**
-     * @param $identifier
+     * @param string|int $identifier
      * @return Snippet|null
      *
      * @experimental

--- a/Core/src/Testing/Snippet/Coverage/ScannerInterface.php
+++ b/Core/src/Testing/Snippet/Coverage/ScannerInterface.php
@@ -38,12 +38,14 @@ interface ScannerInterface
     /**
      * Retrieve a list of classes in the given PHP files.
      *
+     * @param array $files
+     * @param array $exclude
      * @return string[]
      *
      * @experimental
      * @internal
      */
-    public function classes(array $files);
+    public function classes(array $files, array $exclude = []);
 
     /**
      * Get a list of all snippets from the given classes.

--- a/Core/src/Testing/Snippet/Parser/InvokeResult.php
+++ b/Core/src/Testing/Snippet/Parser/InvokeResult.php
@@ -28,8 +28,8 @@ class InvokeResult
     /**
      * InvokeResult constructor.
      *
-     * @param $returnVal
-     * @param $output
+     * @param mixed $returnVal
+     * @param mixed $output
      */
     public function __construct($returnVal, $output)
     {

--- a/Core/src/Testing/Snippet/Parser/Parser.php
+++ b/Core/src/Testing/Snippet/Parser/Parser.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Core\Testing\Snippet\Parser;
 
-use DomDocument;
+use DOMDocument;
 use Google\Cloud\Core\Testing\DocBlockStripSpaces;
 use Parsedown;
 use ReflectionClass;
@@ -175,7 +175,8 @@ class Parser
      * $examples = $parser->examplesFromMethod($parser, 'examplesFromMethod');
      * ```
      *
-     * @param object $class An instance of the class to parse examples from.
+     * @param object|string $class An instance of the class to parse examples,
+     *        or the name of the class.
      * @param string|ReflectionMethod $method The name of the method to parse
      *        examples from.
      * @return array
@@ -293,8 +294,8 @@ class Parser
     /**
      * Create identifier
      *
-     * @param $fqn
-     * @param $indexOrName
+     * @param string $fqn
+     * @param int|string $indexOrName
      * @return string
      */
     public function createIdentifier($fqn, $indexOrName)

--- a/Core/src/TimeTrait.php
+++ b/Core/src/TimeTrait.php
@@ -28,7 +28,7 @@ trait TimeTrait
      * @param string $timestamp A string representation of a timestamp, encoded
      *        in RFC 3339 format (YYYY-MM-DDTHH:MM:SS.000000[000]TZ).
      * @return array [\DateTimeImmutable, int]
-     * @throws \InvalidArgumentException If the timestamp string is in an unrecognized format.
+     * @throws \Exception If the timestamp string is in an unrecognized format.
      */
     private function parseTimeString($timestamp)
     {
@@ -44,12 +44,6 @@ trait TimeTrait
         }
 
         $dt = new \DateTimeImmutable($timestamp);
-        if (!$dt) {
-            throw new \InvalidArgumentException(sprintf(
-                'Could not create a DateTime instance from given timestamp %s.',
-                $timestamp
-            ));
-        }
 
         $nanos = (int) str_pad($subSeconds, 9, '0', STR_PAD_RIGHT);
 

--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -250,7 +250,7 @@ class ResumableUploader extends AbstractUploader
      * Gets the starting range for the upload.
      *
      * @param string $rangeHeader
-     * @return int
+     * @return int|null
      */
     protected function getRangeStart($rangeHeader)
     {

--- a/Core/src/Upload/SignedUrlUploader.php
+++ b/Core/src/Upload/SignedUrlUploader.php
@@ -89,7 +89,7 @@ class SignedUrlUploader extends ResumableUploader
     /**
      * Decode the response body
      *
-     * @param ReponseInterface $response
+     * @param ResponseInterface $response
      * @return string
      */
     protected function decodeResponse(ResponseInterface $response)

--- a/Core/tests/Unit/ArrayTraitTest.php
+++ b/Core/tests/Unit/ArrayTraitTest.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Core\Tests\Unit;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 /**
  * @group core
@@ -52,6 +51,18 @@ class ArrayTraitTest extends TestCase
     {
         $array = [];
         $this->impl->call('pluck', ['not_here', &$array]);
+    }
+
+    public function testPluckNonExistentKey()
+    {
+        $input = ['foo' => 'bar'];
+        $this->assertNull(
+            $this->impl->call('pluck', [
+                'baz',
+                &$input,
+                false
+            ])
+        );
     }
 
     public function testPluckArray()
@@ -104,5 +115,33 @@ class ArrayTraitTest extends TestCase
         $this->assertArrayHasKey('float', $res);
         $this->assertArrayHasKey('empty', $res);
         $this->assertArrayHasKey('array', $res);
+    }
+
+    public function testArrayMergeRecursive()
+    {
+        $array1 = [
+            'a' => [
+                'b' => 'c'
+            ],
+            'e' => 'f'
+        ];
+
+        $array2 = [
+            'a' => [
+                'b' => 'd'
+            ],
+            'g' => 'h'
+        ];
+
+        $expected = [
+            'a' => [
+                'b' => 'd'
+            ],
+            'e' => 'f',
+            'g' => 'h'
+        ];
+
+        $res = $this->impl->call('arrayMergeRecursive', [$array1, $array2]);
+        $this->assertEquals($expected, $res);
     }
 }

--- a/Core/tests/Unit/BlobTest.php
+++ b/Core/tests/Unit/BlobTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Tests\Unit;
+
+use Google\Cloud\Core\Blob;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * @group core
+ */
+class BlobTest extends TestCase
+{
+    private $data = 'foobar';
+
+    public function testBlob()
+    {
+        $blob = new Blob($this->data);
+        $this->assertInstanceOf(StreamInterface::class, $blob->get());
+        $this->assertEquals($this->data, (string) $blob->get());
+        $this->assertEquals($this->data, (string) $blob);
+    }
+}

--- a/Core/tests/Unit/GrpcRequestWrapperTest.php
+++ b/Core/tests/Unit/GrpcRequestWrapperTest.php
@@ -19,17 +19,19 @@
 namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\Api\Http;
-use Google\Auth\FetchAuthTokenInterface;
-use Google\Cloud\Core\Exception;
-use Google\Cloud\Core\Testing\GrpcTestTrait;
-use Google\Cloud\Core\GrpcRequestWrapper;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\ApiCore\Page;
 use Google\ApiCore\PagedListResponse;
 use Google\ApiCore\Serializer;
-use Google\Protobuf\Internal\Message;
-use Prophecy\Argument;
+use Google\Auth\FetchAuthTokenInterface;
+use Google\Cloud\Core\Exception;
+use Google\Cloud\Core\GrpcRequestWrapper;
+use Google\Cloud\Core\Testing\GrpcTestTrait;
+use Google\Rpc\BadRequest;
+use Google\Rpc\BadRequest\FieldViolation;
+use Google\Rpc\Code;
+use Google\Rpc\PreconditionFailure;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -201,15 +203,60 @@ class GrpcRequestWrapperTest extends TestCase
     public function exceptionProvider()
     {
         return [
-            [3, Exception\BadRequestException::class],
-            [5, Exception\NotFoundException::class],
-            [12, Exception\NotFoundException::class],
-            [6, Exception\ConflictException::class],
-            [9, Exception\FailedPreconditionException::class],
-            [2, Exception\ServerException::class],
-            [13, Exception\ServerException::class],
-            [10, Exception\AbortedException::class],
+            [Code::INVALID_ARGUMENT, Exception\BadRequestException::class],
+            [Code::NOT_FOUND, Exception\NotFoundException::class],
+            [Code::UNIMPLEMENTED, Exception\NotFoundException::class],
+            [Code::ALREADY_EXISTS, Exception\ConflictException::class],
+            [Code::FAILED_PRECONDITION, Exception\FailedPreconditionException::class],
+            [Code::UNKNOWN, Exception\ServerException::class],
+            [Code::INTERNAL, Exception\ServerException::class],
+            [Code::ABORTED, Exception\AbortedException::class],
+            [Code::DEADLINE_EXCEEDED, Exception\DeadlineExceededException::class],
             [999, Exception\ServiceException::class]
         ];
+    }
+
+    public function testExceptionMetadata()
+    {
+        $metadata = new BadRequest([
+            'field_violations' => [
+                new FieldViolation([
+                    'field' => 'foo',
+                    'description' => 'bar'
+                ])
+            ]
+        ]);
+
+        $otherMetadata = new PreconditionFailure;
+
+        $e = new ApiException(
+            'Testing',
+            Code::INVALID_ARGUMENT,
+            'foo',
+            [
+                'metadata' => [
+                    'google.rpc.badrequest-bin' => [$metadata->serializeToString()],
+                    'google.rpc.preconditionfailure-bin' => [$otherMetadata->serializeToString()]
+                ]
+            ]
+        );
+
+        $requestWrapper = new GrpcRequestWrapper();
+
+        try {
+            $requestWrapper->send(function () use ($e) {
+                throw $e;
+            }, [[]], ['retries' => 0]);
+
+            $this->assertFalse(true, 'Exception not thrown!');
+        } catch (\Exception $ex) {
+            $this->assertEquals(
+                json_decode($metadata->serializeToJsonString(), true),
+                $ex->getMetadata()[0]
+            );
+
+            // Assert only whitelisted types are included.
+            $this->assertCount(1, $ex->getMetadata());
+        }
     }
 }


### PR DESCRIPTION
This change fixes minor errors or mistakes and does a bit of cleanup across Core. The only thing which may be controversial was my removal of support for the old `Google\GAX` classes from `GrpcRequestWrapper`. My reasoning is that, as we require gax v1.0, it is not possible to install a version of GAX which uses the old class names. If there is disagreement w.r.t. this, I can revert that part.