### PR TITLE
feat: add support for BigQuery routines

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -129,12 +129,14 @@ class BigQueryClient
             'projectIdRequired' => true,
             'returnInt64AsObject' => false,
             'restRetryFunction' => $this->getRetryFunction(),
+            //@codeCoverageIgnoreStart
             'restCalcDelayFunction' => function ($attempt) {
                 return min(
                     mt_rand(0, 1000000) + (pow(2, $attempt) * 1000000),
                     self::MAX_DELAY_MICROSECONDS
                 );
             }
+            //@codeCoverageIgnoreEnd
         ];
 
         $this->connection = new Rest($this->configureAuthentication($config));

--- a/BigQuery/src/Connection/ConnectionInterface.php
+++ b/BigQuery/src/Connection/ConnectionInterface.php
@@ -168,4 +168,34 @@ interface ConnectionInterface
      * @return array
      */
     public function listModels(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function insertRoutine(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function updateRoutine(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function getRoutine(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function deleteRoutine(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listRoutines(array $args = []);
 }

--- a/BigQuery/src/Connection/Rest.php
+++ b/BigQuery/src/Connection/Rest.php
@@ -336,4 +336,49 @@ class Rest implements ConnectionInterface
     {
         return $this->send('models', 'list', $args);
     }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function insertRoutine(array $args = [])
+    {
+        return $this->send('routines', 'insert', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function updateRoutine(array $args = [])
+    {
+        return $this->send('routines', 'update', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function getRoutine(array $args = [])
+    {
+        return $this->send('routines', 'get', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function deleteRoutine(array $args = [])
+    {
+        return $this->send('routines', 'delete', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listRoutines(array $args = [])
+    {
+        return $this->send('routines', 'list', $args);
+    }
 }

--- a/BigQuery/src/Connection/ServiceDefinition/bigquery-v2.json
+++ b/BigQuery/src/Connection/ServiceDefinition/bigquery-v2.json
@@ -1,98 +1,91 @@
 {
   "resources": {
-    "models": {
+    "routines": {
       "methods": {
         "delete": {
+          "description": "Deletes the routine specified by routineId from the dataset.",
+          "httpMethod": "DELETE",
           "parameterOrder": [
             "projectId",
             "datasetId",
-            "modelId"
+            "routineId"
           ],
-          "httpMethod": "DELETE",
+          "parameters": {
+            "projectId": {
+              "description": "Required. Project ID of the routine to delete",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path"
+            },
+            "datasetId": {
+              "description": "Required. Dataset ID of the routine to delete",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path"
+            },
+            "routineId": {
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Routine ID of the routine to delete"
+            }
+          },
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/cloud-platform"
           ],
-          "parameters": {
-            "datasetId": {
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Dataset ID of the model to delete."
-            },
-            "modelId": {
-              "location": "path",
-              "description": "Required. Model ID of the model to delete.",
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$"
-            },
-            "projectId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the model to delete.",
-              "required": true,
-              "type": "string"
-            }
-          },
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
-          "id": "bigquery.models.delete",
-          "description": "Deletes the model specified by modelId from the dataset."
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
+          "id": "bigquery.routines.delete",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}"
         },
-        "get": {
+        "insert": {
+          "description": "Creates a new routine in the dataset.",
+          "request": {
+            "$ref": "Routine"
+          },
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "response": {
+            "$ref": "Routine"
+          },
           "parameters": {
             "projectId": {
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Project ID of the requested model.",
+              "description": "Required. Project ID of the new routine",
               "required": true,
               "type": "string"
             },
             "datasetId": {
-              "required": true,
-              "type": "string",
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Dataset ID of the requested model."
-            },
-            "modelId": {
-              "location": "path",
-              "description": "Required. Model ID of the requested model.",
+              "description": "Required. Dataset ID of the new routine",
               "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$"
+              "type": "string"
             }
           },
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
+            "https://www.googleapis.com/auth/cloud-platform"
           ],
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
-          "id": "bigquery.models.get",
-          "description": "Gets the specified model resource by model ID.",
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines",
+          "id": "bigquery.routines.insert",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/routines"
+        },
+        "get": {
           "response": {
-            "$ref": "Model"
+            "$ref": "Routine"
           },
           "parameterOrder": [
             "projectId",
             "datasetId",
-            "modelId"
-          ],
-          "httpMethod": "GET"
-        },
-        "list": {
-          "description": "Lists all models in the specified dataset. Requires the READER dataset\nrole.",
-          "response": {
-            "$ref": "ListModelsResponse"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
+            "routineId"
           ],
           "httpMethod": "GET",
           "scopes": [
@@ -102,371 +95,85 @@
             "https://www.googleapis.com/auth/cloud-platform.read-only"
           ],
           "parameters": {
-            "pageToken": {
-              "description": "Page token, returned by a previous call to request the next page of\nresults",
-              "type": "string",
-              "location": "query"
-            },
             "projectId": {
+              "location": "path",
+              "description": "Required. Project ID of the requested routine",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$"
+            },
+            "datasetId": {
+              "location": "path",
+              "description": "Required. Dataset ID of the requested routine",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$"
+            },
+            "routineId": {
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Project ID of the models to list.",
+              "description": "Required. Routine ID of the requested routine",
               "required": true,
               "type": "string"
             },
+            "readMask": {
+              "location": "query",
+              "description": "If set, only the Routine fields in the field mask are returned in the\nresponse. If unset, all Routine fields are returned.",
+              "format": "google-fieldmask",
+              "type": "string"
+            }
+          },
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
+          "id": "bigquery.routines.get",
+          "description": "Gets the specified routine resource by routine ID."
+        },
+        "list": {
+          "description": "Lists all routines in the specified dataset. Requires the READER dataset\nrole.",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListRoutinesResponse"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "parameters": {
+            "projectId": {
+              "description": "Required. Project ID of the routines to list",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path"
+            },
+            "filter": {
+              "description": "If set, then only the Routines matching this filter are returned.\nThe current supported form is either \"routine_type:\u003cRoutineType\u003e\" or\n\"routineType:\u003cRoutineType\u003e\", where \u003cRoutineType\u003e is a RoutineType enum.\nExample: \"routineType:SCALAR_FUNCTION\".",
+              "type": "string",
+              "location": "query"
+            },
+            "pageToken": {
+              "location": "query",
+              "description": "Page token, returned by a previous call, to request the next page of\nresults",
+              "type": "string"
+            },
             "maxResults": {
+              "type": "integer",
               "location": "query",
               "description": "The maximum number of results to return in a single response page.\nLeverage the page tokens to iterate through the entire collection.",
-              "format": "uint32",
-              "type": "integer"
+              "format": "uint32"
             },
             "datasetId": {
-              "location": "path",
-              "description": "Required. Dataset ID of the models to list.",
               "required": true,
               "type": "string",
-              "pattern": "^[^/]+$"
-            }
-          },
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/models",
-          "id": "bigquery.models.list"
-        },
-        "patch": {
-          "description": "Patch specific fields in the specified model.",
-          "request": {
-            "$ref": "Model"
-          },
-          "response": {
-            "$ref": "Model"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "modelId"
-          ],
-          "httpMethod": "PATCH",
-          "parameters": {
-            "projectId": {
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Project ID of the model to patch.",
-              "required": true,
+              "description": "Required. Dataset ID of the routines to list"
+            },
+            "readMask": {
+              "location": "query",
+              "description": "If set, then only the Routine fields in the field mask, as well as\nproject_id, dataset_id and routine_id, are returned in the response.\nIf unset, then the following Routine fields are returned:\netag, project_id, dataset_id, routine_id, routine_type, creation_time,\nlast_modified_time, and language.",
+              "format": "google-fieldmask",
               "type": "string"
-            },
-            "datasetId": {
-              "location": "path",
-              "description": "Required. Dataset ID of the model to patch.",
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$"
-            },
-            "modelId": {
-              "location": "path",
-              "description": "Required. Model ID of the model to patch.",
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
-          "id": "bigquery.models.patch"
-        }
-      }
-    },
-    "jobs": {
-      "methods": {
-        "query": {
-          "path": "projects/{projectId}/queries",
-          "id": "bigquery.jobs.query",
-          "request": {
-            "$ref": "QueryRequest"
-          },
-          "description": "Runs a BigQuery SQL query synchronously and returns query results if the query completes within a specified timeout.",
-          "response": {
-            "$ref": "QueryResponse"
-          },
-          "parameterOrder": [
-            "projectId"
-          ],
-          "httpMethod": "POST",
-          "parameters": {
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the project billed for the query",
-              "type": "string",
-              "required": true
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ]
-        },
-        "list": {
-          "description": "Lists all jobs that you started in the specified project. Job information is available for a six month period after creation. The job list is sorted in reverse chronological order, by job creation time. Requires the Can View project role, or the Is Owner project role if you set the allUsers property.",
-          "response": {
-            "$ref": "JobList"
-          },
-          "parameterOrder": [
-            "projectId"
-          ],
-          "httpMethod": "GET",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ],
-          "parameters": {
-            "stateFilter": {
-              "enum": [
-                "done",
-                "pending",
-                "running"
-              ],
-              "type": "string",
-              "repeated": true,
-              "enumDescriptions": [
-                "Finished jobs",
-                "Pending jobs",
-                "Running jobs"
-              ],
-              "location": "query",
-              "description": "Filter for job state"
-            },
-            "projection": {
-              "location": "query",
-              "enum": [
-                "full",
-                "minimal"
-              ],
-              "description": "Restrict information returned to a set of selected fields",
-              "type": "string",
-              "enumDescriptions": [
-                "Includes all job data",
-                "Does not include the job configuration"
-              ]
-            },
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the jobs to list",
-              "type": "string",
-              "required": true
-            },
-            "minCreationTime": {
-              "type": "string",
-              "location": "query",
-              "description": "Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned",
-              "format": "uint64"
-            },
-            "parentJobId": {
-              "description": "If set, retrieves only jobs whose parent is this job. Otherwise, retrieves only jobs which have no parent",
-              "type": "string",
-              "location": "query"
-            },
-            "allUsers": {
-              "location": "query",
-              "description": "Whether to display jobs owned by all users in the project. Default false",
-              "type": "boolean"
-            },
-            "pageToken": {
-              "description": "Page token, returned by a previous call, to request the next page of results",
-              "type": "string",
-              "location": "query"
-            },
-            "maxCreationTime": {
-              "description": "Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned",
-              "format": "uint64",
-              "type": "string",
-              "location": "query"
-            },
-            "maxResults": {
-              "description": "Maximum number of results to return",
-              "format": "uint32",
-              "type": "integer",
-              "location": "query"
-            }
-          },
-          "path": "projects/{projectId}/jobs",
-          "id": "bigquery.jobs.list"
-        },
-        "getQueryResults": {
-          "description": "Retrieves the results of a query job.",
-          "response": {
-            "$ref": "GetQueryResultsResponse"
-          },
-          "parameterOrder": [
-            "projectId",
-            "jobId"
-          ],
-          "httpMethod": "GET",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ],
-          "parameters": {
-            "startIndex": {
-              "description": "Zero-based index of the starting row",
-              "format": "uint64",
-              "type": "string",
-              "location": "query"
-            },
-            "location": {
-              "location": "query",
-              "description": "The geographic location where the job should run. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.",
-              "type": "string"
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, to request the next page of results",
-              "type": "string"
-            },
-            "timeoutMs": {
-              "description": "How long to wait for the query to complete, in milliseconds, before returning. Default is 10 seconds. If the timeout passes before the job completes, the 'jobComplete' field in the response will be false",
-              "format": "uint32",
-              "type": "integer",
-              "location": "query"
-            },
-            "maxResults": {
-              "location": "query",
-              "description": "Maximum number of results to read",
-              "format": "uint32",
-              "type": "integer"
-            },
-            "projectId": {
-              "location": "path",
-              "description": "[Required] Project ID of the query job",
-              "type": "string",
-              "required": true
-            },
-            "jobId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "[Required] Job ID of the query job"
-            }
-          },
-          "path": "projects/{projectId}/queries/{jobId}",
-          "id": "bigquery.jobs.getQueryResults"
-        },
-        "cancel": {
-          "description": "Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs.",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "JobCancelResponse"
-          },
-          "parameterOrder": [
-            "projectId",
-            "jobId"
-          ],
-          "parameters": {
-            "location": {
-              "type": "string",
-              "location": "query",
-              "description": "The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location."
-            },
-            "jobId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "[Required] Job ID of the job to cancel"
-            },
-            "projectId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "[Required] Project ID of the job to cancel"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "id": "bigquery.jobs.cancel",
-          "path": "projects/{projectId}/jobs/{jobId}/cancel"
-        },
-        "insert": {
-          "request": {
-            "$ref": "Job"
-          },
-          "description": "Starts a new asynchronous job. Requires the Can View project role.",
-          "supportsMediaUpload": true,
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "Job"
-          },
-          "parameterOrder": [
-            "projectId"
-          ],
-          "parameters": {
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the project that will be billed for the job",
-              "type": "string",
-              "required": true
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/devstorage.full_control",
-            "https://www.googleapis.com/auth/devstorage.read_only",
-            "https://www.googleapis.com/auth/devstorage.read_write"
-          ],
-          "mediaUpload": {
-            "protocols": {
-              "resumable": {
-                "path": "/resumable/upload/bigquery/v2/projects/{projectId}/jobs",
-                "multipart": true
-              },
-              "simple": {
-                "path": "/upload/bigquery/v2/projects/{projectId}/jobs",
-                "multipart": true
-              }
-            },
-            "accept": [
-              "*/*"
-            ]
-          },
-          "path": "projects/{projectId}/jobs",
-          "id": "bigquery.jobs.insert"
-        },
-        "get": {
-          "response": {
-            "$ref": "Job"
-          },
-          "parameterOrder": [
-            "projectId",
-            "jobId"
-          ],
-          "httpMethod": "GET",
-          "parameters": {
-            "location": {
-              "location": "query",
-              "description": "The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.",
-              "type": "string"
-            },
-            "jobId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "[Required] Job ID of the requested job"
-            },
-            "projectId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "[Required] Project ID of the requested job"
             }
           },
           "scopes": [
@@ -475,308 +182,25 @@
             "https://www.googleapis.com/auth/cloud-platform",
             "https://www.googleapis.com/auth/cloud-platform.read-only"
           ],
-          "path": "projects/{projectId}/jobs/{jobId}",
-          "id": "bigquery.jobs.get",
-          "description": "Returns information about a specific job. Job information is available for a six month period after creation. Requires that you're the person who ran the job, or have the Is Owner project role."
-        }
-      }
-    },
-    "projects": {
-      "methods": {
-        "list": {
-          "description": "Lists all projects to which you have been granted any project role.",
-          "response": {
-            "$ref": "ProjectList"
-          },
-          "httpMethod": "GET",
-          "parameters": {
-            "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, to request the next page of results",
-              "type": "string"
-            },
-            "maxResults": {
-              "location": "query",
-              "description": "Maximum number of results to return",
-              "format": "uint32",
-              "type": "integer"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ],
-          "id": "bigquery.projects.list",
-          "path": "projects"
-        },
-        "getServiceAccount": {
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "GetServiceAccountResponse"
-          },
-          "parameterOrder": [
-            "projectId"
-          ],
-          "parameters": {
-            "projectId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "Project ID for which the service account is requested."
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ],
-          "id": "bigquery.projects.getServiceAccount",
-          "path": "projects/{projectId}/serviceAccount",
-          "description": "Returns the email address of the service account for your project used for interactions with Google Cloud KMS."
-        }
-      }
-    },
-    "tabledata": {
-      "methods": {
-        "list": {
-          "id": "bigquery.tabledata.list",
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/data",
-          "description": "Retrieves table data from a specified set of rows. Requires the READER dataset role.",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "TableDataList"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "tableId"
-          ],
-          "parameters": {
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the table to read",
-              "type": "string",
-              "required": true
-            },
-            "projectId": {
-              "description": "Project ID of the table to read",
-              "type": "string",
-              "required": true,
-              "location": "path"
-            },
-            "selectedFields": {
-              "location": "query",
-              "description": "List of fields to return (comma-separated). If unspecified, all fields are returned",
-              "type": "string"
-            },
-            "startIndex": {
-              "description": "Zero-based index of the starting row to read",
-              "format": "uint64",
-              "type": "string",
-              "location": "query"
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, identifying the result set",
-              "type": "string"
-            },
-            "tableId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "Table ID of the table to read"
-            },
-            "maxResults": {
-              "location": "query",
-              "description": "Maximum number of results to return",
-              "format": "uint32",
-              "type": "integer"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ]
-        },
-        "insertAll": {
-          "description": "Streams data into BigQuery one record at a time without needing to run a load job. Requires the WRITER dataset role.",
-          "request": {
-            "$ref": "TableDataInsertAllRequest"
-          },
-          "response": {
-            "$ref": "TableDataInsertAllResponse"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "tableId"
-          ],
-          "httpMethod": "POST",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.insertdata",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "parameters": {
-            "tableId": {
-              "location": "path",
-              "description": "Table ID of the destination table.",
-              "type": "string",
-              "required": true
-            },
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the destination table.",
-              "type": "string",
-              "required": true
-            },
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the destination table.",
-              "type": "string",
-              "required": true
-            }
-          },
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/insertAll",
-          "id": "bigquery.tabledata.insertAll"
-        }
-      }
-    },
-    "tables": {
-      "methods": {
-        "insert": {
-          "id": "bigquery.tables.insert",
-          "path": "projects/{projectId}/datasets/{datasetId}/tables",
-          "request": {
-            "$ref": "Table"
-          },
-          "description": "Creates a new, empty table in the dataset.",
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
-          ],
-          "response": {
-            "$ref": "Table"
-          },
-          "parameters": {
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the new table",
-              "type": "string",
-              "required": true
-            },
-            "projectId": {
-              "description": "Project ID of the new table",
-              "type": "string",
-              "required": true,
-              "location": "path"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ]
-        },
-        "get": {
-          "id": "bigquery.tables.get",
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
-          "description": "Gets the specified table resource by table ID. This method does not return the data in the table, it only returns the table resource, which describes the structure of this table.",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "Table"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "tableId"
-          ],
-          "parameters": {
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the requested table",
-              "type": "string",
-              "required": true
-            },
-            "datasetId": {
-              "description": "Dataset ID of the requested table",
-              "type": "string",
-              "required": true,
-              "location": "path"
-            },
-            "selectedFields": {
-              "description": "List of fields to return (comma-separated). If unspecified, all fields are returned",
-              "type": "string",
-              "location": "query"
-            },
-            "tableId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "Table ID of the requested table"
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ]
-        },
-        "patch": {
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "parameters": {
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the table to update",
-              "type": "string",
-              "required": true
-            },
-            "tableId": {
-              "location": "path",
-              "description": "Table ID of the table to update",
-              "type": "string",
-              "required": true
-            },
-            "projectId": {
-              "description": "Project ID of the table to update",
-              "type": "string",
-              "required": true,
-              "location": "path"
-            }
-          },
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
-          "id": "bigquery.tables.patch",
-          "description": "Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports patch semantics.",
-          "request": {
-            "$ref": "Table"
-          },
-          "response": {
-            "$ref": "Table"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "tableId"
-          ],
-          "httpMethod": "PATCH"
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines",
+          "id": "bigquery.routines.list",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/routines"
         },
         "update": {
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
+          "id": "bigquery.routines.update",
+          "request": {
+            "$ref": "Routine"
+          },
+          "description": "Updates information in an existing routine. The update method replaces the\nentire Routine resource.",
           "response": {
-            "$ref": "Table"
+            "$ref": "Routine"
           },
           "parameterOrder": [
             "projectId",
             "datasetId",
-            "tableId"
+            "routineId"
           ],
           "httpMethod": "PUT",
           "scopes": [
@@ -785,109 +209,27 @@
           ],
           "parameters": {
             "projectId": {
-              "location": "path",
-              "description": "Project ID of the table to update",
+              "required": true,
               "type": "string",
-              "required": true
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Project ID of the routine to update"
             },
             "datasetId": {
-              "description": "Dataset ID of the table to update",
-              "type": "string",
               "required": true,
-              "location": "path"
-            },
-            "tableId": {
+              "type": "string",
+              "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Table ID of the table to update",
-              "type": "string",
-              "required": true
-            }
-          },
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
-          "id": "bigquery.tables.update",
-          "description": "Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource.",
-          "request": {
-            "$ref": "Table"
-          }
-        },
-        "delete": {
-          "description": "Deletes the table specified by tableId from the dataset. If the table contains data, all the data will be deleted.",
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "tableId"
-          ],
-          "httpMethod": "DELETE",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "parameters": {
-            "projectId": {
-              "description": "Project ID of the table to delete",
-              "type": "string",
+              "description": "Required. Dataset ID of the routine to update"
+            },
+            "routineId": {
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Routine ID of the routine to update",
               "required": true,
-              "location": "path"
-            },
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the table to delete",
-              "type": "string",
-              "required": true
-            },
-            "tableId": {
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "Table ID of the table to delete"
-            }
-          },
-          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
-          "id": "bigquery.tables.delete"
-        },
-        "list": {
-          "id": "bigquery.tables.list",
-          "path": "projects/{projectId}/datasets/{datasetId}/tables",
-          "description": "Lists all tables in the specified dataset. Requires the READER dataset role.",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "TableList"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
-          ],
-          "parameters": {
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the tables to list",
-              "type": "string",
-              "required": true
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, to request the next page of results",
               "type": "string"
-            },
-            "maxResults": {
-              "description": "Maximum number of results to return",
-              "format": "uint32",
-              "type": "integer",
-              "location": "query"
-            },
-            "projectId": {
-              "description": "Project ID of the tables to list",
-              "type": "string",
-              "required": true,
-              "location": "path"
             }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ]
+          }
         }
       }
     },
@@ -927,24 +269,24 @@
           "description": "Returns the dataset specified by datasetID."
         },
         "patch": {
-          "response": {
-            "$ref": "Dataset"
-          },
+          "httpMethod": "PATCH",
           "parameterOrder": [
             "projectId",
             "datasetId"
           ],
-          "httpMethod": "PATCH",
+          "response": {
+            "$ref": "Dataset"
+          },
           "parameters": {
+            "datasetId": {
+              "description": "Dataset ID of the dataset being updated",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
             "projectId": {
               "location": "path",
               "description": "Project ID of the dataset being updated",
-              "type": "string",
-              "required": true
-            },
-            "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of the dataset being updated",
               "type": "string",
               "required": true
             }
@@ -953,22 +295,14 @@
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/cloud-platform"
           ],
-          "path": "projects/{projectId}/datasets/{datasetId}",
           "id": "bigquery.datasets.patch",
+          "path": "projects/{projectId}/datasets/{datasetId}",
           "request": {
             "$ref": "Dataset"
           },
           "description": "Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource. This method supports patch semantics."
         },
         "update": {
-          "response": {
-            "$ref": "Dataset"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
-          ],
-          "httpMethod": "PUT",
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/cloud-platform"
@@ -981,10 +315,10 @@
               "required": true
             },
             "datasetId": {
-              "location": "path",
               "description": "Dataset ID of the dataset being updated",
               "type": "string",
-              "required": true
+              "required": true,
+              "location": "path"
             }
           },
           "path": "projects/{projectId}/datasets/{datasetId}",
@@ -992,9 +326,26 @@
           "description": "Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource.",
           "request": {
             "$ref": "Dataset"
-          }
+          },
+          "response": {
+            "$ref": "Dataset"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "httpMethod": "PUT"
         },
         "delete": {
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "httpMethod": "DELETE",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
           "parameters": {
             "deleteContents": {
               "location": "query",
@@ -1008,24 +359,15 @@
               "required": true
             },
             "datasetId": {
-              "location": "path",
-              "description": "Dataset ID of dataset being deleted",
               "type": "string",
-              "required": true
+              "required": true,
+              "location": "path",
+              "description": "Dataset ID of dataset being deleted"
             }
           },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "id": "bigquery.datasets.delete",
           "path": "projects/{projectId}/datasets/{datasetId}",
-          "description": "Deletes the dataset specified by the datasetId value. Before you can delete a dataset, you must delete all its tables, either manually or by specifying deleteContents. Immediately after deletion, you can create another dataset with the same name.",
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
-          ],
-          "httpMethod": "DELETE"
+          "id": "bigquery.datasets.delete",
+          "description": "Deletes the dataset specified by the datasetId value. Before you can delete a dataset, you must delete all its tables, either manually or by specifying deleteContents. Immediately after deletion, you can create another dataset with the same name."
         },
         "list": {
           "response": {
@@ -1035,29 +377,18 @@
             "projectId"
           ],
           "httpMethod": "GET",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/bigquery.readonly",
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/cloud-platform.read-only"
-          ],
           "parameters": {
-            "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, to request the next page of results",
-              "type": "string"
-            },
             "maxResults": {
-              "type": "integer",
               "location": "query",
               "description": "The maximum number of results to return",
-              "format": "uint32"
+              "format": "uint32",
+              "type": "integer"
             },
             "projectId": {
-              "location": "path",
               "description": "Project ID of the datasets to be listed",
               "type": "string",
-              "required": true
+              "required": true,
+              "location": "path"
             },
             "all": {
               "type": "boolean",
@@ -1068,49 +399,59 @@
               "location": "query",
               "description": "An expression for filtering the results of the request by label. The syntax is \"labels.\u003cname\u003e[:\u003cvalue\u003e]\". Multiple filters can be ANDed together by connecting with a space. Example: \"labels.department:receiving labels.active\". See Filtering datasets using labels for details.",
               "type": "string"
+            },
+            "pageToken": {
+              "type": "string",
+              "location": "query",
+              "description": "Page token, returned by a previous call, to request the next page of results"
             }
           },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
           "path": "projects/{projectId}/datasets",
           "id": "bigquery.datasets.list",
           "description": "Lists all datasets in the specified project to which you have been granted the READER dataset role."
         },
         "insert": {
-          "parameters": {
-            "projectId": {
-              "location": "path",
-              "description": "Project ID of the new dataset",
-              "type": "string",
-              "required": true
-            }
-          },
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
           "path": "projects/{projectId}/datasets",
           "id": "bigquery.datasets.insert",
+          "description": "Creates a new empty dataset.",
           "request": {
             "$ref": "Dataset"
           },
-          "description": "Creates a new empty dataset.",
           "response": {
             "$ref": "Dataset"
           },
           "parameterOrder": [
             "projectId"
           ],
-          "httpMethod": "POST"
+          "httpMethod": "POST",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {
+            "projectId": {
+              "description": "Project ID of the new dataset",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          }
         }
       }
     },
-    "routines": {
+    "models": {
       "methods": {
         "delete": {
-          "description": "Deletes the routine specified by routineId from the dataset.",
           "parameterOrder": [
             "projectId",
             "datasetId",
-            "routineId"
+            "modelId"
           ],
           "httpMethod": "DELETE",
           "scopes": [
@@ -1119,127 +460,85 @@
           ],
           "parameters": {
             "projectId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the routine to delete",
-              "required": true,
-              "type": "string"
-            },
-            "datasetId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Dataset ID of the routine to delete",
-              "required": true,
-              "type": "string"
-            },
-            "routineId": {
               "required": true,
               "type": "string",
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Routine ID of the routine to delete"
-            }
-          },
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
-          "id": "bigquery.routines.delete"
-        },
-        "insert": {
-          "response": {
-            "$ref": "Routine"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId"
-          ],
-          "httpMethod": "POST",
-          "scopes": [
-            "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/cloud-platform"
-          ],
-          "parameters": {
+              "description": "Required. Project ID of the model to delete."
+            },
             "datasetId": {
               "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Dataset ID of the new routine",
+              "description": "Required. Dataset ID of the model to delete.",
               "required": true,
               "type": "string"
             },
-            "projectId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the new routine",
+            "modelId": {
+              "description": "Required. Model ID of the model to delete.",
               "required": true,
-              "type": "string"
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path"
             }
           },
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/routines",
-          "id": "bigquery.routines.insert",
-          "request": {
-            "$ref": "Routine"
-          },
-          "description": "Creates a new routine in the dataset."
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
+          "id": "bigquery.models.delete",
+          "description": "Deletes the model specified by modelId from the dataset."
         },
         "get": {
-          "httpMethod": "GET",
           "response": {
-            "$ref": "Routine"
+            "$ref": "Model"
           },
           "parameterOrder": [
             "projectId",
             "datasetId",
-            "routineId"
+            "modelId"
           ],
-          "parameters": {
-            "fieldMask": {
-              "description": "If set, only the Routine fields in the field mask are returned in the\nresponse. If unset, all Routine fields are returned.",
-              "format": "google-fieldmask",
-              "type": "string",
-              "location": "query"
-            },
-            "projectId": {
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the requested routine"
-            },
-            "datasetId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Dataset ID of the requested routine",
-              "required": true,
-              "type": "string"
-            },
-            "routineId": {
-              "required": true,
-              "type": "string",
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Routine ID of the requested routine"
-            }
-          },
+          "httpMethod": "GET",
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/bigquery.readonly",
             "https://www.googleapis.com/auth/cloud-platform",
             "https://www.googleapis.com/auth/cloud-platform.read-only"
           ],
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
-          "id": "bigquery.routines.get",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
-          "description": "Gets the specified routine resource by routine ID."
+          "parameters": {
+            "projectId": {
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Project ID of the requested model."
+            },
+            "datasetId": {
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Dataset ID of the requested model."
+            },
+            "modelId": {
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Model ID of the requested model."
+            }
+          },
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
+          "id": "bigquery.models.get",
+          "description": "Gets the specified model resource by model ID."
         },
         "list": {
-          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListModelsResponse"
+          },
           "parameterOrder": [
             "projectId",
             "datasetId"
           ],
