### PR TITLE
Stop saving failures to flush jobs in InMemoryConfigStorage to disk

### DIFF
--- a/Core/src/Batch/InMemoryConfigStorage.php
+++ b/Core/src/Batch/InMemoryConfigStorage.php
@@ -29,8 +29,6 @@ final class InMemoryConfigStorage implements
     ConfigStorageInterface,
     ProcessItemInterface
 {
-    use HandleFailureTrait;
-
     /* @var JobConfig */
     private $config;
 
@@ -89,7 +87,6 @@ final class InMemoryConfigStorage implements
     {
         $this->config = new JobConfig();
         $this->created = microtime(true);
-        $this->initFailureFile();
         $this->hasShutdownHookRegistered = false;
     }
 
@@ -191,9 +188,7 @@ final class InMemoryConfigStorage implements
         if (isset($this->items[$idNum])) {
             $job = $this->config->getJobFromIdNum($idNum);
 
-            if (!$job->flush($this->items[$idNum])) {
-                $this->handleFailure($idNum, $this->items[$idNum]);
-            }
+            $job->flush($this->items[$idNum]);
 
             $this->items[$idNum] = [];
             $this->lastInvoked[$idNum] = microtime(true);


### PR DESCRIPTION
I've found several problems with this approach:

1. Call to `\Google\Cloud\Core\Batch\HandleFailureTrait::initFailureFile` leads to a `RuntimeException` when constructing the class.
2. Persisting job flushing failures to disk is very unexpected from a class called with the words `in memory` in the name. This can lead to very unexpected situations, like the disk filling up.
3. As far as I can tell, it is not useful unless `google-cloud-batch` is running. This is unexpected to users when the `InMemoryConfigStorage` is used - which is a default in the `\Google\Cloud\Trace\TraceClient`, for example.

What do you think about removing the failure handling features from `InMemoryConfigStorage`?