### PR TITLE
Fix typo in Redis sample code

### DIFF
--- a/Redis/README.md
+++ b/Redis/README.md
@@ -52,8 +52,8 @@ $formattedLocationName = $client->locationName($projectId, $location);
 $response = $client->listInstances($formattedLocationName);
 foreach ($response->iterateAllElements() as $instance) {
     printf('Instance: %s : %s' . PHP_EOL,
-        $device->getDisplayName(),
-        $device->getName()
+        $instance->getDisplayName(),
+        $instance->getName()
     );
 }
 ```


### PR DESCRIPTION
There is a typo in the PHP sample code in the Redis README file.

A variable (`$device`) is misnamed in the example. It should be `$instance`. Running the example as is will gives the following error(s):

```
PHP Notice:  Undefined variable: device
PHP Fatal error:  Uncaught Error: Call to a member function getDisplayName() on null
```

This PR corrects that typo.