### PR TITLE
feat: enable 'FieldMask' param in Instance::reload() method options

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -228,8 +228,12 @@ class Grpc implements ConnectionInterface
 
         if (isset($args['fieldMask'])) {
             $mask = [];
-            foreach (array_values($args['fieldMask']) as $field) {
-                $mask[] = Serializer::toSnakeCase($field);
+            if (is_array($args['fieldMask'])) {
+                foreach (array_values($args['fieldMask']) as $field) {
+                    $mask[] = Serializer::toSnakeCase($field);
+                }
+            } else {
+                $mask[] = Serializer::toSnakeCase($args['fieldMask']);
             }
             $fieldMask = $this->serializer->decodeMessage(new FieldMask(), ['paths' => $mask]);
             $args['fieldMask'] = $fieldMask;

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -225,6 +225,14 @@ class Grpc implements ConnectionInterface
     public function getInstance(array $args)
     {
         $projectId = $this->pluck('projectId', $args);
+
+        $mask = [];
+        foreach (array_values($this->pluck('fieldMask', $args)) as $key) {
+            $mask[] = Serializer::toSnakeCase($key);
+        }
+
+        $fieldMask = $this->serializer->decodeMessage(new FieldMask(), ['paths' => $mask]);
+        $args['fieldMask'] = $fieldMask;
         return $this->send([$this->getInstanceAdminClient(), 'getInstance'], [
             $this->pluck('name', $args),
             $this->addResourcePrefixHeader($args, $projectId)

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -226,13 +226,15 @@ class Grpc implements ConnectionInterface
     {
         $projectId = $this->pluck('projectId', $args);
 
-        $mask = [];
-        foreach (array_values($this->pluck('fieldMask', $args)) as $key) {
-            $mask[] = Serializer::toSnakeCase($key);
+        if (isset($args['fieldMask'])) {
+            $mask = [];
+            foreach (array_values($args['fieldMask']) as $field) {
+                $mask[] = Serializer::toSnakeCase($field);
+            }
+            $fieldMask = $this->serializer->decodeMessage(new FieldMask(), ['paths' => $mask]);
+            $args['fieldMask'] = $fieldMask;
         }
 
-        $fieldMask = $this->serializer->decodeMessage(new FieldMask(), ['paths' => $mask]);
-        $args['fieldMask'] = $fieldMask;
         return $this->send([$this->getInstanceAdminClient(), 'getInstance'], [
             $this->pluck('name', $args),
             $this->addResourcePrefixHeader($args, $projectId)

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -181,7 +181,7 @@ class Instance
      * @param array $options [optional] {
      *     Configuration options
      *
-     *     @type string[] $fieldMask A list of `Instance` fields that should be returned.
+     *     @type string|string[] $fieldMask One or a list of `Instance` fields that should be returned.
      *           Eligible values are: `name`, `displayName`, `endpointUris`, `labels`, `config`, `nodeCount`, `state`.
      *           If absent, all fields are returned.
      *           Note: This parameter will only apply when service call is required (`info` values are not present).
@@ -239,7 +239,7 @@ class Instance
      * @param array $options [optional] {
      *     Configuration options
      *
-     *     @type string[] $fieldMask A list of `Instance` fields that should be returned.
+     *     @type string|string[] $fieldMask One or a list of `Instance` fields that should be returned.
      *           Eligible values are: `name`, `displayName`, `endpointUris`, `labels`, `config`, `nodeCount`, `state`.
      *           If absent, all fields are returned.
      * }
@@ -249,7 +249,7 @@ class Instance
     {
         $this->info = $this->connection->getInstance($options + [
             'name' => $this->name,
-            'projectId' => $this->projectId,
+            'projectId' => $this->projectId
         ]);
 
         return $this->info;

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -247,14 +247,9 @@ class Instance
      */
     public function reload(array $options = [])
     {
-        $fieldMask = [];
-        if (isset($options['fieldMask'])) {
-            $fieldMask = $this->pluck('fieldMask', $options);
-        }
         $this->info = $this->connection->getInstance($options + [
             'name' => $this->name,
             'projectId' => $this->projectId,
-            'fieldMask' => $fieldMask
         ]);
 
         return $this->info;

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -178,7 +178,15 @@ class Instance
      * echo $info['nodeCount'];
      * ```
      *
-     * @param array $options [optional] Configuration options.
+     * @param array $options [optional] {
+     *     Configuration options
+     *
+     *     @type string[] $fieldMask A list of `Instance` fields that should be returned.
+     *           Eligible values are: `name`, `displayName`, `endpointUris`, `labels`, `config`, `nodeCount`, `state`.
+     *           If absent, all fields are returned.
+     *           Note: This parameter will only apply when service call is required (`info` values are not present).
+     * }
+     *
      * @return array
      */
     public function info(array $options = [])
@@ -228,14 +236,25 @@ class Instance
      * @see https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.GetInstanceRequest GetInstanceRequest
      * @codingStandardsIgnoreEnd
      *
-     * @param array $options [optional] Configuration options.
+     * @param array $options [optional] {
+     *     Configuration options
+     *
+     *     @type string[] $fieldMask A list of `Instance` fields that should be returned.
+     *           Eligible values are: `name`, `displayName`, `endpointUris`, `labels`, `config`, `nodeCount`, `state`.
+     *           If absent, all fields are returned.
+     * }
      * @return array
      */
     public function reload(array $options = [])
     {
+        $fieldMask = [];
+        if (isset($options['fieldMask'])) {
+            $fieldMask = $this->pluck('fieldMask', $options);
+        }
         $this->info = $this->connection->getInstance($options + [
             'name' => $this->name,
-            'projectId' => $this->projectId
+            'projectId' => $this->projectId,
+            'fieldMask' => $fieldMask
         ]);
 
         return $this->info;

--- a/Spanner/tests/System/AdminTest.php
+++ b/Spanner/tests/System/AdminTest.php
@@ -61,7 +61,7 @@ class AdminTest extends SpannerTestCase
         $instance = $client->instance(self::INSTANCE_NAME);
         $this->assertEquals($displayName, $instance->info()['displayName']);
 
-        $requestedFieldNames = ["name", 'state'];
+        $requestedFieldNames = ['name', 'state'];
         $expectedInfo = [
             'endpointUris' => [],
             'labels' => [],

--- a/Spanner/tests/System/AdminTest.php
+++ b/Spanner/tests/System/AdminTest.php
@@ -60,6 +60,19 @@ class AdminTest extends SpannerTestCase
 
         $instance = $client->instance(self::INSTANCE_NAME);
         $this->assertEquals($displayName, $instance->info()['displayName']);
+
+        $requestedFieldNames = ["name", 'state'];
+        $expectedInfo = [
+            'endpointUris' => [],
+            'labels' => [],
+            'name' => $instance->name(),
+            'displayName' => '',
+            'nodeCount' => 0,
+            'state' => Instance::STATE_READY,
+            'config' => ''
+        ];
+        $info = $instance->reload(['fieldMask' => $requestedFieldNames]);
+        $this->assertEquals($expectedInfo, $info);
     }
 
     /**

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -124,21 +124,11 @@ class GrpcTest extends TestCase
 
     public function testGetInstance()
     {
-        $fieldNames = [];
-
-        $mask = [];
-        foreach (array_values($fieldNames) as $key) {
-            $mask[] = Serializer::toSnakeCase($key);
-        }
-
-        $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
         $this->assertCallCorrect('getInstance', [
             'name' => self::INSTANCE,
-            'projectId' => self::PROJECT,
-            'fieldMask' => $fieldNames
+            'projectId' => self::PROJECT
         ], $this->expectResourceHeader(self::PROJECT, [
-            self::INSTANCE,
-            ['fieldMask' => $fieldMask]
+            self::INSTANCE
         ]));
     }
 

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -132,7 +132,7 @@ class GrpcTest extends TestCase
         ]));
     }
 
-    public function testGetInstanceWithFieldMask()
+    public function testGetInstanceWithFieldMaskArray()
     {
         $fieldNames = ['name', 'displayName', 'nodeCount'];
 
@@ -140,6 +140,22 @@ class GrpcTest extends TestCase
         foreach (array_values($fieldNames) as $key) {
             $mask[] = Serializer::toSnakeCase($key);
         }
+
+        $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
+        $this->assertCallCorrect('getInstance', [
+            'name' => self::INSTANCE,
+            'projectId' => self::PROJECT,
+            'fieldMask' => $fieldNames
+        ], $this->expectResourceHeader(self::PROJECT, [
+            self::INSTANCE,
+            ['fieldMask' => $fieldMask]
+        ]));
+    }
+
+    public function testGetInstanceWithFieldMaskString()
+    {
+        $fieldNames = 'nodeCount';
+        $mask[] = Serializer::toSnakeCase($fieldNames);
 
         $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
         $this->assertCallCorrect('getInstance', [

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -124,11 +124,41 @@ class GrpcTest extends TestCase
 
     public function testGetInstance()
     {
+        $fieldNames = [];
+
+        $mask = [];
+        foreach (array_values($fieldNames) as $key) {
+            $mask[] = Serializer::toSnakeCase($key);
+        }
+
+        $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
         $this->assertCallCorrect('getInstance', [
             'name' => self::INSTANCE,
-            'projectId' => self::PROJECT
+            'projectId' => self::PROJECT,
+            'fieldMask' => $fieldNames
         ], $this->expectResourceHeader(self::PROJECT, [
-            self::INSTANCE
+            self::INSTANCE,
+            ['fieldMask' => $fieldMask]
+        ]));
+    }
+
+    public function testGetInstanceWithFieldMask()
+    {
+        $fieldNames = ['name', 'displayName', 'nodeCount'];
+
+        $mask = [];
+        foreach (array_values($fieldNames) as $key) {
+            $mask[] = Serializer::toSnakeCase($key);
+        }
+
+        $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
+        $this->assertCallCorrect('getInstance', [
+            'name' => self::INSTANCE,
+            'projectId' => self::PROJECT,
+            'fieldMask' => $fieldNames
+        ], $this->expectResourceHeader(self::PROJECT, [
+            self::INSTANCE,
+            ['fieldMask' => $fieldMask]
         ]));
     }
 

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -141,8 +141,7 @@ class InstanceTest extends TestCase
 
         $this->connection->getInstance(Argument::allOf(
             Argument::withEntry('name', $this->instance->name()),
-            Argument::withEntry('projectId', self::PROJECT_ID),
-            Argument::withEntry('fieldMask', [])
+            Argument::withEntry('projectId', self::PROJECT_ID)
         ))
             ->shouldBeCalledTimes(1)
             ->willReturn($instance);

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -93,6 +93,28 @@ class InstanceTest extends TestCase
         $this->assertEquals($info, $this->instance->info());
     }
 
+    public function testInfoWithReloadAndFieldMask()
+    {
+        $instance = [
+            'name' => $this->instance->name(),
+            'node_count' => 1
+        ];
+
+        $requestedFieldNames = ["name", 'node_count'];
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('name', $this->instance->name()),
+            Argument::withEntry('fieldMask', $requestedFieldNames)
+        ))
+            ->shouldBeCalledTimes(1)
+            ->willReturn($instance);
+
+        $this->instance->___setProperty('connection', $this->connection->reveal());
+
+        $info = $this->instance->info(['fieldMask' => $requestedFieldNames]);
+        
+        $this->assertEquals($info, $this->instance->info());
+    }
+
     public function testExists()
     {
         $this->connection->getInstance(Argument::any())->shouldBeCalled()->willReturn([]);
@@ -117,7 +139,11 @@ class InstanceTest extends TestCase
     {
         $instance = $this->getDefaultInstance();
 
-        $this->connection->getInstance(Argument::any())
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('name', $this->instance->name()),
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('fieldMask', [])
+        ))
             ->shouldBeCalledTimes(1)
             ->willReturn($instance);
 
@@ -126,6 +152,29 @@ class InstanceTest extends TestCase
         $info = $this->instance->reload();
 
         $this->assertEquals('Instance Name', $info['displayName']);
+    }
+
+    public function testReloadWithFieldMask()
+    {
+        $instance = [
+            'name' => $this->instance->name(),
+            'node_count' => 1
+        ];
+
+        $requestedFieldNames = ["name", 'node_count'];
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('name', $this->instance->name()),
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('fieldMask', $requestedFieldNames)
+        ))
+            ->shouldBeCalledTimes(1)
+            ->willReturn($instance);
+
+        $this->instance->___setProperty('connection', $this->connection->reveal());
+
+        $info = $this->instance->reload(['fieldMask' => $requestedFieldNames]);
+
+        $this->assertEquals($info, $this->instance->info());
     }
 
     public function testState()


### PR DESCRIPTION
Enabling `FieldMask` param in the `getInstance` call.
[Link](https://github.com/googleapis/googleapis/blob/master/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L472) to proto