-          "response": {
-            "$ref": "ListRoutinesResponse"
-          },
+          "httpMethod": "GET",
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/bigquery.readonly",
@@ -1247,110 +546,825 @@
             "https://www.googleapis.com/auth/cloud-platform.read-only"
           ],
           "parameters": {
-            "datasetId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Dataset ID of the routines to list",
-              "required": true,
-              "type": "string"
-            },
             "pageToken": {
-              "location": "query",
-              "description": "Page token, returned by a previous call, to request the next page of\nresults",
-              "type": "string"
+              "description": "Page token, returned by a previous call to request the next page of\nresults",
+              "type": "string",
+              "location": "query"
             },
             "projectId": {
+              "location": "path",
+              "description": "Required. Project ID of the models to list.",
               "required": true,
               "type": "string",
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the routines to list"
+              "pattern": "^[^/]+$"
             },
             "maxResults": {
               "type": "integer",
               "location": "query",
               "description": "The maximum number of results to return in a single response page.\nLeverage the page tokens to iterate through the entire collection.",
               "format": "uint32"
-            }
-          },
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines",
-          "id": "bigquery.routines.list",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/routines",
-          "description": "Lists all routines in the specified dataset. Requires the READER dataset\nrole."
-        },
-        "update": {
-          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/routines/{routinesId}",
-          "path": "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
-          "id": "bigquery.routines.update",
-          "description": "Updates information in an existing routine. The update method replaces the\nentire Routine resource.",
-          "request": {
-            "$ref": "Routine"
-          },
-          "response": {
-            "$ref": "Routine"
-          },
-          "parameterOrder": [
-            "projectId",
-            "datasetId",
-            "routineId"
-          ],
-          "httpMethod": "PUT",
-          "parameters": {
-            "projectId": {
-              "pattern": "^[^/]+$",
-              "location": "path",
-              "description": "Required. Project ID of the routine to update",
-              "required": true,
-              "type": "string"
             },
             "datasetId": {
-              "pattern": "^[^/]+$",
               "location": "path",
-              "description": "Required. Dataset ID of the routine to update",
-              "required": true,
-              "type": "string"
-            },
-            "routineId": {
-              "location": "path",
-              "description": "Required. Routine ID of the routine to update",
+              "description": "Required. Dataset ID of the models to list.",
               "required": true,
               "type": "string",
               "pattern": "^[^/]+$"
             }
           },
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/models",
+          "id": "bigquery.models.list",
+          "description": "Lists all models in the specified dataset. Requires the READER dataset\nrole."
+        },
+        "patch": {
+          "response": {
+            "$ref": "Model"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "modelId"
+          ],
+          "httpMethod": "PATCH",
+          "parameters": {
+            "projectId": {
+              "description": "Required. Project ID of the model to patch.",
+              "required": true,
+              "type": "string",
+              "pattern": "^[^/]+$",
+              "location": "path"
+            },
+            "datasetId": {
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Dataset ID of the model to patch.",
+              "required": true,
+              "type": "string"
+            },
+            "modelId": {
+              "pattern": "^[^/]+$",
+              "location": "path",
+              "description": "Required. Model ID of the model to patch.",
+              "required": true,
+              "type": "string"
+            }
+          },
           "scopes": [
             "https://www.googleapis.com/auth/bigquery",
             "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "flatPath": "projects/{projectsId}/datasets/{datasetsId}/models/{modelsId}",
+          "path": "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
+          "id": "bigquery.models.patch",
+          "description": "Patch specific fields in the specified model.",
+          "request": {
+            "$ref": "Model"
+          }
+        }
+      }
+    },
+    "jobs": {
+      "methods": {
+        "get": {
+          "parameters": {
+            "location": {
+              "location": "query",
+              "description": "The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.",
+              "type": "string"
+            },
+            "jobId": {
+              "description": "[Required] Job ID of the requested job",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "projectId": {
+              "description": "[Required] Project ID of the requested job",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "path": "projects/{projectId}/jobs/{jobId}",
+          "id": "bigquery.jobs.get",
+          "description": "Returns information about a specific job. Job information is available for a six month period after creation. Requires that you're the person who ran the job, or have the Is Owner project role.",
+          "response": {
+            "$ref": "Job"
+          },
+          "parameterOrder": [
+            "projectId",
+            "jobId"
+          ],
+          "httpMethod": "GET"
+        },
+        "query": {
+          "path": "projects/{projectId}/queries",
+          "id": "bigquery.jobs.query",
+          "description": "Runs a BigQuery SQL query synchronously and returns query results if the query completes within a specified timeout.",
+          "request": {
+            "$ref": "QueryRequest"
+          },
+          "response": {
+            "$ref": "QueryResponse"
+          },
+          "parameterOrder": [
+            "projectId"
+          ],
+          "httpMethod": "POST",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "parameters": {
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the project billed for the query",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        "list": {
+          "description": "Lists all jobs that you started in the specified project. Job information is available for a six month period after creation. The job list is sorted in reverse chronological order, by job creation time. Requires the Can View project role, or the Is Owner project role if you set the allUsers property.",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "JobList"
+          },
+          "parameterOrder": [
+            "projectId"
+          ],
+          "parameters": {
+            "stateFilter": {
+              "description": "Filter for job state",
+              "enum": [
+                "done",
+                "pending",
+                "running"
+              ],
+              "type": "string",
+              "repeated": true,
+              "enumDescriptions": [
+                "Finished jobs",
+                "Pending jobs",
+                "Running jobs"
+              ],
+              "location": "query"
+            },
+            "projection": {
+              "type": "string",
+              "enumDescriptions": [
+                "Includes all job data",
+                "Does not include the job configuration"
+              ],
+              "location": "query",
+              "enum": [
+                "full",
+                "minimal"
+              ],
+              "description": "Restrict information returned to a set of selected fields"
+            },
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the jobs to list",
+              "type": "string",
+              "required": true
+            },
+            "minCreationTime": {
+              "location": "query",
+              "description": "Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned",
+              "format": "uint64",
+              "type": "string"
+            },
+            "parentJobId": {
+              "type": "string",
+              "location": "query",
+              "description": "If set, retrieves only jobs whose parent is this job. Otherwise, retrieves only jobs which have no parent"
+            },
+            "allUsers": {
+              "location": "query",
+              "description": "Whether to display jobs owned by all users in the project. Default false",
+              "type": "boolean"
+            },
+            "pageToken": {
+              "description": "Page token, returned by a previous call, to request the next page of results",
+              "type": "string",
+              "location": "query"
+            },
+            "maxCreationTime": {
+              "description": "Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned",
+              "format": "uint64",
+              "type": "string",
+              "location": "query"
+            },
+            "maxResults": {
+              "location": "query",
+              "description": "Maximum number of results to return",
+              "format": "uint32",
+              "type": "integer"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "id": "bigquery.jobs.list",
+          "path": "projects/{projectId}/jobs"
+        },
+        "getQueryResults": {
+          "response": {
+            "$ref": "GetQueryResultsResponse"
+          },
+          "parameterOrder": [
+            "projectId",
+            "jobId"
+          ],
+          "httpMethod": "GET",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "parameters": {
+            "jobId": {
+              "location": "path",
+              "description": "[Required] Job ID of the query job",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "location": "path",
+              "description": "[Required] Project ID of the query job",
+              "type": "string",
+              "required": true
+            },
+            "startIndex": {
+              "location": "query",
+              "description": "Zero-based index of the starting row",
+              "format": "uint64",
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "location": "query",
+              "description": "The geographic location where the job should run. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location."
+            },
+            "pageToken": {
+              "location": "query",
+              "description": "Page token, returned by a previous call, to request the next page of results",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "integer",
+              "location": "query",
+              "description": "How long to wait for the query to complete, in milliseconds, before returning. Default is 10 seconds. If the timeout passes before the job completes, the 'jobComplete' field in the response will be false",
+              "format": "uint32"
+            },
+            "maxResults": {
+              "location": "query",
+              "description": "Maximum number of results to read",
+              "format": "uint32",
+              "type": "integer"
+            }
+          },
+          "path": "projects/{projectId}/queries/{jobId}",
+          "id": "bigquery.jobs.getQueryResults",
+          "description": "Retrieves the results of a query job."
+        },
+        "cancel": {
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "JobCancelResponse"
+          },
+          "parameterOrder": [
+            "projectId",
+            "jobId"
+          ],
+          "parameters": {
+            "location": {
+              "description": "The geographic location of the job. Required except for US and EU. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.",
+              "type": "string",
+              "location": "query"
+            },
+            "jobId": {
+              "location": "path",
+              "description": "[Required] Job ID of the job to cancel",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "description": "[Required] Project ID of the job to cancel",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "id": "bigquery.jobs.cancel",
+          "path": "projects/{projectId}/jobs/{jobId}/cancel",
+          "description": "Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs."
+        },
+        "insert": {
+          "parameters": {
+            "projectId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Project ID of the project that will be billed for the job"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/devstorage.full_control",
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/devstorage.read_write"
+          ],
+          "mediaUpload": {
+            "protocols": {
+              "simple": {
+                "multipart": true,
+                "path": "/upload/bigquery/v2/projects/{projectId}/jobs"
+              },
+              "resumable": {
+                "path": "/resumable/upload/bigquery/v2/projects/{projectId}/jobs",
+                "multipart": true
+              }
+            },
+            "accept": [
+              "*/*"
+            ]
+          },
+          "id": "bigquery.jobs.insert",
+          "path": "projects/{projectId}/jobs",
+          "request": {
+            "$ref": "Job"
+          },
+          "description": "Starts a new asynchronous job. Requires the Can View project role.",
+          "supportsMediaUpload": true,
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "projectId"
+          ],
+          "response": {
+            "$ref": "Job"
+          }
+        }
+      }
+    },
+    "projects": {
+      "methods": {
+        "getServiceAccount": {
+          "description": "Returns the email address of the service account for your project used for interactions with Google Cloud KMS.",
+          "response": {
+            "$ref": "GetServiceAccountResponse"
+          },
+          "parameterOrder": [
+            "projectId"
+          ],
+          "httpMethod": "GET",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "parameters": {
+            "projectId": {
+              "location": "path",
+              "description": "Project ID for which the service account is requested.",
+              "type": "string",
+              "required": true
+            }
+          },
+          "path": "projects/{projectId}/serviceAccount",
+          "id": "bigquery.projects.getServiceAccount"
+        },
+        "list": {
+          "parameters": {
+            "pageToken": {
+              "location": "query",
+              "description": "Page token, returned by a previous call, to request the next page of results",
+              "type": "string"
+            },
+            "maxResults": {
+              "type": "integer",
+              "location": "query",
+              "description": "Maximum number of results to return",
+              "format": "uint32"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "id": "bigquery.projects.list",
+          "path": "projects",
+          "description": "Lists all projects to which you have been granted any project role.",
+          "response": {
+            "$ref": "ProjectList"
+          },
+          "httpMethod": "GET"
+        }
+      }
+    },
+    "tables": {
+      "methods": {
+        "delete": {
+          "id": "bigquery.tables.delete",
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+          "description": "Deletes the table specified by tableId from the dataset. If the table contains data, all the data will be deleted.",
+          "httpMethod": "DELETE",
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {
+            "tableId": {
+              "location": "path",
+              "description": "Table ID of the table to delete",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the table to delete",
+              "type": "string",
+              "required": true
+            },
+            "datasetId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Dataset ID of the table to delete"
+            }
+          }
+        },
+        "list": {
+          "description": "Lists all tables in the specified dataset. Requires the READER dataset role.",
+          "response": {
+            "$ref": "TableList"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "httpMethod": "GET",
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ],
+          "parameters": {
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the tables to list",
+              "type": "string",
+              "required": true
+            },
+            "pageToken": {
+              "location": "query",
+              "description": "Page token, returned by a previous call, to request the next page of results",
+              "type": "string"
+            },
+            "maxResults": {
+              "description": "Maximum number of results to return",
+              "format": "uint32",
+              "type": "integer",
+              "location": "query"
+            },
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the tables to list",
+              "type": "string",
+              "required": true
+            }
+          },
+          "path": "projects/{projectId}/datasets/{datasetId}/tables",
+          "id": "bigquery.tables.list"
+        },
+        "insert": {
+          "description": "Creates a new, empty table in the dataset.",
+          "request": {
+            "$ref": "Table"
+          },
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "projectId",
+            "datasetId"
+          ],
+          "response": {
+            "$ref": "Table"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the new table",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the new table",
+              "type": "string",
+              "required": true
+            }
+          },
+          "id": "bigquery.tables.insert",
+          "path": "projects/{projectId}/datasets/{datasetId}/tables"
+        },
+        "get": {
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+          "id": "bigquery.tables.get",
+          "description": "Gets the specified table resource by table ID. This method does not return the data in the table, it only returns the table resource, which describes the structure of this table.",
+          "response": {
+            "$ref": "Table"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "httpMethod": "GET",
+          "parameters": {
+            "tableId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Table ID of the requested table"
+            },
+            "projectId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Project ID of the requested table"
+            },
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the requested table",
+              "type": "string",
+              "required": true
+            },
+            "selectedFields": {
+              "type": "string",
+              "location": "query",
+              "description": "List of fields to return (comma-separated). If unspecified, all fields are returned"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
+          ]
+        },
+        "patch": {
+          "request": {
+            "$ref": "Table"
+          },
+          "description": "Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports patch semantics.",
+          "response": {
+            "$ref": "Table"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "httpMethod": "PATCH",
+          "parameters": {
+            "projectId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Project ID of the table to update"
+            },
+            "datasetId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Dataset ID of the table to update"
+            },
+            "tableId": {
+              "location": "path",
+              "description": "Table ID of the table to update",
+              "type": "string",
+              "required": true
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+          "id": "bigquery.tables.patch"
+        },
+        "update": {
+          "httpMethod": "PUT",
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "response": {
+            "$ref": "Table"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the table to update",
+              "type": "string",
+              "required": true
+            },
+            "tableId": {
+              "location": "path",
+              "description": "Table ID of the table to update",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "location": "path",
+              "description": "Project ID of the table to update",
+              "type": "string",
+              "required": true
+            }
+          },
+          "id": "bigquery.tables.update",
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+          "description": "Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource.",
+          "request": {
+            "$ref": "Table"
+          }
+        }
+      }
+    },
+    "tabledata": {
+      "methods": {
+        "insertAll": {
+          "id": "bigquery.tabledata.insertAll",
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/insertAll",
+          "request": {
+            "$ref": "TableDataInsertAllRequest"
+          },
+          "description": "Streams data into BigQuery one record at a time without needing to run a load job. Requires the WRITER dataset role.",
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "response": {
+            "$ref": "TableDataInsertAllResponse"
+          },
+          "parameters": {
+            "tableId": {
+              "description": "Table ID of the destination table.",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "projectId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Project ID of the destination table."
+            },
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the destination table.",
+              "type": "string",
+              "required": true
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.insertdata",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        },
+        "list": {
+          "id": "bigquery.tabledata.list",
+          "path": "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/data",
+          "description": "Retrieves table data from a specified set of rows. Requires the READER dataset role.",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "TableDataList"
+          },
+          "parameterOrder": [
+            "projectId",
+            "datasetId",
+            "tableId"
+          ],
+          "parameters": {
+            "pageToken": {
+              "type": "string",
+              "location": "query",
+              "description": "Page token, returned by a previous call, identifying the result set"
+            },
+            "tableId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Table ID of the table to read"
+            },
+            "maxResults": {
+              "location": "query",
+              "description": "Maximum number of results to return",
+              "format": "uint32",
+              "type": "integer"
+            },
+            "datasetId": {
+              "location": "path",
+              "description": "Dataset ID of the table to read",
+              "type": "string",
+              "required": true
+            },
+            "projectId": {
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Project ID of the table to read"
+            },
+            "selectedFields": {
+              "description": "List of fields to return (comma-separated). If unspecified, all fields are returned",
+              "type": "string",
+              "location": "query"
+            },
+            "startIndex": {
+              "description": "Zero-based index of the starting row to read",
+              "format": "uint64",
+              "type": "string",
+              "location": "query"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/bigquery.readonly",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only"
           ]
         }
       }
     }
   },
   "parameters": {
+    "key": {
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string"
+    },
     "quotaUser": {
-      "description": "An opaque string that represents a user for quota purposes. Must not exceed 40 characters.",
+      "type": "string",
+      "location": "query",
+      "description": "An opaque string that represents a user for quota purposes. Must not exceed 40 characters."
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean",
+      "default": "true"
+    },
+    "fields": {
+      "type": "string",
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response."
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
       "type": "string",
       "location": "query"
     },
-    "prettyPrint": {
-      "description": "Returns response with indentations and line breaks.",
-      "type": "boolean",
-      "default": "true",
-      "location": "query"
-    },
-    "fields": {
-      "location": "query",
-      "description": "Selector specifying which fields to include in a partial response.",
-      "type": "string"
-    },
-    "oauth_token": {
-      "location": "query",
-      "description": "OAuth 2.0 token for the current user.",
-      "type": "string"
-    },
     "alt": {
-      "description": "Data format for the response.",
-      "default": "json",
       "enum": [
         "json"
       ],
@@ -1358,1307 +1372,34 @@
       "enumDescriptions": [
         "Responses with Content-Type of application/json"
       ],
-      "location": "query"
+      "location": "query",
+      "description": "Data format for the response.",
+      "default": "json"
     },
     "userIp": {
       "location": "query",
       "description": "Deprecated. Please use quotaUser instead.",
       "type": "string"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "type": "string",
-      "location": "query"
     }
   },
   "schemas": {
-    "CategoryCount": {
-      "type": "object",
-      "properties": {
-        "count": {
-          "type": "string",
-          "description": "The count of training samples matching the category within the\ncluster.",
-          "format": "int64"
-        },
-        "category": {
-          "type": "string",
-          "description": "The name of category."
-        }
-      },
-      "id": "CategoryCount",
-      "description": "Represents the count of a single category within the cluster."
-    },
-    "EvaluationMetrics": {
-      "id": "EvaluationMetrics",
-      "description": "Evaluation metrics of a model. These are either computed on all training\ndata or just the eval data based on whether eval data was used during\ntraining. These are not present for imported models.",
-      "type": "object",
-      "properties": {
-        "binaryClassificationMetrics": {
-          "description": "Populated for binary classification/classifier models.",
-          "$ref": "BinaryClassificationMetrics"
-        },
-        "regressionMetrics": {
-          "$ref": "RegressionMetrics",
-          "description": "Populated for regression models and explicit feedback type matrix\nfactorization models."
-        },
-        "multiClassClassificationMetrics": {
-          "description": "Populated for multi-class classification/classifier models.",
-          "$ref": "MultiClassClassificationMetrics"
-        },
-        "clusteringMetrics": {
-          "description": "Populated for clustering models.",
-          "$ref": "ClusteringMetrics"
-        }
-      }
-    },
-    "StandardSqlField": {
-      "id": "StandardSqlField",
-      "description": "A field or a column.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Optional. The name of this field. Can be absent for struct fields.",
-          "type": "string"
-        },
-        "type": {
-          "$ref": "StandardSqlDataType",
-          "description": "Optional. The type of this parameter. Absent if not explicitly\nspecified (e.g., CREATE FUNCTION statement can omit the return type;\nin this case the output parameter does not have this \"type\" field)."
-        }
-      }
-    },
-    "TableCell": {
-      "type": "object",
-      "properties": {
-        "v": {
-          "type": "any"
-        }
-      },
-      "id": "TableCell"
-    },
-    "TableReference": {
-      "type": "object",
-      "properties": {
-        "tableId": {
-          "description": "[Required] The ID of the table. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.",
-          "annotations": {
-            "required": [
-              "bigquery.tables.update"
-            ]
-          },
-          "type": "string"
-        },
-        "projectId": {
-          "description": "[Required] The ID of the project containing this table.",
-          "annotations": {
-            "required": [
-              "bigquery.tables.update"
-            ]
-          },
-          "type": "string"
-        },
-        "datasetId": {
-          "description": "[Required] The ID of the dataset containing this table.",
-          "annotations": {
-            "required": [
-              "bigquery.tables.update"
-            ]
-          },
-          "type": "string"
-        }
-      },
-      "id": "TableReference"
-    },
-    "StandardSqlStructType": {
-      "id": "StandardSqlStructType",
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "array",
-          "items": {
-            "$ref": "StandardSqlField"
-          }
-        }
-      }
-    },
-    "JobStatistics4": {
-      "id": "JobStatistics4",
-      "type": "object",
-      "properties": {
-        "destinationUriFileCounts": {
-          "description": "[Output-only] Number of files per destination URI or URI pattern specified in the extract configuration. These values will be in the same order as the URIs specified in the 'destinationUris' field.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "int64"
-          }
-        },
-        "inputBytes": {
-          "description": "[Output-only] Number of user bytes extracted into the result. This is the byte count as computed by BigQuery for billing purposes.",
-          "format": "int64",
-          "type": "string"
-        }
-      }
-    },
-    "ArimaResult": {
-      "id": "ArimaResult",
-      "description": "(Auto-)arima fitting result. Wrap everything in ArimaResult for easier\nrefactoring if we want to use model-specific iteration results.",
-      "type": "object",
-      "properties": {
-        "arimaModelInfo": {
-          "description": "This message is repeated because there are multiple arima models\nfitted in auto-arima. For non-auto-arima model, its size is one.",
-          "type": "array",
-          "items": {
-            "$ref": "ArimaModelInfo"
-          }
-        },
-        "seasonalPeriods": {
-          "description": "Seasonal periods. Repeated because multiple periods are supported for\none time series.",
-          "type": "array",
-          "items": {
-            "enum": [
-              "SEASONAL_PERIOD_TYPE_UNSPECIFIED",
-              "NO_SEASONALITY",
-              "DAILY",
-              "WEEKLY",
-              "MONTHLY",
-              "QUARTERLY",
-              "YEARLY"
-            ],
-            "type": "string"
-          },
-          "enumDescriptions": [
-            "",
-            "No seasonality",
-            "Daily period, 24 hours.",
-            "Weekly period, 7 days.",
-            "Monthly period, can be as 30 days or irregular.",
-            "Quarterly period, can be as 90 days or irregular.",
-            "Yearly period, can be as 365 days or irregular."
-          ]
-        }
-      }
-    },
-    "CsvOptions": {
-      "id": "CsvOptions",
-      "type": "object",
-      "properties": {
-        "encoding": {
-          "description": "[Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.",
-          "type": "string"
-        },
-        "allowQuotedNewlines": {
-          "description": "[Optional] Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.",
-          "type": "boolean"
-        },
-        "quote": {
-          "pattern": ".?",
-          "description": "[Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('\"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.",
-          "type": "string",
-          "default": "\""
-        },
-        "skipLeadingRows": {
-          "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.",
-          "format": "int64",
-          "type": "string"
-        },
-        "allowJaggedRows": {
-          "description": "[Optional] Indicates if BigQuery should accept rows that are missing trailing optional columns. If true, BigQuery treats missing trailing columns as null values. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.",
-          "type": "boolean"
-        },
-        "fieldDelimiter": {
-          "description": "[Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',').",
-          "type": "string"
-        }
-      }
-    },
-    "JobReference": {
-      "type": "object",
-      "properties": {
-        "location": {
-          "type": "string",
-          "description": "The geographic location of the job. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location."
-        },
-        "jobId": {
-          "description": "[Required] The ID of the job. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024 characters.",
-          "annotations": {
-            "required": [
-              "bigquery.jobs.getQueryResults"
-            ]
-          },
-          "type": "string"
-        },
-        "projectId": {
-          "description": "[Required] The ID of the project containing this job.",
-          "annotations": {
-            "required": [
-              "bigquery.jobs.getQueryResults"
-            ]
-          },
-          "type": "string"
-        }
-      },
-      "id": "JobReference"
-    },
-    "JobConfigurationQuery": {
-      "type": "object",
-      "properties": {
-        "allowLargeResults": {
-          "description": "[Optional] If true and query uses legacy SQL dialect, allows the query to produce arbitrarily large result tables at a slight cost in performance. Requires destinationTable to be set. For standard SQL queries, this flag is ignored and large results are always allowed. However, you must still set destinationTable when result size exceeds the allowed maximum response size.",
-          "type": "boolean",
-          "default": "false"
-        },
-        "rangePartitioning": {
-          "$ref": "RangePartitioning",
-          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified."
-        },
-        "parameterMode": {
-          "description": "Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.",
-          "type": "string"
-        },
-        "useQueryCache": {
-          "description": "[Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. Moreover, the query cache is only available when a query does not have a destination table specified. The default value is true.",
-          "type": "boolean",
-          "default": "true"
-        },
-        "flattenResults": {
-          "description": "[Optional] If true and query uses legacy SQL dialect, flattens all nested and repeated fields in the query results. allowLargeResults must be true if this is set to false. For standard SQL queries, this flag is ignored and results are never flattened.",
-          "type": "boolean",
-          "default": "true"
-        },
-        "tableDefinitions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "ExternalDataConfiguration"
-          },
-          "description": "[Optional] If querying an external data source outside of BigQuery, describes the data format, location and other properties of the data source. By defining these properties, the data source can then be queried as if it were a standard BigQuery table."
-        },
-        "defaultDataset": {
-          "description": "[Optional] Specifies the default dataset to use for unqualified table names in the query. Note that this does not alter behavior of unqualified dataset names.",
-          "$ref": "DatasetReference"
-        },
-        "maximumBillingTier": {
-          "description": "[Optional] Limits the billing tier for this job. Queries that have resource usage beyond this tier will fail (without incurring a charge). If unspecified, this will be set to your project default.",
-          "format": "int32",
-          "type": "integer",
-          "default": "1"
-        },
-        "preserveNulls": {
-          "type": "boolean",
-          "description": "[Deprecated] This property is deprecated."
-        },
-        "timePartitioning": {
-          "$ref": "TimePartitioning",
-          "description": "Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified."
-        },
-        "writeDisposition": {
-          "type": "string",
-          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion."
-        },
-        "query": {
-          "type": "string",
-          "description": "[Required] SQL query text to execute. The useLegacySql field can be used to indicate whether the query uses legacy SQL or standard SQL."
-        },
-        "userDefinedFunctionResources": {
-          "description": "Describes user-defined function resources used in the query.",
-          "type": "array",
-          "items": {
-            "$ref": "UserDefinedFunctionResource"
-          }
-        },
-        "destinationTable": {
-          "$ref": "TableReference",
-          "description": "[Optional] Describes the table where the query results should be stored. If not present, a new table will be created to store the results. This property must be set for large results that exceed the maximum response size."
-        },
-        "queryParameters": {
-          "description": "Query parameters for standard SQL queries.",
-          "type": "array",
-          "items": {
-            "$ref": "QueryParameter"
-          }
-        },
-        "useLegacySql": {
-          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.",
-          "type": "boolean",
-          "default": "true"
-        },
-        "clustering": {
-          "$ref": "Clustering",
-          "description": "[Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered."
-        },
-        "destinationEncryptionConfiguration": {
-          "$ref": "EncryptionConfiguration",
-          "description": "Custom encryption configuration (e.g., Cloud KMS keys)."
-        },
-        "createDisposition": {
-          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
-          "type": "string"
-        },
-        "maximumBytesBilled": {
-          "description": "[Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.",
-          "format": "int64",
-          "type": "string"
-        },
-        "schemaUpdateOptions": {
-          "description": "Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "priority": {
-          "description": "[Optional] Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.",
-          "type": "string"
-        }
-      },
-      "id": "JobConfigurationQuery"
-    },
-    "QueryParameterType": {
-      "id": "QueryParameterType",
-      "type": "object",
-      "properties": {
-        "arrayType": {
-          "$ref": "QueryParameterType",
-          "description": "[Optional] The type of the array's elements, if this is an array."
-        },
-        "type": {
-          "description": "[Required] The top level type of this field.",
-          "type": "string"
-        },
-        "structTypes": {
-          "description": "[Optional] The types of the fields of this struct, in order, if this is a struct.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "[Optional] The name of this field.",
-                "type": "string"
-              },
-              "description": {
-                "description": "[Optional] Human-oriented description of the field.",
-                "type": "string"
-              },
-              "type": {
-                "$ref": "QueryParameterType",
-                "description": "[Required] The type of this field."
-              }
-            }
-          }
-        }
-      }
-    },
-    "BigQueryModelTraining": {
-      "type": "object",
-      "properties": {
-        "currentIteration": {
-          "type": "integer",
-          "description": "[Output-only, Beta] Index of current ML training iteration. Updated during create model query job to show job progress.",
-          "format": "int32"
-        },
-        "expectedTotalIterations": {
-          "description": "[Output-only, Beta] Expected number of iterations for the create model query job specified as num_iterations in the input query. The actual total number of iterations may be less than this number due to early stop.",
-          "format": "int64",
-          "type": "string"
-        }
-      },
-      "id": "BigQueryModelTraining"
-    },
-    "LocationMetadata": {
-      "type": "object",
-      "properties": {
-        "legacyLocationId": {
-          "description": "The legacy BigQuery location ID, e.g. “EU” for the “europe” location.\nThis is for any API consumers that need the legacy “US” and “EU” locations.",
-          "type": "string"
-        }
-      },
-      "id": "LocationMetadata",
-      "description": "BigQuery-specific metadata about a location. This will be set on\ngoogle.cloud.location.Location.metadata in Cloud Location API\nresponses."
-    },
-    "ProjectList": {
-      "type": "object",
-      "properties": {
-        "nextPageToken": {
-          "description": "A token to request the next page of results.",
-          "type": "string"
-        },
-        "totalItems": {
-          "description": "The total number of projects in the list.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "kind": {
-          "description": "The type of list.",
-          "type": "string",
-          "default": "bigquery#projectList"
-        },
-        "etag": {
-          "description": "A hash of the page of results",
-          "type": "string"
-        },
-        "projects": {
-          "description": "Projects to which you have at least READ access.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "description": "An opaque ID of this project.",
-                "type": "string"
-              },
-              "projectReference": {
-                "$ref": "ProjectReference",
-                "description": "A unique reference to this project."
-              },
-              "friendlyName": {
-                "description": "A descriptive name for this project.",
-                "type": "string"
-              },
-              "numericId": {
-                "type": "string",
-                "description": "The numeric ID of this project.",
-                "format": "uint64"
-              },
-              "kind": {
-                "type": "string",
-                "default": "bigquery#project",
-                "description": "The resource type."
-              }
-            }
-          }
-        }
-      },
-      "id": "ProjectList"
-    },
-    "RoutineReference": {
-      "type": "object",
-      "properties": {
-        "projectId": {
-          "type": "string",
-          "description": "[Required] The ID of the project containing this routine."
-        },
-        "datasetId": {
-          "description": "[Required] The ID of the dataset containing this routine.",
-          "type": "string"
-        },
-        "routineId": {
-          "description": "[Required] The ID of the routine. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 256 characters.",
-          "type": "string"
-        }
-      },
-      "id": "RoutineReference"
-    },
-    "IterationResult": {
-      "description": "Information about a single iteration of the training run.",
-      "type": "object",
-      "properties": {
-        "durationMs": {
-          "description": "Time taken to run the iteration in milliseconds.",
-          "format": "int64",
-          "type": "string"
-        },
-        "arimaResult": {
-          "$ref": "ArimaResult"
-        },
-        "clusterInfos": {
-          "description": "Information about top clusters for clustering models.",
-          "type": "array",
-          "items": {
-            "$ref": "ClusterInfo"
-          }
-        },
-        "trainingLoss": {
-          "description": "Loss computed on the training data at the end of iteration.",
-          "format": "double",
-          "type": "number"
-        },
-        "evalLoss": {
-          "description": "Loss computed on the eval data at the end of iteration.",
-          "format": "double",
-          "type": "number"
-        },
-        "index": {
-          "description": "Index of the iteration, 0 based.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "learnRate": {
-          "description": "Learn rate used for this iteration.",
-          "format": "double",
-          "type": "number"
-        }
-      },
-      "id": "IterationResult"
-    },
-    "JobCancelResponse": {
-      "id": "JobCancelResponse",
-      "type": "object",
-      "properties": {
-        "kind": {
-          "description": "The resource type of the response.",
-          "type": "string",
-          "default": "bigquery#jobCancelResponse"
-        },
-        "job": {
-          "$ref": "Job",
-          "description": "The final state of the job."
-        }
-      }
-    },
-    "ProjectReference": {
-      "type": "object",
-      "properties": {
-        "projectId": {
-          "description": "[Required] ID of the project. Can be either the numeric ID or the assigned ID of the project.",
-          "type": "string"
-        }
-      },
-      "id": "ProjectReference"
-    },
-    "BigtableOptions": {
-      "type": "object",
-      "properties": {
-        "columnFamilies": {
-          "description": "[Optional] List of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.",
-          "type": "array",
-          "items": {
-            "$ref": "BigtableColumnFamily"
-          }
-        },
-        "ignoreUnspecifiedColumnFamilies": {
-          "type": "boolean",
-          "description": "[Optional] If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false."
-        },
-        "readRowkeyAsString": {
-          "type": "boolean",
-          "description": "[Optional] If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false."
-        }
-      },
-      "id": "BigtableOptions"
-    },
-    "ListRoutinesResponse": {
-      "type": "object",
-      "properties": {
-        "routines": {
-          "type": "array",
-          "items": {
-            "$ref": "Routine"
-          },
-          "description": "Routines in the requested dataset. Only the following fields are populated:\netag, project_id, dataset_id, routine_id, routine_type, creation_time,\nlast_modified_time, language."
-        },
-        "nextPageToken": {
-          "description": "A token to request the next page of results.",
-          "type": "string"
-        }
-      },
-      "id": "ListRoutinesResponse"
-    },
-    "JobConfiguration": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "$ref": "JobConfigurationQuery",
-          "description": "[Pick one] Configures a query job."
-        },
-        "dryRun": {
-          "description": "[Optional] If set, don't actually run this job. A valid query will return a mostly empty response with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run. Behavior of non-query jobs is undefined.",
-          "type": "boolean"
-        },
-        "labels": {
-          "description": "The labels associated with this job. You can use these to organize and group your jobs. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "load": {
-          "$ref": "JobConfigurationLoad",
-          "description": "[Pick one] Configures a load job."
-        },
-        "jobType": {
-          "description": "[Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or UNKNOWN.",
-          "type": "string"
-        },
-        "extract": {
-          "description": "[Pick one] Configures an extract job.",
-          "$ref": "JobConfigurationExtract"
-        },
-        "copy": {
-          "$ref": "JobConfigurationTableCopy",
-          "description": "[Pick one] Copies a table."
-        },
-        "jobTimeoutMs": {
-          "type": "string",
-          "description": "[Optional] Job timeout in milliseconds. If this time limit is exceeded, BigQuery may attempt to terminate the job.",
-          "format": "int64"
-        }
-      },
-      "id": "JobConfiguration"
-    },
-    "JsonObject": {
-      "id": "JsonObject",
-      "additionalProperties": {
-        "$ref": "JsonValue"
-      },
-      "description": "Represents a single JSON object.",
-      "type": "object"
-    },
-    "Argument": {
-      "description": "Input/output argument of a function or a stored procedure.",
-      "type": "object",
-      "properties": {
-        "argumentKind": {
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "The argument is a variable with fully specified type, which can be a\nstruct or an array, but not a table.",
-            "The argument is any type, including struct or array, but not a table.\nTo be added: FIXED_TABLE, ANY_TABLE"
-          ],
-          "enum": [
-            "ARGUMENT_KIND_UNSPECIFIED",
-            "FIXED_TYPE",
-            "ANY_TYPE"
-          ],
-          "description": "Optional. Defaults to FIXED_TYPE."
-        },
-        "mode": {
-          "enumDescriptions": [
-            "",
-            "The argument is input-only.",
-            "The argument is output-only.",
-            "The argument is both an input and an output."
-          ],
-          "enum": [
-            "MODE_UNSPECIFIED",
-            "IN",
-            "OUT",
-            "INOUT"
-          ],
-          "description": "Optional. Specifies whether the argument is input or output.\nCan be set for procedures only.",
-          "type": "string"
-        },
-        "dataType": {
-          "$ref": "StandardSqlDataType",
-          "description": "Required unless argument_kind = ANY_TYPE."
-        },
-        "name": {
-          "description": "Optional. The name of this argument. Can be absent for function return argument.",
-          "type": "string"
-        }
-      },
-      "id": "Argument"
-    },
-    "ExplainQueryStep": {
-      "type": "object",
-      "properties": {
-        "substeps": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Human-readable stage descriptions."
-        },
-        "kind": {
-          "description": "Machine-readable operation type.",
-          "type": "string"
-        }
-      },
-      "id": "ExplainQueryStep"
-    },
-    "DatasetList": {
-      "type": "object",
-      "properties": {
-        "datasets": {
-          "description": "An array of the dataset resources in the project. Each resource contains basic information. For full information about a particular dataset resource, use the Datasets: get method. This property is omitted when there are no datasets in the project.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The fully-qualified, unique, opaque ID of the dataset."
-              },
-              "location": {
-                "type": "string",
-                "description": "The geographic location where the data resides."
-              },
-              "friendlyName": {
-                "type": "string",
-                "description": "A descriptive name for the dataset, if one exists."
-              },
-              "kind": {
-                "description": "The resource type. This property always returns the value \"bigquery#dataset\".",
-                "type": "string",
-                "default": "bigquery#dataset"
-              },
-              "labels": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "The labels associated with this dataset. You can use these to organize and group your datasets."
-              },
-              "datasetReference": {
-                "description": "The dataset reference. Use this property to access specific parts of the dataset's ID, such as project ID or dataset ID.",
-                "$ref": "DatasetReference"
-              }
-            }
-          }
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token that can be used to request the next results page. This property is omitted on the final results page."
-        },
-        "kind": {
-          "type": "string",
-          "default": "bigquery#datasetList",
-          "description": "The list type. This property always returns the value \"bigquery#datasetList\"."
-        },
-        "etag": {
-          "description": "A hash value of the results page. You can use this property to determine if the page has changed since the last request.",
-          "type": "string"
-        }
-      },
-      "id": "DatasetList"
-    },
-    "JobConfigurationTableCopy": {
-      "id": "JobConfigurationTableCopy",
-      "type": "object",
-      "properties": {
-        "destinationTable": {
-          "$ref": "TableReference",
-          "description": "[Required] The destination table"
-        },
-        "destinationEncryptionConfiguration": {
-          "$ref": "EncryptionConfiguration",
-          "description": "Custom encryption configuration (e.g., Cloud KMS keys)."
-        },
-        "sourceTables": {
-          "description": "[Pick one] Source tables to copy.",
-          "type": "array",
-          "items": {
-            "$ref": "TableReference"
-          }
-        },
-        "createDisposition": {
-          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
-          "type": "string"
-        },
-        "sourceTable": {
-          "$ref": "TableReference",
-          "description": "[Pick one] Source table to copy."
-        },
-        "writeDisposition": {
-          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.",
-          "type": "string"
-        }
-      }
-    },
-    "BinaryConfusionMatrix": {
-      "type": "object",
-      "properties": {
-        "trueNegatives": {
-          "description": "Number of true samples predicted as false.",
-          "format": "int64",
-          "type": "string"
-        },
-        "falsePositives": {
-          "type": "string",
-          "description": "Number of false samples predicted as true.",
-          "format": "int64"
-        },
-        "f1Score": {
-          "description": "The equally weighted average of recall and precision.",
-          "format": "double",
-          "type": "number"
-        },
-        "precision": {
-          "type": "number",
-          "description": "The fraction of actual positive predictions that had positive actual\nlabels.",
-          "format": "double"
-        },
-        "accuracy": {
-          "description": "The fraction of predictions given the correct label.",
-          "format": "double",
-          "type": "number"
-        },
-        "positiveClassThreshold": {
-          "description": "Threshold value used when computing each of the following metric.",
-          "format": "double",
-          "type": "number"
-        },
-        "truePositives": {
-          "description": "Number of true samples predicted as true.",
-          "format": "int64",
-          "type": "string"
-        },
-        "recall": {
-          "description": "The fraction of actual positive labels that were given a positive\nprediction.",
-          "format": "double",
-          "type": "number"
-        },
-        "falseNegatives": {
-          "description": "Number of false samples predicted as false.",
-          "format": "int64",
-          "type": "string"
-        }
-      },
-      "id": "BinaryConfusionMatrix",
-      "description": "Confusion matrix for binary classification models."
-    },
-    "QueryTimelineSample": {
-      "type": "object",
-      "properties": {
-        "totalSlotMs": {
-          "description": "Cumulative slot-ms consumed by the query.",
-          "format": "int64",
-          "type": "string"
-        },
-        "activeUnits": {
-          "description": "Total number of units currently being processed by workers. This does not correspond directly to slot usage. This is the largest value observed since the last sample.",
-          "format": "int64",
-          "type": "string"
-        },
-        "completedUnits": {
-          "description": "Total parallel units of work completed by this query.",
-          "format": "int64",
-          "type": "string"
-        },
-        "elapsedMs": {
-          "description": "Milliseconds elapsed since the start of query execution.",
-          "format": "int64",
-          "type": "string"
-        },
-        "pendingUnits": {
-          "description": "Total parallel units of work remaining for the active stages.",
-          "format": "int64",
-          "type": "string"
-        }
-      },
-      "id": "QueryTimelineSample"
-    },
-    "QueryRequest": {
-      "type": "object",
-      "properties": {
-        "kind": {
-          "description": "The resource type of the request.",
-          "type": "string",
-          "default": "bigquery#queryRequest"
-        },
-        "timeoutMs": {
-          "description": "[Optional] How long to wait for the query to complete, in milliseconds, before the request times out and returns. Note that this is only a timeout for the request, not the query. If the query takes longer to run than the timeout value, the call returns without any results and with the 'jobComplete' flag set to false. You can call GetQueryResults() to wait for the query to complete and read the results. The default value is 10000 milliseconds (10 seconds).",
-          "format": "uint32",
-          "type": "integer"
-        },
-        "parameterMode": {
-          "description": "Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.",
-          "type": "string"
-        },
-        "useQueryCache": {
-          "description": "[Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. The default value is true.",
-          "type": "boolean",
-          "default": "true"
-        },
-        "defaultDataset": {
-          "description": "[Optional] Specifies the default datasetId and projectId to assume for any unqualified table names in the query. If not set, all table names in the query string must be qualified in the format 'datasetId.tableId'.",
-          "$ref": "DatasetReference"
-        },
-        "location": {
-          "type": "string",
-          "description": "The geographic location where the job should run. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location."
-        },
-        "preserveNulls": {
-          "description": "[Deprecated] This property is deprecated.",
-          "type": "boolean"
-        },
-        "query": {
-          "description": "[Required] A query string, following the BigQuery query syntax, of the query to execute. Example: \"SELECT count(f1) FROM [myProjectId:myDatasetId.myTableId]\".",
-          "annotations": {
-            "required": [
-              "bigquery.jobs.query"
-            ]
-          },
-          "type": "string"
-        },
-        "maxResults": {
-          "description": "[Optional] The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.",
-          "format": "uint32",
-          "type": "integer"
-        },
-        "dryRun": {
-          "type": "boolean",
-          "description": "[Optional] If set to true, BigQuery doesn't run the job. Instead, if the query is valid, BigQuery returns statistics about the job such as how many bytes would be processed. If the query is invalid, an error returns. The default value is false."
-        },
-        "queryParameters": {
-          "description": "Query parameters for Standard SQL queries.",
-          "type": "array",
-          "items": {
-            "$ref": "QueryParameter"
-          }
-        },
-        "useLegacySql": {
-          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false.",
-          "type": "boolean",
-          "default": "true"
-        }
-      },
-      "id": "QueryRequest"
-    },
-    "ErrorProto": {
-      "id": "ErrorProto",
-      "type": "object",
-      "properties": {
-        "message": {
-          "description": "A human-readable description of the error.",
-          "type": "string"
-        },
-        "location": {
-          "description": "Specifies where the error occurred, if present.",
-          "type": "string"
-        },
-        "debugInfo": {
-          "description": "Debugging information. This property is internal to Google and should not be used.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "A short error code that summarizes the error.",
-          "type": "string"
-        }
-      }
-    },
-    "BinaryClassificationMetrics": {
-      "description": "Evaluation metrics for binary classification/classifier models.",
-      "type": "object",
-      "properties": {
-        "aggregateClassificationMetrics": {
-          "$ref": "AggregateClassificationMetrics",
-          "description": "Aggregate classification metrics."
-        },
-        "negativeLabel": {
-          "type": "string",
-          "description": "Label representing the negative class."
-        },
-        "positiveLabel": {
-          "description": "Label representing the positive class.",
-          "type": "string"
-        },
-        "binaryConfusionMatrixList": {
-          "description": "Binary confusion matrix at multiple thresholds.",
-          "type": "array",
-          "items": {
-            "$ref": "BinaryConfusionMatrix"
-          }
-        }
-      },
-      "id": "BinaryClassificationMetrics"
-    },
-    "RangePartitioning": {
-      "type": "object",
-      "properties": {
-        "range": {
-          "description": "[TrustedTester] [Required] Defines the ranges for range partitioning.",
-          "type": "object",
-          "properties": {
-            "interval": {
-              "description": "[TrustedTester] [Required] The width of each interval.",
-              "format": "int64",
-              "type": "string"
-            },
-            "start": {
-              "type": "string",
-              "description": "[TrustedTester] [Required] The start of range partitioning, inclusive.",
-              "format": "int64"
-            },
-            "end": {
-              "description": "[TrustedTester] [Required] The end of range partitioning, exclusive.",
-              "format": "int64",
-              "type": "string"
-            }
-          }
-        },
-        "field": {
-          "description": "[TrustedTester] [Required] The table is partitioned by this field. The field must be a top-level NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.",
-          "type": "string"
-        }
-      },
-      "id": "RangePartitioning"
-    },
-    "JobConfigurationLoad": {
-      "type": "object",
-      "properties": {
-        "schemaUpdateOptions": {
-          "description": "Allows the schema of the destination table to be updated as a side effect of the load job if a schema is autodetected or supplied in the job configuration. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "schemaInline": {
-          "description": "[Deprecated] The inline schema. For CSV schemas, specify as \"Field1:Type1[,Field2:Type2]*\". For example, \"foo:STRING, bar:INTEGER, baz:FLOAT\".",
-          "type": "string"
-        },
-        "rangePartitioning": {
-          "$ref": "RangePartitioning",
-          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified."
-        },
-        "nullMarker": {
-          "type": "string",
-          "description": "[Optional] Specifies a string that represents a null value in a CSV file. For example, if you specify \"\\N\", BigQuery interprets \"\\N\" as a null value when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as an empty value."
-        },
-        "schema": {
-          "$ref": "TableSchema",
-          "description": "[Optional] The schema for the destination table. The schema can be omitted if the destination table already exists, or if you're loading data from Google Cloud Datastore."
-        },
-        "schemaInlineFormat": {
-          "description": "[Deprecated] The format of the schemaInline property.",
-          "type": "string"
-        },
-        "quote": {
-          "description": "[Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('\"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.",
-          "type": "string",
-          "default": "\"",
-          "pattern": ".?"
-        },
-        "writeDisposition": {
-          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.",
-          "type": "string"
-        },
-        "destinationTableProperties": {
-          "$ref": "DestinationTableProperties",
-          "description": "[Beta] [Optional] Properties with which to create the destination table if it is new."
-        },
-        "sourceFormat": {
-          "description": "[Optional] The format of the data files. For CSV files, specify \"CSV\". For datastore backups, specify \"DATASTORE_BACKUP\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". For Avro, specify \"AVRO\". For parquet, specify \"PARQUET\". For orc, specify \"ORC\". The default value is CSV.",
-          "type": "string"
-        },
-        "ignoreUnknownValues": {
-          "description": "[Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names",
-          "type": "boolean"
-        },
-        "destinationTable": {
-          "$ref": "TableReference",
-          "description": "[Required] The destination table to load the data into."
-        },
-        "encoding": {
-          "description": "[Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.",
-          "type": "string"
-        },
-        "clustering": {
-          "$ref": "Clustering",
-          "description": "[Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered."
-        },
-        "createDisposition": {
-          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
-          "type": "string"
-        },
-        "hivePartitioningMode": {
-          "description": "[Optional, Trusted Tester] Deprecated, do not use. Please set hivePartitioningOptions instead.",
-          "type": "string"
-        },
-        "sourceUris": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "[Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups: Exactly one URI can be specified. Also, the '*' wildcard character is not allowed."
-        },
-        "maxBadRecords": {
-          "description": "[Optional] The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV and JSON. The default value is 0, which requires that all records are valid.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "allowJaggedRows": {
-          "description": "[Optional] Accept rows that are missing trailing optional columns. The missing values are treated as nulls. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. Only applicable to CSV, ignored for other formats.",
-          "type": "boolean"
-        },
-        "fieldDelimiter": {
-          "description": "[Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',').",
-          "type": "string"
-        },
-        "projectionFields": {
-          "description": "If sourceFormat is set to \"DATASTORE_BACKUP\", indicates which entity properties to load into BigQuery from a Cloud Datastore backup. Property names are case sensitive and must be top-level properties. If no properties are specified, BigQuery loads all properties. If any named property isn't found in the Cloud Datastore backup, an invalid error is returned in the job result.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "allowQuotedNewlines": {
-          "description": "Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.",
-          "type": "boolean"
-        },
-        "hivePartitioningOptions": {
-          "description": "[Optional, Trusted Tester] Options to configure hive partitioning support.",
-          "$ref": "HivePartitioningOptions"
-        },
-        "useAvroLogicalTypes": {
-          "description": "[Optional] If sourceFormat is set to \"AVRO\", indicates whether to enable interpreting logical types into their corresponding types (ie. TIMESTAMP), instead of only using their raw types (ie. INTEGER).",
-          "type": "boolean"
-        },
-        "skipLeadingRows": {
-          "type": "integer",
-          "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.",
-          "format": "int32"
-        },
-        "timePartitioning": {
-          "$ref": "TimePartitioning",
-          "description": "Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified."
-        },
-        "autodetect": {
-          "description": "[Optional] Indicates if we should automatically infer the options and schema for CSV and JSON sources.",
-          "type": "boolean"
-        },
-        "destinationEncryptionConfiguration": {
-          "$ref": "EncryptionConfiguration",
-          "description": "Custom encryption configuration (e.g., Cloud KMS keys)."
-        }
-      },
-      "id": "JobConfigurationLoad"
-    },
-    "TableDataInsertAllRequest": {
-      "type": "object",
-      "properties": {
-        "ignoreUnknownValues": {
-          "description": "[Optional] Accept rows that contain values that do not match the schema. The unknown values are ignored. Default is false, which treats unknown values as errors.",
-          "type": "boolean"
-        },
-        "skipInvalidRows": {
-          "type": "boolean",
-          "description": "[Optional] Insert all valid rows of a request, even if invalid rows exist. The default value is false, which causes the entire request to fail if any invalid rows exist."
-        },
-        "rows": {
-          "description": "The rows to insert.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "insertId": {
-                "type": "string",
-                "description": "[Optional] A unique ID for each row. BigQuery uses this property to detect duplicate insertion requests on a best-effort basis."
-              },
-              "json": {
-                "description": "[Required] A JSON object that contains a row of data. The object's properties and values must match the destination table's schema.",
-                "$ref": "JsonObject"
-              }
-            }
-          }
-        },
-        "kind": {
-          "description": "The resource type of the response.",
-          "type": "string",
-          "default": "bigquery#tableDataInsertAllRequest"
-        },
-        "templateSuffix": {
-          "description": "If specified, treats the destination table as a base template, and inserts the rows into an instance table named \"{destination}{templateSuffix}\". BigQuery will manage creation of the instance table, using the schema of the base template table. See https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables for considerations when working with templates tables.",
-          "type": "string"
-        }
-      },
-      "id": "TableDataInsertAllRequest"
-    },
-    "TableList": {
-      "type": "object",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "A hash of this page of results."
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token to request the next page of results."
-        },
-        "totalItems": {
-          "description": "The total number of tables in the dataset.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "kind": {
-          "description": "The type of list.",
-          "type": "string",
-          "default": "bigquery#tableList"
-        },
-        "tables": {
-          "description": "Tables in the requested dataset.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "creationTime": {
-                "description": "The time when this table was created, in milliseconds since the epoch.",
-                "format": "int64",
-                "type": "string"
-              },
-              "labels": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "The labels associated with this table. You can use these to organize and group your tables."
-              },
-              "type": {
-                "description": "The type of table. Possible values are: TABLE, VIEW.",
-                "type": "string"
-              },
-              "clustering": {
-                "$ref": "Clustering",
-                "description": "[Beta] Clustering specification for this table, if configured."
-              },
-              "id": {
-                "description": "An opaque ID of the table",
-                "type": "string"
-              },
-              "expirationTime": {
-                "description": "[Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed.",
-                "format": "int64",
-                "type": "string"
-              },
-              "tableReference": {
-                "$ref": "TableReference",
-                "description": "A reference uniquely identifying the table."
-              },
-              "friendlyName": {
-                "description": "The user-friendly name for this table.",
-                "type": "string"
-              },
-              "timePartitioning": {
-                "$ref": "TimePartitioning",
-                "description": "The time-based partitioning specification for this table, if configured."
-              },
-              "kind": {
-                "description": "The resource type.",
-                "type": "string",
-                "default": "bigquery#table"
-              },
-              "view": {
-                "description": "Additional details for a view.",
-                "type": "object",
-                "properties": {
-                  "useLegacySql": {
-                    "description": "True if view is defined in legacy SQL dialect, false if in standard SQL.",
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "id": "TableList"
-    },
     "ModelDefinition": {
       "type": "object",
       "properties": {
         "modelOptions": {
           "type": "object",
           "properties": {
-            "lossType": {
-              "type": "string"
-            },
-            "modelType": {
-              "type": "string"
-            },
             "labels": {
               "type": "array",
               "items": {
                 "type": "string"
               }
+            },
+            "lossType": {
+              "type": "string"
+            },
+            "modelType": {
+              "type": "string"
             }
           },
           "description": "[Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query."
@@ -2677,11 +1418,11 @@
       "type": "object",
       "properties": {
         "errors": {
+          "description": "[Output-only] The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.",
           "type": "array",
           "items": {
             "$ref": "ErrorProto"
-          },
-          "description": "[Output-only] The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful."
+          }
         },
         "state": {
           "description": "[Output-only] Running state of the job.",
@@ -2697,16 +1438,16 @@
     "ListModelsResponse": {
       "type": "object",
       "properties": {
-        "nextPageToken": {
-          "description": "A token to request the next page of results.",
-          "type": "string"
-        },
         "models": {
           "description": "Models in the requested dataset. Only the following fields are populated:\nmodel_reference, model_type, creation_time, last_modified_time and\nlabels.",
           "type": "array",
           "items": {
             "$ref": "Model"
           }
+        },
+        "nextPageToken": {
+          "description": "A token to request the next page of results.",
+          "type": "string"
         }
       },
       "id": "ListModelsResponse"
@@ -2714,22 +1455,21 @@
     "ScriptStatistics": {
       "type": "object",
       "properties": {
+        "evaluationKind": {
+          "type": "string",
+          "description": "[Output-only] Whether this child job was a statement or expression."
+        },
         "stackFrames": {
-          "description": "Stack trace showing the line/column/procedure name of each frame on the stack at the point where the current evaluation happened. The leaf frame is first, the primary script is last. Never empty.",
           "type": "array",
           "items": {
             "$ref": "ScriptStackFrame"
-          }
-        },
-        "evaluationKind": {
-          "description": "[Output-only] Whether this child job was a statement or expression.",
-          "type": "string"
+          },
+          "description": "Stack trace showing the line/column/procedure name of each frame on the stack at the point where the current evaluation happened. The leaf frame is first, the primary script is last. Never empty."
         }
       },
       "id": "ScriptStatistics"
     },
     "Streamingbuffer": {
-      "id": "Streamingbuffer",
       "type": "object",
       "properties": {
         "estimatedBytes": {
@@ -2738,36 +1478,46 @@
           "type": "string"
         },
         "estimatedRows": {
+          "type": "string",
           "description": "[Output-only] A lower-bound estimate of the number of rows currently in the streaming buffer.",
-          "format": "uint64",
-          "type": "string"
+          "format": "uint64"
         },
         "oldestEntryTime": {
+          "type": "string",
           "description": "[Output-only] Contains the timestamp of the oldest entry in the streaming buffer, in milliseconds since the epoch, if the streaming buffer is available.",
-          "format": "uint64",
+          "format": "uint64"
+        }
+      },
+      "id": "Streamingbuffer"
+    },
+    "Entry": {
+      "id": "Entry",
+      "description": "A single entry in the confusion matrix.",
+      "type": "object",
+      "properties": {
+        "predictedLabel": {
+          "description": "The predicted label. For confidence_threshold \u003e 0, we will\nalso add an entry indicating the number of items under the\nconfidence threshold.",
+          "type": "string"
+        },
+        "itemCount": {
+          "description": "Number of items being predicted as this label.",
+          "format": "int64",
           "type": "string"
         }
       }
     },
-    "Entry": {
-      "type": "object",
-      "properties": {
-        "itemCount": {
-          "type": "string",
-          "description": "Number of items being predicted as this label.",
-          "format": "int64"
-        },
-        "predictedLabel": {
-          "description": "The predicted label. For confidence_threshold \u003e 0, we will\nalso add an entry indicating the number of items under the\nconfidence threshold.",
-          "type": "string"
-        }
-      },
-      "id": "Entry",
-      "description": "A single entry in the confusion matrix."
-    },
     "Table": {
       "type": "object",
       "properties": {
+        "creationTime": {
+          "description": "[Output-only] The time when this table was created, in milliseconds since the epoch.",
+          "format": "int64",
+          "type": "string"
+        },
+        "rangePartitioning": {
+          "$ref": "RangePartitioning",
+          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified."
+        },
         "schema": {
           "$ref": "TableSchema",
           "description": "[Optional] Describes the schema of this table."
@@ -2777,17 +1527,17 @@
           "type": "string"
         },
         "requirePartitionFilter": {
-          "description": "[Beta] [Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.",
+          "description": "[Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.",
           "type": "boolean",
           "default": "false"
-        },
-        "tableReference": {
-          "$ref": "TableReference",
-          "description": "[Required] Reference describing the ID of this table."
         },
         "materializedView": {
           "$ref": "MaterializedViewDefinition",
           "description": "[Optional] Materialized view definition."
+        },
+        "tableReference": {
+          "description": "[Required] Reference describing the ID of this table.",
+          "$ref": "TableReference"
         },
         "lastModifiedTime": {
           "description": "[Output-only] The time when this table was last modified, in milliseconds since the epoch.",
@@ -2807,34 +1557,34 @@
           "description": "[Output-only] Describes the table type. The following values are supported: TABLE: A normal BigQuery table. VIEW: A virtual table defined by a SQL query. [TrustedTester] MATERIALIZED_VIEW: SQL query whose result is persisted. EXTERNAL: A table that references data stored in an external storage system, such as Google Cloud Storage. The default value is TABLE.",
           "type": "string"
         },
-        "numLongTermBytes": {
-          "description": "[Output-only] The number of bytes in the table that are considered \"long-term storage\".",
-          "format": "int64",
-          "type": "string"
-        },
         "view": {
           "$ref": "ViewDefinition",
           "description": "[Optional] The view definition."
         },
+        "numLongTermBytes": {
+          "type": "string",
+          "description": "[Output-only] The number of bytes in the table that are considered \"long-term storage\".",
+          "format": "int64"
+        },
         "etag": {
-          "description": "[Output-only] A hash of the table metadata. Used to ensure there were no concurrent modifications to the resource when attempting an update. Not guaranteed to change when the table contents or the fields numRows, numBytes, numLongTermBytes or lastModifiedTime change.",
-          "type": "string"
+          "type": "string",
+          "description": "[Output-only] A hash of the table metadata. Used to ensure there were no concurrent modifications to the resource when attempting an update. Not guaranteed to change when the table contents or the fields numRows, numBytes, numLongTermBytes or lastModifiedTime change."
         },
         "encryptionConfiguration": {
-          "$ref": "EncryptionConfiguration",
-          "description": "Custom encryption configuration (e.g., Cloud KMS keys)."
+          "description": "Custom encryption configuration (e.g., Cloud KMS keys).",
+          "$ref": "EncryptionConfiguration"
         },
         "streamingBuffer": {
           "$ref": "Streamingbuffer",
           "description": "[Output-only] Contains information regarding this table's streaming buffer, if one is present. This field will be absent if the table is not being streamed to or if there is no data in the streaming buffer."
         },
+        "numBytes": {
+          "type": "string",
+          "description": "[Output-only] The size of this table in bytes, excluding any data in the streaming buffer.",
+          "format": "int64"
+        },
         "location": {
           "description": "[Output-only] The geographic location where the table resides. This value is inherited from the dataset.",
-          "type": "string"
-        },
-        "numBytes": {
-          "description": "[Output-only] The size of this table in bytes, excluding any data in the streaming buffer.",
-          "format": "int64",
           "type": "string"
         },
         "friendlyName": {
@@ -2851,23 +1601,23 @@
           "type": "string"
         },
         "labels": {
+          "description": "The labels associated with this table. You can use these to organize and group your tables. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.",
+          "type": "object",
           "additionalProperties": {
             "type": "string"
-          },
-          "description": "The labels associated with this table. You can use these to organize and group your tables. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.",
-          "type": "object"
+          }
         },
         "externalDataConfiguration": {
           "$ref": "ExternalDataConfiguration",
           "description": "[Optional] Describes the data format, location, and other properties of a table stored outside of BigQuery. By defining these properties, the data source can then be queried as if it were a standard BigQuery table."
         },
-        "selfLink": {
-          "description": "[Output-only] A URL that can be used to access this resource again.",
-          "type": "string"
-        },
         "model": {
           "$ref": "ModelDefinition",
           "description": "[Output-only, Beta] Present iff this table represents a ML model. Describes the training information for the model, and it is required to run 'PREDICT' queries."
+        },
+        "selfLink": {
+          "description": "[Output-only] A URL that can be used to access this resource again.",
+          "type": "string"
         },
         "expirationTime": {
           "description": "[Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed. The defaultTableExpirationMs property of the encapsulating dataset can be used to set a default expirationTime on newly created tables.",
@@ -2880,23 +1630,13 @@
           "default": "bigquery#table"
         },
         "description": {
-          "type": "string",
-          "description": "[Optional] A user-friendly description of this table."
-        },
-        "creationTime": {
-          "type": "string",
-          "description": "[Output-only] The time when this table was created, in milliseconds since the epoch.",
-          "format": "int64"
-        },
-        "rangePartitioning": {
-          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.",
-          "$ref": "RangePartitioning"
+          "description": "[Optional] A user-friendly description of this table.",
+          "type": "string"
         }
       },
       "id": "Table"
     },
     "ConfusionMatrix": {
-      "id": "ConfusionMatrix",
       "description": "Confusion matrix for multi-class classification models.",
       "type": "object",
       "properties": {
@@ -2906,25 +1646,35 @@
           "type": "number"
         },
         "rows": {
-          "description": "One row per actual label.",
           "type": "array",
           "items": {
             "$ref": "Row"
-          }
+          },
+          "description": "One row per actual label."
         }
-      }
+      },
+      "id": "ConfusionMatrix"
     },
     "MaterializedViewDefinition": {
       "type": "object",
       "properties": {
+        "query": {
+          "description": "[Required] A query whose result is persisted.",
+          "type": "string"
+        },
+        "enableRefresh": {
+          "type": "boolean",
+          "description": "[Optional] [TrustedTester] Enable automatic refresh of the materialized view when the base table is updated. The default value is \"true\"."
+        },
+        "refreshIntervalMs": {
+          "type": "string",
+          "description": "[Optional] [TrustedTester] The maximum frequency at which this materialized view will be refreshed. The default value is \"1800000\" (30 minutes).",
+          "format": "int64"
+        },
         "lastRefreshTime": {
           "description": "[Output-only] [TrustedTester] The time when this materialized view was last modified, in milliseconds since the epoch.",
           "format": "int64",
           "type": "string"
-        },
-        "query": {
-          "type": "string",
-          "description": "[Required] A query whose result is persisted."
         }
       },
       "id": "MaterializedViewDefinition"
@@ -2947,8 +1697,8 @@
           }
         },
         "value": {
-          "description": "[Optional] The value of this value, if a simple scalar type.",
-          "type": "string"
+          "type": "string",
+          "description": "[Optional] The value of this value, if a simple scalar type."
         }
       },
       "id": "QueryParameterValue"
