### PR TITLE
fix: Address Firestore memory leak (affects long running processes)

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -54,7 +54,7 @@ class ExponentialBackoff
         $this->retryFunction = $retryFunction;
         // @todo revisit this approach
         // @codeCoverageIgnoreStart
-        $this->delayFunction = function ($delay) {
+        $this->delayFunction = static function ($delay) {
             usleep($delay);
         };
         // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Closes: https://github.com/googleapis/google-cloud-php/issues/2128

A snippet to replicate the issue:

```php
use Google\Cloud\Firestore\FirestoreClient;

$client = new FirestoreClient();

while (true) {
    $collection = $client->collection('my-collection');
    $document = $collection->document(uniqid('doc-'));

    $document->set([
        'one' => 1,
        'two' => 2,
        'three' => 3
    ]);

    usleep(100000);
    echo memory_get_usage() . PHP_EOL;
}
```