### PR TITLE
Strip method reference in external type link

### DIFF
--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -789,6 +789,10 @@ class CodeParser implements ParserInterface
              ) = $this->getExternalDepVersion($type, $external);
         }
 
+        // strip method reference from external type, since we can't predict
+        // with certainty how method anchors work.
+        $type = explode('::', $type)[0];
+
         $placeholders['type'] = explode('/', $type);
 
         $uri = new UriTemplate;


### PR DESCRIPTION
Fixes #1970.

Our external types link to various different sources. GitHub code, PHPDoc generated pages, etc. We can't predict an anchor type for each of these, so to fix the 404 errors, strip method names from the type reference.