@@ -2956,19 +1706,6 @@
     "Model": {
       "type": "object",
       "properties": {
-        "location": {
-          "description": "Output only. The geographic location where the model resides. This value\nis inherited from the dataset.",
-          "type": "string"
-        },
-        "friendlyName": {
-          "description": "Optional. A descriptive name for this model.",
-          "type": "string"
-        },
-        "lastModifiedTime": {
-          "description": "Output only. The time when this model was last modified, in millisecs since the epoch.",
-          "format": "int64",
-          "type": "string"
-        },
         "labels": {
           "additionalProperties": {
             "type": "string"
@@ -2976,14 +1713,14 @@
           "description": "The labels associated with this model. You can use these to organize\nand group your models. Label keys and values can be no longer\nthan 63 characters, can only contain lowercase letters, numeric\ncharacters, underscores and dashes. International characters are allowed.\nLabel values are optional. Label keys must start with a letter and each\nlabel in the list must have a different key.",
           "type": "object"
         },
+        "labelColumns": {
+          "description": "Output only. Label columns that were used to train this model.\nThe output of the model will have a \"predicted_\" prefix to these columns.",
+          "type": "array",
+          "items": {
+            "$ref": "StandardSqlField"
+          }
+        },
         "modelType": {
-          "enum": [
-            "MODEL_TYPE_UNSPECIFIED",
-            "LINEAR_REGRESSION",
-            "LOGISTIC_REGRESSION",
-            "KMEANS",
-            "TENSORFLOW"
-          ],
           "description": "Output only. Type of the model resource.",
           "type": "string",
           "enumDescriptions": [
@@ -2992,14 +1729,14 @@
             "Logistic regression based classification model.",
             "K-means clustering model.",
             "[Beta] An imported TensorFlow model."
+          ],
+          "enum": [
+            "MODEL_TYPE_UNSPECIFIED",
+            "LINEAR_REGRESSION",
+            "LOGISTIC_REGRESSION",
+            "KMEANS",
+            "TENSORFLOW"
           ]
-        },
-        "labelColumns": {
-          "description": "Output only. Label columns that were used to train this model.\nThe output of the model will have a \"predicted_\" prefix to these columns.",
-          "type": "array",
-          "items": {
-            "$ref": "StandardSqlField"
-          }
         },
         "featureColumns": {
           "type": "array",
@@ -3009,24 +1746,24 @@
           "description": "Output only. Input feature columns that were used to train this model."
         },
         "expirationTime": {
+          "type": "string",
           "description": "Optional. The time when this model expires, in milliseconds since the epoch.\nIf not present, the model will persist indefinitely. Expired models\nwill be deleted and their storage reclaimed.  The defaultTableExpirationMs\nproperty of the encapsulating dataset can be used to set a default\nexpirationTime on newly created models.",
-          "format": "int64",
-          "type": "string"
+          "format": "int64"
         },
         "trainingRuns": {
+          "description": "Output only. Information for all training runs in increasing order of start_time.",
           "type": "array",
           "items": {
             "$ref": "TrainingRun"
-          },
-          "description": "Output only. Information for all training runs in increasing order of start_time."
+          }
         },
         "modelReference": {
           "$ref": "ModelReference",
           "description": "Required. Unique identifier for this model."
         },
         "description": {
-          "description": "Optional. A user-friendly description of this model.",
-          "type": "string"
+          "type": "string",
+          "description": "Optional. A user-friendly description of this model."
         },
         "etag": {
           "type": "string",
@@ -3039,20 +1776,40 @@
         },
         "encryptionConfiguration": {
           "$ref": "EncryptionConfiguration",
-          "description": "Custom encryption configuration (e.g., Cloud KMS keys). This shows the\nencryption configuration of the model data while stored in BigQuery\nstorage."
+          "description": "Custom encryption configuration (e.g., Cloud KMS keys). This shows the\nencryption configuration of the model data while stored in BigQuery\nstorage. This field can be used with PatchModel to update encryption key\nfor an already encrypted model."
+        },
+        "location": {
+          "type": "string",
+          "description": "Output only. The geographic location where the model resides. This value\nis inherited from the dataset."
+        },
+        "friendlyName": {
+          "description": "Optional. A descriptive name for this model.",
+          "type": "string"
+        },
+        "lastModifiedTime": {
+          "description": "Output only. The time when this model was last modified, in millisecs since the epoch.",
+          "format": "int64",
+          "type": "string"
         }
       },
       "id": "Model"
     },
     "StandardSqlDataType": {
+      "id": "StandardSqlDataType",
       "description": "The type of a variable, e.g., a function argument.\nExamples:\nINT64: {type_kind=\"INT64\"}\nARRAY\u003cSTRING\u003e: {type_kind=\"ARRAY\", array_element_type=\"STRING\"}\nSTRUCT\u003cx STRING, y ARRAY\u003cDATE\u003e\u003e:\n  {type_kind=\"STRUCT\",\n   struct_type={fields=[\n     {name=\"x\", type={type_kind=\"STRING\"}},\n     {name=\"y\", type={type_kind=\"ARRAY\", array_element_type=\"DATE\"}}\n   ]}}",
       "type": "object",
       "properties": {
+        "structType": {
+          "$ref": "StandardSqlStructType",
+          "description": "The fields of this struct, in order, if type_kind = \"STRUCT\"."
+        },
         "arrayElementType": {
           "$ref": "StandardSqlDataType",
           "description": "The type of the array's elements, if type_kind = \"ARRAY\"."
         },
         "typeKind": {
+          "description": "Required. The top level type of this field.\nCan be any standard SQL data type (e.g., \"INT64\", \"DATE\", \"ARRAY\").",
+          "type": "string",
           "enumDescriptions": [
             "Invalid type.",
             "Encoded as a string in decimal format.",
@@ -3084,20 +1841,17 @@
             "NUMERIC",
             "ARRAY",
             "STRUCT"
-          ],
-          "description": "Required. The top level type of this field.\nCan be any standard SQL data type (e.g., \"INT64\", \"DATE\", \"ARRAY\").",
-          "type": "string"
-        },
-        "structType": {
-          "$ref": "StandardSqlStructType",
-          "description": "The fields of this struct, in order, if type_kind = \"STRUCT\"."
+          ]
         }
-      },
-      "id": "StandardSqlDataType"
+      }
     },
     "ModelReference": {
       "type": "object",
       "properties": {
+        "projectId": {
+          "description": "[Required] The ID of the project containing this model.",
+          "type": "string"
+        },
         "datasetId": {
           "description": "[Required] The ID of the dataset containing this model.",
           "type": "string"
@@ -3105,34 +1859,13 @@
         "modelId": {
           "description": "[Required] The ID of the model. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.",
           "type": "string"
-        },
-        "projectId": {
-          "description": "[Required] The ID of the project containing this model.",
-          "type": "string"
         }
       },
       "id": "ModelReference"
     },
     "JobConfigurationExtract": {
-      "id": "JobConfigurationExtract",
       "type": "object",
       "properties": {
-        "printHeader": {
-          "description": "[Optional] Whether to print out a header row in the results. Default is true.",
-          "type": "boolean",
-          "default": "true"
-        },
-        "compression": {
-          "type": "string",
-          "description": "[Optional] The compression type to use for exported files. Possible values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is NONE. DEFLATE and SNAPPY are only supported for Avro."
-        },
-        "destinationUris": {
-          "description": "[Pick one] A list of fully-qualified Google Cloud Storage URIs where the extracted table should be written.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "destinationFormat": {
           "description": "[Optional] The exported file format. Possible values include CSV, NEWLINE_DELIMITED_JSON and AVRO. The default value is CSV. Tables with nested or repeated fields cannot be exported as CSV.",
           "type": "string"
@@ -3142,8 +1875,8 @@
           "description": "A reference to the model being exported."
         },
         "useAvroLogicalTypes": {
-          "description": "[Optional] If destinationFormat is set to \"AVRO\", this flag indicates whether to enable extracting applicable column types (such as TIMESTAMP) to their corresponding AVRO logical types (timestamp-micros), instead of only using their raw types (avro-long).",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "[Optional] If destinationFormat is set to \"AVRO\", this flag indicates whether to enable extracting applicable column types (such as TIMESTAMP) to their corresponding AVRO logical types (timestamp-micros), instead of only using their raw types (avro-long)."
         },
         "sourceTable": {
           "$ref": "TableReference",
@@ -3156,18 +1889,30 @@
         "destinationUri": {
           "type": "string",
           "description": "[Pick one] DEPRECATED: Use destinationUris instead, passing only one URI as necessary. The fully-qualified Google Cloud Storage URI where the extracted table should be written."
+        },
+        "printHeader": {
+          "description": "[Optional] Whether to print out a header row in the results. Default is true.",
+          "type": "boolean",
+          "default": "true"
+        },
+        "compression": {
+          "description": "[Optional] The compression type to use for exported files. Possible values include GZIP, DEFLATE, SNAPPY, and NONE. The default value is NONE. DEFLATE and SNAPPY are only supported for Avro.",
+          "type": "string"
+        },
+        "destinationUris": {
+          "description": "[Pick one] A list of fully-qualified Google Cloud Storage URIs where the extracted table should be written.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-      }
+      },
+      "id": "JobConfigurationExtract"
     },
     "FeatureValue": {
       "description": "Representative value of a single feature within the cluster.",
       "type": "object",
       "properties": {
-        "numericalValue": {
-          "description": "The numerical feature value. This is the centroid value for this\nfeature.",
-          "format": "double",
-          "type": "number"
-        },
         "featureColumn": {
           "description": "The feature column name.",
           "type": "string"
@@ -3175,11 +1920,17 @@
         "categoricalValue": {
           "$ref": "CategoricalValue",
           "description": "The categorical feature value."
+        },
+        "numericalValue": {
+          "description": "The numerical feature value. This is the centroid value for this\nfeature.",
+          "format": "double",
+          "type": "number"
         }
       },
       "id": "FeatureValue"
     },
     "ClusterInfo": {
+      "id": "ClusterInfo",
       "description": "Information about a single cluster for clustering model.",
       "type": "object",
       "properties": {
@@ -3189,21 +1940,27 @@
           "type": "string"
         },
         "clusterRadius": {
-          "type": "number",
           "description": "Cluster radius, the average distance from centroid\nto each point assigned to the cluster.",
-          "format": "double"
+          "format": "double",
+          "type": "number"
         },
         "clusterSize": {
-          "type": "string",
           "description": "Cluster size, the total number of points assigned to the cluster.",
-          "format": "int64"
+          "format": "int64",
+          "type": "string"
         }
-      },
-      "id": "ClusterInfo"
+      }
     },
     "TimePartitioning": {
       "type": "object",
       "properties": {
+        "requirePartitionFilter": {
+          "type": "boolean"
+        },
+        "field": {
+          "description": "[Beta] [Optional] If not set, the table is partitioned by pseudo column, referenced via either '_PARTITIONTIME' as TIMESTAMP type, or '_PARTITIONDATE' as DATE type. If field is specified, the table is instead partitioned by this field. The field must be a top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.",
+          "type": "string"
+        },
         "expirationMs": {
           "description": "[Optional] Number of milliseconds for which to keep the storage for partitions in the table. The storage in a partition will have an expiration time of its partition time plus this value.",
           "format": "int64",
@@ -3212,13 +1969,6 @@
         "type": {
           "type": "string",
           "description": "[Required] The only type supported is DAY, which will generate one partition per day."
-        },
-        "requirePartitionFilter": {
-          "type": "boolean"
-        },
-        "field": {
-          "description": "[Beta] [Optional] If not set, the table is partitioned by pseudo column, referenced via either '_PARTITIONTIME' as TIMESTAMP type, or '_PARTITIONDATE' as DATE type. If field is specified, the table is instead partitioned by this field. The field must be a top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.",
-          "type": "string"
         }
       },
       "id": "TimePartitioning"
@@ -3234,8 +1984,8 @@
           }
         },
         "useLegacySql": {
-          "type": "boolean",
-          "description": "Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value."
+          "description": "Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value.",
+          "type": "boolean"
         },
         "query": {
           "description": "[Required] A query that BigQuery executes when the view is referenced.",
@@ -3245,22 +1995,71 @@
       "id": "ViewDefinition"
     },
     "JobStatistics": {
+      "id": "JobStatistics",
       "type": "object",
       "properties": {
+        "startTime": {
+          "description": "[Output-only] Start time of this job, in milliseconds since the epoch. This field will be present when the job transitions from the PENDING state to either RUNNING or DONE.",
+          "format": "int64",
+          "type": "string"
+        },
+        "completionRatio": {
+          "type": "number",
+          "description": "[TrustedTester] [Output-only] Job progress (0.0 -\u003e 1.0) for LOAD and EXTRACT jobs.",
+          "format": "double"
+        },
+        "query": {
+          "description": "[Output-only] Statistics for a query job.",
+          "$ref": "JobStatistics2"
+        },
+        "scriptStatistics": {
+          "$ref": "ScriptStatistics",
+          "description": "[Output-only] Statistics for a child job of a script."
+        },
+        "totalBytesProcessed": {
+          "description": "[Output-only] [Deprecated] Use the bytes processed in the query statistics instead.",
+          "format": "int64",
+          "type": "string"
+        },
+        "numChildJobs": {
+          "type": "string",
+          "description": "[Output-only] Number of child jobs executed.",
+          "format": "int64"
+        },
+        "totalSlotMs": {
+          "description": "[Output-only] Slot-milliseconds for the job.",
+          "format": "int64",
+          "type": "string"
+        },
+        "reservation_id": {
+          "type": "string",
+          "description": "[Output-only] Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job."
+        },
+        "parentJobId": {
+          "type": "string",
+          "description": "[Output-only] If this is a child job, the id of the parent."
+        },
+        "quotaDeferments": {
+          "description": "[Output-only] Quotas which delayed this job's start time.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "reservationUsage": {
           "description": "[Output-only] Job resource usage breakdown by reservation.",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
+              "name": {
+                "type": "string",
+                "description": "[Output-only] Reservation name or \"unreserved\" for on-demand resources usage."
+              },
               "slotMs": {
                 "description": "[Output-only] Slot-milliseconds the job spent in the given reservation.",
                 "format": "int64",
                 "type": "string"
-              },
-              "name": {
-                "type": "string",
-                "description": "[Output-only] Reservation name or \"unreserved\" for on-demand resources usage."
               }
             }
           }
@@ -3282,94 +2081,41 @@
           "description": "[Output-only] End time of this job, in milliseconds since the epoch. This field will be present whenever a job is in the DONE state.",
           "format": "int64",
           "type": "string"
-        },
-        "completionRatio": {
-          "description": "[TrustedTester] [Output-only] Job progress (0.0 -\u003e 1.0) for LOAD and EXTRACT jobs.",
-          "format": "double",
-          "type": "number"
-        },
-        "startTime": {
-          "description": "[Output-only] Start time of this job, in milliseconds since the epoch. This field will be present when the job transitions from the PENDING state to either RUNNING or DONE.",
-          "format": "int64",
-          "type": "string"
-        },
-        "query": {
-          "$ref": "JobStatistics2",
-          "description": "[Output-only] Statistics for a query job."
-        },
-        "scriptStatistics": {
-          "$ref": "ScriptStatistics",
-          "description": "[Output-only] Statistics for a child job of a script."
-        },
-        "totalBytesProcessed": {
-          "description": "[Output-only] [Deprecated] Use the bytes processed in the query statistics instead.",
-          "format": "int64",
-          "type": "string"
-        },
-        "numChildJobs": {
-          "type": "string",
-          "description": "[Output-only] Number of child jobs executed.",
-          "format": "int64"
-        },
-        "totalSlotMs": {
-          "description": "[Output-only] Slot-milliseconds for the job.",
-          "format": "int64",
-          "type": "string"
-        },
-        "parentJobId": {
-          "description": "[Output-only] If this is a child job, the id of the parent.",
-          "type": "string"
-        },
-        "reservation_id": {
-          "description": "[Output-only] Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.",
-          "type": "string"
-        },
-        "quotaDeferments": {
-          "description": "[Output-only] Quotas which delayed this job's start time.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
-      },
-      "id": "JobStatistics"
+      }
     },
     "Row": {
       "id": "Row",
       "description": "A single row in the confusion matrix.",
       "type": "object",
       "properties": {
+        "actualLabel": {
+          "type": "string",
+          "description": "The original label of this row."
+        },
         "entries": {
           "description": "Info describing predicted label distribution.",
           "type": "array",
           "items": {
             "$ref": "Entry"
           }
-        },
-        "actualLabel": {
-          "description": "The original label of this row.",
-          "type": "string"
         }
       }
     },
     "RegressionMetrics": {
+      "id": "RegressionMetrics",
       "description": "Evaluation metrics for regression and explicit feedback type matrix\nfactorization models.",
       "type": "object",
       "properties": {
-        "meanAbsoluteError": {
-          "type": "number",
-          "description": "Mean absolute error.",
-          "format": "double"
-        },
         "meanSquaredError": {
           "description": "Mean squared error.",
           "format": "double",
           "type": "number"
         },
         "rSquared": {
+          "type": "number",
           "description": "R^2 score.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "medianAbsoluteError": {
           "description": "Median absolute error.",
@@ -3380,9 +2126,13 @@
           "type": "number",
           "description": "Mean squared log error.",
           "format": "double"
+        },
+        "meanAbsoluteError": {
+          "description": "Mean absolute error.",
+          "format": "double",
+          "type": "number"
         }
-      },
-      "id": "RegressionMetrics"
+      }
     },
     "ArimaModelInfo": {
       "description": "Arima model information.",
@@ -3393,33 +2143,52 @@
           "description": "Non-seasonal order."
         },
         "arimaCoefficients": {
-          "description": "Arima coefficients.",
-          "$ref": "ArimaCoefficients"
+          "$ref": "ArimaCoefficients",
+          "description": "Arima coefficients."
         },
         "arimaFittingMetrics": {
-          "$ref": "ArimaFittingMetrics",
-          "description": "Arima fitting metrics."
+          "description": "Arima fitting metrics.",
+          "$ref": "ArimaFittingMetrics"
         }
       },
       "id": "ArimaModelInfo"
     },
     "JsonValue": {
-      "id": "JsonValue",
-      "type": "any"
+      "type": "any",
+      "id": "JsonValue"
     },
     "GetQueryResultsResponse": {
       "type": "object",
       "properties": {
+        "totalBytesProcessed": {
+          "description": "The total number of bytes processed for this query.",
+          "format": "int64",
+          "type": "string"
+        },
+        "totalRows": {
+          "description": "The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.",
+          "format": "uint64",
+          "type": "string"
+        },
+        "jobComplete": {
+          "type": "boolean",
+          "description": "Whether the query has completed or not. If rows or totalRows are present, this will always be true. If this is false, totalRows will not be available."
+        },
+        "numDmlAffectedRows": {
+          "description": "[Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.",
+          "format": "int64",
+          "type": "string"
+        },
         "rows": {
-          "description": "An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above. Present only when the query completes successfully.",
           "type": "array",
           "items": {
             "$ref": "TableRow"
-          }
+          },
+          "description": "An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above. Present only when the query completes successfully."
         },
         "pageToken": {
-          "type": "string",
-          "description": "A token used for paging results."
+          "description": "A token used for paging results.",
+          "type": "string"
         },
         "kind": {
           "description": "The resource type of the response.",
@@ -3431,8 +2200,8 @@
           "type": "string"
         },
         "jobReference": {
-          "description": "Reference to the BigQuery Job that was created to run the query. This field will be present even if the original request timed out, in which case GetQueryResults can be used to read the results once the query has completed. Since this API only returns the first page of results, subsequent pages can be fetched via the same mechanism (GetQueryResults).",
-          "$ref": "JobReference"
+          "$ref": "JobReference",
+          "description": "Reference to the BigQuery Job that was created to run the query. This field will be present even if the original request timed out, in which case GetQueryResults can be used to read the results once the query has completed. Since this API only returns the first page of results, subsequent pages can be fetched via the same mechanism (GetQueryResults)."
         },
         "cacheHit": {
           "description": "Whether the query result was fetched from the query cache.",
@@ -3448,25 +2217,6 @@
           "items": {
             "$ref": "ErrorProto"
           }
-        },
-        "totalBytesProcessed": {
-          "description": "The total number of bytes processed for this query.",
-          "format": "int64",
-          "type": "string"
-        },
-        "totalRows": {
-          "description": "The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.",
-          "format": "uint64",
-          "type": "string"
-        },
-        "jobComplete": {
-          "description": "Whether the query has completed or not. If rows or totalRows are present, this will always be true. If this is false, totalRows will not be available.",
-          "type": "boolean"
-        },
-        "numDmlAffectedRows": {
-          "description": "[Output-only] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.",
-          "format": "int64",
-          "type": "string"
         }
       },
       "id": "GetQueryResultsResponse"
