### PR TITLE
fix: Add namespaces and test configs in component tool

### DIFF
--- a/dev/src/AddComponent/Command/AddComponent.php
+++ b/dev/src/AddComponent/Command/AddComponent.php
@@ -26,6 +26,7 @@ use Google\Cloud\Dev\AddComponent\Manifest;
 use Google\Cloud\Dev\AddComponent\PullRequestTemplate;
 use Google\Cloud\Dev\AddComponent\Readmes;
 use Google\Cloud\Dev\AddComponent\TableOfContents;
+use Google\Cloud\Dev\AddComponent\TestConfig;
 use Google\Cloud\Dev\Command\GoogleCloudCommand;
 use Google\Cloud\Dev\QuestionTrait;
 use Symfony\Component\Console\Input\InputInterface;
@@ -89,6 +90,13 @@ class AddComponent extends GoogleCloudCommand
         ));
 
         (new GitAttributes($this->rootPath, $info['path']))->run();
+
+        $output->writeln($formatter->formatSection(
+            'Test Config',
+            'Creating PHPUnit configs by copying from templates.'
+        ));
+
+        (new TestConfig($this->rootPath, $info['path']))->run();
 
         $output->writeln($formatter->formatSection(
             'Readme',
@@ -163,8 +171,7 @@ class AddComponent extends GoogleCloudCommand
         $output->writeln('Success!');
         $output->writeln(
             "All done! Before committing, be sure to complete the following manual steps:\n"
-            . "1. Check the PSR-4 Namespace value for GPBMetadata in /path/to/Folder/composer.json.\n"
-            . "2. Add a code sample to /path/to/Folder/README.md"
+            . "1. Add a code sample to /path/to/Folder/README.md"
         );
     }
 

--- a/dev/src/AddComponent/TestConfig.php
+++ b/dev/src/AddComponent/TestConfig.php
@@ -49,7 +49,7 @@ class TestConfig
 
         foreach ($files as $file) {
             $source = $this->rootPath . '/dev/src/AddComponent/templates/template-' . $file . '.txt';
-            $dest = $this->path .'/' . $file;
+            $dest = $this->path . '/' . $file;
 
             copy($source, $dest);
         }

--- a/dev/src/AddComponent/TestConfig.php
+++ b/dev/src/AddComponent/TestConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dev/src/AddComponent/TestConfig.php
+++ b/dev/src/AddComponent/TestConfig.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Create PHPUnit Configs.
+ */
+class TestConfig
+{
+    /**
+     * @var string
+     */
+    private $rootPath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+
+    public function __construct($rootPath, $path)
+    {
+        $this->rootPath = $rootPath;
+        $this->path = $path;
+    }
+
+    public function run()
+    {
+        $files = [
+            'phpunit.xml.dist',
+            'phpunit-snippets.xml.dist',
+            'phpunit-system.xml.dist'
+        ];
+
+        foreach ($files as $file) {
+            $source = $this->rootPath . '/dev/src/AddComponent/templates/template-' . $file . '.txt';
+            $dest = $this->path .'/' . $file;
+
+            copy($source, $dest);
+        }
+    }
+}

--- a/dev/src/AddComponent/templates/template-phpunit-snippets.xml.dist.txt
+++ b/dev/src/AddComponent/templates/template-phpunit-snippets.xml.dist.txt
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
+  colors="true"
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  <testsuites>
+    <testsuite>
+      <directory>tests/Snippet</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/dev/src/AddComponent/templates/template-phpunit-system.xml.dist.txt
+++ b/dev/src/AddComponent/templates/template-phpunit-system.xml.dist.txt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests/System</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/dev/src/AddComponent/templates/template-phpunit.xml.dist.txt
+++ b/dev/src/AddComponent/templates/template-phpunit.xml.dist.txt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
`dev/google-cloud component` now adds PHPUnit configuration files and namespaces for the component, component tests, and metadata to the main composer.json file.