### PR TITLE
Add support for Monolog 2.x

### DIFF
--- a/Core/src/Logger/AppEngineFlexFormatterV2.php
+++ b/Core/src/Logger/AppEngineFlexFormatterV2.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ namespace Google\Cloud\Core\Logger;
 use Monolog\Formatter\LineFormatter;
 
 /**
- * Monolog 1.x formatter for formatting logs on App Engine flexible environment.
+ * Monolog 2.x formatter for formatting logs on App Engine flexible environment.
  *
- * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatterV2} instead.
+ * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatter} instead.
  */
-class AppEngineFlexFormatter extends LineFormatter
+class AppEngineFlexFormatterV2 extends LineFormatter
 {
     use FormatterTrait;
 
@@ -44,7 +44,7 @@ class AppEngineFlexFormatter extends LineFormatter
      * @param array $record A record to format
      * @return string The formatted record
      */
-    public function format(array $record)
+    public function format(array $record): string
     {
         return $this->formatPayload($record, parent::format($record));
     }

--- a/Core/src/Logger/AppEngineFlexHandler.php
+++ b/Core/src/Logger/AppEngineFlexHandler.php
@@ -46,7 +46,7 @@ class AppEngineFlexHandler extends StreamHandler
         $stream = null
     ) {
         if ($stream === null) {
-            $pid = posix_getpid();
+            $pid = getmypid();
             $stream = "file:///var/log/app_engine/app.$pid.json";
         }
         parent::__construct(

--- a/Core/src/Logger/AppEngineFlexHandlerV2.php
+++ b/Core/src/Logger/AppEngineFlexHandlerV2.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
 /**
- * Monolog 1.x handler for logging on App Engine flexible environment.
+ * Monolog 2.x handler for logging on App Engine flexible environment.
  *
- * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV2} instead.
+ * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandler} instead.
  */
-class AppEngineFlexHandler extends StreamHandler
+class AppEngineFlexHandlerV2 extends StreamHandler
 {
     /**
      * @param int $level [optional] The minimum logging level at which this
@@ -58,13 +58,8 @@ class AppEngineFlexHandler extends StreamHandler
         );
     }
 
-    /**
-     * Get the default formatter.
-     *
-     * @return FormatterInterface
-     */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
-        return new AppEngineFlexFormatter();
+        return new AppEngineFlexFormatterV2();
     }
 }

--- a/Core/src/Logger/AppEngineFlexHandlerV2.php
+++ b/Core/src/Logger/AppEngineFlexHandlerV2.php
@@ -46,7 +46,7 @@ class AppEngineFlexHandlerV2 extends StreamHandler
         $stream = null
     ) {
         if ($stream === null) {
-            $pid = posix_getpid();
+            $pid = getmypid();
             $stream = "file:///var/log/app_engine/app.$pid.json";
         }
         parent::__construct(

--- a/Core/src/Logger/FormatterTrait.php
+++ b/Core/src/Logger/FormatterTrait.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Google\Cloud\Core\Logger;
+
+/**
+ * Shared trait to enrich and format a record with
+ * App Engine Flex specific information.
+ */
+trait FormatterTrait
+{
+    protected function formatPayload(array $record, $message)
+    {
+        list($usec, $sec) = explode(' ', microtime());
+        $usec = (int)(((float)$usec)*1000000000);
+        $sec = (int)$sec;
+
+        $payload = [
+            'message' => $message,
+            'timestamp'=> ['seconds' => $sec, 'nanos' => $usec],
+            'thread' => '',
+            'severity' => $record['level_name'],
+        ];
+
+        if (isset($_SERVER['HTTP_X_CLOUD_TRACE_CONTEXT'])) {
+            $payload['traceId'] = explode(
+                '/',
+                $_SERVER['HTTP_X_CLOUD_TRACE_CONTEXT']
+            )[0];
+        }
+
+        return "\n" . json_encode($payload);
+    }
+}

--- a/Core/src/Testing/Snippet/Coverage/Coverage.php
+++ b/Core/src/Testing/Snippet/Coverage/Coverage.php
@@ -28,8 +28,9 @@ use Google\Cloud\Core\Testing\Snippet\Parser\Snippet;
 class Coverage
 {
     private static $snippetExcludeList = [
+        '/\\\GcTestListener/',
+        '/\\\Google\\\Cloud\\\Core\\\Logger/',
         '/\\\Google\\\Cloud\\\Core\\\PhpArray/',
-        '/\\\GcTestListener/'
     ];
 
     /**

--- a/Core/tests/Unit/Logger/AppEngineFlexHandlerFactoryTest.php
+++ b/Core/tests/Unit/Logger/AppEngineFlexHandlerFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Google\Cloud\Core\Tests\Unit\Logger;
+
+use Google\Cloud\Core\Logger\AppEngineFlexHandler;
+use Google\Cloud\Core\Logger\AppEngineFlexHandlerFactory;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Google\Cloud\Core\Logger\AppEngineFlexHandlerV2;
+
+/**
+ * @group core
+ * @group logger
+ */
+class AppEngineFlexHandlerFactoryTest extends TestCase
+{
+    public function testBuildMonologV1Handler()
+    {
+        $this->skipIfNotMonologVersion(1);
+
+        $this->assertInstanceOf(AppEngineFlexHandler::class, AppEngineFlexHandlerFactory::build());
+    }
+
+    public function testBuildMonologV2Handler()
+    {
+        $this->skipIfNotMonologVersion(2);
+
+        $this->assertInstanceOf(AppEngineFlexHandlerV2::class, AppEngineFlexHandlerFactory::build());
+    }
+
+    private function skipIfNotMonologVersion($expected)
+    {
+        $version = defined('Monolog\Logger::API') ? Logger::API : 1;
+
+        if ($expected !== $version) {
+            $this->markTestSkipped("Monolog {$expected} only");
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "rize/uri-template": "~0.3",
         "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
-        "monolog/monolog": "~1",
+        "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*",
         "ramsey/uuid": "~3",
         "google/gax": "^1.1",

--- a/dev/src/DocGenerator/Parser/ClassReference.php
+++ b/dev/src/DocGenerator/Parser/ClassReference.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Google\Cloud\Dev\DocGenerator\Parser;
+
+class ClassReference
+{
+    /** @var string */
+    private $className;
+
+    /** @var string */
+    private $fileName;
+
+    public function __construct($className, $fileName)
+    {
+        $this->className = $className;
+        $this->fileName = $fileName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName()
+    {
+        return $this->fileName;
+    }
+}


### PR DESCRIPTION
Hey everyone 👋

This is a follow up to #2293 and aims to add support for both monolog/monolog 1.x and 2.x.

Monolog 2.x was released on August 30th, 2019 and requires PHP ^7.2 whereas google/cloud keeps supporting PHP 5.6.

The specific issue is that Monolog 2.x adds method return types which are not supported by PHP 5.x. On the other hand, leaving the return type declarations out causes PHP 7.x to throw errors.

`AppEngineFlexHandler` and `AppEngineFlexFormatter` remain the implementation for Monolog 1.x.

`AppEngineFlexV2Handler` and `AppEngineFlexV2Formatter` are the new implementations for Monolog 2.x.

The new classes are the same as the old ones with the only difference being added return type declarations.

#### Notes

* I thought about extracting the common code instead of duplicating it, but I didn't want to go overboard in the very first iteration of the PR, I first wanted to check if you would consider merging the change at all :)
* The Monolog\Logger::API constant has been added in Monolog 1.6, which requires the version bump for the 1.x constraint. Monolog 1.6 has been released in 2013, so I don't think this should be a real-world issue compared to the previous `~1` constraint.
* The only place where I could find the handlers referenced is on https://cloud.google.com/php/getting-started/logging-application-events?hl=de (switching to English via the language switcher resulted in a 404 for me).

:octocat: 