@@ -3474,19 +2224,43 @@
     "JobList": {
       "type": "object",
       "properties": {
+        "etag": {
+          "description": "A hash of this page of results.",
+          "type": "string"
+        },
         "jobs": {
-          "description": "List of jobs that were requested.",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique opaque ID of the job."
+              },
+              "configuration": {
+                "description": "[Full-projection-only] Specifies the job configuration.",
+                "$ref": "JobConfiguration"
+              },
+              "user_email": {
+                "description": "[Full-projection-only] Email address of the user who ran the job.",
+                "type": "string"
+              },
+              "errorResult": {
+                "$ref": "ErrorProto",
+                "description": "A result object that will be present only if the job has failed."
+              },
+              "kind": {
+                "type": "string",
+                "default": "bigquery#job",
+                "description": "The resource type."
+              },
               "jobReference": {
                 "description": "Job reference uniquely identifying the job.",
                 "$ref": "JobReference"
               },
               "status": {
-                "$ref": "JobStatus",
-                "description": "[Full-projection-only] Describes the state of the job."
+                "description": "[Full-projection-only] Describes the state of the job.",
+                "$ref": "JobStatus"
               },
               "state": {
                 "description": "Running state of the job. When the state is DONE, errorResult can be checked to determine whether the job succeeded or failed.",
@@ -3495,30 +2269,10 @@
               "statistics": {
                 "$ref": "JobStatistics",
                 "description": "[Output-only] Information about the job, including starting time and ending time of the job."
-              },
-              "id": {
-                "description": "Unique opaque ID of the job.",
-                "type": "string"
-              },
-              "configuration": {
-                "$ref": "JobConfiguration",
-                "description": "[Full-projection-only] Specifies the job configuration."
-              },
-              "user_email": {
-                "description": "[Full-projection-only] Email address of the user who ran the job.",
-                "type": "string"
-              },
-              "kind": {
-                "description": "The resource type.",
-                "type": "string",
-                "default": "bigquery#job"
-              },
-              "errorResult": {
-                "description": "A result object that will be present only if the job has failed.",
-                "$ref": "ErrorProto"
               }
             }
-          }
+          },
+          "description": "List of jobs that were requested."
         },
         "nextPageToken": {
           "description": "A token to request the next page of results.",
@@ -3528,10 +2282,6 @@
           "description": "The resource type of the response.",
           "type": "string",
           "default": "bigquery#jobList"
-        },
-        "etag": {
-          "type": "string",
-          "description": "A hash of this page of results."
         }
       },
       "id": "JobList"
@@ -3540,9 +2290,9 @@
       "type": "object",
       "properties": {
         "totalRows": {
+          "type": "string",
           "description": "The total number of rows in the complete table.",
-          "format": "int64",
-          "type": "string"
+          "format": "int64"
         },
         "etag": {
           "description": "A hash of this page of results.",
@@ -3560,91 +2310,21 @@
           "type": "string"
         },
         "kind": {
+          "description": "The resource type of the response.",
           "type": "string",
-          "default": "bigquery#tableDataList",
-          "description": "The resource type of the response."
+          "default": "bigquery#tableDataList"
         }
       },
       "id": "TableDataList"
     },
     "JobStatistics2": {
+      "id": "JobStatistics2",
       "type": "object",
       "properties": {
-        "modelTraining": {
-          "description": "[Output-only, Beta] Information about create model query job progress.",
-          "$ref": "BigQueryModelTraining"
-        },
-        "referencedRoutines": {
-          "type": "array",
-          "items": {
-            "$ref": "RoutineReference"
-          },
-          "description": "[Output-only] Referenced routines (persistent user-defined functions and stored procedures) for the job."
-        },
-        "timeline": {
-          "type": "array",
-          "items": {
-            "$ref": "QueryTimelineSample"
-          },
-          "description": "[Output-only] [Beta] Describes a timeline of job execution."
-        },
-        "reservationUsage": {
-          "description": "[Output-only] Job resource usage breakdown by reservation.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "slotMs": {
-                "description": "[Output-only] Slot-milliseconds the job spent in the given reservation.",
-                "format": "int64",
-                "type": "string"
-              },
-              "name": {
-                "description": "[Output-only] Reservation name or \"unreserved\" for on-demand resources usage.",
-                "type": "string"
-              }
-            }
-          }
-        },
-        "cacheHit": {
-          "type": "boolean",
-          "description": "[Output-only] Whether the query result was fetched from the query cache."
-        },
-        "undeclaredQueryParameters": {
-          "type": "array",
-          "items": {
-            "$ref": "QueryParameter"
-          },
-          "description": "Standard SQL only: list of undeclared query parameters detected during a dry run validation."
-        },
-        "queryPlan": {
-          "description": "[Output-only] Describes execution plan for the query.",
-          "type": "array",
-          "items": {
-            "$ref": "ExplainQueryStage"
-          }
-        },
-        "ddlTargetRoutine": {
-          "description": "The DDL target routine. Present only for CREATE/DROP FUNCTION/PROCEDURE queries.",
-          "$ref": "RoutineReference"
-        },
-        "ddlTargetTable": {
-          "$ref": "TableReference",
-          "description": "The DDL target table. Present only for CREATE/DROP TABLE/VIEW queries."
-        },
-        "totalPartitionsProcessed": {
-          "type": "string",
-          "description": "[Output-only] Total number of partitions processed from all partitioned tables referenced in the job.",
-          "format": "int64"
-        },
-        "schema": {
-          "$ref": "TableSchema",
-          "description": "[Output-only] The schema of the results. Present only for successful dry run of non-legacy SQL queries."
-        },
         "modelTrainingExpectedTotalIteration": {
-          "type": "string",
           "description": "[Output-only, Beta] Deprecated; do not use.",
-          "format": "int64"
+          "format": "int64",
+          "type": "string"
         },
         "estimatedBytesProcessed": {
           "description": "[Output-only] The original estimate of bytes processed for the job.",
@@ -3674,36 +2354,107 @@
           "type": "string"
         },
         "billingTier": {
+          "type": "integer",
           "description": "[Output-only] Billing tier for the job.",
-          "format": "int32",
-          "type": "integer"
+          "format": "int32"
         },
         "ddlOperationPerformed": {
           "description": "The DDL operation performed, possibly dependent on the pre-existence of the DDL target. Possible values (new values might be added in the future): \"CREATE\": The query created the DDL target. \"SKIP\": No-op. Example cases: the query is CREATE TABLE IF NOT EXISTS while the table already exists, or the query is DROP TABLE IF EXISTS while the table does not exist. \"REPLACE\": The query replaced the DDL target. Example case: the query is CREATE OR REPLACE TABLE, and the table already exists. \"DROP\": The query deleted the DDL target.",
           "type": "string"
         },
         "statementType": {
-          "type": "string",
-          "description": "The type of query statement, if valid. Possible values (new values might be added in the future): \"SELECT\": SELECT query. \"INSERT\": INSERT query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"UPDATE\": UPDATE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"DELETE\": DELETE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"MERGE\": MERGE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"ALTER_TABLE\": ALTER TABLE query. \"ALTER_VIEW\": ALTER VIEW query. \"ASSERT\": ASSERT condition AS 'description'. \"CREATE_FUNCTION\": CREATE FUNCTION query. \"CREATE_MODEL\": CREATE [OR REPLACE] MODEL ... AS SELECT ... . \"CREATE_PROCEDURE\": CREATE PROCEDURE query. \"CREATE_TABLE\": CREATE [OR REPLACE] TABLE without AS SELECT. \"CREATE_TABLE_AS_SELECT\": CREATE [OR REPLACE] TABLE ... AS SELECT ... . \"CREATE_VIEW\": CREATE [OR REPLACE] VIEW ... AS SELECT ... . \"DROP_FUNCTION\" : DROP FUNCTION query. \"DROP_PROCEDURE\": DROP PROCEDURE query. \"DROP_TABLE\": DROP TABLE query. \"DROP_VIEW\": DROP VIEW query."
+          "description": "The type of query statement, if valid. Possible values (new values might be added in the future): \"SELECT\": SELECT query. \"INSERT\": INSERT query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"UPDATE\": UPDATE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"DELETE\": DELETE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"MERGE\": MERGE query; see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language. \"ALTER_TABLE\": ALTER TABLE query. \"ALTER_VIEW\": ALTER VIEW query. \"ASSERT\": ASSERT condition AS 'description'. \"CREATE_FUNCTION\": CREATE FUNCTION query. \"CREATE_MODEL\": CREATE [OR REPLACE] MODEL ... AS SELECT ... . \"CREATE_PROCEDURE\": CREATE PROCEDURE query. \"CREATE_TABLE\": CREATE [OR REPLACE] TABLE without AS SELECT. \"CREATE_TABLE_AS_SELECT\": CREATE [OR REPLACE] TABLE ... AS SELECT ... . \"CREATE_VIEW\": CREATE [OR REPLACE] VIEW ... AS SELECT ... . \"DROP_FUNCTION\" : DROP FUNCTION query. \"DROP_PROCEDURE\": DROP PROCEDURE query. \"DROP_TABLE\": DROP TABLE query. \"DROP_VIEW\": DROP VIEW query.",
+          "type": "string"
         },
         "totalSlotMs": {
-          "type": "string",
           "description": "[Output-only] Slot-milliseconds for the job.",
-          "format": "int64"
-        },
-        "totalBytesProcessedAccuracy": {
-          "description": "[Output-only] For dry-run jobs, totalBytesProcessed is an estimate and this field specifies the accuracy of the estimate. Possible values can be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is precise. LOWER_BOUND: estimate is lower bound of what the query would cost. UPPER_BOUND: estimate is upper bound of what the query would cost.",
-          "type": "string"
-        },
-        "totalBytesBilled": {
-          "description": "[Output-only] Total bytes billed for the job.",
           "format": "int64",
           "type": "string"
+        },
+        "totalBytesProcessedAccuracy": {
+          "type": "string",
+          "description": "[Output-only] For dry-run jobs, totalBytesProcessed is an estimate and this field specifies the accuracy of the estimate. Possible values can be: UNKNOWN: accuracy of the estimate is unknown. PRECISE: estimate is precise. LOWER_BOUND: estimate is lower bound of what the query would cost. UPPER_BOUND: estimate is upper bound of what the query would cost."
+        },
+        "totalBytesBilled": {
+          "type": "string",
+          "description": "[Output-only] Total bytes billed for the job.",
+          "format": "int64"
+        },
+        "modelTraining": {
+          "$ref": "BigQueryModelTraining",
+          "description": "[Output-only, Beta] Information about create model query job progress."
+        },
+        "referencedRoutines": {
+          "description": "[Output-only] Referenced routines (persistent user-defined functions and stored procedures) for the job.",
+          "type": "array",
+          "items": {
+            "$ref": "RoutineReference"
+          }
+        },
+        "timeline": {
+          "type": "array",
+          "items": {
+            "$ref": "QueryTimelineSample"
+          },
+          "description": "[Output-only] [Beta] Describes a timeline of job execution."
+        },
+        "reservationUsage": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slotMs": {
+                "description": "[Output-only] Slot-milliseconds the job spent in the given reservation.",
+                "format": "int64",
+                "type": "string"
+              },
+              "name": {
+                "type": "string",
+                "description": "[Output-only] Reservation name or \"unreserved\" for on-demand resources usage."
+              }
+            }
+          },
+          "description": "[Output-only] Job resource usage breakdown by reservation."
+        },
+        "cacheHit": {
+          "description": "[Output-only] Whether the query result was fetched from the query cache.",
+          "type": "boolean"
+        },
+        "undeclaredQueryParameters": {
+          "type": "array",
+          "items": {
+            "$ref": "QueryParameter"
+          },
+          "description": "Standard SQL only: list of undeclared query parameters detected during a dry run validation."
+        },
+        "queryPlan": {
+          "description": "[Output-only] Describes execution plan for the query.",
+          "type": "array",
+          "items": {
+            "$ref": "ExplainQueryStage"
+          }
+        },
+        "ddlTargetRoutine": {
+          "$ref": "RoutineReference",
+          "description": "The DDL target routine. Present only for CREATE/DROP FUNCTION/PROCEDURE queries."
+        },
+        "ddlTargetTable": {
+          "$ref": "TableReference",
+          "description": "The DDL target table. Present only for CREATE/DROP TABLE/VIEW queries."
+        },
+        "totalPartitionsProcessed": {
+          "description": "[Output-only] Total number of partitions processed from all partitioned tables referenced in the job.",
+          "format": "int64",
+          "type": "string"
+        },
+        "schema": {
+          "description": "[Output-only] The schema of the results. Present only for successful dry run of non-legacy SQL queries.",
+          "$ref": "TableSchema"
         }
-      },
-      "id": "JobStatistics2"
+      }
     },
     "CategoricalValue": {
+      "description": "Representative value of a categorical feature.",
       "type": "object",
       "properties": {
         "categoryCounts": {
@@ -3714,12 +2465,26 @@
           }
         }
       },
