### PR TITLE
fix: Use updated URIs for operations

### DIFF
--- a/VideoIntelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
+++ b/VideoIntelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
@@ -12,11 +12,30 @@ return [
         'google.longrunning.Operations' => [
             'ListOperations' => [
                 'method' => 'get',
-                'uriTemplate' => '/v1/operations',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*}/operations',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/operations'
+                    ]
+                ],
+                'placeholders' => [
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                ],
             ],
             'GetOperation' => [
                 'method' => 'get',
-                'uriTemplate' => '/v1/operations/{name=*}',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/operations/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/operations/{name=*}'
+                    ]
+                ],
                 'placeholders' => [
                     'name' => [
                         'getters' => [
@@ -27,7 +46,13 @@ return [
             ],
             'DeleteOperation' => [
                 'method' => 'delete',
-                'uriTemplate' => '/v1/operations/{name=*}',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/operations/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'delete',
+                        'uriTemplate' => '/v1/operations/{name=*}'
+                    ]
+                ],
                 'placeholders' => [
                     'name' => [
                         'getters' => [
@@ -38,7 +63,13 @@ return [
             ],
             'CancelOperation' => [
                 'method' => 'post',
-                'uriTemplate' => '/v1/operations/{name=*}:cancel',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/operations/*}:cancel',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/operations/{name=*}:cancel'
+                    ]
+                ],
                 'body' => '*',
                 'placeholders' => [
                     'name' => [


### PR DESCRIPTION
Towards: https://github.com/googleapis/google-cloud-php/issues/2064

This is only a temporary solution. We are waiting on updates to land in https://github.com/googleapis/googleapis/tree/master/google/cloud/videointelligence/v1, at which point synthtool will take over.

/cc @bshaffer 