### PR TITLE
Updates to FirestoreSessionHandler

### DIFF
--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -595,7 +595,7 @@ class FirestoreClient
      *     Configuration Options.
      *
      *     @type int $gcLimit The number of entities to delete in the garbage
-     *        collection. Values larger than 1000 will be limited to 1000.
+     *        collection. Values larger than 500 will be limited to 500.
      *        **Defaults to** `0`, indicating garbage collection is disabled by
      *        default.
      *     @type string $collectionNameTemplate A sprintf compatible template

--- a/Firestore/src/FirestoreSessionHandler.php
+++ b/Firestore/src/FirestoreSessionHandler.php
@@ -396,6 +396,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
 
             throw $e;
         }
+        // Begin a new transaction.
+        $this->open($this->savePath, $this->sessionName);
     }
 
     /**

--- a/Firestore/src/FirestoreSessionHandler.php
+++ b/Firestore/src/FirestoreSessionHandler.php
@@ -243,7 +243,18 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      */
     public function close()
     {
-        $this->commitTransaction($this->transaction);
+        if (is_null($this->transaction)) {
+            throw new \LogicException('open() must be called before close()');
+        }
+        try {
+            $this->commitTransaction($this->transaction);
+        } catch (ServiceException $e) {
+            trigger_error(
+                sprintf('Session close failed: %s', $e->getMessage()),
+                E_USER_WARNING
+            );
+            return false;
+        }
         return true;
     }
 

--- a/Firestore/src/FirestoreSessionHandler.php
+++ b/Firestore/src/FirestoreSessionHandler.php
@@ -300,25 +300,17 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      */
     public function write($id, $data)
     {
-        try {
-            $docRef = $this->getDocumentReference(
-                $this->connection,
-                $this->valueMapper,
-                $this->projectId,
-                $this->database,
-                $this->docId($id)
-            );
-            $this->transaction->set($docRef, [
-                'data' => $data,
-                't' => time()
-            ]);
-        } catch (ServiceException $e) {
-            trigger_error(
-                sprintf('Firestore upsert failed: %s', $e->getMessage()),
-                E_USER_WARNING
-            );
-            return false;
-        }
+        $docRef = $this->getDocumentReference(
+            $this->connection,
+            $this->valueMapper,
+            $this->projectId,
+            $this->database,
+            $this->docId($id)
+        );
+        $this->transaction->set($docRef, [
+            'data' => $data,
+            't' => time()
+        ]);
         return true;
     }
 
@@ -330,22 +322,14 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      */
     public function destroy($id)
     {
-        try {
-            $docRef = $this->getDocumentReference(
-                $this->connection,
-                $this->valueMapper,
-                $this->projectId,
-                $this->database,
-                $this->docId($id)
-            );
-            $this->transaction->delete($docRef);
-        } catch (ServiceException $e) {
-            trigger_error(
-                sprintf('Firestore delete failed: %s', $e->getMessage()),
-                E_USER_WARNING
-            );
-            return false;
-        }
+        $docRef = $this->getDocumentReference(
+            $this->connection,
+            $this->valueMapper,
+            $this->projectId,
+            $this->database,
+            $this->docId($id)
+        );
+        $this->transaction->delete($docRef);
         return true;
     }
 

