### PR TITLE
fix: fix compatibility with phpspec/prophecy v1.10

### DIFF
--- a/Firestore/tests/Unit/FirestoreClientTest.php
+++ b/Firestore/tests/Unit/FirestoreClientTest.php
@@ -513,23 +513,6 @@ class FirestoreClientTest extends TestCase
         }, ['maxRetries' => 2]);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testInvalidNestedTransaction()
-    {
-        $transactionId = 'foobar';
-        $this->connection->beginTransaction(Argument::any())->willReturn([
-            'transaction' => $transactionId
-        ]);
-
-        $this->client->___setProperty('connection', $this->connection->reveal());
-
-        $this->client->runTransaction(function ($t) {
-            $this->client->runTransaction($this->noop());
-        });
-    }
-
     public function testGeoPoint()
     {
         $lat = 1.1;

--- a/Spanner/tests/Snippet/ArrayTypeTest.php
+++ b/Spanner/tests/Snippet/ArrayTypeTest.php
@@ -23,13 +23,13 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\ArrayType;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\StructType;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -40,6 +40,7 @@ class ArrayTypeTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -64,7 +65,7 @@ class ArrayTypeTest extends SnippetTestCase
         $sessionPool->setDatabase(Argument::any())
             ->willReturn(null);
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->database = TestHelpers::stub(Database::class, [
             $this->connection->reveal(),
             $instance->reveal(),

--- a/Spanner/tests/Snippet/Batch/BatchClientTest.php
+++ b/Spanner/tests/Snippet/Batch/BatchClientTest.php
@@ -29,6 +29,7 @@ use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
@@ -40,6 +41,7 @@ class BatchClientTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
@@ -52,7 +54,7 @@ class BatchClientTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->client = TestHelpers::stub(BatchClient::class, [
             new Operation($this->connection->reveal(), false),
             self::DATABASE

--- a/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
+++ b/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
@@ -24,12 +24,12 @@ use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
 use Google\Cloud\Spanner\Batch\PartitionInterface;
 use Google\Cloud\Spanner\Batch\QueryPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Result;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\V1\SpannerClient;
 use Prophecy\Argument;
@@ -42,6 +42,7 @@ class BatchSnapshotTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
@@ -56,7 +57,7 @@ class BatchSnapshotTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
 
         $sessData = SpannerClient::parseName(self::SESSION, 'session');
         $this->session = $this->prophesize(Session::class);

--- a/Spanner/tests/Snippet/Batch/QueryPartitionTest.php
+++ b/Spanner/tests/Snippet/Batch/QueryPartitionTest.php
@@ -22,8 +22,8 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\QueryPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Operation;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
@@ -35,6 +35,7 @@ class QueryPartitionTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use PartitionSharedSnippetTestTrait;
+    use StubCreationTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
@@ -54,7 +55,7 @@ class QueryPartitionTest extends SnippetTestCase
 
     public function testClass()
     {
-        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection = $this->getConnStub();
         $connection->createSession(Argument::any())
             ->shouldBeCalledTimes(1)
             ->willReturn([

--- a/Spanner/tests/Snippet/Batch/ReadPartitionTest.php
+++ b/Spanner/tests/Snippet/Batch/ReadPartitionTest.php
@@ -22,9 +22,9 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\ReadPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
@@ -38,6 +38,7 @@ class ReadPartitionTest extends SnippetTestCase
     use PartitionSharedSnippetTestTrait {
         provideGetters as private getters;
     }
+    use StubCreationTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
@@ -62,7 +63,7 @@ class ReadPartitionTest extends SnippetTestCase
 
     public function testClass()
     {
-        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection = $this->getConnStub();
         $connection->createSession(Argument::any())
             ->shouldBeCalledTimes(1)
             ->willReturn([

--- a/Spanner/tests/Snippet/BatchDmlResultTest.php
+++ b/Spanner/tests/Snippet/BatchDmlResultTest.php
@@ -17,18 +17,18 @@
 
 namespace Google\Cloud\Spanner\Tests\Snippet;
 
-use Prophecy\Argument;
-use Google\Cloud\Core\TimeTrait;
-use Google\Cloud\Spanner\Database;
-use Google\Cloud\Spanner\Instance;
-use Google\Cloud\Spanner\BatchDmlResult;
-use Google\Cloud\Spanner\Session\Session;
-use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Core\TimeTrait;
+use Google\Cloud\Spanner\BatchDmlResult;
+use Google\Cloud\Spanner\Database;
+use Google\Cloud\Spanner\Instance;
+use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
-use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
+use Prophecy\Argument;
 
 /**
  * @group spanner
@@ -36,6 +36,7 @@ use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 class BatchDmlResultTest extends SnippetTestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
     use TimeTrait;
 
     private $result;
@@ -66,7 +67,7 @@ class BatchDmlResultTest extends SnippetTestCase
 
     public function testClass()
     {
-        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection = $this->getConnStub();
         $connection->executeBatchDml(Argument::any())
             ->shouldBeCalled()
             ->willReturn([

--- a/Spanner/tests/Snippet/CommitTimestampTest.php
+++ b/Spanner/tests/Snippet/CommitTimestampTest.php
@@ -22,8 +22,8 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Spanner\CommitTimestamp;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -33,6 +33,7 @@ use Prophecy\Argument;
 class CommitTimestampTest extends SnippetTestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
 
@@ -46,7 +47,7 @@ class CommitTimestampTest extends SnippetTestCase
         $id = 'abc';
 
         $client = TestHelpers::stub(SpannerClient::class);
-        $conn = $this->prophesize(ConnectionInterface::class);
+        $conn = $this->getConnStub();
         $conn->createSession(Argument::any())
             ->willReturn([
                 'name' => self::SESSION

--- a/Spanner/tests/Snippet/DatabaseTest.php
+++ b/Spanner/tests/Snippet/DatabaseTest.php
@@ -26,7 +26,6 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\KeySet;
@@ -36,6 +35,7 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Prophecy\Argument;
@@ -49,6 +49,7 @@ class DatabaseTest extends SnippetTestCase
     use GrpcTestTrait;
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -74,7 +75,7 @@ class DatabaseTest extends SnippetTestCase
             ->willReturn(null);
         $sessionPool->clear()->willReturn(null);
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->database = TestHelpers::stub(Database::class, [
             $this->connection->reveal(),
             $instance->reveal(),

--- a/Spanner/tests/Snippet/InstanceConfigurationTest.php
+++ b/Spanner/tests/Snippet/InstanceConfigurationTest.php
@@ -21,8 +21,8 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\InstanceConfiguration;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -32,6 +32,7 @@ use Prophecy\Argument;
 class InstanceConfigurationTest extends SnippetTestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const CONFIG = 'regional-europe-west';
@@ -43,7 +44,7 @@ class InstanceConfigurationTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->config = TestHelpers::stub(InstanceConfiguration::class, [
             $this->connection->reveal(),
             self::PROJECT,

--- a/Spanner/tests/Snippet/InstanceTest.php
+++ b/Spanner/tests/Snippet/InstanceTest.php
@@ -26,10 +26,10 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\InstanceConfiguration;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -39,6 +39,7 @@ use Prophecy\Argument;
 class InstanceTest extends SnippetTestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const INSTANCE = 'my-instance';
@@ -51,7 +52,7 @@ class InstanceTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->instance = TestHelpers::stub(Instance::class, [
             $this->connection->reveal(),
             $this->prophesize(LongRunningConnectionInterface::class)->reveal(),

--- a/Spanner/tests/Snippet/SnapshotTest.php
+++ b/Spanner/tests/Snippet/SnapshotTest.php
@@ -20,12 +20,12 @@ namespace Google\Cloud\Spanner\Tests\Snippet;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 
 /**
@@ -35,6 +35,7 @@ class SnapshotTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const TRANSACTION = 'my-transaction';
 
@@ -45,7 +46,7 @@ class SnapshotTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $operation = $this->prophesize(Operation::class);
         $session = $this->prophesize(Session::class);
 

--- a/Spanner/tests/Snippet/SpannerClientTest.php
+++ b/Spanner/tests/Snippet/SpannerClientTest.php
@@ -27,7 +27,6 @@ use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Bytes;
 use Google\Cloud\Spanner\CommitTimestamp;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\Duration;
@@ -36,6 +35,7 @@ use Google\Cloud\Spanner\InstanceConfiguration;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
@@ -45,6 +45,7 @@ use Prophecy\Argument;
 class SpannerClientTest extends SnippetTestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const CONFIG = 'foo';
@@ -57,7 +58,7 @@ class SpannerClientTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->client = TestHelpers::stub(SpannerClient::class);
         $this->client->___setProperty('connection', $this->connection->reveal());
     }

--- a/Spanner/tests/Snippet/StructTypeTest.php
+++ b/Spanner/tests/Snippet/StructTypeTest.php
@@ -23,13 +23,13 @@ use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\ArrayType;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\StructType;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -40,6 +40,7 @@ class StructTypeTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -64,7 +65,7 @@ class StructTypeTest extends SnippetTestCase
         $sessionPool->setDatabase(Argument::any())
             ->willReturn(null);
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->database = TestHelpers::stub(Database::class, [
             $this->connection->reveal(),
             $instance->reveal(),

--- a/Spanner/tests/Snippet/StructValueTest.php
+++ b/Spanner/tests/Snippet/StructValueTest.php
@@ -22,13 +22,13 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\StructValue;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Prophecy\Argument;
 
 /**
@@ -39,6 +39,7 @@ class StructValueTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -63,7 +64,7 @@ class StructValueTest extends SnippetTestCase
         $sessionPool->setDatabase(Argument::any())
             ->willReturn(null);
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->database = TestHelpers::stub(Database::class, [
             $this->connection->reveal(),
             $instance->reveal(),

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Spanner\Tests\Snippet;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
@@ -30,6 +29,7 @@ use Google\Cloud\Spanner\StructType;
 use Google\Cloud\Spanner\StructValue;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Prophecy\Argument;
@@ -42,6 +42,7 @@ class TransactionTest extends SnippetTestCase
     use GrpcTestTrait;
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
+    use StubCreationTrait;
 
     const TRANSACTION = 'my-transaction';
 
@@ -52,7 +53,7 @@ class TransactionTest extends SnippetTestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $operation = $this->prophesize(Operation::class);
         $session = $this->prophesize(Session::class);
 

--- a/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
+++ b/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Operation;
@@ -31,6 +30,7 @@ use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\Gapic\SpannerGapicClient;
@@ -49,6 +49,7 @@ class TransactionalReadMethodsTest extends SnippetTestCase
 {
     use GrpcTestTrait;
     use OperationRefreshTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -68,7 +69,7 @@ class TransactionalReadMethodsTest extends SnippetTestCase
     {
         parent::setUpBeforeClass();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->session = $this->prophesize(Session::class);
         $this->operation = $this->prophesize(Operation::class);
     }

--- a/Spanner/tests/StubCreationTrait.php
+++ b/Spanner/tests/StubCreationTrait.php
@@ -33,5 +33,5 @@ trait StubCreationTrait
         return $c;
     }
 
-    abstract protected function prophesize();
+    abstract protected function prophesize($classOrInterface = null);
 }

--- a/Spanner/tests/StubCreationTrait.php
+++ b/Spanner/tests/StubCreationTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Spanner\Tests;
+
+use Google\Cloud\Spanner\Connection\ConnectionInterface;
+use Prophecy\Argument;
+
+/**
+ * Creates stubs with required global expectations.
+ */
+trait StubCreationTrait
+{
+    private function getConnStub()
+    {
+        $c = $this->prophesize(ConnectionInterface::class);
+        $c->deleteSession(Argument::any())->willReturn([]);
+
+        return $c;
+    }
+
+    abstract protected function prophesize();
+}

--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -24,12 +24,12 @@ use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Batch\ReadPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 
 /**
  * @group spanner
@@ -39,6 +39,7 @@ use Prophecy\Argument;
 class BatchClientTest extends TestCase
 {
     use OperationRefreshTrait;
+    use StubCreationTrait;
     use TimeTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
@@ -50,7 +51,7 @@ class BatchClientTest extends TestCase
 
     public function setUp()
     {
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->client = TestHelpers::stub(BatchClient::class, [
             new Operation($this->connection->reveal(), false),
             self::DATABASE

--- a/Spanner/tests/Unit/Batch/BatchSnapshotTest.php
+++ b/Spanner/tests/Unit/Batch/BatchSnapshotTest.php
@@ -22,13 +22,13 @@ use Google\Cloud\Spanner\Batch\BatchSnapshot;
 use Google\Cloud\Spanner\Batch\PartitionInterface;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Batch\ReadPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Result;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\V1\SpannerClient;
 use PHPUnit\Framework\TestCase;
@@ -43,6 +43,7 @@ class BatchSnapshotTest extends TestCase
 {
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
+    use StubCreationTrait;
 
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const SESSION = 'projects/my-awesome-project/instances/my-instance/databases/my-database/sessions/session-id';
@@ -64,7 +65,7 @@ class BatchSnapshotTest extends TestCase
 
         $this->timestamp = new Timestamp(new \DateTime());
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->snapshot = TestHelpers::stub(BatchSnapshot::class, [
             new Operation($this->connection->reveal(), false),
             $this->session->reveal(),

--- a/Spanner/tests/Unit/Connection/IamDatabaseTest.php
+++ b/Spanner/tests/Unit/Connection/IamDatabaseTest.php
@@ -18,8 +18,8 @@
 namespace Google\Cloud\Spanner\Tests\Unit\Connection;
 
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamDatabase;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,13 +28,15 @@ use PHPUnit\Framework\TestCase;
  */
 class IamDatabaseTest extends TestCase
 {
+    use StubCreationTrait;
+
     private $connection;
 
     private $iam;
 
     public function setUp()
     {
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
 
         $this->iam = TestHelpers::stub(IamDatabase::class, [$this->connection->reveal()]);
     }

--- a/Spanner/tests/Unit/Connection/IamInstanceTest.php
+++ b/Spanner/tests/Unit/Connection/IamInstanceTest.php
@@ -18,8 +18,8 @@
 namespace Google\Cloud\Spanner\Tests\Unit\Connection;
 
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamInstance;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,13 +28,15 @@ use PHPUnit\Framework\TestCase;
  */
 class IamInstanceTest extends TestCase
 {
+    use StubCreationTrait;
+
     private $connection;
 
     private $iam;
 
     public function setUp()
     {
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
 
         $this->iam = TestHelpers::stub(IamInstance::class, [$this->connection->reveal()]);
     }

--- a/Spanner/tests/Unit/Connection/LongRunningConnectionTest.php
+++ b/Spanner/tests/Unit/Connection/LongRunningConnectionTest.php
@@ -18,8 +18,8 @@
 namespace Google\Cloud\Spanner\Tests\Unit\Connection;
 
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\LongRunningConnection;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,12 +28,14 @@ use PHPUnit\Framework\TestCase;
  */
 class LongRunningConnectionTest extends TestCase
 {
+    use StubCreationTrait;
+
     private $connection;
     private $lro;
 
     public function setUp()
     {
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->lro = TestHelpers::stub(LongRunningConnection::class, [
             $this->connection->reveal()
         ]);

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -38,6 +38,7 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\SpannerClient;
@@ -53,6 +54,7 @@ class DatabaseTest extends TestCase
     use GrpcTestTrait;
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const DATABASE = 'my-database';
@@ -72,7 +74,7 @@ class DatabaseTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->instance = $this->prophesize(Instance::class);
         $this->sessionPool = $this->prophesize(SessionPoolInterface::class);
         $this->lro = $this->prophesize(LongRunningConnectionInterface::class);

--- a/Spanner/tests/Unit/InstanceConfigurationTest.php
+++ b/Spanner/tests/Unit/InstanceConfigurationTest.php
@@ -21,8 +21,8 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\InstanceConfiguration;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -33,6 +33,7 @@ use Prophecy\Argument;
 class InstanceConfigurationTest extends TestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT_ID = 'test-project';
     const NAME = 'test-config';
@@ -44,7 +45,7 @@ class InstanceConfigurationTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->configuration = TestHelpers::stub(InstanceConfiguration::class, [
             $this->connection->reveal(),
             self::PROJECT_ID,

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -26,9 +26,9 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -39,6 +39,7 @@ use Prophecy\Argument;
 class InstanceTest extends TestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT_ID = 'test-project';
     const NAME = 'instance-name';
@@ -50,7 +51,7 @@ class InstanceTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->instance = TestHelpers::stub(Instance::class, [
             $this->connection->reveal(),
             $this->prophesize(LongRunningConnectionInterface::class)->reveal(),

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Batch\ReadPartition;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
@@ -30,6 +29,7 @@ use Google\Cloud\Spanner\Result;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Snapshot;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +41,7 @@ use Prophecy\Argument;
 class OperationTest extends TestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const SESSION = 'my-session-id';
     const TRANSACTION = 'my-transaction-id';
@@ -55,7 +56,7 @@ class OperationTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
 
         $this->operation = TestHelpers::stub(Operation::class, [
             $this->connection->reveal(),

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -27,7 +27,6 @@ use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Bytes;
 use Google\Cloud\Spanner\CommitTimestamp;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\Duration;
@@ -36,6 +35,7 @@ use Google\Cloud\Spanner\InstanceConfiguration;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\SpannerClient;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -46,6 +46,7 @@ use Prophecy\Argument;
 class SpannerClientTest extends TestCase
 {
     use GrpcTestTrait;
+    use StubCreationTrait;
 
     const PROJECT = 'my-awesome-project';
     const INSTANCE = 'inst';
@@ -58,7 +59,7 @@ class SpannerClientTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->client = TestHelpers::stub(SpannerClient::class, [
             ['projectId' => self::PROJECT]
         ]);

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -17,20 +17,20 @@
 
 namespace Google\Cloud\Spanner\Tests\Unit;
 
-use Prophecy\Argument;
-use PHPUnit\Framework\TestCase;
-use Google\Cloud\Spanner\KeySet;
-use Google\Cloud\Spanner\Result;
-use Google\Cloud\Spanner\Database;
-use Google\Cloud\Spanner\Operation;
-use Google\Cloud\Spanner\Transaction;
-use Google\Cloud\Spanner\BatchDmlResult;
-use Google\Cloud\Spanner\Session\Session;
-use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
-use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Spanner\BatchDmlResult;
+use Google\Cloud\Spanner\Database;
+use Google\Cloud\Spanner\KeySet;
+use Google\Cloud\Spanner\Operation;
+use Google\Cloud\Spanner\Result;
+use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
-use Google\Cloud\Spanner\Connection\ConnectionInterface;
+use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
+use Google\Cloud\Spanner\Transaction;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group spanner
@@ -40,6 +40,7 @@ class TransactionTest extends TestCase
     use GrpcTestTrait;
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
+    use StubCreationTrait;
 
     const TIMESTAMP = '2017-01-09T18:05:22.534799Z';
 
@@ -61,7 +62,7 @@ class TransactionTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
         $this->operation = new Operation($this->connection->reveal(), false);
 
         $this->session = new Session(

--- a/Spanner/tests/Unit/TransactionTypeTest.php
+++ b/Spanner/tests/Unit/TransactionTypeTest.php
@@ -30,6 +30,7 @@ use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Snapshot;
+use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\SpannerClient;
@@ -44,6 +45,7 @@ class TransactionTypeTest extends TestCase
 {
     use GrpcTestTrait;
     use ResultTestTrait;
+    use StubCreationTrait;
     use TimeTrait;
 
     const PROJECT = 'my-project';
@@ -62,7 +64,7 @@ class TransactionTypeTest extends TestCase
 
         $this->timestamp = (new Timestamp(\DateTime::createFromFormat('U', time()), 500000005))->formatAsString();
 
-        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->connection = $this->getConnStub();
 
         $this->connection->createSession(Argument::any())
             ->willReturn(['name' => SpannerClient::sessionName(

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",
-        "phpspec/prophecy": "1.9.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "symfony/console": "^3.0",


### PR DESCRIPTION
The latest update to prophecy broke our Spanner tests. Prophecy now evaluates expectations later in execution, and started to notice that `Database::__destruct()` was calling `ConnectionInterface::deleteSession()` even though we didn't say it would.

This change adds a utility trait to create connection stubs with the globally-expected method calls already enqueued.