-      "id": "CategoricalValue",
-      "description": "Representative value of a categorical feature."
+      "id": "CategoricalValue"
     },
     "QueryResponse": {
+      "id": "QueryResponse",
       "type": "object",
       "properties": {
+        "rows": {
+          "description": "An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above.",
+          "type": "array",
+          "items": {
+            "$ref": "TableRow"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "ErrorProto"
+          },
+          "description": "[Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful."
+        },
         "pageToken": {
           "description": "A token used for paging results.",
           "type": "string"
@@ -3757,86 +2522,44 @@
           "type": "boolean"
         },
         "schema": {
-          "$ref": "TableSchema",
-          "description": "The schema of the results. Present only when the query completes successfully."
-        },
-        "rows": {
-          "description": "An object with as many results as can be contained within the maximum permitted reply size. To get any additional rows, you can call GetQueryResults and specify the jobReference returned above.",
-          "type": "array",
-          "items": {
-            "$ref": "TableRow"
-          }
-        },
-        "errors": {
-          "description": "[Output-only] The first errors or warnings encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.",
-          "type": "array",
-          "items": {
-            "$ref": "ErrorProto"
-          }
+          "description": "The schema of the results. Present only when the query completes successfully.",
+          "$ref": "TableSchema"
         }
-      },
-      "id": "QueryResponse"
+      }
     },
     "ExplainQueryStage": {
+      "id": "ExplainQueryStage",
       "type": "object",
       "properties": {
-        "inputStages": {
-          "description": "IDs for stages that are inputs to this stage.",
-          "type": "array",
-          "items": {
-            "format": "int64",
-            "type": "string"
-          }
-        },
-        "computeMsAvg": {
-          "type": "string",
-          "description": "Milliseconds the average shard spent on CPU-bound tasks.",
-          "format": "int64"
-        },
-        "computeMsMax": {
-          "description": "Milliseconds the slowest shard spent on CPU-bound tasks.",
-          "format": "int64",
-          "type": "string"
-        },
-        "readMsMax": {
-          "description": "Milliseconds the slowest shard spent reading input.",
-          "format": "int64",
-          "type": "string"
-        },
-        "shuffleOutputBytes": {
-          "description": "Total number of bytes written to shuffle.",
-          "format": "int64",
-          "type": "string"
-        },
         "parallelInputs": {
           "description": "Number of parallel input segments to be processed.",
           "format": "int64",
           "type": "string"
         },
         "status": {
-          "type": "string",
-          "description": "Current status for the stage."
+          "description": "Current status for the stage.",
+          "type": "string"
         },
         "name": {
           "description": "Human-readable name for stage.",
           "type": "string"
         },
         "computeRatioMax": {
+          "type": "number",
           "description": "Relative amount of time the slowest shard spent on CPU-bound tasks.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "steps": {
-          "description": "List of operations within the stage in dependency order (approximately chronological).",
           "type": "array",
           "items": {
             "$ref": "ExplainQueryStep"
-          }
+          },
+          "description": "List of operations within the stage in dependency order (approximately chronological)."
         },
         "startMs": {
+          "type": "string",
           "description": "Stage start time represented as milliseconds since epoch.",
-          "format": "int64",
-          "type": "string"
+          "format": "int64"
         },
         "writeMsMax": {
           "description": "Milliseconds the slowest shard spent on writing output.",
@@ -3854,29 +2577,29 @@
           "type": "string"
         },
         "waitMsAvg": {
-          "type": "string",
           "description": "Milliseconds the average shard spent waiting to be scheduled.",
-          "format": "int64"
+          "format": "int64",
+          "type": "string"
         },
         "recordsRead": {
           "description": "Number of records read into the stage.",
           "format": "int64",
           "type": "string"
         },
-        "writeMsAvg": {
-          "description": "Milliseconds the average shard spent on writing output.",
-          "format": "int64",
-          "type": "string"
-        },
-        "waitRatioMax": {
-          "type": "number",
-          "description": "Relative amount of time the slowest shard spent waiting to be scheduled.",
-          "format": "double"
-        },
         "waitMsMax": {
           "description": "Milliseconds the slowest shard spent waiting to be scheduled.",
           "format": "int64",
           "type": "string"
+        },
+        "waitRatioMax": {
+          "description": "Relative amount of time the slowest shard spent waiting to be scheduled.",
+          "format": "double",
+          "type": "number"
+        },
+        "writeMsAvg": {
+          "type": "string",
+          "description": "Milliseconds the average shard spent on writing output.",
+          "format": "int64"
         },
         "writeRatioAvg": {
           "description": "Relative amount of time the average shard spent on writing output.",
@@ -3889,19 +2612,19 @@
           "type": "number"
         },
         "completedParallelInputs": {
+          "type": "string",
           "description": "Number of parallel input segments completed.",
-          "format": "int64",
-          "type": "string"
-        },
-        "recordsWritten": {
-          "description": "Number of records written by the stage.",
-          "format": "int64",
-          "type": "string"
+          "format": "int64"
         },
         "waitRatioAvg": {
           "description": "Relative amount of time the average shard spent waiting to be scheduled.",
           "format": "double",
           "type": "number"
+        },
+        "recordsWritten": {
+          "type": "string",
+          "description": "Number of records written by the stage.",
+          "format": "int64"
         },
         "readRatioMax": {
           "description": "Relative amount of time the slowest shard spent reading input.",
@@ -3909,55 +2632,63 @@
           "type": "number"
         },
         "readRatioAvg": {
+          "type": "number",
           "description": "Relative amount of time the average shard spent reading input.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "id": {
           "description": "Unique ID for stage within plan.",
           "format": "int64",
           "type": "string"
         },
+        "endMs": {
+          "type": "string",
+          "description": "Stage end time represented as milliseconds since epoch.",
+          "format": "int64"
+        },
         "writeRatioMax": {
           "description": "Relative amount of time the slowest shard spent on writing output.",
           "format": "double",
           "type": "number"
         },
-        "endMs": {
-          "description": "Stage end time represented as milliseconds since epoch.",
+        "computeMsAvg": {
+          "description": "Milliseconds the average shard spent on CPU-bound tasks.",
+          "format": "int64",
+          "type": "string"
+        },
+        "inputStages": {
+          "description": "IDs for stages that are inputs to this stage.",
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "string"
+          }
+        },
+        "computeMsMax": {
+          "description": "Milliseconds the slowest shard spent on CPU-bound tasks.",
+          "format": "int64",
+          "type": "string"
+        },
+        "slotMs": {
+          "description": "Slot-milliseconds used by the stage.",
+          "format": "int64",
+          "type": "string"
+        },
+        "readMsMax": {
+          "type": "string",
+          "description": "Milliseconds the slowest shard spent reading input.",
+          "format": "int64"
+        },
+        "shuffleOutputBytes": {
+          "description": "Total number of bytes written to shuffle.",
           "format": "int64",
           "type": "string"
         }
-      },
-      "id": "ExplainQueryStage"
+      }
     },
     "Job": {
       "type": "object",
       "properties": {
-        "jobReference": {
-          "$ref": "JobReference",
-          "description": "[Optional] Reference describing the unique-per-user name of the job."
-        },
-        "status": {
-          "$ref": "JobStatus",
-          "description": "[Output-only] The status of this job. Examine this value when polling an asynchronous job to see if the job is complete."
-        },
-        "statistics": {
-          "description": "[Output-only] Information about the job, including starting time and ending time of the job.",
-          "$ref": "JobStatistics"
-        },
-        "selfLink": {
-          "description": "[Output-only] A URL that can be used to access this resource again.",
-          "type": "string"
-        },
-        "id": {
-          "description": "[Output-only] Opaque ID field of the job",
-          "type": "string"
-        },
-        "configuration": {
-          "$ref": "JobConfiguration",
-          "description": "[Required] Describes the job configuration."
-        },
         "user_email": {
           "description": "[Output-only] Email address of the user who ran the job.",
           "type": "string"
@@ -3970,6 +2701,30 @@
         "etag": {
           "type": "string",
           "description": "[Output-only] A hash of this resource."
+        },
+        "jobReference": {
+          "$ref": "JobReference",
+          "description": "[Optional] Reference describing the unique-per-user name of the job."
+        },
+        "status": {
+          "description": "[Output-only] The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.",
+          "$ref": "JobStatus"
+        },
+        "statistics": {
+          "description": "[Output-only] Information about the job, including starting time and ending time of the job.",
+          "$ref": "JobStatistics"
+        },
+        "selfLink": {
+          "description": "[Output-only] A URL that can be used to access this resource again.",
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "description": "[Output-only] Opaque ID field of the job"
+        },
+        "configuration": {
+          "description": "[Required] Describes the job configuration.",
+          "$ref": "JobConfiguration"
         }
       },
       "id": "Job"
@@ -3998,149 +2753,33 @@
       "id": "TableSchema"
     },
     "DestinationTableProperties": {
-      "id": "DestinationTableProperties",
       "type": "object",
       "properties": {
+        "description": {
+          "description": "[Optional] The description for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current description is provided, the job will fail.",
+          "type": "string"
+        },
         "labels": {
-          "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "[Optional] The labels associated with this table. You can use these to organize and group your tables. This will only be used if the destination table is newly created. If the table already exists and labels are different than the current labels are provided, the job will fail."
+          "description": "[Optional] The labels associated with this table. You can use these to organize and group your tables. This will only be used if the destination table is newly created. If the table already exists and labels are different than the current labels are provided, the job will fail.",
+          "type": "object"
         },
         "friendlyName": {
           "description": "[Optional] The friendly name for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current friendly name is provided, the job will fail.",
           "type": "string"
-        },
-        "description": {
-          "description": "[Optional] The description for the destination table. This will only be used if the destination table is newly created. If the table already exists and a value different than the current description is provided, the job will fail.",
-          "type": "string"
         }
-      }
+      },
+      "id": "DestinationTableProperties"
     },
     "TrainingOptions": {
-      "id": "TrainingOptions",
       "type": "object",
       "properties": {
-        "modelUri": {
-          "description": "[Beta] Google Cloud Storage URI from which the model was imported. Only\napplicable for imported models.",
-          "type": "string"
-        },
-        "minRelativeProgress": {
-          "type": "number",
-          "description": "When early_stop is true, stops training when accuracy improvement is\nless than 'min_relative_progress'. Used only for iterative training\nalgorithms.",
-          "format": "double"
-        },
-        "initialLearnRate": {
-          "description": "Specifies the initial learning rate for the line search learn rate\nstrategy.",
-          "format": "double",
-          "type": "number"
-        },
-        "kmeansInitializationColumn": {
-          "description": "The column used to provide the initial centroids for kmeans algorithm\nwhen kmeans_initialization_method is CUSTOM.",
-          "type": "string"
-        },
-        "numClusters": {
-          "type": "string",
-          "description": "Number of clusters for clustering models.",
-          "format": "int64"
-        },
-        "inputLabelColumns": {
-          "description": "Name of input label columns in training data.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "learnRateStrategy": {
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "Use line search to determine learning rate.",
-            "Use a constant learning rate."
-          ],
-          "enum": [
-            "LEARN_RATE_STRATEGY_UNSPECIFIED",
-            "LINE_SEARCH",
-            "CONSTANT"
-          ],
-          "description": "The strategy to determine learn rate for the current iteration."
-        },
-        "warmStart": {
-          "type": "boolean",
-          "description": "Whether to train a model from the last checkpoint."
-        },
-        "lossType": {
-          "description": "Type of loss function used during training run.",
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "Mean squared loss, used for linear regression.",
-            "Mean log loss, used for logistic regression."
-          ],
-          "enum": [
-            "LOSS_TYPE_UNSPECIFIED",
-            "MEAN_SQUARED_LOSS",
-            "MEAN_LOG_LOSS"
-          ]
-        },
-        "dataSplitMethod": {
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "Splits data randomly.",
-            "Splits data with the user provided tags.",
-            "Splits data sequentially.",
-            "Data split will be skipped.",
-            "Splits data automatically: Uses NO_SPLIT if the data size is small.\nOtherwise uses RANDOM."
-          ],
-          "enum": [
-            "DATA_SPLIT_METHOD_UNSPECIFIED",
-            "RANDOM",
-            "CUSTOM",
-            "SEQUENTIAL",
-            "NO_SPLIT",
-            "AUTO_SPLIT"
-          ],
-          "description": "The data split type for training and evaluation, e.g. RANDOM."
-        },
-        "l1Regularization": {
-          "description": "L1 regularization coefficient.",
-          "format": "double",
-          "type": "number"
-        },
-        "kmeansInitializationMethod": {
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "Initializes the centroids randomly.",
-            "Initializes the centroids using data specified in\nkmeans_initialization_column."
-          ],
-          "enum": [
-            "KMEANS_INITIALIZATION_METHOD_UNSPECIFIED",
-            "RANDOM",
-            "CUSTOM"
-          ],
-          "description": "The method used to initialize the centroids for kmeans algorithm."
-        },
-        "distanceType": {
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "Eculidean distance.",
-            "Cosine distance."
-          ],
-          "enum": [
-            "DISTANCE_TYPE_UNSPECIFIED",
-            "EUCLIDEAN",
-            "COSINE"
-          ],
-          "description": "Distance type for clustering models."
-        },
         "learnRate": {
+          "type": "number",
           "description": "Learning rate in training. Used only for iterative training algorithms.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "optimizationStrategy": {
           "type": "string",
@@ -4174,25 +2813,154 @@
           "type": "object"
         },
         "l2Regularization": {
+          "type": "number",
           "description": "L2 regularization coefficient.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "earlyStop": {
           "description": "Whether to stop early when the loss doesn't improve significantly\nany more (compared to min_relative_progress). Used only for iterative\ntraining algorithms.",
           "type": "boolean"
         },
         "dataSplitEvalFraction": {
+          "type": "number",
           "description": "The fraction of evaluation data over the whole input data. The rest\nof data will be used as training data. The format should be double.\nAccurate to two decimal places.\nDefault value is 0.2.",
+          "format": "double"
+        },
+        "modelUri": {
+          "description": "[Beta] Google Cloud Storage URI from which the model was imported. Only\napplicable for imported models.",
+          "type": "string"
+        },
+        "minRelativeProgress": {
+          "description": "When early_stop is true, stops training when accuracy improvement is\nless than 'min_relative_progress'. Used only for iterative training\nalgorithms.",
           "format": "double",
           "type": "number"
+        },
+        "initialLearnRate": {
+          "description": "Specifies the initial learning rate for the line search learn rate\nstrategy.",
+          "format": "double",
+          "type": "number"
+        },
+        "kmeansInitializationColumn": {
+          "description": "The column used to provide the initial centroids for kmeans algorithm\nwhen kmeans_initialization_method is CUSTOM.",
+          "type": "string"
+        },
+        "numClusters": {
+          "description": "Number of clusters for clustering models.",
+          "format": "int64",
+          "type": "string"
+        },
+        "inputLabelColumns": {
+          "description": "Name of input label columns in training data.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "learnRateStrategy": {
+          "enum": [
+            "LEARN_RATE_STRATEGY_UNSPECIFIED",
+            "LINE_SEARCH",
+            "CONSTANT"
+          ],
+          "description": "The strategy to determine learn rate for the current iteration.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "Use line search to determine learning rate.",
+            "Use a constant learning rate."
+          ]
+        },
+        "warmStart": {
+          "type": "boolean",
+          "description": "Whether to train a model from the last checkpoint."
+        },
+        "lossType": {
+          "enumDescriptions": [
+            "",
+            "Mean squared loss, used for linear regression.",
+            "Mean log loss, used for logistic regression."
+          ],
+          "enum": [
+            "LOSS_TYPE_UNSPECIFIED",
+            "MEAN_SQUARED_LOSS",
+            "MEAN_LOG_LOSS"
+          ],
+          "description": "Type of loss function used during training run.",
+          "type": "string"
+        },
+        "dataSplitMethod": {
+          "description": "The data split type for training and evaluation, e.g. RANDOM.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "Splits data randomly.",
+            "Splits data with the user provided tags.",
+            "Splits data sequentially.",
+            "Data split will be skipped.",
+            "Splits data automatically: Uses NO_SPLIT if the data size is small.\nOtherwise uses RANDOM."
+          ],
+          "enum": [
+            "DATA_SPLIT_METHOD_UNSPECIFIED",
+            "RANDOM",
+            "CUSTOM",
+            "SEQUENTIAL",
+            "NO_SPLIT",
+            "AUTO_SPLIT"
+          ]
+        },
+        "l1Regularization": {
+          "type": "number",
+          "description": "L1 regularization coefficient.",
+          "format": "double"
+        },
+        "kmeansInitializationMethod": {
+          "description": "The method used to initialize the centroids for kmeans algorithm.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "Initializes the centroids randomly.",
+            "Initializes the centroids using data specified in\nkmeans_initialization_column.",
+            "Initializes with kmeans++."
+          ],
+          "enum": [
+            "KMEANS_INITIALIZATION_METHOD_UNSPECIFIED",
+            "RANDOM",
+            "CUSTOM",
+            "KMEANS_PLUS_PLUS"
+          ]
+        },
+        "distanceType": {
+          "description": "Distance type for clustering models.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "Eculidean distance.",
+            "Cosine distance."
+          ],
+          "enum": [
+            "DISTANCE_TYPE_UNSPECIFIED",
+            "EUCLIDEAN",
+            "COSINE"
+          ]
         }
-      }
+      },
+      "id": "TrainingOptions"
     },
     "TrainingRun": {
-      "description": "Information about a single training query run for the model.",
       "type": "object",
       "properties": {
+        "startTime": {
+          "description": "The start time of this training run.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "results": {
+          "description": "Output of each iteration run, results.size() \u003c= max_iterations.",
+          "type": "array",
+          "items": {
+            "$ref": "IterationResult"
+          }
+        },
         "evaluationMetrics": {
           "$ref": "EvaluationMetrics",
           "description": "The evaluation metrics over training/eval data that were computed at the\nend of training."
@@ -4201,73 +2969,24 @@
           "$ref": "TrainingOptions",
           "description": "Options that were used for this training run, includes\nuser specified and default options that were used."
         },
-        "startTime": {
-          "type": "string",
-          "description": "The start time of this training run.",
-          "format": "google-datetime"
-        },
-        "results": {
-          "description": "Output of each iteration run, results.size() \u003c= max_iterations.",
-          "type": "array",
-          "items": {
-            "$ref": "IterationResult"
-          }
+        "dataSplitResult": {
+          "description": "Data split result of the training run. Only set when the input data is\nactually split.",
+          "$ref": "DataSplitResult"
         }
       },
-      "id": "TrainingRun"
+      "id": "TrainingRun",
+      "description": "Information about a single training query run for the model."
     },
     "Routine": {
-      "description": "A user-defined function or a stored procedure.",
       "type": "object",
       "properties": {
-        "importedLibraries": {
-          "description": "Optional. If language = \"JAVASCRIPT\", this field stores the path of the\nimported JAVASCRIPT libraries.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "returnType": {
-          "$ref": "StandardSqlDataType",
-          "description": "Optional if language = \"SQL\"; required otherwise.\n\nIf absent, the return type is inferred from definition_body at query time\nin each query that references this routine. If present, then the evaluated\nresult will be cast to the specified returned type at query time.\n\nFor example, for the functions created with the following statements:\n\n* `CREATE FUNCTION Add(x FLOAT64, y FLOAT64) RETURNS FLOAT64 AS (x + y);`\n\n* `CREATE FUNCTION Increment(x FLOAT64) AS (Add(x, 1));`\n\n* `CREATE FUNCTION Decrement(x FLOAT64) RETURNS FLOAT64 AS (Add(x, -1));`\n\nThe return_type is `{type_kind: \"FLOAT64\"}` for `Add` and `Decrement`, and\nis absent for `Increment` (inferred as FLOAT64 at query time).\n\nSuppose the function `Add` is replaced by\n  `CREATE OR REPLACE FUNCTION Add(x INT64, y INT64) AS (x + y);`\n\nThen the inferred return type of `Increment` is automatically changed to\nINT64 at query time, while the return type of `Decrement` remains FLOAT64."
-        },
-        "language": {
-          "description": "Optional. Defaults to \"SQL\".",
-          "type": "string",
-          "enumDescriptions": [
-            "",
-            "SQL language.",
-            "JavaScript language."
-          ],
-          "enum": [
-            "LANGUAGE_UNSPECIFIED",
-            "SQL",
-            "JAVASCRIPT"
-          ]
-        },
-        "lastModifiedTime": {
-          "description": "Output only. The time when this routine was last modified, in milliseconds\nsince the epoch.",
-          "format": "int64",
-          "type": "string"
-        },
-        "description": {
-          "type": "string",
-          "description": "Optional. [Experimental] The description of the routine if defined."
-        },
-        "etag": {
-          "description": "Output only. A hash of this resource.",
-          "type": "string"
-        },
-        "definitionBody": {
-          "description": "Required. The body of the routine.\n\nFor functions, this is the expression in the AS clause.\n\nIf language=SQL, it is the substring inside (but excluding) the\nparentheses. For example, for the function created with the following\nstatement:\n\n`CREATE FUNCTION JoinLines(x string, y string) as (concat(x, \"\\n\", y))`\n\nThe definition_body is `concat(x, \"\\n\", y)` (\\n is not replaced with\nlinebreak).\n\nIf language=JAVASCRIPT, it is the evaluated string in the AS clause.\nFor example, for the function created with the following statement:\n\n`CREATE FUNCTION f() RETURNS STRING LANGUAGE js AS 'return \"\\n\";\\n'`\n\nThe definition_body is\n\n`return \"\\n\";\\n`\n\nNote that both \\n are replaced with linebreaks.",
-          "type": "string"
-        },
         "creationTime": {
           "description": "Output only. The time when this routine was created, in milliseconds since\nthe epoch.",
           "format": "int64",
           "type": "string"
         },
         "routineType": {
+          "type": "string",
           "enumDescriptions": [
             "",
             "Non-builtin permanent scalar function.",
@@ -4278,24 +2997,67 @@
             "SCALAR_FUNCTION",
             "PROCEDURE"
           ],
-          "description": "Required. The type of routine.",
-          "type": "string"
+          "description": "Required. The type of routine."
         },
         "routineReference": {
-          "description": "Required. Reference describing the ID of this routine.",
-          "$ref": "RoutineReference"
+          "$ref": "RoutineReference",
+          "description": "Required. Reference describing the ID of this routine."
         },
         "arguments": {
-          "description": "Optional.",
           "type": "array",
           "items": {
             "$ref": "Argument"
-          }
+          },
+          "description": "Optional."
+        },
+        "importedLibraries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. If language = \"JAVASCRIPT\", this field stores the path of the\nimported JAVASCRIPT libraries."
+        },
+        "returnType": {
+          "$ref": "StandardSqlDataType",
+          "description": "Optional if language = \"SQL\"; required otherwise.\n\nIf absent, the return type is inferred from definition_body at query time\nin each query that references this routine. If present, then the evaluated\nresult will be cast to the specified returned type at query time.\n\nFor example, for the functions created with the following statements:\n\n* `CREATE FUNCTION Add(x FLOAT64, y FLOAT64) RETURNS FLOAT64 AS (x + y);`\n\n* `CREATE FUNCTION Increment(x FLOAT64) AS (Add(x, 1));`\n\n* `CREATE FUNCTION Decrement(x FLOAT64) RETURNS FLOAT64 AS (Add(x, -1));`\n\nThe return_type is `{type_kind: \"FLOAT64\"}` for `Add` and `Decrement`, and\nis absent for `Increment` (inferred as FLOAT64 at query time).\n\nSuppose the function `Add` is replaced by\n  `CREATE OR REPLACE FUNCTION Add(x INT64, y INT64) AS (x + y);`\n\nThen the inferred return type of `Increment` is automatically changed to\nINT64 at query time, while the return type of `Decrement` remains FLOAT64."
+        },
+        "language": {
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "SQL language.",
+            "JavaScript language."
+          ],
+          "enum": [
+            "LANGUAGE_UNSPECIFIED",
+            "SQL",
+            "JAVASCRIPT"
+          ],
+          "description": "Optional. Defaults to \"SQL\"."
+        },
+        "lastModifiedTime": {
+          "description": "Output only. The time when this routine was last modified, in milliseconds\nsince the epoch.",
+          "format": "int64",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. [Experimental] The description of the routine if defined.",
+          "type": "string"
+        },
+        "etag": {
+          "type": "string",
+          "description": "Output only. A hash of this resource."
+        },
+        "definitionBody": {
+          "description": "Required. The body of the routine.\n\nFor functions, this is the expression in the AS clause.\n\nIf language=SQL, it is the substring inside (but excluding) the\nparentheses. For example, for the function created with the following\nstatement:\n\n`CREATE FUNCTION JoinLines(x string, y string) as (concat(x, \"\\n\", y))`\n\nThe definition_body is `concat(x, \"\\n\", y)` (\\n is not replaced with\nlinebreak).\n\nIf language=JAVASCRIPT, it is the evaluated string in the AS clause.\nFor example, for the function created with the following statement:\n\n`CREATE FUNCTION f() RETURNS STRING LANGUAGE js AS 'return \"\\n\";\\n'`\n\nThe definition_body is\n\n`return \"\\n\";\\n`\n\nNote that both \\n are replaced with linebreaks.",
+          "type": "string"
         }
       },
-      "id": "Routine"
+      "id": "Routine",
+      "description": "A user-defined function or a stored procedure."
     },
     "UserDefinedFunctionResource": {
+      "id": "UserDefinedFunctionResource",
       "type": "object",
       "properties": {
         "resourceUri": {
@@ -4306,28 +3068,31 @@
           "description": "[Pick one] An inline resource that contains code for a user-defined function (UDF). Providing a inline code resource is equivalent to providing a URI for a file containing the same code.",
           "type": "string"
         }
-      },
-      "id": "UserDefinedFunctionResource"
+      }
     },
     "AggregateClassificationMetrics": {
-      "id": "AggregateClassificationMetrics",
       "description": "Aggregate metrics for classification/classifier models. For multi-class\nmodels, the metrics are either macro-averaged or micro-averaged. When\nmacro-averaged, the metrics are calculated for each label and then an\nunweighted average is taken of those values. When micro-averaged, the\nmetric is calculated globally by counting the total number of correctly\npredicted rows.",
       "type": "object",
       "properties": {
+        "accuracy": {
+          "type": "number",
+          "description": "Accuracy is the fraction of predictions given the correct label. For\nmulticlass this is a micro-averaged metric.",
+          "format": "double"
+        },
         "recall": {
           "description": "Recall is the fraction of actual positive labels that were given a\npositive prediction. For multiclass this is a macro-averaged metric.",
           "format": "double",
           "type": "number"
         },
         "threshold": {
-          "type": "number",
           "description": "Threshold at which the metrics are computed. For binary\nclassification models this is the positive class threshold.\nFor multi-class classfication models this is the confidence\nthreshold.",
-          "format": "double"
-        },
-        "rocAuc": {
-          "description": "Area Under a ROC Curve. For multiclass this is a macro-averaged\nmetric.",
           "format": "double",
           "type": "number"
+        },
+        "rocAuc": {
+          "type": "number",
+          "description": "Area Under a ROC Curve. For multiclass this is a macro-averaged\nmetric.",
+          "format": "double"
         },
         "logLoss": {
           "description": "Logarithmic Loss. For multiclass this is a macro-averaged metric.",
@@ -4335,21 +3100,17 @@
           "type": "number"
         },
         "f1Score": {
+          "type": "number",
           "description": "The F1 score is an average of recall and precision. For multiclass\nthis is a macro-averaged metric.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "precision": {
           "description": "Precision is the fraction of actual positive predictions that had\npositive actual labels. For multiclass this is a macro-averaged\nmetric treating each class as a binary classifier.",
           "format": "double",
           "type": "number"
-        },
-        "accuracy": {
-          "type": "number",
-          "description": "Accuracy is the fraction of predictions given the correct label. For\nmulticlass this is a micro-averaged metric.",
-          "format": "double"
         }
-      }
+      },
+      "id": "AggregateClassificationMetrics"
     },
     "QueryParameter": {
       "type": "object",
@@ -4370,7 +3131,6 @@
       "id": "QueryParameter"
     },
     "TableRow": {
-      "id": "TableRow",
       "type": "object",
       "properties": {
         "f": {
@@ -4380,11 +3140,33 @@
             "$ref": "TableCell"
           }
         }
-      }
+      },
+      "id": "TableRow"
     },
-    "ArimaOrder": {
+    "DataSplitResult": {
+      "description": "Data split result. This contains references to the training and evaluation\ndata tables that were used to train the model.",
       "type": "object",
       "properties": {
+        "trainingTable": {
+          "$ref": "TableReference",
+          "description": "Table reference of the training data after split."
+        },
+        "evaluationTable": {
+          "$ref": "TableReference",
+          "description": "Table reference of the evaluation data after split."
+        }
+      },
+      "id": "DataSplitResult"
+    },
+    "ArimaOrder": {
+      "description": "Arima order, can be used for both non-seasonal and seasonal parts.",
+      "type": "object",
+      "properties": {
+        "q": {
+          "description": "Order of the moving-average part.",
+          "format": "int64",
+          "type": "string"
+        },
         "d": {
           "type": "string",
           "description": "Order of the differencing part.",
@@ -4394,31 +3176,16 @@
           "description": "Order of the autoregressive part.",
           "format": "int64",
           "type": "string"
-        },
-        "q": {
-          "description": "Order of the moving-average part.",
-          "format": "int64",
-          "type": "string"
         }
       },
-      "id": "ArimaOrder",
-      "description": "Arima order, can be used for both non-seasonal and seasonal parts."
+      "id": "ArimaOrder"
     },
     "ScriptStackFrame": {
       "type": "object",
       "properties": {
-        "procedureId": {
-          "description": "[Output-only] Name of the active procedure, empty if in a top-level script.",
-          "type": "string"
-        },
-        "startLine": {
-          "description": "[Output-only] One-based start line.",
-          "format": "int32",
-          "type": "integer"
-        },
         "text": {
-          "description": "[Output-only] Text of the current statement/expression.",
-          "type": "string"
+          "type": "string",
+          "description": "[Output-only] Text of the current statement/expression."
         },
         "endColumn": {
           "description": "[Output-only] One-based end column.",
@@ -4434,17 +3201,27 @@
           "description": "[Output-only] One-based start column.",
           "format": "int32",
           "type": "integer"
+        },
+        "procedureId": {
+          "description": "[Output-only] Name of the active procedure, empty if in a top-level script.",
+          "type": "string"
+        },
+        "startLine": {
+          "description": "[Output-only] One-based start line.",
+          "format": "int32",
+          "type": "integer"
         }
       },
       "id": "ScriptStackFrame"
     },
     "MultiClassClassificationMetrics": {
+      "id": "MultiClassClassificationMetrics",
       "description": "Evaluation metrics for multi-class classification/classifier models.",
       "type": "object",
       "properties": {
         "aggregateClassificationMetrics": {
-          "description": "Aggregate classification metrics.",
-          "$ref": "AggregateClassificationMetrics"
+          "$ref": "AggregateClassificationMetrics",
+          "description": "Aggregate classification metrics."
         },
         "confusionMatrixList": {
           "description": "Confusion matrix at different thresholds.",
@@ -4453,29 +3230,49 @@
             "$ref": "ConfusionMatrix"
           }
         }
-      },
-      "id": "MultiClassClassificationMetrics"
+      }
     },
     "Clustering": {
       "type": "object",
       "properties": {
         "fields": {
-          "description": "[Repeated] One or more fields on which data should be clustered. Only top-level, non-repeated, simple-type fields are supported. When you cluster a table using multiple columns, the order of columns you specify is important. The order of the specified columns determines the sort order of the data.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "[Repeated] One or more fields on which data should be clustered. Only top-level, non-repeated, simple-type fields are supported. When you cluster a table using multiple columns, the order of columns you specify is important. The order of the specified columns determines the sort order of the data."
         }
       },
       "id": "Clustering"
     },
     "BqmlTrainingRun": {
-      "id": "BqmlTrainingRun",
       "type": "object",
       "properties": {
         "trainingOptions": {
+          "description": "[Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.",
           "type": "object",
           "properties": {
+            "minRelProgress": {
+              "type": "number",
+              "format": "double"
+            },
+            "l2Reg": {
+              "format": "double",
+              "type": "number"
+            },
+            "learnRateStrategy": {
+              "type": "string"
+            },
+            "warmStart": {
+              "type": "boolean"
+            },
+            "lineSearchInitLearnRate": {
+              "format": "double",
+              "type": "number"
+            },
+            "earlyStop": {
+              "type": "boolean"
+            },
             "l1Reg": {
               "type": "number",
               "format": "double"
@@ -4487,60 +3284,31 @@
             "learnRate": {
               "format": "double",
               "type": "number"
-            },
-            "minRelProgress": {
-              "format": "double",
-              "type": "number"
-            },
-            "l2Reg": {
-              "format": "double",
-              "type": "number"
-            },
-            "warmStart": {
-              "type": "boolean"
-            },
-            "learnRateStrategy": {
-              "type": "string"
-            },
-            "lineSearchInitLearnRate": {
-              "format": "double",
-              "type": "number"
-            },
-            "earlyStop": {
-              "type": "boolean"
             }
-          },
-          "description": "[Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run."
+          }
         },
         "state": {
           "description": "[Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.",
           "type": "string"
         },
         "iterationResults": {
+          "description": "[Output-only, Beta] List of each iteration results.",
           "type": "array",
           "items": {
             "$ref": "BqmlIterationResult"
-          },
-          "description": "[Output-only, Beta] List of each iteration results."
+          }
         },
         "startTime": {
+          "type": "string",
           "description": "[Output-only, Beta] Training run start time in milliseconds since the epoch.",
-          "format": "date-time",
-          "type": "string"
+          "format": "date-time"
         }
-      }
+      },
+      "id": "BqmlTrainingRun"
     },
     "BigtableColumnFamily": {
       "type": "object",
       "properties": {
-        "onlyReadLatest": {
-          "type": "boolean",
-          "description": "[Optional] If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column."
-        },
-        "encoding": {
-          "type": "string",
-          "description": "[Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it."
-        },
         "columns": {
           "description": "[Optional] Lists of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as .. Other columns can be accessed as a list through .Column field.",
           "type": "array",
@@ -4553,19 +3321,28 @@
           "type": "string"
         },
         "familyId": {
-          "type": "string",
-          "description": "Identifier of the column family."
+          "description": "Identifier of the column family.",
+          "type": "string"
+        },
+        "onlyReadLatest": {
+          "description": "[Optional] If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.",
+          "type": "boolean"
+        },
+        "encoding": {
+          "description": "[Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.",
+          "type": "string"
         }
       },
       "id": "BigtableColumnFamily"
     },
     "Cluster": {
+      "description": "Message containing the information about one cluster.",
       "type": "object",
       "properties": {
         "centroidId": {
-          "type": "string",
           "description": "Centroid id.",
-          "format": "int64"
+          "format": "int64",
+          "type": "string"
         },
         "count": {
           "description": "Count of training data rows that were assigned to this cluster.",
@@ -4573,31 +3350,18 @@
           "type": "string"
         },
         "featureValues": {
-          "description": "Values of highly variant features for this cluster.",
           "type": "array",
           "items": {
             "$ref": "FeatureValue"
-          }
+          },
+          "description": "Values of highly variant features for this cluster."
         }
       },