--- a/Firestore/tests/System/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/System/FirestoreSessionHandlerTest.php
@@ -27,7 +27,7 @@ use Google\Cloud\Firestore\FirestoreSessionHandler;
  */
 class FirestoreSessionHandlerTest extends FirestoreTestCase
 {
-    public function testSessionHandler()
+    public function testSessionWrite()
     {
         $client = self::$client;
 
@@ -48,9 +48,9 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
         sleep(1);
 
         $hasDocument = false;
-        $query = $client->collection($namespace . ':' . session_name());
-        foreach ($query->documents() as $snapshot) {
-            self::$localDeletionQueue->add($snapshot->reference());
+        $collection = $client->collection($namespace . ':' . session_name());
+        self::$localDeletionQueue->add($collection);
+        foreach ($collection->documents() as $snapshot) {
             if (!$hasDocument) {
                 $hasDocument = $snapshot['data'] === $storedValue;
             }
@@ -59,25 +59,67 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
         $this->assertTrue($hasDocument);
     }
 
-    public function testSessionHandlerGarbageCollection()
+    public function testGarbageCollection()
     {
         $client = self::$client;
 
+        // Set session max lifetime to 0 to ensure deletion
+        ini_set('session.gc_maxlifetime', 0);
+
         $namespace = uniqid('sess-' . self::COLLECTION_NAME);
-        $sessionName = 'PHPSESSID';
-        $collection = $client->collection($namespace . ':' . $sessionName);
+        $collection = $client->collection($namespace . ':' . self::$sessionName);
+        self::$localDeletionQueue->add($collection);
         $collection->document('foo1')->set(['data' => 'foo1', 't' => time() - 1]);
         $collection->document('foo2')->set(['data' => 'foo2', 't' => time() - 1]);
-
-        $this->assertCount(2, $collection->documents());
+        $collection->document('foo3')->set(['data' => 'foo3', 't' => time() + 1]);
+        $this->assertCount(3, $collection->documents());
 
         $handler = $client->sessionHandler([
             'gcLimit' => 1000,
             'query' => ['maxRetries' => 0]
         ]);
-        $handler->open($namespace, $sessionName);
-        $handler->gc(0);
 
-        $this->assertCount(0, $collection->documents());
+        session_set_save_handler($handler, true);
+        session_save_path($namespace);
+        session_start();
+
+        session_gc();
+
+        $this->assertCount(1, $collection->documents());
+    }
+
+    public function testGarbageCollectionBeforeWrite()
+    {
+        $client = self::$client;
+
+        // Set session max lifetime to 0 to ensure deletion
+        ini_set('session.gc_maxlifetime', 0);
+
+        // Set GC divisor and probability to 1 so GC execution happens 100%
+        ini_set('session.gc_divisor', 1);
+        ini_set('session.gc_probability', 1);
+
+        $namespace = uniqid('sess-' . self::COLLECTION_NAME);
+        $content = 'foo';
+        $storedValue = 'name|' . serialize($content);
+        $collection = $client->collection($namespace . ':' . self::$sessionName);
+        self::$localDeletionQueue->add($collection);
+        $collection->document('foo1')->set(['data' => 'foo1', 't' => time() - 1]);
+        $collection->document('foo2')->set(['data' => 'foo2', 't' => time() - 1]);
+        $this->assertCount(2, $collection->documents());
+
+        $handler = $client->sessionHandler(['gcLimit' => 500]);
+        session_set_save_handler($handler, true);
+        session_save_path($namespace);
+        session_start();
+
+        $sessionId = session_id();
+        $_SESSION['name'] = $content;
+
+        session_write_close();
+        sleep(1);
+
+        // assert old records have been removed and the new record has been added.
+        $this->assertCount(1, $collection->documents());
     }
 }

--- a/Firestore/tests/System/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/System/FirestoreSessionHandlerTest.php
@@ -128,10 +128,10 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
     public function testSessionGcReturnValue()
     {
         // "session_gc" returns false for user-defined session handlers.
-        // The following returns false no matter what:
-        //     ```
-        //     $this->assertGreaterThan(session_gc(), $result);
-        //     ```
+        // The following test will always fail:
+        // ```
+        // $this->assertGreaterThan(0, session_gc());
+        // ```
         // This test is to remind us to implement a test the issue is fixed.
         $this->markTestSkipped('session_gc returns false due to a core PHP bug');
     }

--- a/Firestore/tests/System/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/System/FirestoreSessionHandlerTest.php
@@ -66,6 +66,9 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
         // Set session max lifetime to 0 to ensure deletion
         ini_set('session.gc_maxlifetime', 0);
 
+        // Disable probability-based GC
+        ini_set('session.gc_probability', 0);
+
         $namespace = uniqid('sess-' . self::COLLECTION_NAME);
         $collection = $client->collection($namespace . ':' . session_name());
         self::$localDeletionQueue->add($collection);

--- a/Firestore/tests/System/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/System/FirestoreSessionHandlerTest.php
@@ -85,12 +85,9 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
         session_save_path($namespace);
         session_start();
 
-        $result = session_gc();
+        session_gc();
 
         $this->assertCount(1, $collection->documents());
-
-        // This is failing and we don't know why
-        // $this->assertGreaterThan(0, $result);
     }
 
     public function testGarbageCollectionBeforeWrite()
@@ -126,5 +123,16 @@ class FirestoreSessionHandlerTest extends FirestoreTestCase
 
         // assert old records have been removed and the new record has been added.
         $this->assertCount(1, $collection->documents());
+    }
+
+    public function testSessionGcReturnValue()
+    {
+        // "session_gc" returns false for user-defined session handlers.
+        // The following returns false no matter what:
+        //     ```
+        //     $this->assertGreaterThan(session_gc(), $result);
+        //     ```
+        // This test is to remind us to implement a test the issue is fixed.
+        $this->markTestSkipped('session_gc returns false due to a core PHP bug');
     }
 }

