### PR TITLE
feat: distribution of sessions in lifo order

### DIFF
--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -604,14 +604,14 @@ class CacheSessionPool implements SessionPoolInterface
     }
 
     /**
-     * Gets the next session in the queue, clearing out any which are expired.
+     * Gets the last session in the queue, clearing out any which are expired.
      *
      * @param array $data
      * @return array|null
      */
     private function getSession(array &$data)
     {
-        $session = array_shift($data['queue']);
+        $session = array_pop($data['queue']);
 
         if ($session) {
             if ($session['expiration'] - self::DURATION_ONE_MINUTE < $this->time()) {

--- a/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
@@ -556,7 +556,12 @@ class CacheSessionPoolTest extends TestCase
                     'maxInUseSessions' => 1
                 ],
                 [
-                    'queue' => [],
+                    'queue' => [
+                        [
+                            'name' => 'expiresSoon',
+                            'expiration' => $time + 1500
+                        ],
+                    ],
                     'inUse' => [
                         'session' => [
                             'name' => 'session',
@@ -631,8 +636,8 @@ class CacheSessionPoolTest extends TestCase
                 [
                     'queue' => [],
                     'inUse' => [
-                        'session1' => [
-                            'name' => 'session1',
+                        'session4' => [
+                            'name' => 'session4',
                             'expiration' => $time + 3600,
                             'lastActive' => $time
                         ]


### PR DESCRIPTION
Changed the order of distribution of the session from CacheSessionPool::getSession(). Fixed data for unit tests with this in mind.

Closes #2368.