### PR TITLE
feat: Add explicit support for dataset filters

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -519,6 +519,7 @@ class BigQueryClient
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/list Datasets list API documentation.
      *
+     * @codingStandardsIgnoreStart
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -529,7 +530,14 @@ class BigQueryClient
      *           **Defaults to** `0` (return all results).
      *     @type string $pageToken A previously-returned page token used to
      *           resume the loading of results from a specific point.
+     *     @type string $filter An expression for filtering the results of the
+     *           request by label. The syntax is "labels.<name>[:<value>]".
+     *           Multiple filters can be ANDed together by connecting with a
+     *           space. Example: "labels.department:receiving labels.active".
+     *           See [Filtering datasets using labels](https://cloud.google.com/bigquery/docs/labeling-datasets#filtering_datasets_using_labels)
+     *           for details.
      * }
+     * @codingStandardsIgnoreEnd
      * @return ItemIterator<Dataset>
      */
     public function datasets(array $options = [])

--- a/BigQuery/tests/System/ManageDatasetsTest.php
+++ b/BigQuery/tests/System/ManageDatasetsTest.php
@@ -48,6 +48,41 @@ class ManageDatasetsTest extends BigQueryTestCase
         $this->assertEquals($datasetsToCreate, $foundDatasets);
     }
 
+    public function testListDatasetsWithFilter()
+    {
+        $foundDatasets = [];
+        $datasetsToCreate = [
+            uniqid(self::TESTING_PREFIX),
+        ];
+
+        $labelKey = uniqid(self::TESTING_PREFIX);
+        $labelValue = uniqid(self::TESTING_PREFIX);
+
+        foreach ($datasetsToCreate as $datasetToCreate) {
+            $this->createDataset(self::$client, $datasetToCreate, [
+                'metadata' => [
+                    'labels' => [
+                        $labelKey => $labelValue
+                    ]
+                ]
+            ]);
+        }
+
+        $datasets = self::$client->datasets([
+            'filter' => 'labels.' . $labelKey . ':' . $labelValue
+        ]);
+
+        foreach ($datasets as $dataset) {
+            foreach ($datasetsToCreate as $key => $datasetToCreate) {
+                if ($dataset->id() === $datasetToCreate) {
+                    $foundDatasets[$key] = $dataset->id();
+                }
+            }
+        }
+
+        $this->assertEquals($datasetsToCreate, $foundDatasets);
+    }
+
     public function testCreatesDataset()
     {
         $id = uniqid(self::TESTING_PREFIX);


### PR DESCRIPTION
Closes #2118.

Adds documentation explaining existing support for filtering datasets via `BigQueryClient::datasets()` and a system test to exercise the functionality.