### PR TITLE
Fix incorrect return value in LoadJobConfiguration

### DIFF
--- a/BigQuery/src/LoadJobConfiguration.php
+++ b/BigQuery/src/LoadJobConfiguration.php
@@ -574,5 +574,7 @@ class LoadJobConfiguration implements JobConfigurationInterface
     public function useAvroLogicalTypes($useAvroLogicalTypes)
     {
         $this->config['configuration']['load']['useAvroLogicalTypes'] = $useAvroLogicalTypes;
+        
+        return $this;
     }
 }


### PR DESCRIPTION
This corrects a minor issue in the BigQuery `LoadJobConfiguration` where `useAvroLogicalTypes` isn't adhering to the documented return type.