-      "id": "Cluster",
-      "description": "Message containing the information about one cluster."
+      "id": "Cluster"
     },
     "ExternalDataConfiguration": {
       "type": "object",
       "properties": {
-        "csvOptions": {
-          "$ref": "CsvOptions",
-          "description": "Additional properties to set if sourceFormat is set to CSV."
-        },
-        "bigtableOptions": {
-          "$ref": "BigtableOptions",
-          "description": "[Optional] Additional options if sourceFormat is set to BIGTABLE."
-        },
-        "schema": {
-          "$ref": "TableSchema",
-          "description": "[Optional] The schema for the data. Schema is required for CSV and JSON formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats."
-        },
         "hivePartitioningOptions": {
           "$ref": "HivePartitioningOptions",
           "description": "[Optional, Trusted Tester] Options to configure hive partitioning support."
@@ -4607,8 +3371,8 @@
           "description": "[Optional] Additional options if sourceFormat is set to GOOGLE_SHEETS."
         },
         "autodetect": {
-          "description": "Try to detect schema and format options automatically. Any option specified explicitly will be honored.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Try to detect schema and format options automatically. Any option specified explicitly will be honored."
         },
         "ignoreUnknownValues": {
           "type": "boolean",
@@ -4623,8 +3387,8 @@
           "type": "string"
         },
         "hivePartitioningMode": {
-          "description": "[Optional, Trusted Tester] Deprecated, do not use. Please set hivePartitioningOptions instead.",
-          "type": "string"
+          "type": "string",
+          "description": "[Optional, Trusted Tester] Deprecated, do not use. Please set hivePartitioningOptions instead."
         },
         "maxBadRecords": {
           "description": "[Optional] The maximum number of bad records that BigQuery can ignore when reading data. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV, JSON, and Google Sheets. The default value is 0, which requires that all records are valid. This setting is ignored for Google Cloud Bigtable, Google Cloud Datastore backups and Avro formats.",
@@ -4637,49 +3401,60 @@
           "items": {
             "type": "string"
           }
+        },
+        "csvOptions": {
+          "$ref": "CsvOptions",
+          "description": "Additional properties to set if sourceFormat is set to CSV."
+        },
+        "bigtableOptions": {
+          "description": "[Optional] Additional options if sourceFormat is set to BIGTABLE.",
+          "$ref": "BigtableOptions"
+        },
+        "schema": {
+          "$ref": "TableSchema",
+          "description": "[Optional] The schema for the data. Schema is required for CSV and JSON formats. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, and Avro formats."
         }
       },
       "id": "ExternalDataConfiguration"
     },
     "GoogleSheetsOptions": {
+      "id": "GoogleSheetsOptions",
       "type": "object",
       "properties": {
         "range": {
-          "description": "[Optional] Range of a sheet to query from. Only used when non-empty. Typical format: sheet_name!top_left_cell_id:bottom_right_cell_id For example: sheet1!A1:B20",
-          "type": "string"
+          "type": "string",
+          "description": "[Optional] Range of a sheet to query from. Only used when non-empty. Typical format: sheet_name!top_left_cell_id:bottom_right_cell_id For example: sheet1!A1:B20"
         },
         "skipLeadingRows": {
           "description": "[Optional] The number of rows at the top of a sheet that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows that should be skipped. When autodetect is on, behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N \u003e 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.",
           "format": "int64",
           "type": "string"
         }
-      },
-      "id": "GoogleSheetsOptions"
+      }
     },
     "ArimaFittingMetrics": {
       "id": "ArimaFittingMetrics",
       "description": "ARIMA model fitting metrics.",
       "type": "object",
       "properties": {
-        "aic": {
-          "description": "AIC",
-          "format": "double",
-          "type": "number"
-        },
         "logLikelihood": {
           "description": "log-likelihood",
           "format": "double",
           "type": "number"
         },
         "variance": {
-          "type": "number",
           "description": "variance.",
-          "format": "double"
+          "format": "double",
+          "type": "number"
+        },
+        "aic": {
+          "description": "AIC",
+          "format": "double",
+          "type": "number"
         }
       }
     },
     "ArimaCoefficients": {
-      "id": "ArimaCoefficients",
       "description": "Arima coefficients.",
       "type": "object",
       "properties": {
@@ -4695,8 +3470,8 @@
           "description": "Auto-regressive coefficients, an array of double.",
           "type": "array",
           "items": {
-            "format": "double",
-            "type": "number"
+            "type": "number",
+            "format": "double"
           }
         },
         "interceptCoefficient": {
@@ -4704,66 +3479,52 @@
           "format": "double",
           "type": "number"
         }
-      }
+      },
+      "id": "ArimaCoefficients"
     },
     "BigtableColumn": {
-      "id": "BigtableColumn",
       "type": "object",
       "properties": {
-        "type": {
-          "description": "[Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.",
-          "type": "string"
-        },
         "onlyReadLatest": {
           "description": "[Optional] If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.",
           "type": "boolean"
         },
         "qualifierEncoded": {
+          "type": "string",
           "description": "[Required] Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifier_string field. Otherwise, a base-64 encoded value must be set to qualifier_encoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as field_name.",
-          "format": "byte",
-          "type": "string"
+          "format": "byte"
         },
         "fieldName": {
-          "type": "string",
-          "description": "[Optional] If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries."
+          "description": "[Optional] If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries.",
+          "type": "string"
         },
         "qualifierString": {
           "type": "string"
         },
         "encoding": {
-          "type": "string",
-          "description": "[Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels."
-        }
-      }
-    },
-    "TableFieldSchema": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "[Optional] The field description. The maximum length is 1,024 characters."
-        },
-        "fields": {
-          "type": "array",
-          "items": {
-            "$ref": "TableFieldSchema"
-          },
-          "description": "[Optional] Describes the nested schema fields if the type property is set to RECORD."
-        },
-        "name": {
-          "description": "[Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.",
+          "description": "[Optional] The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.",
           "type": "string"
         },
         "type": {
-          "description": "[Required] The field data type. Possible values include STRING, BYTES, INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT), BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, RECORD (where RECORD indicates that the field contains a nested schema) or STRUCT (same as RECORD).",
+          "description": "[Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.",
+          "type": "string"
+        }
+      },
+      "id": "BigtableColumn"
+    },
+    "TableFieldSchema": {
+      "id": "TableFieldSchema",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "[Optional] The field description. The maximum length is 1,024 characters.",
           "type": "string"
         },
-        "categories": {
-          "description": "[Optional] The categories attached to this field, used for field-level access control.",
+        "policyTags": {
           "type": "object",
           "properties": {
             "names": {
-              "description": "A list of category resource names. For example, \"projects/1/taxonomies/2/categories/3\". At most 5 categories are allowed.",
+              "description": "A list of category resource names. For example, \"projects/1/location/eu/taxonomies/2/policyTags/3\". At most 1 policy tag is allowed.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -4771,17 +3532,59 @@
             }
           }
         },
-        "mode": {
+        "fields": {
+          "description": "[Optional] Describes the nested schema fields if the type property is set to RECORD.",
+          "type": "array",
+          "items": {
+            "$ref": "TableFieldSchema"
+          }
+        },
+        "name": {
+          "description": "[Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.",
+          "type": "string"
+        },
+        "type": {
           "type": "string",
-          "description": "[Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE."
+          "description": "[Required] The field data type. Possible values include STRING, BYTES, INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT), BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, RECORD (where RECORD indicates that the field contains a nested schema) or STRUCT (same as RECORD)."
+        },
+        "categories": {
+          "type": "object",
+          "properties": {
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of category resource names. For example, \"projects/1/taxonomies/2/categories/3\". At most 5 categories are allowed."
+            }
+          },
+          "description": "[Optional] The categories attached to this field, used for field-level access control."
+        },
+        "mode": {
+          "description": "[Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.",
+          "type": "string"
         }
-      },
-      "id": "TableFieldSchema"
+      }
     },
     "BqmlIterationResult": {
       "id": "BqmlIterationResult",
       "type": "object",
       "properties": {
+        "evalLoss": {
+          "description": "[Output-only, Beta] Eval loss computed on the eval data at the end of the iteration. The eval loss is used for early stopping to avoid overfitting. No eval loss if eval_split_method option is specified as no_split or auto_split with input data size less than 500 rows.",
+          "format": "double",
+          "type": "number"
+        },
+        "index": {
+          "description": "[Output-only, Beta] Index of the ML training iteration, starting from zero for each training run.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "learnRate": {
+          "type": "number",
+          "description": "[Output-only, Beta] Learning rate used for this iteration, it varies for different training iterations if learn_rate_strategy option is not constant.",
+          "format": "double"
+        },
         "durationMs": {
           "description": "[Output-only, Beta] Time taken to run the training iteration in milliseconds.",
           "format": "int64",
@@ -4791,26 +3594,10 @@
           "description": "[Output-only, Beta] Training loss computed on the training data at the end of the iteration. The training loss function is defined by model type.",
           "format": "double",
           "type": "number"
-        },
-        "evalLoss": {
-          "type": "number",
-          "description": "[Output-only, Beta] Eval loss computed on the eval data at the end of the iteration. The eval loss is used for early stopping to avoid overfitting. No eval loss if eval_split_method option is specified as no_split or auto_split with input data size less than 500 rows.",
-          "format": "double"
-        },
-        "index": {
-          "description": "[Output-only, Beta] Index of the ML training iteration, starting from zero for each training run.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "learnRate": {
-          "description": "[Output-only, Beta] Learning rate used for this iteration, it varies for different training iterations if learn_rate_strategy option is not constant.",
-          "format": "double",
-          "type": "number"
         }
       }
     },
     "TableDataInsertAllResponse": {
-      "id": "TableDataInsertAllResponse",
       "type": "object",
       "properties": {
         "insertErrors": {
@@ -4839,11 +3626,10 @@
           "type": "string",
           "default": "bigquery#tableDataInsertAllResponse"
         }
-      }
+      },
+      "id": "TableDataInsertAllResponse"
     },
     "ClusteringMetrics": {
-      "id": "ClusteringMetrics",
-      "description": "Evaluation metrics for clustering models.",
       "type": "object",
       "properties": {
         "meanSquaredDistance": {
@@ -4852,52 +3638,64 @@
           "type": "number"
         },
         "daviesBouldinIndex": {
+          "type": "number",
           "description": "Davies-Bouldin index.",
-          "format": "double",
-          "type": "number"
+          "format": "double"
         },
         "clusters": {
+          "description": "[Beta] Information for all clusters.",
           "type": "array",
           "items": {
             "$ref": "Cluster"
-          },
-          "description": "[Beta] Information for all clusters."
+          }
         }
-      }
+      },
+      "id": "ClusteringMetrics",
+      "description": "Evaluation metrics for clustering models."
     },
     "GetServiceAccountResponse": {
-      "id": "GetServiceAccountResponse",
       "type": "object",
       "properties": {
         "email": {
-          "type": "string",
-          "description": "The service account email address."
+          "description": "The service account email address.",
+          "type": "string"
         },
         "kind": {
           "description": "The resource type of the response.",
           "type": "string",
           "default": "bigquery#getServiceAccountResponse"
         }
-      }
+      },
+      "id": "GetServiceAccountResponse"
     },
     "Dataset": {
       "type": "object",
       "properties": {
-        "location": {
+        "creationTime": {
           "type": "string",
-          "description": "The geographic location where the dataset should reside. The default value is US. See details at https://cloud.google.com/bigquery/docs/locations."
+          "description": "[Output-only] The time when this dataset was created, in milliseconds since the epoch.",
+          "format": "int64"
+        },
+        "datasetReference": {
+          "description": "[Required] A reference that identifies the dataset.",
+          "$ref": "DatasetReference"
+        },
+        "id": {
+          "description": "[Output-only] The fully-qualified unique name of the dataset in the format projectId:datasetId. The dataset name without the project name is given in the datasetId field. When creating a new dataset, leave this field blank, and instead specify the datasetId field.",
+          "type": "string"
+        },
+        "location": {
+          "description": "The geographic location where the dataset should reside. The default value is US. See details at https://cloud.google.com/bigquery/docs/locations.",
+          "type": "string"
         },
         "friendlyName": {
-          "type": "string",
-          "description": "[Optional] A descriptive name for the dataset."
+          "description": "[Optional] A descriptive name for the dataset.",
+          "type": "string"
         },
         "lastModifiedTime": {
           "description": "[Output-only] The date when this dataset or any of its tables was last modified, in milliseconds since the epoch.",
           "format": "int64",
           "type": "string"
-        },
-        "defaultEncryptionConfiguration": {
-          "$ref": "EncryptionConfiguration"
         },
         "labels": {
           "type": "object",
@@ -4905,6 +3703,9 @@
             "type": "string"
           },
           "description": "The labels associated with this dataset. You can use these to organize and group your datasets. You can set this property when inserting or updating a dataset. See Creating and Updating Dataset Labels for more information."
+        },
+        "defaultEncryptionConfiguration": {
+          "$ref": "EncryptionConfiguration"
         },
         "selfLink": {
           "description": "[Output-only] A URL that can be used to access the resource again. You can use this URL in Get or Update requests to the resource.",
@@ -4916,41 +3717,41 @@
           "type": "string"
         },
         "access": {
-          "description": "[Optional] An array of objects that define dataset access for one or more entities. You can set this property when inserting or updating a dataset in order to control who is allowed to access the data. If unspecified at dataset creation time, BigQuery adds default dataset access for the following entities: access.specialGroup: projectReaders; access.role: READER; access.specialGroup: projectWriters; access.role: WRITER; access.specialGroup: projectOwners; access.role: OWNER; access.userByEmail: [dataset creator email]; access.role: OWNER;",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
+              "role": {
+                "description": "[Required] An IAM role ID that should be granted to the user, group, or domain specified in this access entry. The following legacy mappings will be applied: OWNER  roles/bigquery.dataOwner WRITER  roles/bigquery.dataEditor READER  roles/bigquery.dataViewer This field will accept any of the above formats, but will return only the legacy format. For example, if you set this field to \"roles/bigquery.dataOwner\", it will be returned back as \"OWNER\".",
+                "type": "string"
+              },
               "view": {
                 "$ref": "TableReference",
                 "description": "[Pick one] A view from a different dataset to grant access to. Queries executed against that view will have read access to tables in this dataset. The role field is not required when this field is set. If that view is updated by any user, access to the view needs to be granted again via an update operation."
               },
               "groupByEmail": {
-                "type": "string",
-                "description": "[Pick one] An email address of a Google Group to grant access to. Maps to IAM policy member \"group:GROUP\"."
-              },
-              "userByEmail": {
-                "description": "[Pick one] An email address of a user to grant access to. For example: fred@example.com. Maps to IAM policy member \"user:EMAIL\" or \"serviceAccount:EMAIL\".",
+                "description": "[Pick one] An email address of a Google Group to grant access to. Maps to IAM policy member \"group:GROUP\".",
                 "type": "string"
               },
               "domain": {
+                "description": "[Pick one] A domain to grant access to. Any users signed in with the domain specified will be granted the specified access. Example: \"example.com\". Maps to IAM policy member \"domain:DOMAIN\".",
+                "type": "string"
+              },
+              "userByEmail": {
                 "type": "string",
-                "description": "[Pick one] A domain to grant access to. Any users signed in with the domain specified will be granted the specified access. Example: \"example.com\". Maps to IAM policy member \"domain:DOMAIN\"."
+                "description": "[Pick one] An email address of a user to grant access to. For example: fred@example.com. Maps to IAM policy member \"user:EMAIL\" or \"serviceAccount:EMAIL\"."
               },
               "iamMember": {
-                "type": "string",
-                "description": "[Pick one] Some other type of member that appears in the IAM Policy but isn't a user, group, domain, or special group."
+                "description": "[Pick one] Some other type of member that appears in the IAM Policy but isn't a user, group, domain, or special group.",
+                "type": "string"
               },
               "specialGroup": {
-                "description": "[Pick one] A special group to grant access to. Possible values include: projectOwners: Owners of the enclosing project. projectReaders: Readers of the enclosing project. projectWriters: Writers of the enclosing project. allAuthenticatedUsers: All authenticated BigQuery users. Maps to similarly-named IAM members.",
-                "type": "string"
-              },
-              "role": {
-                "description": "[Required] An IAM role ID that should be granted to the user, group, or domain specified in this access entry. The following legacy mappings will be applied: OWNER  roles/bigquery.dataOwner WRITER  roles/bigquery.dataEditor READER  roles/bigquery.dataViewer This field will accept any of the above formats, but will return only the legacy format. For example, if you set this field to \"roles/bigquery.dataOwner\", it will be returned back as \"OWNER\".",
-                "type": "string"
+                "type": "string",
+                "description": "[Pick one] A special group to grant access to. Possible values include: projectOwners: Owners of the enclosing project. projectReaders: Readers of the enclosing project. projectWriters: Writers of the enclosing project. allAuthenticatedUsers: All authenticated BigQuery users. Maps to similarly-named IAM members."
               }
             }
-          }
+          },
+          "description": "[Optional] An array of objects that define dataset access for one or more entities. You can set this property when inserting or updating a dataset in order to control who is allowed to access the data. If unspecified at dataset creation time, BigQuery adds default dataset access for the following entities: access.specialGroup: projectReaders; access.role: READER; access.specialGroup: projectWriters; access.role: WRITER; access.specialGroup: projectOwners; access.role: OWNER; access.userByEmail: [dataset creator email]; access.role: OWNER;"
         },
         "kind": {
           "description": "[Output-only] The resource type.",
@@ -4968,19 +3769,6 @@
         },
         "etag": {
           "description": "[Output-only] A hash of the resource.",
-          "type": "string"
-        },
-        "creationTime": {
-          "description": "[Output-only] The time when this dataset was created, in milliseconds since the epoch.",
-          "format": "int64",
-          "type": "string"
-        },
-        "datasetReference": {
-          "$ref": "DatasetReference",
-          "description": "[Required] A reference that identifies the dataset."
-        },
-        "id": {
-          "description": "[Output-only] The fully-qualified unique name of the dataset in the format projectId:datasetId. The dataset name without the project name is given in the datasetId field. When creating a new dataset, leave this field blank, and instead specify the datasetId field.",
           "type": "string"
         }
       },
@@ -5000,24 +3788,20 @@
           "type": "string"
         },
         "datasetId": {
-          "type": "string",
           "description": "[Required] A unique ID for this dataset, without the project name. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.",
           "annotations": {
             "required": [
               "bigquery.datasets.update"
             ]
-          }
+          },
+          "type": "string"
         }
       }
     },
     "JobStatistics3": {
+      "id": "JobStatistics3",
       "type": "object",
       "properties": {
-        "outputBytes": {
-          "type": "string",
-          "description": "[Output-only] Size of the loaded data in bytes. Note that while a load job is in the running state, this value may change.",
-          "format": "int64"
-        },
         "badRecords": {
           "description": "[Output-only] The number of bad records encountered. Note that if the job has failed because of more bad records encountered than the maximum allowed in the load job configuration, then this number can be less than the total number of bad records present in the input data.",
           "format": "int64",
@@ -5037,9 +3821,13 @@
           "description": "[Output-only] Number of rows imported in a load job. Note that while an import job is in the running state, this value may change.",
           "format": "int64",
           "type": "string"
+        },
+        "outputBytes": {
+          "description": "[Output-only] Size of the loaded data in bytes. Note that while a load job is in the running state, this value may change.",
+          "format": "int64",
+          "type": "string"
         }
-      },
-      "id": "JobStatistics3"
+      }
     },
     "HivePartitioningOptions": {
       "type": "object",
@@ -5049,16 +3837,1290 @@
           "type": "string"
         },
         "mode": {
-          "type": "string",
-          "description": "[Optional, Trusted Tester] When set, what mode of hive partitioning to use when reading data. Two modes are supported. (1) AUTO: automatically infer partition key name(s) and type(s). (2) STRINGS: automatically infer partition key name(s). All types are interpreted as strings. Not all storage formats support hive partitioning. Requesting hive partitioning on an unsupported format will lead to an error. Currently supported types include: AVRO, CSV, JSON, ORC and Parquet."
+          "description": "[Optional, Trusted Tester] When set, what mode of hive partitioning to use when reading data. Two modes are supported. (1) AUTO: automatically infer partition key name(s) and type(s). (2) STRINGS: automatically infer partition key name(s). All types are interpreted as strings. Not all storage formats support hive partitioning. Requesting hive partitioning on an unsupported format will lead to an error. Currently supported types include: AVRO, CSV, JSON, ORC and Parquet.",
+          "type": "string"
         }
       },
       "id": "HivePartitioningOptions"
