### PR TITLE
Only throw exception when creating directory really failed in HandleFailureTrait

### DIFF
--- a/Core/src/Batch/HandleFailureTrait.php
+++ b/Core/src/Batch/HandleFailureTrait.php
@@ -49,16 +49,16 @@ trait HandleFailureTrait
                 sys_get_temp_dir()
             );
         }
-        if (! is_dir($this->baseDir)) {
-            if (@mkdir($this->baseDir, 0700, true) === false) {
-                throw new \RuntimeException(
-                    sprintf(
-                        'Couuld not create a directory: %s',
-                        $this->baseDir
-                    )
-                );
-            }
+
+        if (!is_dir($this->baseDir) && !@mkdir($this->baseDir, 0700, true) && !is_dir($this->baseDir)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Could not create a directory: %s',
+                    $this->baseDir
+                )
+            );
         }
+
         // Use getmypid for simplicity.
         $this->failureFile = sprintf(
             '%s/failed-items-%d',


### PR DESCRIPTION
When multiple processes try to create a directory at the same time `mkdir` is going to fail and return false. This should not warrant an exception.

This change ensures the directory exists - and only throws when it does not.