### PR TITLE
Added suggested App Engine config to docs

### DIFF
--- a/Datastore/README.md
+++ b/Datastore/README.md
@@ -69,11 +69,10 @@ any minor or patch releases. We will address issues and requests with the highes
 
 This component is compatible with PHP projects on Google App Engine in the Standard or Flexible environments. To maximize the performance of datastore operations in your app, we recommend the following configuration:
 1. PHP 7 runtime
-2. Require grpc via Composer
-3. Enable grpc.so and protobuf.so in your php.ini file
-4. Set your DatastoreClient object's 'transport' option to 'grpc'
+2. Enable grpc.so and protobuf.so in your php.ini file
+3. Set your DatastoreClient object's 'transport' option to 'grpc'
 
-You are likely to experience less optimal datastore performance using the PHP 5 runtime.
+You are likely to experience less optimal datastore performance using the PHP 5 runtime on App Engine standard due to the lack of the protobuf extension.
 
 
 ### Next Steps

--- a/Datastore/README.md
+++ b/Datastore/README.md
@@ -65,6 +65,17 @@ $entity = $datastore->lookup($key);
 This component is considered GA (generally available). As such, it will not introduce backwards-incompatible changes in
 any minor or patch releases. We will address issues and requests with the highest priority.
 
+### Compatibility with Google App Engine
+
+This component is compatible with PHP projects on Google App Engine in the Standard or Flexible environments. To maximize the performance of datastore operations in your app, we recommend the following configuration:
+1. PHP 7 runtime
+2. Require grpc via Composer
+3. Enable grpc.so and protobuf.so in your php.ini file
+4. Set your DatastoreClient object's 'transport' option to 'grpc'
+
+You are likely to experience less optimal datastore performance using the PHP 5 runtime.
+
+
 ### Next Steps
 
 1. Understand the [official documentation](https://cloud.google.com/datastore/docs/).


### PR DESCRIPTION
App Engine users will experience extremely poor datastore performance if they use this component in the PHP 5 runtime. I presume there are a large number of developers using this component with their App Engine project, so I added a section that highlights how developers can avoid this pitfall. 
Background context on poor datastore performance in PHP 5: https://github.com/googleapis/google-cloud-php/issues/1937