### PR TITLE
fix: Remove unset content type in system test

### DIFF
--- a/Storage/tests/System/SignedUrlTest.php
+++ b/Storage/tests/System/SignedUrlTest.php
@@ -197,10 +197,6 @@ class SignedUrlTest extends StorageTestCase
         $disposition = 'attachment;filename="image.jpg"';
         $obj = $this->createFile(uniqid(self::TESTING_PREFIX) .'.txt');
 
-        $obj->update([
-            'contentType' => null
-        ]);
-
         $url = $obj->signedUrl(time() + 2, [
             'responseDisposition' => $disposition,
             'responseType' => $contentType,


### PR DESCRIPTION
This operation is not necessary and may be responsible for kokoro test failures.