### PR TITLE
chore: Use minor version bump before GA

### DIFF
--- a/.kokoro/continuous/node10/release.sh
+++ b/.kokoro/continuous/node10/release.sh
@@ -26,6 +26,7 @@ if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; th
     --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
     --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
     --release-type=php-yoshi
+    --bump-minor-pre-major=true
 
   # Look for merged commit PRs and create releases on GitHub.
   npx release-please github-release --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \


### PR DESCRIPTION
ref: https://github.com/googleapis/release-please/issues/259

Prefer minor version bumps on pre-GA packages.