### PR TITLE
fix: Fix BigQueryDataTransfer smoke test

### DIFF
--- a/BigQueryDataTransfer/tests/System/V1/DataTransferServiceSmokeTest.php
+++ b/BigQueryDataTransfer/tests/System/V1/DataTransferServiceSmokeTest.php
@@ -42,7 +42,7 @@ class DataTransferServiceSmokeTest extends GeneratedTest
         }
 
         $dataTransferServiceClient = new DataTransferServiceClient();
-        $formattedParent = $dataTransferServiceClient->locationName($projectId, 'us-central1');
+        $formattedParent = $dataTransferServiceClient->projectName($projectId, 'us-central1');
         $dataTransferServiceClient->listDataSources($formattedParent);
     }
 }


### PR DESCRIPTION
The test file says it's generated, but it wasn't updated to take into account recent changes. This fixes the failing system test.