### PR TITLE
fix: Bump core dependency for BigQuery and Translate

### DIFF
--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.31",
+        "google/cloud-core": "^1.32",
         "ramsey/uuid": "~3"
     },
     "require-dev": {

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.31"
+        "google/cloud-core": "^1.32"
     },
      "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
Changes to the RequestBuilder constructor are required for BigQuery and Translate to function properly. Once I implement `apiEndpoint` in Storage, it'll be needed there too, but I'll do that with the storage PR.