### PR TITLE
Removes STDERR const, which is defined by CLI SAPI

### DIFF
--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -144,7 +144,8 @@ class Bootstrap
                 ]
             ]);
         } else {
-            fwrite(fopen('php://stderr', 'w'), $message . PHP_EOL);
+            $stderr = defined('STDERR') ? STDERR : fopen('php://stderr', 'w');
+            fwrite($stderr, $message . PHP_EOL);
         }
     }
 

--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -144,7 +144,7 @@ class Bootstrap
                 ]
             ]);
         } else {
-            fwrite(STDERR, $message . PHP_EOL);
+            fwrite(fopen('php://stderr', 'w'), $message . PHP_EOL);
         }
     }
 


### PR DESCRIPTION
Removes use of  `STDERR` const, which is defined by [CLI SAPI](https://php.net/manual/en/features.commandline.io-streams.php) and so isn't available when PHP is executed through a web server