### PR TITLE
chore: Add a stricter replacement for serviceAddress

### DIFF
--- a/Asset/synth.py
+++ b/Asset/synth.py
@@ -51,11 +51,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/AutoMl/synth.py
+++ b/AutoMl/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/BigQueryDataTransfer/synth.py
+++ b/BigQueryDataTransfer/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Bigtable/synth.py
+++ b/Bigtable/synth.py
@@ -68,11 +68,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Container/synth.py
+++ b/Container/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Dataproc/synth.py
+++ b/Dataproc/synth.py
@@ -57,11 +57,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Datastore/synth.py
+++ b/Datastore/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Debugger/synth.py
+++ b/Debugger/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Dialogflow/synth.py
+++ b/Dialogflow/synth.py
@@ -48,11 +48,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Dlp/synth.py
+++ b/Dlp/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/ErrorReporting/synth.py
+++ b/ErrorReporting/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Firestore/synth.py
+++ b/Firestore/synth.py
@@ -75,11 +75,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Iot/synth.py
+++ b/Iot/synth.py
@@ -50,11 +50,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Kms/synth.py
+++ b/Kms/synth.py
@@ -44,11 +44,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Language/synth.py
+++ b/Language/synth.py
@@ -50,11 +50,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Logging/synth.py
+++ b/Logging/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Monitoring/synth.py
+++ b/Monitoring/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/OsLogin/synth.py
+++ b/OsLogin/synth.py
@@ -58,11 +58,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/PubSub/synth.py
+++ b/PubSub/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Redis/synth.py
+++ b/Redis/synth.py
@@ -65,11 +65,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Scheduler/synth.py
+++ b/Scheduler/synth.py
@@ -52,11 +52,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/SecurityCenter/synth.py
+++ b/SecurityCenter/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Spanner/synth.py
+++ b/Spanner/synth.py
@@ -86,11 +86,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Speech/synth.py
+++ b/Speech/synth.py
@@ -52,11 +52,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Talent/synth.py
+++ b/Talent/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Tasks/synth.py
+++ b/Tasks/synth.py
@@ -50,11 +50,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/TextToSpeech/synth.py
+++ b/TextToSpeech/synth.py
@@ -43,11 +43,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Trace/synth.py
+++ b/Trace/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/VideoIntelligence/synth.py
+++ b/VideoIntelligence/synth.py
@@ -51,11 +51,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/Vision/synth.py
+++ b/Vision/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/WebRisk/synth.py
+++ b/WebRisk/synth.py
@@ -48,11 +48,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",

--- a/WebSecurityScanner/synth.py
+++ b/WebSecurityScanner/synth.py
@@ -49,11 +49,12 @@ s.replace(
     r"'apiEndpoint' =>")
 s.replace(
     "**/Gapic/*GapicClient.php",
-    r"@type string \$serviceAddress",
+    r"@type string \$serviceAddress\n\s+\*\s+The address",
     r"""@type string $serviceAddress
      *           **Deprecated**. This option will be removed in a future major release. Please
      *           utilize the `$apiEndpoint` option instead.
-     *     @type string $apiEndpoint""")
+     *     @type string $apiEndpoint
+     *           The address""")
 s.replace(
     "**/Gapic/*GapicClient.php",
     r"\$transportConfig, and any \$serviceAddress",


### PR DESCRIPTION
To fix synth PRs like the following: https://github.com/googleapis/google-cloud-php/pull/2240