### PR TITLE
Add projectId getter to ClientTrait

### DIFF
--- a/Core/src/ClientTrait.php
+++ b/Core/src/ClientTrait.php
@@ -37,6 +37,17 @@ trait ClientTrait
     private $projectId;
 
     /**
+     * Return the detected project ID, may be null if detectProjectId has not
+     * yet been called.
+     *
+     * @return string|null
+     */
+    public function getProjectId()
+    {
+        return $this->projectId;
+    }
+
+    /**
      * Get either a gRPC or REST connection based on the provided config
      * and the system dependencies available.
      *

--- a/Core/tests/Unit/ClientTraitTest.php
+++ b/Core/tests/Unit/ClientTraitTest.php
@@ -130,7 +130,7 @@ class ClientTraitTest extends TestCase
         $conf = $this->impl->call('configureAuthentication', [[]]);
 
         $this->assertEquals(json_decode(file_get_contents($keyFilePath), true), $conf['keyFile']);
-        $this->assertEquals('example_project', $this->impl->___getProperty('projectId'));
+        $this->assertEquals('example_project', $this->impl->call('getProjectId', []));
     }
 
     public function testConfigureAuthenticationWithKeyFile()
@@ -144,7 +144,7 @@ class ClientTraitTest extends TestCase
         ]]);
 
         $this->assertEquals($keyFile, $conf['keyFile']);
-        $this->assertEquals('test', $this->impl->___getProperty('projectId'));
+        $this->assertEquals('test', $this->impl->call('getProjectId', []));
     }
 
     public function testConfigureAuthenticationWithKeyFilePath()
@@ -157,7 +157,7 @@ class ClientTraitTest extends TestCase
         ]]);
 
         $this->assertEquals($keyFile, $conf['keyFile']);
-        $this->assertEquals('example_project', $this->impl->___getProperty('projectId'));
+        $this->assertEquals('example_project', $this->impl->call('getProjectId', []));
     }
 
     /**


### PR DESCRIPTION
Hello!

I've run across a use-case where it would be nice to get the project ID dynamically in code. `\Google\Cloud\Core\ClientTrait` already implements project ID detection, but does not expose the property and so I would be left with either reimplementing the logic or using reflection.

This PR simply adds a `getProjectId` function to the trait so that a caller can pull out the detected project ID.

Example:

```php
$storage = new \Google\Cloud\Storage\StorageClient;

$project_id = $storage->getProjectId();

$bucket = $storage->bucket($project_id . "-data");
```

I've updated some tests to take advantage of this method, ran them with `vendor/bin/phpunit --group=client-trait` and also ran `composer style`.

Let me know if there is anything else needed.