### PR TITLE
fix: allow mkdir() via stream wrapper when UBL is enabled

### DIFF
--- a/Storage/src/StreamWrapper.php
+++ b/Storage/src/StreamWrapper.php
@@ -388,11 +388,22 @@ class StreamWrapper
             // If the file name is empty, we were trying to create a bucket. In this case,
             // don't create the placeholder file.
             if ($this->file != '') {
+                $bucketInfo = $this->bucket->info();
+                $ublEnabled = isset($bucketInfo['iamConfiguration']['uniformBucketLevelAccess']) &&
+                    $bucketInfo['iamConfiguration']['uniformBucketLevelAccess']['enabled'] === true;
+
+                // if bucket has uniform bucket level access enabled, don't set ACLs.
+                $acl = [];
+                if (!$ublEnabled) {
+                    $acl = [
+                        'predefinedAcl' => $predefinedAcl
+                    ];
+                }
+
                 // Fake a directory by creating an empty placeholder file whose name ends in '/'
                 $this->bucket->upload('', [
                     'name' => $this->file,
-                    'predefinedAcl' => $predefinedAcl
-                ]);
+                ] + $acl);
             }
         } catch (ServiceException $e) {
             return false;

--- a/Storage/tests/System/StreamWrapper/DirectoryTest.php
+++ b/Storage/tests/System/StreamWrapper/DirectoryTest.php
@@ -43,6 +43,26 @@ class DirectoryTest extends StreamWrapperTestCase
         $this->assertTrue(is_dir($dir . '/'));
     }
 
+    public function testMkDirWithUbl()
+    {
+        $bucket = self::createBucket(
+            self::$client,
+            uniqid(self::TESTING_PREFIX),
+            [
+                'iamConfiguration' => [
+                    'uniformBucketLevelAccess' => [
+                        'enabled' => true
+                    ]
+                ]
+            ]
+        );
+
+        $dir = self::generateUrl('test_directory', $bucket);
+        $this->assertTrue(mkdir($dir));
+        $this->assertFileExists($dir . '/');
+        $this->assertTrue(is_dir($dir . '/'));
+    }
+
     public function testIsDir()
     {
         $dir = self::generateUrl('test_directory');

--- a/Storage/tests/System/StreamWrapper/StreamWrapperTestCase.php
+++ b/Storage/tests/System/StreamWrapper/StreamWrapperTestCase.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\System\StreamWrapper;
 
-use Google\Cloud\Storage\Storage\Tests\SystemTestCase;
+use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Tests\System\StorageTestCase;
 
 /**
@@ -38,9 +38,10 @@ class StreamWrapperTestCase extends StorageTestCase
         parent::tearDownAfterClass();
     }
 
-    protected static function generateUrl($file)
+    protected static function generateUrl($file, Bucket $bucket = null)
     {
-        $bucketName = self::$bucket->name();
+        $bucket = $bucket ?: self::$bucket;
+        $bucketName = $bucket->name();
         return "gs://$bucketName/$file";
     }
 }

--- a/Storage/tests/Unit/StreamWrapperTest.php
+++ b/Storage/tests/Unit/StreamWrapperTest.php
@@ -250,7 +250,18 @@ class StreamWrapperTest extends TestCase
      */
     public function testMkdir()
     {
+        $this->mockBucketInfoUbl(false);
         $this->bucket->upload('', ['name' => 'foo/bar/', 'predefinedAcl' => 'publicRead'])->shouldBeCalled();
+        $this->assertTrue(mkdir('gs://my_bucket/foo/bar'));
+    }
+
+    /**
+     * @group storageDirectory
+     */
+    public function testMkdirWithUbl()
+    {
+        $this->mockBucketInfoUbl(true);
+        $this->bucket->upload('', ['name' => 'foo/bar/'])->shouldBeCalled();
         $this->assertTrue(mkdir('gs://my_bucket/foo/bar'));
     }
 
@@ -259,6 +270,7 @@ class StreamWrapperTest extends TestCase
      */
     public function testMkdirProjectPrivate()
     {
+        $this->mockBucketInfoUbl(false);
         $this->bucket->upload('', ['name' => 'foo/bar/', 'predefinedAcl' => 'projectPrivate'])->shouldBeCalled();
         $this->assertTrue(mkdir('gs://my_bucket/foo/bar', 0740));
     }
@@ -268,6 +280,7 @@ class StreamWrapperTest extends TestCase
      */
     public function testMkdirPrivate()
     {
+        $this->mockBucketInfoUbl(false);
         $this->bucket->upload('', ['name' => 'foo/bar/', 'predefinedAcl' => 'private'])->shouldBeCalled();
         $this->assertTrue(mkdir('gs://my_bucket/foo/bar', 0700));
     }
@@ -277,6 +290,7 @@ class StreamWrapperTest extends TestCase
      */
     public function testMkdirOnBadDirectory()
     {
+        $this->mockBucketInfoUbl(false);
         $this->bucket->upload('', ['name' => 'foo/bar/', 'predefinedAcl' => 'publicRead'])
             ->willThrow(NotFoundException::class);
         $this->assertFalse(mkdir('gs://my_bucket/foo/bar'));
@@ -289,6 +303,7 @@ class StreamWrapperTest extends TestCase
     {
         $this->bucket->exists()->willReturn(false);
         $this->bucket->name()->willReturn('my_bucket');
+        $this->mockBucketInfoUbl(false);
         $this->client->createBucket('my_bucket', [
             'predefinedAcl' => 'publicRead',
             'predefinedDefaultObjectAcl' => 'publicRead'
@@ -449,5 +464,16 @@ class StreamWrapperTest extends TestCase
                 yield $file;
             }
         }
+    }
+
+    private function mockBucketInfoUbl($enabled = false)
+    {
+        $this->bucket->info()->willReturn([
+            'iamConfiguration' => [
+                'uniformBucketLevelAccess' => [
+                    'enabled' => $enabled
+                ]
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
fixes #2540.