### PR TITLE
build: add release-please bin to CI

### DIFF
--- a/.kokoro/continuous/node10/release.sh
+++ b/.kokoro/continuous/node10/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/continuous/node10/release.sh
+++ b/.kokoro/continuous/node10/release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
+  # Groom the release PR as new commits are merged.
+  npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
+    --repo-url=googleapis/google-cloud-php \
+    --package-name="Google Cloud PHP" \
+    --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
+    --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please
+
+  # Look for merged commit PRs and create releases on GitHub.
+  npx release-please github-release --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
+    --repo-url=googleapis/google-cloud-php \
+    --package-name="Google Cloud PHP" \
+    --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
+    --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please
+fi

--- a/.kokoro/continuous/node10/test.cfg
+++ b/.kokoro/continuous/node10/test.cfg
@@ -1,0 +1,52 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-cloud-php/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+}
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-cloud-php/.kokoro/continuous/node10/release.sh"
+}
+
+# tokens used by release-please to keep an up-to-date release PR.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-key-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-token-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-url-release-please"
+    }
+  }
+}


### PR DESCRIPTION
Adds a script which runs when commits are merged and:

1. keeps a release PR (see: https://github.com/googleapis/google-cloud-php/pull/2055) up to date.
2. if it sees a merged release-pr, it uses the GitHub API to create a new GitHub release tag.