--- a/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
@@ -429,7 +429,7 @@ class FirestoreSessionHandlerTest extends TestCase
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE,
-            ['gcLimit' => 1000, 'query' => ['maxRetries' => 0]]
+            ['gcLimit' => 500, 'query' => ['maxRetries' => 0]]
         );
 
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);

--- a/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
@@ -102,12 +102,18 @@ class FirestoreSessionHandlerTest extends TestCase
 
     public function testClose()
     {
+        $this->connection->beginTransaction(['database' => $this->dbName()])
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['transaction' => 123]);
+        $this->connection->rollback(Argument::any())
+            ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
         );
+        $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->close();
         $this->assertTrue($ret);
     }
@@ -234,6 +240,7 @@ class FirestoreSessionHandlerTest extends TestCase
         );
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->write('sessionid', 'sessiondata');
+        $firestoreSessionHandler->close();
 
         $this->assertTrue($ret);
     }
@@ -267,8 +274,10 @@ class FirestoreSessionHandlerTest extends TestCase
             self::PROJECT,
             self::DATABASE
         );
+
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->write('sessionid', 'sessiondata');
+        $firestoreSessionHandler->close();
 
         $this->assertFalse($ret);
     }
@@ -296,6 +305,7 @@ class FirestoreSessionHandlerTest extends TestCase
         );
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->destroy('sessionid');
+        $firestoreSessionHandler->close();
 
         $this->assertTrue($ret);
     }
@@ -324,6 +334,7 @@ class FirestoreSessionHandlerTest extends TestCase
         );
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->destroy('sessionid');
+        $firestoreSessionHandler->close();
 
         $this->assertFalse($ret);
     }
@@ -366,7 +377,7 @@ class FirestoreSessionHandlerTest extends TestCase
         $this->documents->next()
             ->shouldBeCalledTimes(1);
         $this->connection->beginTransaction(['database' => $this->dbName()])
-            ->shouldBeCalledTimes(1)
+            ->shouldBeCalledTimes(2)
             ->willReturn(['transaction' => 123]);
         $this->connection->runQuery(Argument::any())
             ->shouldBeCalledTimes(1)
@@ -376,7 +387,7 @@ class FirestoreSessionHandlerTest extends TestCase
                     $phpunit->dbName() . '/documents',
                     $options['parent']
                 );
-                $phpunit->assertEquals(999, $options['structuredQuery']['limit']);
+                $phpunit->assertEquals(499, $options['structuredQuery']['limit']);
                 $phpunit->assertEquals(
                     self::SESSION_SAVE_PATH . ':' . self::SESSION_NAME,
                     $options['structuredQuery']['from'][0]['collectionId']
@@ -404,13 +415,13 @@ class FirestoreSessionHandlerTest extends TestCase
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE,
-            ['gcLimit' => 999, 'query' => ['maxRetries' => 0]]
+            ['gcLimit' => 499, 'query' => ['maxRetries' => 0]]
         );
 
         $firestoreSessionHandler->open(self::SESSION_SAVE_PATH, self::SESSION_NAME);
         $ret = $firestoreSessionHandler->gc(100);
 
-        $this->assertTrue($ret);
+        $this->assertEquals(1, $ret);
     }
 
     /**
@@ -419,7 +430,7 @@ class FirestoreSessionHandlerTest extends TestCase
     public function testGcWithException()
     {
         $this->connection->beginTransaction(['database' => $this->dbName()])
-            ->shouldBeCalledTimes(1)
+            ->shouldBeCalledTimes(2)
             ->willReturn(['transaction' => 123]);
         $this->connection->runQuery(Argument::any())
             ->shouldBeCalledTimes(1)


### PR DESCRIPTION
There are still a few issues:
 - `session_gc` returns `false`, even though the records get deleted as expected. I do not know why.
 - The `FirestoreTestCase` function to delete `$deletionQueue` does not get registered. This is because the call do do this, which is in `bootstrap.php`, does not exist in `system-bootstrap.php`.
 - Even when the deletion function is registered, the collections registered to be deleted in these tests are not deleted. I suspect it has something to do with them running in separate processes but I can't figure it out.