+    },
+    "CategoryCount": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "The count of training samples matching the category within the\ncluster.",
+          "format": "int64",
+          "type": "string"
+        },
+        "category": {
+          "description": "The name of category.",
+          "type": "string"
+        }
+      },
+      "id": "CategoryCount",
+      "description": "Represents the count of a single category within the cluster."
+    },
+    "EvaluationMetrics": {
+      "id": "EvaluationMetrics",
+      "description": "Evaluation metrics of a model. These are either computed on all training\ndata or just the eval data based on whether eval data was used during\ntraining. These are not present for imported models.",
+      "type": "object",
+      "properties": {
+        "multiClassClassificationMetrics": {
+          "$ref": "MultiClassClassificationMetrics",
+          "description": "Populated for multi-class classification/classifier models."
+        },
+        "clusteringMetrics": {
+          "$ref": "ClusteringMetrics",
+          "description": "Populated for clustering models."
+        },
+        "binaryClassificationMetrics": {
+          "$ref": "BinaryClassificationMetrics",
+          "description": "Populated for binary classification/classifier models."
+        },
+        "regressionMetrics": {
+          "$ref": "RegressionMetrics",
+          "description": "Populated for regression models and explicit feedback type matrix\nfactorization models."
+        }
+      }
+    },
+    "StandardSqlField": {
+      "description": "A field or a column.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Optional. The name of this field. Can be absent for struct fields.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "StandardSqlDataType",
+          "description": "Optional. The type of this parameter. Absent if not explicitly\nspecified (e.g., CREATE FUNCTION statement can omit the return type;\nin this case the output parameter does not have this \"type\" field)."
+        }
+      },
+      "id": "StandardSqlField"
+    },
+    "TableCell": {
+      "type": "object",
+      "properties": {
+        "v": {
+          "type": "any"
+        }
+      },
+      "id": "TableCell"
+    },
+    "TableReference": {
+      "type": "object",
+      "properties": {
+        "datasetId": {
+          "description": "[Required] The ID of the dataset containing this table.",
+          "annotations": {
+            "required": [
+              "bigquery.tables.update"
+            ]
+          },
+          "type": "string"
+        },
+        "tableId": {
+          "description": "[Required] The ID of the table. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 1,024 characters.",
+          "annotations": {
+            "required": [
+              "bigquery.tables.update"
+            ]
+          },
+          "type": "string"
+        },
+        "projectId": {
+          "type": "string",
+          "description": "[Required] The ID of the project containing this table.",
+          "annotations": {
+            "required": [
+              "bigquery.tables.update"
+            ]
+          }
+        }
+      },
+      "id": "TableReference"
+    },
+    "StandardSqlStructType": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "StandardSqlField"
+          }
+        }
+      },
+      "id": "StandardSqlStructType"
+    },
+    "JobStatistics4": {
+      "id": "JobStatistics4",
+      "type": "object",
+      "properties": {
+        "inputBytes": {
+          "type": "string",
+          "description": "[Output-only] Number of user bytes extracted into the result. This is the byte count as computed by BigQuery for billing purposes.",
+          "format": "int64"
+        },
+        "destinationUriFileCounts": {
+          "description": "[Output-only] Number of files per destination URI or URI pattern specified in the extract configuration. These values will be in the same order as the URIs specified in the 'destinationUris' field.",
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ArimaResult": {
+      "id": "ArimaResult",
+      "description": "(Auto-)arima fitting result. Wrap everything in ArimaResult for easier\nrefactoring if we want to use model-specific iteration results.",
+      "type": "object",
+      "properties": {
+        "seasonalPeriods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "SEASONAL_PERIOD_TYPE_UNSPECIFIED",
+              "NO_SEASONALITY",
+              "DAILY",
+              "WEEKLY",
+              "MONTHLY",
+              "QUARTERLY",
+              "YEARLY"
+            ]
+          },
+          "enumDescriptions": [
+            "",
+            "No seasonality",
+            "Daily period, 24 hours.",
+            "Weekly period, 7 days.",
+            "Monthly period, can be as 30 days or irregular.",
+            "Quarterly period, can be as 90 days or irregular.",
+            "Yearly period, can be as 365 days or irregular."
+          ],
+          "description": "Seasonal periods. Repeated because multiple periods are supported for\none time series."
+        },
+        "arimaModelInfo": {
+          "description": "This message is repeated because there are multiple arima models\nfitted in auto-arima. For non-auto-arima model, its size is one.",
+          "type": "array",
+          "items": {
+            "$ref": "ArimaModelInfo"
+          }
+        }
+      }
+    },
+    "CsvOptions": {
+      "id": "CsvOptions",
+      "type": "object",
+      "properties": {
+        "fieldDelimiter": {
+          "type": "string",
+          "description": "[Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',')."
+        },
+        "encoding": {
+          "type": "string",
+          "description": "[Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties."
+        },
+        "allowQuotedNewlines": {
+          "description": "[Optional] Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.",
+          "type": "boolean"
+        },
+        "quote": {
+          "description": "[Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('\"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.",
+          "type": "string",
+          "default": "\"",
+          "pattern": ".?"
+        },
+        "skipLeadingRows": {
+          "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped. When autodetect is on, the behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N \u003e 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.",
+          "format": "int64",
+          "type": "string"
+        },
+        "allowJaggedRows": {
+          "description": "[Optional] Indicates if BigQuery should accept rows that are missing trailing optional columns. If true, BigQuery treats missing trailing columns as null values. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false.",
+          "type": "boolean"
+        }
+      }
+    },
+    "JobReference": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "description": "[Required] The ID of the job. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024 characters.",
+          "annotations": {
+            "required": [
+              "bigquery.jobs.getQueryResults"
+            ]
+          },
+          "type": "string"
+        },
+        "projectId": {
+          "description": "[Required] The ID of the project containing this job.",
+          "annotations": {
+            "required": [
+              "bigquery.jobs.getQueryResults"
+            ]
+          },
+          "type": "string"
+        },
+        "location": {
+          "type": "string",
+          "description": "The geographic location of the job. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location."
+        }
+      },
+      "id": "JobReference"
+    },
+    "JobConfigurationQuery": {
+      "type": "object",
+      "properties": {
+        "flattenResults": {
+          "description": "[Optional] If true and query uses legacy SQL dialect, flattens all nested and repeated fields in the query results. allowLargeResults must be true if this is set to false. For standard SQL queries, this flag is ignored and results are never flattened.",
+          "type": "boolean",
+          "default": "true"
+        },
+        "tableDefinitions": {
+          "additionalProperties": {
+            "$ref": "ExternalDataConfiguration"
+          },
+          "description": "[Optional] If querying an external data source outside of BigQuery, describes the data format, location and other properties of the data source. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.",
+          "type": "object"
+        },
+        "defaultDataset": {
+          "$ref": "DatasetReference",
+          "description": "[Optional] Specifies the default dataset to use for unqualified table names in the query. Note that this does not alter behavior of unqualified dataset names."
+        },
+        "maximumBillingTier": {
+          "description": "[Optional] Limits the billing tier for this job. Queries that have resource usage beyond this tier will fail (without incurring a charge). If unspecified, this will be set to your project default.",
+          "format": "int32",
+          "type": "integer",
+          "default": "1"
+        },
+        "preserveNulls": {
+          "description": "[Deprecated] This property is deprecated.",
+          "type": "boolean"
+        },
+        "timePartitioning": {
+          "description": "Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified.",
+          "$ref": "TimePartitioning"
+        },
+        "writeDisposition": {
+          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "query": {
+          "type": "string",
+          "description": "[Required] SQL query text to execute. The useLegacySql field can be used to indicate whether the query uses legacy SQL or standard SQL."
+        },
+        "userDefinedFunctionResources": {
+          "type": "array",
+          "items": {
+            "$ref": "UserDefinedFunctionResource"
+          },
+          "description": "Describes user-defined function resources used in the query."
+        },
+        "destinationTable": {
+          "$ref": "TableReference",
+          "description": "[Optional] Describes the table where the query results should be stored. If not present, a new table will be created to store the results. This property must be set for large results that exceed the maximum response size."
+        },
+        "queryParameters": {
+          "description": "Query parameters for standard SQL queries.",
+          "type": "array",
+          "items": {
+            "$ref": "QueryParameter"
+          }
+        },
+        "useLegacySql": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false."
+        },
+        "destinationEncryptionConfiguration": {
+          "description": "Custom encryption configuration (e.g., Cloud KMS keys).",
+          "$ref": "EncryptionConfiguration"
+        },
+        "clustering": {
+          "description": "[Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered.",
+          "$ref": "Clustering"
+        },
+        "createDisposition": {
+          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "maximumBytesBilled": {
+          "description": "[Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.",
+          "format": "int64",
+          "type": "string"
+        },
+        "schemaUpdateOptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable."
+        },
+        "priority": {
+          "description": "[Optional] Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.",
+          "type": "string"
+        },
+        "allowLargeResults": {
+          "description": "[Optional] If true and query uses legacy SQL dialect, allows the query to produce arbitrarily large result tables at a slight cost in performance. Requires destinationTable to be set. For standard SQL queries, this flag is ignored and large results are always allowed. However, you must still set destinationTable when result size exceeds the allowed maximum response size.",
+          "type": "boolean",
+          "default": "false"
+        },
+        "rangePartitioning": {
+          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified.",
+          "$ref": "RangePartitioning"
+        },
+        "parameterMode": {
+          "description": "Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.",
+          "type": "string"
+        },
+        "useQueryCache": {
+          "description": "[Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. Moreover, the query cache is only available when a query does not have a destination table specified. The default value is true.",
+          "type": "boolean",
+          "default": "true"
+        }
+      },
+      "id": "JobConfigurationQuery"
+    },
+    "QueryParameterType": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "[Required] The top level type of this field.",
+          "type": "string"
+        },
+        "structTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "[Optional] The name of this field.",
+                "type": "string"
+              },
+              "description": {
+                "description": "[Optional] Human-oriented description of the field.",
+                "type": "string"
+              },
+              "type": {
+                "description": "[Required] The type of this field.",
+                "$ref": "QueryParameterType"
+              }
+            }
+          },
+          "description": "[Optional] The types of the fields of this struct, in order, if this is a struct."
+        },
+        "arrayType": {
+          "description": "[Optional] The type of the array's elements, if this is an array.",
+          "$ref": "QueryParameterType"
+        }
+      },
+      "id": "QueryParameterType"
+    },
+    "BigQueryModelTraining": {
+      "id": "BigQueryModelTraining",
+      "type": "object",
+      "properties": {
+        "expectedTotalIterations": {
+          "type": "string",
+          "description": "[Output-only, Beta] Expected number of iterations for the create model query job specified as num_iterations in the input query. The actual total number of iterations may be less than this number due to early stop.",
+          "format": "int64"
+        },
+        "currentIteration": {
+          "description": "[Output-only, Beta] Index of current ML training iteration. Updated during create model query job to show job progress.",
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "LocationMetadata": {
+      "id": "LocationMetadata",
+      "description": "BigQuery-specific metadata about a location. This will be set on\ngoogle.cloud.location.Location.metadata in Cloud Location API\nresponses.",
+      "type": "object",
+      "properties": {
+        "legacyLocationId": {
+          "description": "The legacy BigQuery location ID, e.g. “EU” for the “europe” location.\nThis is for any API consumers that need the legacy “US” and “EU” locations.",
+          "type": "string"
+        }
+      }
+    },
+    "ProjectList": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token to request the next page of results."
+        },
+        "totalItems": {
+          "description": "The total number of projects in the list.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "kind": {
+          "type": "string",
+          "default": "bigquery#projectList",
+          "description": "The type of list."
+        },
+        "etag": {
+          "description": "A hash of the page of results",
+          "type": "string"
+        },
+        "projects": {
+          "description": "Projects to which you have at least READ access.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "friendlyName": {
+                "description": "A descriptive name for this project.",
+                "type": "string"
+              },
+              "numericId": {
+                "description": "The numeric ID of this project.",
+                "format": "uint64",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string",
+                "default": "bigquery#project",
+                "description": "The resource type."
+              },
+              "id": {
+                "type": "string",
+                "description": "An opaque ID of this project."
+              },
+              "projectReference": {
+                "$ref": "ProjectReference",
+                "description": "A unique reference to this project."
+              }
+            }
+          }
+        }
+      },
+      "id": "ProjectList"
+    },
+    "RoutineReference": {
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "description": "[Required] The ID of the project containing this routine.",
+          "type": "string"
+        },
+        "datasetId": {
+          "description": "[Required] The ID of the dataset containing this routine.",
+          "type": "string"
+        },
+        "routineId": {
+          "description": "[Required] The ID of the routine. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 256 characters.",
+          "type": "string"
+        }
+      },
+      "id": "RoutineReference"
+    },
+    "IterationResult": {
+      "description": "Information about a single iteration of the training run.",
+      "type": "object",
+      "properties": {
+        "durationMs": {
+          "type": "string",
+          "description": "Time taken to run the iteration in milliseconds.",
+          "format": "int64"
+        },
+        "arimaResult": {
+          "$ref": "ArimaResult"
+        },
+        "clusterInfos": {
+          "description": "Information about top clusters for clustering models.",
+          "type": "array",
+          "items": {
+            "$ref": "ClusterInfo"
+          }
+        },
+        "trainingLoss": {
+          "type": "number",
+          "description": "Loss computed on the training data at the end of iteration.",
+          "format": "double"
+        },
+        "evalLoss": {
+          "description": "Loss computed on the eval data at the end of iteration.",
+          "format": "double",
+          "type": "number"
+        },
+        "index": {
+          "description": "Index of the iteration, 0 based.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "learnRate": {
+          "description": "Learn rate used for this iteration.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "id": "IterationResult"
+    },
+    "JobCancelResponse": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "The resource type of the response.",
+          "type": "string",
+          "default": "bigquery#jobCancelResponse"
+        },
+        "job": {
+          "$ref": "Job",
+          "description": "The final state of the job."
+        }
+      },
+      "id": "JobCancelResponse"
+    },
+    "ProjectReference": {
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "type": "string",
+          "description": "[Required] ID of the project. Can be either the numeric ID or the assigned ID of the project."
+        }
+      },
+      "id": "ProjectReference"
+    },
+    "BigtableOptions": {
+      "type": "object",
+      "properties": {
+        "readRowkeyAsString": {
+          "description": "[Optional] If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.",
+          "type": "boolean"
+        },
+        "columnFamilies": {
+          "description": "[Optional] List of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.",
+          "type": "array",
+          "items": {
+            "$ref": "BigtableColumnFamily"
+          }
+        },
+        "ignoreUnspecifiedColumnFamilies": {
+          "description": "[Optional] If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.",
+          "type": "boolean"
+        }
+      },
+      "id": "BigtableOptions"
+    },
+    "ListRoutinesResponse": {
+      "type": "object",
+      "properties": {
+        "routines": {
+          "description": "Routines in the requested dataset. Unless read_mask is set in the request,\nonly the following fields are populated:\netag, project_id, dataset_id, routine_id, routine_type, creation_time,\nlast_modified_time, and language.",
+          "type": "array",
+          "items": {
+            "$ref": "Routine"
+          }
+        },
+        "nextPageToken": {
+          "description": "A token to request the next page of results.",
+          "type": "string"
+        }
+      },
+      "id": "ListRoutinesResponse"
+    },
+    "JobConfiguration": {
+      "type": "object",
+      "properties": {
+        "extract": {
+          "$ref": "JobConfigurationExtract",
+          "description": "[Pick one] Configures an extract job."
+        },
+        "copy": {
+          "$ref": "JobConfigurationTableCopy",
+          "description": "[Pick one] Copies a table."
+        },
+        "jobTimeoutMs": {
+          "description": "[Optional] Job timeout in milliseconds. If this time limit is exceeded, BigQuery may attempt to terminate the job.",
+          "format": "int64",
+          "type": "string"
+        },
+        "query": {
+          "$ref": "JobConfigurationQuery",
+          "description": "[Pick one] Configures a query job."
+        },
+        "dryRun": {
+          "description": "[Optional] If set, don't actually run this job. A valid query will return a mostly empty response with some processing statistics, while an invalid query will return the same error it would if it wasn't a dry run. Behavior of non-query jobs is undefined.",
+          "type": "boolean"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The labels associated with this job. You can use these to organize and group your jobs. Label keys and values can be no longer than 63 characters, can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and each label in the list must have a different key.",
+          "type": "object"
+        },
+        "load": {
+          "description": "[Pick one] Configures a load job.",
+          "$ref": "JobConfigurationLoad"
+        },
+        "jobType": {
+          "description": "[Output-only] The type of the job. Can be QUERY, LOAD, EXTRACT, COPY or UNKNOWN.",
+          "type": "string"
+        }
+      },
+      "id": "JobConfiguration"
+    },
+    "JsonObject": {
+      "id": "JsonObject",
+      "additionalProperties": {
+        "$ref": "JsonValue"
+      },
+      "description": "Represents a single JSON object.",
+      "type": "object"
+    },
+    "ExplainQueryStep": {
+      "type": "object",
+      "properties": {
+        "substeps": {
+          "description": "Human-readable stage descriptions.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "Machine-readable operation type."
+        }
+      },
+      "id": "ExplainQueryStep"
+    },
+    "Argument": {
+      "type": "object",
+      "properties": {
+        "argumentKind": {
+          "description": "Optional. Defaults to FIXED_TYPE.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "The argument is a variable with fully specified type, which can be a\nstruct or an array, but not a table.",
+            "The argument is any type, including struct or array, but not a table.\nTo be added: FIXED_TABLE, ANY_TABLE"
+          ],
+          "enum": [
+            "ARGUMENT_KIND_UNSPECIFIED",
+            "FIXED_TYPE",
+            "ANY_TYPE"
+          ]
+        },
+        "mode": {
+          "description": "Optional. Specifies whether the argument is input or output.\nCan be set for procedures only.",
+          "type": "string",
+          "enumDescriptions": [
+            "",
+            "The argument is input-only.",
+            "The argument is output-only.",
+            "The argument is both an input and an output."
+          ],
+          "enum": [
+            "MODE_UNSPECIFIED",
+            "IN",
+            "OUT",
+            "INOUT"
+          ]
+        },
+        "dataType": {
+          "$ref": "StandardSqlDataType",
+          "description": "Required unless argument_kind = ANY_TYPE."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional. The name of this argument. Can be absent for function return argument."
+        }
+      },
+      "id": "Argument",
+      "description": "Input/output argument of a function or a stored procedure."
+    },
+    "DatasetList": {
+      "type": "object",
+      "properties": {
+        "datasets": {
+          "description": "An array of the dataset resources in the project. Each resource contains basic information. For full information about a particular dataset resource, use the Datasets: get method. This property is omitted when there are no datasets in the project.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The fully-qualified, unique, opaque ID of the dataset.",
+                "type": "string"
+              },
+              "location": {
+                "type": "string",
+                "description": "The geographic location where the data resides."
+              },
+              "friendlyName": {
+                "description": "A descriptive name for the dataset, if one exists.",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string",
+                "default": "bigquery#dataset",
+                "description": "The resource type. This property always returns the value \"bigquery#dataset\"."
+              },
+              "labels": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "The labels associated with this dataset. You can use these to organize and group your datasets."
+              },
+              "datasetReference": {
+                "description": "The dataset reference. Use this property to access specific parts of the dataset's ID, such as project ID or dataset ID.",
+                "$ref": "DatasetReference"
+              }
+            }
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token that can be used to request the next results page. This property is omitted on the final results page."
+        },
+        "kind": {
+          "description": "The list type. This property always returns the value \"bigquery#datasetList\".",
+          "type": "string",
+          "default": "bigquery#datasetList"
+        },
+        "etag": {
+          "type": "string",
+          "description": "A hash value of the results page. You can use this property to determine if the page has changed since the last request."
+        }
+      },
+      "id": "DatasetList"
+    },
+    "JobConfigurationTableCopy": {
+      "type": "object",
+      "properties": {
+        "destinationEncryptionConfiguration": {
+          "description": "Custom encryption configuration (e.g., Cloud KMS keys).",
+          "$ref": "EncryptionConfiguration"
+        },
+        "sourceTables": {
+          "description": "[Pick one] Source tables to copy.",
+          "type": "array",
+          "items": {
+            "$ref": "TableReference"
+          }
+        },
+        "createDisposition": {
+          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "sourceTable": {
+          "$ref": "TableReference",
+          "description": "[Pick one] Source table to copy."
+        },
+        "writeDisposition": {
+          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "destinationTable": {
+          "$ref": "TableReference",
+          "description": "[Required] The destination table"
+        }
+      },
+      "id": "JobConfigurationTableCopy"
+    },
+    "BinaryConfusionMatrix": {
+      "type": "object",
+      "properties": {
+        "falsePositives": {
+          "description": "Number of false samples predicted as true.",
+          "format": "int64",
+          "type": "string"
+        },
+        "trueNegatives": {
+          "type": "string",
+          "description": "Number of true samples predicted as false.",
+          "format": "int64"
+        },
+        "f1Score": {
+          "description": "The equally weighted average of recall and precision.",
+          "format": "double",
+          "type": "number"
+        },
+        "precision": {
+          "type": "number",
+          "description": "The fraction of actual positive predictions that had positive actual\nlabels.",
+          "format": "double"
+        },
+        "positiveClassThreshold": {
+          "description": "Threshold value used when computing each of the following metric.",
+          "format": "double",
+          "type": "number"
+        },
+        "accuracy": {
+          "description": "The fraction of predictions given the correct label.",
+          "format": "double",
+          "type": "number"
+        },
+        "truePositives": {
+          "description": "Number of true samples predicted as true.",
+          "format": "int64",
+          "type": "string"
+        },
+        "recall": {
+          "type": "number",
+          "description": "The fraction of actual positive labels that were given a positive\nprediction.",
+          "format": "double"
+        },
+        "falseNegatives": {
+          "description": "Number of false samples predicted as false.",
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "id": "BinaryConfusionMatrix",
+      "description": "Confusion matrix for binary classification models."
+    },
+    "QueryTimelineSample": {
+      "id": "QueryTimelineSample",
+      "type": "object",
+      "properties": {
+        "totalSlotMs": {
+          "type": "string",
+          "description": "Cumulative slot-ms consumed by the query.",
+          "format": "int64"
+        },
+        "activeUnits": {
+          "description": "Total number of units currently being processed by workers. This does not correspond directly to slot usage. This is the largest value observed since the last sample.",
+          "format": "int64",
+          "type": "string"
+        },
+        "completedUnits": {
+          "description": "Total parallel units of work completed by this query.",
+          "format": "int64",
+          "type": "string"
+        },
+        "elapsedMs": {
+          "description": "Milliseconds elapsed since the start of query execution.",
+          "format": "int64",
+          "type": "string"
+        },
+        "pendingUnits": {
+          "type": "string",
+          "description": "Total parallel units of work remaining for the active stages.",
+          "format": "int64"
+        }
+      }
+    },
+    "QueryRequest": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "The resource type of the request.",
+          "type": "string",
+          "default": "bigquery#queryRequest"
+        },
+        "timeoutMs": {
+          "description": "[Optional] How long to wait for the query to complete, in milliseconds, before the request times out and returns. Note that this is only a timeout for the request, not the query. If the query takes longer to run than the timeout value, the call returns without any results and with the 'jobComplete' flag set to false. You can call GetQueryResults() to wait for the query to complete and read the results. The default value is 10000 milliseconds (10 seconds).",
+          "format": "uint32",
+          "type": "integer"
+        },
+        "parameterMode": {
+          "description": "Standard SQL only. Set to POSITIONAL to use positional (?) query parameters or to NAMED to use named (@myparam) query parameters in this query.",
+          "type": "string"
+        },
+        "useQueryCache": {
+          "description": "[Optional] Whether to look for the result in the query cache. The query cache is a best-effort cache that will be flushed whenever tables in the query are modified. The default value is true.",
+          "type": "boolean",
+          "default": "true"
+        },
+        "defaultDataset": {
+          "$ref": "DatasetReference",
+          "description": "[Optional] Specifies the default datasetId and projectId to assume for any unqualified table names in the query. If not set, all table names in the query string must be qualified in the format 'datasetId.tableId'."
+        },
+        "location": {
+          "description": "The geographic location where the job should run. See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location.",
+          "type": "string"
+        },
+        "preserveNulls": {
+          "description": "[Deprecated] This property is deprecated.",
+          "type": "boolean"
+        },
+        "query": {
+          "description": "[Required] A query string, following the BigQuery query syntax, of the query to execute. Example: \"SELECT count(f1) FROM [myProjectId:myDatasetId.myTableId]\".",
+          "annotations": {
+            "required": [
+              "bigquery.jobs.query"
+            ]
+          },
+          "type": "string"
+        },
+        "maxResults": {
+          "type": "integer",
+          "description": "[Optional] The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.",
+          "format": "uint32"
+        },
+        "dryRun": {
+          "description": "[Optional] If set to true, BigQuery doesn't run the job. Instead, if the query is valid, BigQuery returns statistics about the job such as how many bytes would be processed. If the query is invalid, an error returns. The default value is false.",
+          "type": "boolean"
+        },
+        "queryParameters": {
+          "description": "Query parameters for Standard SQL queries.",
+          "type": "array",
+          "items": {
+            "$ref": "QueryParameter"
+          }
+        },
+        "useLegacySql": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the value of flattenResults is ignored; query will be run as if flattenResults is false."
+        }
+      },
+      "id": "QueryRequest"
+    },
+    "ErrorProto": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "description": "A short error code that summarizes the error.",
+          "type": "string"
+        },
+        "message": {
+          "description": "A human-readable description of the error.",
+          "type": "string"
+        },
+        "location": {
+          "description": "Specifies where the error occurred, if present.",
+          "type": "string"
+        },
+        "debugInfo": {
+          "type": "string",
+          "description": "Debugging information. This property is internal to Google and should not be used."
+        }
+      },
+      "id": "ErrorProto"
+    },
+    "BinaryClassificationMetrics": {
+      "type": "object",
+      "properties": {
+        "binaryConfusionMatrixList": {
+          "description": "Binary confusion matrix at multiple thresholds.",
+          "type": "array",
+          "items": {
+            "$ref": "BinaryConfusionMatrix"
+          }
+        },
+        "aggregateClassificationMetrics": {
+          "$ref": "AggregateClassificationMetrics",
+          "description": "Aggregate classification metrics."
+        },
+        "negativeLabel": {
+          "description": "Label representing the negative class.",
+          "type": "string"
+        },
+        "positiveLabel": {
+          "description": "Label representing the positive class.",
+          "type": "string"
+        }
+      },
+      "id": "BinaryClassificationMetrics",
+      "description": "Evaluation metrics for binary classification/classifier models."
+    },
+    "RangePartitioning": {
+      "type": "object",
+      "properties": {
+        "range": {
+          "description": "[TrustedTester] [Required] Defines the ranges for range partitioning.",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "description": "[TrustedTester] [Required] The width of each interval.",
+              "format": "int64",
+              "type": "string"
+            },
+            "start": {
+              "description": "[TrustedTester] [Required] The start of range partitioning, inclusive.",
+              "format": "int64",
+              "type": "string"
+            },
+            "end": {
+              "description": "[TrustedTester] [Required] The end of range partitioning, exclusive.",
+              "format": "int64",
+              "type": "string"
+            }
+          }
+        },
+        "field": {
+          "description": "[TrustedTester] [Required] The table is partitioned by this field. The field must be a top-level NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.",
+          "type": "string"
+        }
+      },
+      "id": "RangePartitioning"
+    },
+    "JobConfigurationLoad": {
+      "type": "object",
+      "properties": {
+        "schemaInline": {
+          "description": "[Deprecated] The inline schema. For CSV schemas, specify as \"Field1:Type1[,Field2:Type2]*\". For example, \"foo:STRING, bar:INTEGER, baz:FLOAT\".",
+          "type": "string"
+        },
+        "rangePartitioning": {
+          "$ref": "RangePartitioning",
+          "description": "[TrustedTester] Range partitioning specification for this table. Only one of timePartitioning and rangePartitioning should be specified."
+        },
+        "nullMarker": {
+          "description": "[Optional] Specifies a string that represents a null value in a CSV file. For example, if you specify \"\\N\", BigQuery interprets \"\\N\" as a null value when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as an empty value.",
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "TableSchema",
+          "description": "[Optional] The schema for the destination table. The schema can be omitted if the destination table already exists, or if you're loading data from Google Cloud Datastore."
+        },
+        "schemaInlineFormat": {
+          "description": "[Deprecated] The format of the schemaInline property.",
+          "type": "string"
+        },
+        "quote": {
+          "description": "[Optional] The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('\"'). If your data does not contain quoted sections, set the property value to an empty string. If your data contains quoted newline characters, you must also set the allowQuotedNewlines property to true.",
+          "type": "string",
+          "default": "\"",
+          "pattern": ".?"
+        },
+        "writeDisposition": {
+          "description": "[Optional] Specifies the action that occurs if the destination table already exists. The following values are supported: WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data. WRITE_APPEND: If the table already exists, BigQuery appends the data to the table. WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result. The default value is WRITE_APPEND. Each action is atomic and only occurs if BigQuery is able to complete the job successfully. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "destinationTableProperties": {
+          "description": "[Beta] [Optional] Properties with which to create the destination table if it is new.",
+          "$ref": "DestinationTableProperties"
+        },
+        "sourceFormat": {
+          "type": "string",
+          "description": "[Optional] The format of the data files. For CSV files, specify \"CSV\". For datastore backups, specify \"DATASTORE_BACKUP\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". For Avro, specify \"AVRO\". For parquet, specify \"PARQUET\". For orc, specify \"ORC\". The default value is CSV."
+        },
+        "ignoreUnknownValues": {
+          "description": "[Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names",
+          "type": "boolean"
+        },
+        "destinationTable": {
+          "description": "[Required] The destination table to load the data into.",
+          "$ref": "TableReference"
+        },
+        "encoding": {
+          "description": "[Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split using the values of the quote and fieldDelimiter properties.",
+          "type": "string"
+        },
+        "clustering": {
+          "$ref": "Clustering",
+          "description": "[Beta] Clustering specification for the destination table. Must be specified with time-based partitioning, data in the table will be first partitioned and subsequently clustered."
+        },
+        "hivePartitioningMode": {
+          "description": "[Optional, Trusted Tester] Deprecated, do not use. Please set hivePartitioningOptions instead.",
+          "type": "string"
+        },
+        "createDisposition": {
+          "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion.",
+          "type": "string"
+        },
+        "maxBadRecords": {
+          "type": "integer",
+          "description": "[Optional] The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value, an invalid error is returned in the job result. This is only valid for CSV and JSON. The default value is 0, which requires that all records are valid.",
+          "format": "int32"
+        },
+        "sourceUris": {
+          "description": "[Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups: Exactly one URI can be specified. Also, the '*' wildcard character is not allowed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowJaggedRows": {
+          "description": "[Optional] Accept rows that are missing trailing optional columns. The missing values are treated as nulls. If false, records with missing trailing columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. Only applicable to CSV, ignored for other formats.",
+          "type": "boolean"
+        },
+        "fieldDelimiter": {
+          "description": "[Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',').",
+          "type": "string"
+        },
+        "projectionFields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "If sourceFormat is set to \"DATASTORE_BACKUP\", indicates which entity properties to load into BigQuery from a Cloud Datastore backup. Property names are case sensitive and must be top-level properties. If no properties are specified, BigQuery loads all properties. If any named property isn't found in the Cloud Datastore backup, an invalid error is returned in the job result."
+        },
+        "allowQuotedNewlines": {
+          "description": "Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false.",
+          "type": "boolean"
+        },
+        "useAvroLogicalTypes": {
+          "description": "[Optional] If sourceFormat is set to \"AVRO\", indicates whether to enable interpreting logical types into their corresponding types (ie. TIMESTAMP), instead of only using their raw types (ie. INTEGER).",
+          "type": "boolean"
+        },
+        "hivePartitioningOptions": {
+          "description": "[Optional, Trusted Tester] Options to configure hive partitioning support.",
+          "$ref": "HivePartitioningOptions"
+        },
+        "timePartitioning": {
+          "$ref": "TimePartitioning",
+          "description": "Time-based partitioning specification for the destination table. Only one of timePartitioning and rangePartitioning should be specified."
+        },
+        "skipLeadingRows": {
+          "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "autodetect": {
+          "type": "boolean",
+          "description": "[Optional] Indicates if we should automatically infer the options and schema for CSV and JSON sources."
+        },
+        "destinationEncryptionConfiguration": {
+          "$ref": "EncryptionConfiguration",
+          "description": "Custom encryption configuration (e.g., Cloud KMS keys)."
+        },
+        "schemaUpdateOptions": {
+          "description": "Allows the schema of the destination table to be updated as a side effect of the load job if a schema is autodetected or supplied in the job configuration. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "JobConfigurationLoad"
+    },
+    "TableDataInsertAllRequest": {
+      "type": "object",
+      "properties": {
+        "ignoreUnknownValues": {
+          "description": "[Optional] Accept rows that contain values that do not match the schema. The unknown values are ignored. Default is false, which treats unknown values as errors.",
+          "type": "boolean"
+        },
+        "skipInvalidRows": {
+          "type": "boolean",
+          "description": "[Optional] Insert all valid rows of a request, even if invalid rows exist. The default value is false, which causes the entire request to fail if any invalid rows exist."
+        },
+        "rows": {
+          "description": "The rows to insert.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "insertId": {
+                "type": "string",
+                "description": "[Optional] A unique ID for each row. BigQuery uses this property to detect duplicate insertion requests on a best-effort basis."
+              },
+              "json": {
+                "$ref": "JsonObject",
+                "description": "[Required] A JSON object that contains a row of data. The object's properties and values must match the destination table's schema."
+              }
+            }
+          }
+        },
+        "kind": {
+          "type": "string",
+          "default": "bigquery#tableDataInsertAllRequest",
+          "description": "The resource type of the response."
+        },
+        "templateSuffix": {
+          "type": "string",
+          "description": "If specified, treats the destination table as a base template, and inserts the rows into an instance table named \"{destination}{templateSuffix}\". BigQuery will manage creation of the instance table, using the schema of the base template table. See https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables for considerations when working with templates tables."
+        }
+      },
+      "id": "TableDataInsertAllRequest"
+    },
+    "TableList": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token to request the next page of results.",
+          "type": "string"
+        },
+        "totalItems": {
+          "description": "The total number of tables in the dataset.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "kind": {
+          "description": "The type of list.",
+          "type": "string",
+          "default": "bigquery#tableList"
+        },
+        "tables": {
+          "description": "Tables in the requested dataset.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "expirationTime": {
+                "description": "[Optional] The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed.",
+                "format": "int64",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The resource type.",
+                "type": "string",
+                "default": "bigquery#table"
+              },
+              "view": {
+                "description": "Additional details for a view.",
+                "type": "object",
+                "properties": {
+                  "useLegacySql": {
+                    "description": "True if view is defined in legacy SQL dialect, false if in standard SQL.",
+                    "type": "boolean"
+                  }
+                }
+              },
+              "creationTime": {
+                "description": "The time when this table was created, in milliseconds since the epoch.",
+                "format": "int64",
+                "type": "string"
+              },
+              "rangePartitioning": {
+                "$ref": "RangePartitioning",
+                "description": "The range partitioning specification for this table, if configured."
+              },
+              "id": {
+                "type": "string",
+                "description": "An opaque ID of the table"
+              },
+              "tableReference": {
+                "$ref": "TableReference",
+                "description": "A reference uniquely identifying the table."
+              },
+              "friendlyName": {
+                "description": "The user-friendly name for this table.",
+                "type": "string"
+              },
+              "timePartitioning": {
+                "$ref": "TimePartitioning",
+                "description": "The time-based partitioning specification for this table, if configured."
+              },
+              "labels": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "The labels associated with this table. You can use these to organize and group your tables."
+              },
+              "type": {
+                "description": "The type of table. Possible values are: TABLE, VIEW.",
+                "type": "string"
+              },
+              "clustering": {
+                "$ref": "Clustering",
+                "description": "[Beta] Clustering specification for this table, if configured."
+              }
+            }
+          }
+        },
+        "etag": {
+          "description": "A hash of this page of results.",
+          "type": "string"
+        }
+      },
+      "id": "TableList"
     }
   },
   "icons": {
-    "x32": "https://www.google.com/images/icons/product/search-32.gif",
-    "x16": "https://www.google.com/images/icons/product/search-16.gif"
+    "x16": "https://www.google.com/images/icons/product/search-16.gif",
+    "x32": "https://www.google.com/images/icons/product/search-32.gif"
   },
   "protocol": "rest",
   "version": "v2",
@@ -5066,18 +5128,6 @@
   "auth": {
     "oauth2": {
       "scopes": {
-        "https://www.googleapis.com/auth/devstorage.full_control": {
-          "description": "Manage your data and permissions in Google Cloud Storage"
-        },
-        "https://www.googleapis.com/auth/devstorage.read_only": {
-          "description": "View your data in Google Cloud Storage"
-        },
-        "https://www.googleapis.com/auth/devstorage.read_write": {
-          "description": "Manage your data in Google Cloud Storage"
-        },
-        "https://www.googleapis.com/auth/bigquery": {
-          "description": "View and manage your data in Google BigQuery"
-        },
         "https://www.googleapis.com/auth/cloud-platform.read-only": {
           "description": "View your data across Google Cloud Platform services"
         },
@@ -5089,21 +5139,33 @@
         },
         "https://www.googleapis.com/auth/bigquery.readonly": {
           "description": "View your data in Google BigQuery"
+        },
+        "https://www.googleapis.com/auth/devstorage.full_control": {
+          "description": "Manage your data and permissions in Google Cloud Storage"
+        },
+        "https://www.googleapis.com/auth/devstorage.read_only": {
+          "description": "View your data in Google Cloud Storage"
+        },
+        "https://www.googleapis.com/auth/devstorage.read_write": {
+          "description": "Manage your data in Google Cloud Storage"
+        },
+        "https://www.googleapis.com/auth/bigquery": {
+          "description": "View and manage your data in Google BigQuery"
         }
       }
     }
   },
-  "kind": "discovery#restDescription",
   "description": "A data platform for customers to create, manage, share and query data.",
   "servicePath": "bigquery/v2/",
+  "kind": "discovery#restDescription",
   "rootUrl": "https://bigquery.googleapis.com/",
   "basePath": "/bigquery/v2/",
   "ownerDomain": "google.com",
   "name": "bigquery",
   "batchPath": "batch/bigquery/v2",
-  "revision": "20191003",
-  "id": "bigquery:v2",
+  "revision": "20200121",
   "documentationLink": "https://cloud.google.com/bigquery/",
+  "id": "bigquery:v2",
   "title": "BigQuery API",
   "discoveryVersion": "v1",
   "ownerName": "Google"

