### PR TITLE
fix: Fix fluent setter in ExtractJobConfiguration

### DIFF
--- a/BigQuery/src/ExtractJobConfiguration.php
+++ b/BigQuery/src/ExtractJobConfiguration.php
@@ -184,5 +184,7 @@ class ExtractJobConfiguration implements JobConfigurationInterface
     public function useAvroLogicalTypes($useAvroLogicalTypes)
     {
         $this->config['configuration']['extract']['useAvroLogicalTypes'] = $useAvroLogicalTypes;
+
+        return $this;
     }
 }

--- a/BigQuery/tests/Unit/CopyJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/CopyJobConfigurationTest.php
@@ -77,12 +77,13 @@ class CopyJobConfigurationTest extends TestCase
         ];
         $this->expectedConfig['configuration']['copy'] = $copy
             + $this->expectedConfig['configuration']['copy'];
-        $this->config
+
+        $this->assertInstanceOf(CopyJobConfiguration::class, $this->config
             ->createDisposition($copy['createDisposition'])
             ->destinationEncryptionConfiguration($copy['destinationEncryptionConfiguration'])
             ->destinationTable($destinationTable->reveal())
             ->sourceTable($sourceTable->reveal())
-            ->writeDisposition($copy['writeDisposition']);
+            ->writeDisposition($copy['writeDisposition']));
 
         $this->assertEquals(
             $this->expectedConfig,

--- a/BigQuery/tests/Unit/CopyJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/CopyJobConfigurationTest.php
@@ -78,12 +78,14 @@ class CopyJobConfigurationTest extends TestCase
         $this->expectedConfig['configuration']['copy'] = $copy
             + $this->expectedConfig['configuration']['copy'];
 
-        $this->assertInstanceOf(CopyJobConfiguration::class, $this->config
+        $config = $this->config
             ->createDisposition($copy['createDisposition'])
             ->destinationEncryptionConfiguration($copy['destinationEncryptionConfiguration'])
             ->destinationTable($destinationTable->reveal())
             ->sourceTable($sourceTable->reveal())
-            ->writeDisposition($copy['writeDisposition']));
+            ->writeDisposition($copy['writeDisposition']);
+
+        $this->assertInstanceOf(CopyJobConfiguration::class, $config);
 
         $this->assertEquals(
             $this->expectedConfig,

--- a/BigQuery/tests/Unit/CopyJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/CopyJobConfigurationTest.php
@@ -86,7 +86,6 @@ class CopyJobConfigurationTest extends TestCase
             ->writeDisposition($copy['writeDisposition']);
 
         $this->assertInstanceOf(CopyJobConfiguration::class, $config);
-
         $this->assertEquals(
             $this->expectedConfig,
             $this->config->toArray()

--- a/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
@@ -74,14 +74,15 @@ class ExtractJobConfigurationTest extends TestCase
         ];
         $this->expectedConfig['configuration']['extract'] = $extract
             + $this->expectedConfig['configuration']['extract'];
-        $this->config
+
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $this->config
             ->compression($extract['compression'])
             ->destinationFormat($extract['destinationFormat'])
             ->destinationUris($extract['destinationUris'])
             ->fieldDelimiter($extract['fieldDelimiter'])
             ->printHeader($extract['printHeader'])
             ->sourceTable($sourceTable->reveal())
-            ->useAvroLogicalTypes($extract['useAvroLogicalTypes']);
+            ->useAvroLogicalTypes($extract['useAvroLogicalTypes']));
 
         $this->assertEquals(
             $this->expectedConfig,

--- a/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
@@ -85,7 +85,6 @@ class ExtractJobConfigurationTest extends TestCase
             ->useAvroLogicalTypes($extract['useAvroLogicalTypes']);
 
         $this->assertInstanceOf(ExtractJobConfiguration::class, $config);
-
         $this->assertEquals(
             $this->expectedConfig,
             $this->config->toArray()

--- a/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/ExtractJobConfigurationTest.php
@@ -75,14 +75,16 @@ class ExtractJobConfigurationTest extends TestCase
         $this->expectedConfig['configuration']['extract'] = $extract
             + $this->expectedConfig['configuration']['extract'];
 
-        $this->assertInstanceOf(ExtractJobConfiguration::class, $this->config
+        $config = $this->config
             ->compression($extract['compression'])
             ->destinationFormat($extract['destinationFormat'])
             ->destinationUris($extract['destinationUris'])
             ->fieldDelimiter($extract['fieldDelimiter'])
             ->printHeader($extract['printHeader'])
             ->sourceTable($sourceTable->reveal())
-            ->useAvroLogicalTypes($extract['useAvroLogicalTypes']));
+            ->useAvroLogicalTypes($extract['useAvroLogicalTypes']);
+
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $config);
 
         $this->assertEquals(
             $this->expectedConfig,

--- a/BigQuery/tests/Unit/LoadJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/LoadJobConfigurationTest.php
@@ -96,7 +96,8 @@ class LoadJobConfigurationTest extends TestCase
         ];
         $this->expectedConfig['configuration']['load'] = $load
             + $this->expectedConfig['configuration']['load'];
-        $this->config
+
+        $this->assertInstanceOf(LoadJobConfiguration::class, $this->config
             ->allowJaggedRows($load['allowJaggedRows'])
             ->allowQuotedNewlines($load['allowQuotedNewlines'])
             ->autodetect($load['autodetect'])
@@ -119,7 +120,7 @@ class LoadJobConfigurationTest extends TestCase
             ->sourceUris($load['sourceUris'])
             ->timePartitioning($load['timePartitioning'])
             ->writeDisposition($load['writeDisposition'])
-            ->useAvroLogicalTypes($load['useAvroLogicalTypes']);
+            ->useAvroLogicalTypes($load['useAvroLogicalTypes']));
 
         $this->assertEquals(
             $this->expectedConfig + ['data' => $data],

--- a/BigQuery/tests/Unit/LoadJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/LoadJobConfigurationTest.php
@@ -97,7 +97,7 @@ class LoadJobConfigurationTest extends TestCase
         $this->expectedConfig['configuration']['load'] = $load
             + $this->expectedConfig['configuration']['load'];
 
-        $this->assertInstanceOf(LoadJobConfiguration::class, $this->config
+        $config = $this->config
             ->allowJaggedRows($load['allowJaggedRows'])
             ->allowQuotedNewlines($load['allowQuotedNewlines'])
             ->autodetect($load['autodetect'])
@@ -120,7 +120,9 @@ class LoadJobConfigurationTest extends TestCase
             ->sourceUris($load['sourceUris'])
             ->timePartitioning($load['timePartitioning'])
             ->writeDisposition($load['writeDisposition'])
-            ->useAvroLogicalTypes($load['useAvroLogicalTypes']));
+            ->useAvroLogicalTypes($load['useAvroLogicalTypes']);
+
+        $this->assertInstanceOf(LoadJobConfiguration::class, $config);
 
         $this->assertEquals(
             $this->expectedConfig + ['data' => $data],

--- a/BigQuery/tests/Unit/LoadJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/LoadJobConfigurationTest.php
@@ -123,7 +123,6 @@ class LoadJobConfigurationTest extends TestCase
             ->useAvroLogicalTypes($load['useAvroLogicalTypes']);
 
         $this->assertInstanceOf(LoadJobConfiguration::class, $config);
-
         $this->assertEquals(
             $this->expectedConfig + ['data' => $data],
             $this->config->toArray()

--- a/BigQuery/tests/Unit/QueryJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/QueryJobConfigurationTest.php
@@ -132,7 +132,6 @@ class QueryJobConfigurationTest extends TestCase
             ->writeDisposition($query['writeDisposition']);
 
         $this->assertInstanceOf(QueryJobConfiguration::class, $config);
-
         $this->assertEquals($this->expectedConfig, $this->config->toArray());
     }
 

--- a/BigQuery/tests/Unit/QueryJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/QueryJobConfigurationTest.php
@@ -111,7 +111,7 @@ class QueryJobConfigurationTest extends TestCase
         $this->expectedConfig['configuration']['query'] = $query
             + $this->expectedConfig['configuration']['query'];
 
-        $this->assertInstanceOf(QueryJobConfiguration::class, $this->config
+        $config = $this->config
             ->allowLargeResults($query['allowLargeResults'])
             ->clustering($query['clustering'])
             ->createDisposition($query['createDisposition'])
@@ -129,7 +129,9 @@ class QueryJobConfigurationTest extends TestCase
             ->useLegacySql($query['useLegacySql'])
             ->useQueryCache($query['useQueryCache'])
             ->userDefinedFunctionResources($query['userDefinedFunctionResources'])
-            ->writeDisposition($query['writeDisposition']));
+            ->writeDisposition($query['writeDisposition']);
+
+        $this->assertInstanceOf(QueryJobConfiguration::class, $config);
 
         $this->assertEquals($this->expectedConfig, $this->config->toArray());
     }

--- a/BigQuery/tests/Unit/QueryJobConfigurationTest.php
+++ b/BigQuery/tests/Unit/QueryJobConfigurationTest.php
@@ -110,7 +110,8 @@ class QueryJobConfigurationTest extends TestCase
         ];
         $this->expectedConfig['configuration']['query'] = $query
             + $this->expectedConfig['configuration']['query'];
-        $this->config
+
+        $this->assertInstanceOf(QueryJobConfiguration::class, $this->config
             ->allowLargeResults($query['allowLargeResults'])
             ->clustering($query['clustering'])
             ->createDisposition($query['createDisposition'])
@@ -128,7 +129,7 @@ class QueryJobConfigurationTest extends TestCase
             ->useLegacySql($query['useLegacySql'])
             ->useQueryCache($query['useQueryCache'])
             ->userDefinedFunctionResources($query['userDefinedFunctionResources'])
-            ->writeDisposition($query['writeDisposition']);
+            ->writeDisposition($query['writeDisposition']));
 
         $this->assertEquals($this->expectedConfig, $this->config->toArray());
     }


### PR DESCRIPTION
Counterpart to #2327 and an extra assertion in the job configuration tests to make sure the last setter (the most likely to be newly added) returns as expected.