### PR TITLE
Make ExponentialBackoff::retryFunction protected

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -30,11 +30,6 @@ class ExponentialBackoff
     private $retries;
 
     /**
-     * @var callable|null
-     */
-    private $retryFunction;
-
-    /**
      * @var callable
      */
     private $delayFunction;
@@ -43,6 +38,11 @@ class ExponentialBackoff
      * @var callable|null
      */
     private $calcDelayFunction;
+
+    /**
+     * @var callable|null
+     */
+    protected $retryFunction;
 
     /**
      * @param int $retries [optional] Number of retries for a failed request.


### PR DESCRIPTION
This would allow for backoff chaining, like the following: 

```php
$retryCount1 = 1;
$retryCount2 = 2;
$backoff1 = new ExponentialBackoff($retryCount1, function ($exception) {
    return $exception instanceof MyRetryableException1;
});

$backoff2 = new ExponentialBackoff($retryCount2, function($exception) use ($backoff1) {
    return $exception instanceof MyRetryableException2
     || call_user_func($backoff1->retryFunction, $exception);
});

$backoff2->execute($someFunction, $args);
```

Note `$retryCount1` will be completely ignored, and only `$retryCount2` will be used. This appears to be clear from the context of the retry function.

If we wanted to fix this aspect as well, I see two other options:

1. Pass `$function` and `$arguments` to every invocation of `$retryFunction`:
```php
$backoff1 = new ExponentialBackoff(1, function ($exception) {
    return $exception instanceof MyRetryableException1;
});

$backoff2 = new ExponentialBackoff(2, function($exception, $function, $arguments) use ($backoff1) {
    return $exception instanceof MyRetryableException2
     || call_user_func($backoff1->retryFunction, $exception, $function, $arguments);
});

$backoff2->execute($someFunction, $args);
```

2. Implement special logic in the `ExponentialBackoff` plugin, a la:
```php
$backoff1 = new ExponentialBackoff(1, function ($exception) {
    return $exception instanceof MyRetryableException1;
});

$backoff2 = new ExponentialBackoff(2, function($exception) use ($backoff1) {
    return $exception instanceof MyRetryableException2;
});

$backoff2->chain($backoff1)->execute($someFunction, $args);
```


Thoughts?