--- a/BigQuery/src/Dataset.php
+++ b/BigQuery/src/Dataset.php
@@ -494,11 +494,7 @@ class Dataset
      *        [Routine Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/routines#resource).
      *        Omit `routineReference` as it is computed and appended by the
      *        client.
-     * @param array $options [optional] {
-     *     Configuration options.
-     *
-     *     @type
-     * }
+     * @param array $options [optional] Configuration options.
      * @return Routine
      */
     public function createRoutine($id, array $metadata, array $options = [])

--- a/BigQuery/src/Dataset.php
+++ b/BigQuery/src/Dataset.php
@@ -305,82 +305,6 @@ class Dataset
     }
 
     /**
-     * Retrieves the dataset's details. If no dataset data is cached a network
-     * request will be made to retrieve it.
-     *
-     * Example:
-     * ```
-     * $info = $dataset->info();
-     * echo $info['selfLink'];
-     * ```
-     *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource Datasets resource documentation.
-     *
-     * @param array $options [optional] Configuration options.
-     * @return array
-     */
-    public function info(array $options = [])
-    {
-        if (!$this->info) {
-            $this->reload($options);
-        }
-
-        return $this->info;
-    }
-
-    /**
-     * Triggers a network request to reload the dataset's details.
-     *
-     * Example:
-     * ```
-     * $dataset->reload();
-     * $info = $dataset->info();
-     * echo $info['selfLink'];
-     * ```
-     *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/get Datasets get API documentation.
-     *
-     * @param array $options [optional] Configuration options.
-     * @return array
-     */
-    public function reload(array $options = [])
-    {
-        return $this->info = $this->connection->getDataset($options + $this->identity);
-    }
-
-    /**
-     * Retrieves the dataset's ID.
-     *
-     * Example:
-     * ```
-     * echo $dataset->id();
-     * ```
-     *
-     * @return string
-     */
-    public function id()
-    {
-        return $this->identity['datasetId'];
-    }
-
-    /**
-     * Retrieves the dataset's identity.
-     *
-     * An identity provides a description of a resource that is nested in nature.
-     *
-     * Example:
-     * ```
-     * echo $dataset->identity()['projectId'];
-     * ```
-     *
-     * @return array
-     */
-    public function identity()
-    {
-        return $this->identity;
-    }
-
-    /**
      * Lazily instantiates a machine learning model in the dataset. There are no
      * network requests made at this point. To see the operations that can be performed on a
      * model, please see {@see Google\Cloud\BigQuery\Model}.
@@ -456,5 +380,216 @@ class Dataset
                 ]
             )
         );
+    }
+
+    /**
+     * Lazily instantiates a routine.
+     *
+     * There are no network requests made at this point. To see the operations
+     * that can be performed on a routine, please see
+     * {@see Google\Cloud\BigQuery\Routine}.
+     *
+     * Example:
+     * ```
+     * $routine = $dataset->routine('my_routine');
+     * echo $routine->identity()['routineId'];
+     * ```
+     *
+     * @param string $id The routine's ID.
+     * @param array $info [optional] The routine resource data.
+     * @return Routine
+     */
+    public function routine($id, array $info = [])
+    {
+        return new Routine(
+            $this->connection,
+            $id,
+            $this->identity['datasetId'],
+            $this->identity['projectId'],
+            $info
+        );
+    }
+
+    /**
+     * Fetches all of the routines in the dataset.
+     *
+     * Please note that Routine instances obtained from this method contain only a
+     * subset of the resource representation. Fields returned include `etag`,
+     * `projectId`, `datasetId`, `routineId`, `routineType`, `creationTime`,
+     * `lastModifiedTime` and `language`. To obtain a full representation, call
+     * {@see Google\Cloud\BigQuery\Routine::reload()}.
+     *
+     * Example:
+     * ```
+     * $routines = $dataset->routines();
+     *
+     * foreach ($routines as $routine) {
+     *     echo $routine->identity()['routineId'] . PHP_EOL;
+     * }
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/routines/list List Routines API documentation.
+     *
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type int $maxResults Maximum number of results to return per page.
+     *     @type int $resultLimit Limit the number of results returned in total.
+     *           **Defaults to** `0` (return all results).
+     *     @type string $pageToken A previously-returned page token used to
+     *           resume the loading of results from a specific point.
+     * }
+     * @return ItemIterator<Model>
+     */
+    public function routines(array $options = [])
+    {
+        $resultLimit = $this->pluck('resultLimit', $options, false);
+
+        return new ItemIterator(
+            new PageIterator(
+                function (array $routine) {
+                    return $this->routine($routine['routineReference']['routineId'], $routine);
+                },
+                [$this->connection, 'listRoutines'],
+                $this->identity + $options,
+                [
+                    'itemsKey' => 'routines',
+                    'resultLimit' => $resultLimit
+                ]
+            )
+        );
+    }
+
+    /**
+     * Creates a routine.
+     *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
+     * Example:
+     * ```
+     * $routine = $dataset->createRoutine('my_routine', [
+     *     'routineType' => 'SCALAR_FUNCTION',
+     *     'definitionBody' => 'concat(x, "\n", y)',
+     *     'arguments' => [
+     *         [
+     *             'name' => 'x',
+     *             'dataType' => [
+     *                 'typeKind' => 'STRING'
+     *             ]
+     *         ], [
+     *             'name' => 'y',
+     *             'dataType' => [
+     *                 'typeKind' => 'STRING'
+     *             ]
+     *         ]
+     *     ]
+     * ]);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/routines/insert Insert Routines API documentation.
+     *
+     * @param string $id The routine ID.
+     * @param array $metadata The available options for metadata are outlined at the
+     *        [Routine Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/routines#resource).
+     *        Omit `routineReference` as it is computed and appended by the
+     *        client.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type
+     * }
+     * @return Routine
+     */
+    public function createRoutine($id, array $metadata, array $options = [])
+    {
+        $metadata = [
+            'routineReference' => $this->identity + ['routineId' => $id]
+        ] + $metadata;
+
+        $response = $this->connection->insertRoutine(
+            $this->identity
+            + $metadata
+            + ['retries' => 0]
+            + $options
+        );
+
+        return $this->routine($id, $response);
+    }
+
+    /**
+     * Retrieves the dataset's details. If no dataset data is cached a network
+     * request will be made to retrieve it.
+     *
+     * Example:
+     * ```
+     * $info = $dataset->info();
+     * echo $info['selfLink'];
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource Datasets resource documentation.
+     *
+     * @param array $options [optional] Configuration options.
+     * @return array
+     */
+    public function info(array $options = [])
+    {
+        if (!$this->info) {
+            $this->reload($options);
+        }
+
+        return $this->info;
+    }
+
+    /**
+     * Triggers a network request to reload the dataset's details.
+     *
+     * Example:
+     * ```
+     * $dataset->reload();
+     * $info = $dataset->info();
+     * echo $info['selfLink'];
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/get Datasets get API documentation.
+     *
+     * @param array $options [optional] Configuration options.
+     * @return array
+     */
+    public function reload(array $options = [])
+    {
+        return $this->info = $this->connection->getDataset($options + $this->identity);
+    }
+
+    /**
+     * Retrieves the dataset's ID.
+     *
+     * Example:
+     * ```
+     * echo $dataset->id();
+     * ```
+     *
+     * @return string
+     */
+    public function id()
+    {
+        return $this->identity['datasetId'];
+    }
+
+    /**
+     * Retrieves the dataset's identity.
+     *
+     * An identity provides a description of a resource that is nested in nature.
+     *
+     * Example:
+     * ```
+     * echo $dataset->identity()['projectId'];
+     * ```
+     *
+     * @return array
+     */
+    public function identity()
+    {
+        return $this->identity;
     }
 }

--- a/BigQuery/src/Dataset.php
+++ b/BigQuery/src/Dataset.php
@@ -506,8 +506,8 @@ class Dataset
         $response = $this->connection->insertRoutine(
             $this->identity
             + $metadata
-            + ['retries' => 0]
             + $options
+            + ['retries' => 0]
         );
 
         return $this->routine($id, $response);

--- a/BigQuery/src/Routine.php
+++ b/BigQuery/src/Routine.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\ConcurrencyControlTrait;
+use Google\Cloud\Core\Exception\NotFoundException;
+
+/**
+ * [Routines](https://cloud.google.com/bigquery/docs/reference/rest/v2/routines)
+ * are used-defined functions or stored procedures.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigquery = new BigQueryClient();
+ * $dataset = $bigquery->dataset('my_dataset');
+ * $routine = $dataset->routine('my_routine');
+ * ```
+ */
+class Routine
+{
+    use ArrayTrait;
+    use ConcurrencyControlTrait;
+
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $identity;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * @param ConnectionInterface $connection A connection to the BigQuery API.
+     * @param string $id The routine ID.
+     * @param string $datasetId The dataset ID.
+     * @param string $projectId The project ID.
+     * @param array $info [optional] An optional representation of the routine
+     *        resource.
+     */
+    public function __construct(ConnectionInterface $connection, $id, $datasetId, $projectId, array $info = [])
+    {
+        $this->connection = $connection;
+        $this->identity = [
+            'routineId' => $id,
+            'datasetId' => $datasetId,
+            'projectId' => $projectId
+        ];
+        $this->info = $info;
+    }
+
+    /**
+     * Get the routine identity.
+     *
+     * An identity provides a description of a nested resource.
+     *
+     * Example:
+     * ```
+     * $identity = $routine->identity();
+     * echo $identity['routineId'];
+     * ```
+     *
+     * @return array
+     */
+    public function identity()
+    {
+        return $this->identity;
+    }
+
+    /**
+     * Return the routine resource.
+     *
+     * If the value is not already cached, a service call will be made. To force
+     * a refresh of the cached value, use
+     * {@see Google\Cloud\BigQuery\Routine::reload()}.
+     *
+     * Example:
+     * ```
+     * $res = $routine->info();
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/get Get Routines API documentation.
+     * @param array $options [optional] Configuration options
+     * @return array
+     */
+    public function info(array $options = [])
+    {
+        return $this->info ?: $this->reload($options);
+    }
+
+    /**
+     * Fetch the routine resource from the API.
+     *
+     * This method will always trigger a service request. To make use of a
+     * cached representation of the resource, see
+     * {@see Google\Cloud\BigQuery\Routine::info()}.
+     *
+     * Example:
+     * ```
+     * $res = $routine->reload();
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/get Get Routines API documentation.
+     * @param array $options [optional] Configuration options
+     * @return array
+     */
+    public function reload(array $options = [])
+    {
+        return $this->info = $this->connection->getRoutine($this->identity + $options);
+    }
+
+    /**
+     * Check whether or not the routine exists.
+     *
+     * Example:
+     * ```
+     * if ($routine->exists()) {
+     *     echo 'Routine exists!';
+     * }
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/get Get Routines API documentation.
+     * @param array $options [optional] Configuration options.
+     * @return bool
+     */
+    public function exists(array $options = [])
+    {
+        try {
+            $this->reload($options);
+        } catch (NotFoundException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Update information in an existing routine.
+     *
+     * Providing an `etag` key as part of `$metadata` will enable simultaneous
+     * update protection. This is useful in preventing override of modifications
+     * made by another user. The resource's current etag can be obtained via a
+     * GET request on the resource.
+     *
+     * Please note that by default the library will not automatically retry this
+     * call on your behalf unless an `etag` is set.
+     *
+     * Please note that in order to implement partial updates, this method will
+     * trigger two service calls: the first to fetch the most up-to-date version
+     * of the resource and the second to apply the update.
+     *
+     * Example:
+     * ```
+     * $routine->update([
+     *     'definitionBody' => 'CONCAT(x, "\n", y)'
+     * ]);
+     * ```
+     *
+     * ```
+     * // Using update masks to limit modified fields
+     * $newData = [
+     *     'displayName' => 'My Function',
+     *     'definitionBody' => 'return x + y;',
+     *     'language' => 'JAVASCRIPT'
+     * ];
+     *
+     * // Update the routine, excluding 'displayName' from updating.
+     * $routine->update($newData, [
+     *     'updateMask' => [
+     *         'definitionBody',
+     *         'language'
+     *     ]
+     * ]);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/update Update Routines API documentation.
+     * @param array $metadata The full routine resource with desired
+     *        modifications.
+     * @param array $options [optional] {
+     *     Configuration options
+     *
+     *     @type array $updateMask A list of field paths to be modified. Nested
+     *           key names should be dot-separated, e.g. `pushConfig.pushEndpoint`.
+     *           Google Cloud PHP will attempt to infer this value on your
+     *           behalf. You may use this field to limit which parts of the
+     *           resource are updated, should you choose to provide the full
+     *           resource as the `$metadata` argument.
+     * }
+     * @return array
+     */
+    public function update(array $metadata, array $options = [])
+    {
+        $current = $this->reload($options);
+
+        $updateMaskPaths = $this->pluck('updateMask', $options, false) ?: [];
+        if (!$updateMaskPaths) {
+            $excludes = ['creationTime', 'lastModifiedTime'];
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($metadata));
+            foreach ($iterator as $leafValue) {
+                $keys = [];
+                foreach (range(0, $iterator->getDepth()) as $depth) {
+                    $keys[] = $iterator->getSubIterator($depth)->key();
+                }
+
+                $path = implode('.', $keys);
+                if (!in_array($path, $excludes)) {
+                    $updateMaskPaths[] = $path;
+                }
+            }
+        }
+
+        // apply new fields to full resource.
+        $merged = $this->mergeUpdateResource($current, $metadata, $updateMaskPaths);
+
+        $options = $this->applyEtagHeader(
+            $this->identity
+            + $options
+            + $merged
+        );
+
+        if (!isset($options['etag']) && !isset($options['retries'])) {
+            $options['retries'] = 0;
+        }
+
+        return $this->info = $this->connection->updateRoutine($options);
+    }
+
+    /**
+     * Delete a routine.
+     *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
+     * Example:
+     * ```
+     * $routine->delete();
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/delete Delete Routines API documentation.
+     * @param array $options [optional] Configuration options.
+     */
+    public function delete(array $options = [])
+    {
+        return $this->connection->deleteRoutine($this->identity + ['retries' => 0] + $options);
+    }
+
+    /**
+     * Apply partial updates to routine resources.
+     *
+     * @param array $current The current API resource
+     * @param array $new The new metadata
+     * @param array $updateMaskPaths A list of paths for fields to be updated
+     * @return array
+     */
+    private function mergeUpdateResource(array $current, array $new, array $updateMaskPaths)
+    {
+        $walk = function (array $tail, array &$current, array $new) use (&$walk) {
+            if (count($tail) === 1 && isset($new[$tail[0]])) {
+                $current[$tail[0]] = $new[$tail[0]];
+                return;
+            }
+
+            $key = array_shift($tail);
+            if (isset($new[$key])) {
+                if (!isset($current[$key])) {
+                    $current[$key] = [];
+                }
+
+                $walk($tail, $current[$key], $new[$key]);
+            }
+
+            return;
+        };
+
+        foreach ($updateMaskPaths as $path) {
+            $parts = explode('.', $path);
+
+            $walk($parts, $current, $new);
+        }
+
+        return $current;
+    }
+}

--- a/BigQuery/src/Routine.php
+++ b/BigQuery/src/Routine.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ class Routine
      *     Configuration options
      *
      *     @type array $updateMask A list of field paths to be modified. Nested
-     *           key names should be dot-separated, e.g. `pushConfig.pushEndpoint`.
+     *           key names should be dot-separated, e.g. `returnType.typeKind`.
      *           Google Cloud PHP will attempt to infer this value on your
      *           behalf. You may use this field to limit which parts of the
      *           resource are updated, should you choose to provide the full
@@ -266,7 +266,11 @@ class Routine
      */
     public function delete(array $options = [])
     {
-        return $this->connection->deleteRoutine($this->identity + ['retries' => 0] + $options);
+        return $this->connection->deleteRoutine(
+            $this->identity
+            + $options
+            + ['retries' => 0]
+        );
     }
 
     /**

--- a/BigQuery/tests/Snippet/DatasetTest.php
+++ b/BigQuery/tests/Snippet/DatasetTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\BigQuery\Tests\Snippet;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\Routine;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Core\Iterator\ItemIterator;
@@ -209,5 +210,52 @@ class DatasetTest extends SnippetTestCase
 
         $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('my_model', trim($res->output()));
+    }
+
+    public function testRoutine()
+    {
+        $snippet = $this->snippetFromMethod(Dataset::class, 'routine');
+        $snippet->addLocal('dataset', $this->getDataset($this->connection));
+
+        $res = $snippet->invoke('routine');
+        $this->assertInstanceOf(Routine::class, $res->returnVal());
+        $this->assertEquals('my_routine', $res->output());
+    }
+
+    public function testRoutines()
+    {
+        $this->connection->listRoutines(Argument::any())
+            ->shouldBeCalledTimes(1)
+            ->willReturn([
+                'routines' => [
+                    [
+                        'routineReference' => [
+                            'routineId' => 'my_routine'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $dataset = $this->getDataset($this->connection);
+        $snippet = $this->snippetFromMethod(Dataset::class, 'routines');
+        $snippet->addLocal('dataset', $dataset);
+        $res = $snippet->invoke('routines');
+
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
+        $this->assertEquals('my_routine', trim($res->output()));
+    }
+
+    public function testCreateRoutine()
+    {
+        $this->connection->insertRoutine(Argument::any())
+            ->shouldBeCalledTimes(1)
+            ->willReturn([]);
+
+        $dataset = $this->getDataset($this->connection);
+        $snippet = $this->snippetFromMethod(Dataset::class, 'createRoutine');
+        $snippet->addLocal('dataset', $dataset);
+        $res = $snippet->invoke('routine');
+
+        $this->assertInstanceOf(Routine::class, $res->returnVal());
     }
 }

--- a/BigQuery/tests/Snippet/RoutineTest.php
+++ b/BigQuery/tests/Snippet/RoutineTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQuery/tests/Snippet/RoutineTest.php
+++ b/BigQuery/tests/Snippet/RoutineTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery\Tests\Snippet;
+
+use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\BigQuery\Routine;
+use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Prophecy\Argument;
+
+/**
+ * @group bigquery
+ */
+class RoutineTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const ROUTINE_ID = 'my_routine';
+
+    private $connection;
+    private $routine;
+    private $identity;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->identity = [
+            'routineId' => self::ROUTINE_ID,
+            'datasetId' => self::DATASET_ID,
+            'projectId' => self::PROJECT_ID
+        ];
+
+        $this->routine = TestHelpers::stub(Routine::class, [
+            $this->connection->reveal(),
+            self::ROUTINE_ID,
+            self::DATASET_ID,
+            self::PROJECT_ID
+        ]);
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(Routine::class);
+        $res = $snippet->invoke('routine');
+        $this->assertInstanceOf(Routine::class, $res->returnVal());
+        $this->assertEquals(self::ROUTINE_ID, $res->returnVal()->identity()['routineId']);
+        $this->assertEquals(self::DATASET_ID, $res->returnVal()->identity()['datasetId']);
+    }
+
+    public function testIdentity()
+    {
+        $snippet = $this->snippetFromMethod(Routine::class, 'identity');
+        $snippet->addLocal('routine', $this->routine);
+        $res = $snippet->invoke('identity');
+
+        $this->assertEquals($this->identity, $res->returnVal());
+        $this->assertEquals(self::ROUTINE_ID, $res->output());
+    }
+
+    public function testInfo()
+    {
+        $info = ['foo' => 'bar'];
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn($info);
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'info');
+        $snippet->addLocal('routine', $this->routine);
+        $res = $snippet->invoke('res');
+        $this->assertEquals($info, $res->returnVal());
+    }
+
+    public function testReload()
+    {
+        $info = ['foo' => 'bar'];
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn($info);
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'reload');
+        $snippet->addLocal('routine', $this->routine);
+        $res = $snippet->invoke('res');
+        $this->assertEquals($info, $res->returnVal());
+    }
+
+    public function testExists()
+    {
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn([]);
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'exists');
+        $snippet->addLocal('routine', $this->routine);
+        $res = $snippet->invoke();
+        $this->assertEquals('Routine exists!', $res->output());
+    }
+
+    public function testUpdate()
+    {
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn([]);
+        $this->connection->updateRoutine(Argument::that(function ($args) {
+            return isset($args['definitionBody']);
+        }))->shouldBeCalled()->willReturn([]);
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'update');
+        $snippet->addLocal('routine', $this->routine);
+        $snippet->invoke();
+    }
+
+    public function testUpdateWithMask()
+    {
+        $this->connection->getRoutine(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'displayName' => 'foo',
+                'definitionBody' => 'xxx',
+                'language' => 'yyy'
+            ]);
+        $this->connection->updateRoutine(Argument::allOf(
+            Argument::withEntry('definitionBody', 'return x + y;'),
+            Argument::withEntry('language', 'JAVASCRIPT'),
+            Argument::withEntry('displayName', 'foo')
+        ))->willReturn([]);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'update', 1);
+        $snippet->addLocal('routine', $this->routine);
+        $snippet->invoke();
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteRoutine(Argument::any())
+            ->shouldBeCalled();
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Routine::class, 'delete');
+        $snippet->addLocal('routine', $this->routine);
+        $snippet->invoke();
+    }
+}

--- a/BigQuery/tests/System/ManageRoutinesTest.php
+++ b/BigQuery/tests/System/ManageRoutinesTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery\Tests\System;
+
+use Google\Cloud\BigQuery\Routine;
+
+/**
+ * @group bigquery
+ * @group bigquery-routine
+ */
+class ManageRoutinesTest extends BigQueryTestCase
+{
+    private static $routines = [];
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        for ($i = 0; $i < 2; $i++) {
+            $routineId = uniqid(self::TESTING_PREFIX);
+            $sql = 'CREATE FUNCTION %s.%s(x string, y string) as (concat(x, "\n", y))';
+            $query = self::$client->query(sprintf(
+                $sql,
+                self::$dataset->identity()['datasetId'],
+                $routineId
+            ));
+
+            self::$client->runQuery($query)->waitUntilComplete();
+            $routine = self::$dataset->routine($routineId);
+            self::$routines[] = $routine;
+            self::$deletionQueue->add($routine);
+        }
+    }
+
+    public function testListRoutinesAndVerifyCreateFunction()
+    {
+        $routines = iterator_to_array(self::$dataset->routines());
+        $this->assertContainsOnlyInstancesOf(Routine::class, $routines);
+
+        $shouldContain = [];
+        foreach (self::$routines as $r) {
+            $shouldContain[$r->identity()['routineId']] = $r->identity()['routineId'];
+        }
+
+        $this->assertNotEmpty($routines);
+
+        foreach ($routines as $routine) {
+            if (in_array($routine->identity()['routineId'], $shouldContain)) {
+                unset($shouldContain[$routine->identity()['routineId']]);
+            } else {
+                $this->assertTrue(false, 'Unexpected routine!');
+            }
+
+            $this->assertTrue($routine->exists());
+        }
+
+        $this->assertEmpty($shouldContain);
+    }
+
+    public function testUpdateRoutine()
+    {
+        $routine = self::$routines[0];
+
+        $patch = [
+            'arguments' => [
+                ['name' => 'z']
+            ],
+            'definitionBody' => 'concat(z, "\n", y)'
+        ];
+
+        $newInfo = $routine->update($patch);
+        $this->assertEquals($patch['arguments'][0]['name'], $newInfo['arguments'][0]['name']);
+        $this->assertEquals($patch['definitionBody'], $newInfo['definitionBody']);
+    }
+
+    public function testUpdateRoutineUpdateMask()
+    {
+        $routine = self::$routines[1];
+
+        $patch = [
+            'arguments' => [
+                ['name' => 'z']
+            ],
+            'definitionBody' => 'concat(z, "\n", y)',
+            'description' => 'This is my routine. there are many like it but this one is mine.'
+        ];
+
+        $newInfo = $routine->update($patch, ['updateMask' => ['description']]);
+        $this->assertNotEquals($patch['arguments'][0]['name'], $newInfo['arguments'][0]['name']);
+        $this->assertNotEquals($patch['definitionBody'], $newInfo['definitionBody']);
+        $this->assertEquals($patch['description'], $newInfo['description']);
+    }
+
+    public function testCreateAndDeleteRoutine()
+    {
+        $routine = self::$dataset->createRoutine(uniqid(self::TESTING_PREFIX), [
+            'routineType' => 'SCALAR_FUNCTION',
+            'definitionBody' => 'concat(x, "\n", y)',
+            'arguments' => [
+                [
+                    'name' => 'x',
+                    'dataType' => [
+                        'typeKind' => 'STRING'
+                    ]
+                ], [
+                    'name' => 'y',
+                    'dataType' => [
+                        'typeKind' => 'STRING'
+                    ]
+                ]
+            ]
+        ]);
+
+        $routine->delete();
+
+        $this->assertFalse($routine->exists());
+    }
+}

--- a/BigQuery/tests/System/ManageRoutinesTest.php
+++ b/BigQuery/tests/System/ManageRoutinesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQuery/tests/Unit/BigQueryClientTest.php
+++ b/BigQuery/tests/Unit/BigQueryClientTest.php
@@ -28,9 +28,10 @@ use Google\Cloud\BigQuery\QueryJobConfiguration;
 use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\Time;
 use Google\Cloud\BigQuery\Timestamp;
+use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Testing\TestHelpers;
-use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group bigquery
@@ -408,6 +409,14 @@ class BigQueryClientTest extends TestCase
         $date = $this->getClient()->date(new \DateTime());
 
         $this->assertInstanceOf(Date::class, $date);
+    }
+
+    public function testInt64()
+    {
+        $i = 1111;
+        $i64 = $this->getClient()->int64($i);
+        $this->assertInstanceOf(Int64::class, $i64);
+        $this->assertEquals((string)$i, $i64->get());
     }
 
     public function testGetsTime()

--- a/BigQuery/tests/Unit/Connection/RestTest.php
+++ b/BigQuery/tests/Unit/Connection/RestTest.php
@@ -114,6 +114,11 @@ class RestTest extends TestCase
             ['listModels'],
             ['patchModel'],
             ['deleteModel'],
+            ['insertRoutine'],
+            ['updateRoutine'],
+            ['getRoutine'],
+            ['deleteRoutine'],
+            ['listRoutines']
         ];
     }
 

--- a/BigQuery/tests/Unit/QueryResultsTest.php
+++ b/BigQuery/tests/Unit/QueryResultsTest.php
@@ -22,8 +22,9 @@ use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\Numeric;
 use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\ValueMapper;
-use Prophecy\Argument;
+use Google\Cloud\Core\Testing\TestHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group bigquery
@@ -194,5 +195,48 @@ class QueryResultsTest extends TestCase
 
         $this->assertEquals($this->jobId, $queryResults->identity()['jobId']);
         $this->assertEquals($this->projectId, $queryResults->identity()['projectId']);
+    }
+
+    /**
+     * @dataProvider locations
+     */
+    public function testLocation($expected, $info, $jobIdentity)
+    {
+        $job = $this->prophesize(Job::class);
+        $job->identity()->willReturn($jobIdentity);
+        $queryResults = TestHelpers::stub(QueryResults::class, [
+            $this->connection->reveal(),
+            $this->jobId,
+            $this->projectId,
+            $info,
+            new ValueMapper(false),
+            $job->reveal()
+        ]);
+
+        $this->assertEquals($expected, $queryResults->identity()['location']);
+    }
+
+    public function locations()
+    {
+        return [
+            [
+                'foo',
+                [
+                    'jobReference' => [
+                        'location' => 'foo'
+                    ]
+                ],
+                [
+                    'location' => 'bar'
+                ]
+            ],
+            [
+                'bar',
+                [],
+                [
+                    'location' => 'bar'
+                ]
+            ]
+        ];
     }
 }

--- a/BigQuery/tests/Unit/RoutineTest.php
+++ b/BigQuery/tests/Unit/RoutineTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery\Tests\Unit;
+
+use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\BigQuery\Routine;
+use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Testing\TestHelpers;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+/**
+ * @group bigquery
+ * @group bigquery-routine
+ */
+class RoutineTest extends TestCase
+{
+    const PROJECT_ID = 'project-id';
+    const DATASET_ID = 'dataset-id';
+    const ROUTINE_ID = 'routine-id';
+
+    private $connection;
+    private $routine;
+    private $identity = [
+        'routineId' => self::ROUTINE_ID,
+        'datasetId' => self::DATASET_ID,
+        'projectId' => self::PROJECT_ID
+    ];
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->routine = TestHelpers::stub(Routine::class, [
+            $this->connection->reveal(),
+            self::ROUTINE_ID,
+            self::DATASET_ID,
+            self::PROJECT_ID
+        ], ['connection', 'info']);
+    }
+
+    public function testIdentity()
+    {
+        $this->assertEquals($this->identity, $this->routine->identity());
+    }
+
+    public function testInfo()
+    {
+        $res = ['foo' => 'bar'];
+        $this->connection->getRoutine($this->identity)
+            ->shouldBeCalledOnce()
+            ->willReturn($res);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->assertEquals($res, $this->routine->info());
+
+        // test cached value.
+        $this->routine->info();
+    }
+
+    public function testReload()
+    {
+        $res = ['foo' => 'bar'];
+        $this->connection->getRoutine($this->identity)
+            ->shouldBeCalledTimes(2)
+            ->willReturn($res);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->assertEquals($res, $this->routine->reload());
+
+        // test refreshes value
+        $this->routine->reload();
+    }
+
+    public function testExists()
+    {
+        $this->connection->getRoutine($this->identity)
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->assertTrue($this->routine->exists());
+    }
+
+    public function testExistsFalse()
+    {
+        $this->connection->getRoutine($this->identity)
+            ->shouldBeCalled()
+            ->willThrow(NotFoundException::class);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->assertFalse($this->routine->exists());
+    }
+
+    public function testUpdate()
+    {
+        $updateData = ['description' => 'wow a name'];
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn(['description' => 'old and busted name'])
+            ->shouldBeCalledTimes(1);
+        $this->connection->updateRoutine($this->identity + $updateData + ['retries' => 0])
+            ->willReturn($updateData)
+            ->shouldBeCalledTimes(1);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->routine->update($updateData);
+
+        $this->assertEquals($updateData['description'], $this->routine->info()['description']);
+    }
+
+    public function testUpdateWithEtag()
+    {
+        $updateData = ['description' => 'wow a name', 'etag' => 'foo'];
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn(['description' => 'old and busted name'])
+            ->shouldBeCalledTimes(1);
+        $this->connection->updateRoutine(Argument::that(function ($args) {
+            return $args['restOptions']['headers']['If-Match'] === 'foo';
+        }))->willReturn($updateData)->shouldBeCalledTimes(1);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->routine->update($updateData);
+
+        $this->assertEquals($updateData['description'], $this->routine->info()['description']);
+    }
+
+    public function testUpdateWithMask()
+    {
+        $old = [
+            'description' => 'wow a name',
+            'routineType' => 'PROCEDURE',
+            'arguments' => [
+                [
+                    'name' => 'a',
+                    'dataType' => [
+                        'typeKind' => 'STRING'
+                    ]
+                ], [
+                    'name' => 'b',
+                    'dataType' => [
+                        'typeKind' => 'ARRAY'
+                    ]
+                ]
+            ]
+        ];
+
+        $new = $old;
+        $new['description'] = 'this one is better i guess';
+        $new['routineType'] = 'SCALAR_FUNCTION';
+        $new['arguments'][0]['name'] = 'aa';
+        $new['arguments'][1]['name'] = 'bb';
+        $new['arguments'][1]['dataType']['typeKind'] = 'STRING';
+
+        $paths = [
+            'description',
+            'arguments.0.name',
+            'arguments.1.dataType.typeKind'
+        ];
+
+        $expected = $old;
+        $expected['description'] = $new['description'];
+        $expected['arguments'][0]['name'] = $new['arguments'][0]['name'];
+        $expected['arguments'][1]['dataType']['typeKind'] = $new['arguments'][1]['dataType']['typeKind'];
+
+        $this->connection->getRoutine(Argument::any())
+            ->willReturn($old)
+            ->shouldBeCalledTimes(1);
+        $this->connection->updateRoutine($this->identity + $expected + ['retries' => 0])
+            ->shouldBeCalledTimes(1)
+            ->willReturn($expected);
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $res = $this->routine->update($new, [
+            'updateMask' => $paths
+        ]);
+
+        $this->assertEquals($expected, $res);
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteRoutine($this->identity + ['retries' => 0])
+            ->shouldBeCalled();
+
+        $this->routine->___setProperty('connection', $this->connection->reveal());
+        $this->routine->delete();
+    }
+}

--- a/BigQuery/tests/Unit/RoutineTest.php
+++ b/BigQuery/tests/Unit/RoutineTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/Testing/TestHelpers.php
+++ b/Core/src/Testing/TestHelpers.php
@@ -241,6 +241,23 @@ class TestHelpers
     }
 
     /**
+     * Get the value of a private property.
+     *
+     * @param mixed The class
+     * @param string The property name.
+     * @return mixed
+     */
+    public static function getPrivateProperty($class, $property)
+    {
+        $className = get_class($class);
+        $c = \Closure::bind(function ($class) use ($property) {
+            return $class->$property;
+        }, null, $className);
+
+        return $c($class);
+    }
+
+    /**
      * Determine the path of the project root based on where the composer
      * autoloader is located.
      *

--- a/Core/src/Testing/TestHelpers.php
+++ b/Core/src/Testing/TestHelpers.php
@@ -21,7 +21,6 @@ namespace Google\Cloud\Core\Testing;
 use Google\Cloud\Core\Testing\RegexFileFilter;
 use Google\Cloud\Core\Testing\Snippet\Container;
 use Google\Cloud\Core\Testing\Snippet\Coverage\Coverage;
-use Google\Cloud\Core\Testing\Snippet\Coverage\ExcludeFilter;
 use Google\Cloud\Core\Testing\Snippet\Coverage\Scanner;
 use Google\Cloud\Core\Testing\Snippet\Parser\Parser;
 use Google\Cloud\Core\Testing\System\SystemTestCase;
@@ -238,23 +237,6 @@ class TestHelpers
 
             $shutdown();
         });
-    }
-
-    /**
-     * Get the value of a private property.
-     *
-     * @param mixed The class
-     * @param string The property name.
-     * @return mixed
-     */
-    public static function getPrivateProperty($class, $property)
-    {
-        $className = get_class($class);
-        $c = \Closure::bind(function ($class) use ($property) {
-            return $class->$property;
-        }, null, $className);
-
-        return $c($class);
     }
 
     /**


### PR DESCRIPTION
~~This is ready except for handling partial updates.~~

~~@shollyman @tswast can you give any insight into how partial updates will be handled by the server? I'd really like to implement this in a way that will be forward-compatible for our users once the API is updated. Will it use a PATCH method? An Update Mask? If the latter, I can handle that on the client side now in a manner compatible with the existing field masks, then remove that code once the server accepts it.~~

Ready for review.