### PR TITLE
feat: add support for ordering keys

### DIFF
--- a/PubSub/src/Connection/Grpc.php
+++ b/PubSub/src/Connection/Grpc.php
@@ -67,6 +67,7 @@ class Grpc implements ConnectionInterface
      */
     public function __construct(array $config = [])
     {
+        //@codeCoverageIgnoreStart
         $this->serializer = new Serializer([
             'publish_time' => function ($v) {
                 return $this->formatTimestampFromApi($v);
@@ -98,6 +99,7 @@ class Grpc implements ConnectionInterface
         if ((bool) $config['emulatorHost']) {
             $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
         }
+        //@codeCoverageIgnoreEnd
 
         $this->publisherClient = $this->constructGapic(PublisherClient::class, $grpcConfig);
         $this->subscriberClient = $this->constructGapic(SubscriberClient::class, $grpcConfig);

--- a/PubSub/src/Message.php
+++ b/PubSub/src/Message.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\PubSub;
 
+use Google\Cloud\Core\ArrayTrait;
+
 /**
  * Represents a PubSub Message.
  *
@@ -35,6 +37,8 @@ namespace Google\Cloud\PubSub;
  */
 class Message
 {
+    use ArrayTrait;
+
     /**
      * @var array
      */
@@ -64,8 +68,9 @@ class Message
      *     @type string $publishTime The time at which the message was
      *           published, populated by the server when it receives the publish
      *           call.
+     *     @type string $orderingKey The message ordering key.
      * }
-     * @param array $metadata {
+     * @param array $metadata [optional] {
      *     Message metadata
      *
      *     @type string $ackId The message ackId. This is only set when messages
@@ -74,13 +79,14 @@ class Message
      *           obtained from. This is only set when messages are delivered by
      *           pushDelivery.
      */
-    public function __construct(array $message, array $metadata)
+    public function __construct(array $message, array $metadata = [])
     {
         $this->message = $message + [
             'data' => null,
             'messageId' => null,
             'publishTime' => null,
             'attributes' => [],
+            'orderingKey' => null
         ];
 
         $metadata += [
@@ -159,6 +165,21 @@ class Message
     }
 
     /**
+     * Get the message ordering key.
+     *
+     * Example:
+     * ```
+     * $orderingKey = $message->orderingKey();
+     * ```
+     *
+     * @return string|null
+     */
+    public function orderingKey()
+    {
+        return $this->message['orderingKey'];
+    }
+
+    /**
      * Get the message published time.
      *
      * Example:
@@ -229,5 +250,23 @@ class Message
             'subscription' => $this->subscription,
             'message' => $this->message
         ];
+    }
+
+    /**
+     * Get the message as an array.
+     *
+     * @return array
+     * @internal
+     */
+    public function toArray()
+    {
+        $message = $this->arrayFilterRemoveNull($this->message);
+
+        // force json-encode to empty map instead of empty list.
+        if (isset($message['attributes']) && empty($message['attributes'])) {
+            $message['attributes'] = (object) [];
+        }
+
+        return $message;
     }
 }

--- a/PubSub/src/MessageBuilder.php
+++ b/PubSub/src/MessageBuilder.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use Google\Cloud\Core\ArrayTrait;
+
+/**
+ * Builds a PubSub Message.
+ *
+ * This class may be used to build an API-compliant message for publication.
+ *
+ * This class is immutable and each build method returns a new instance with
+ * your changes applied.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\PubSub\MessageBuilder;
+ * use Google\Cloud\PubSub\PubSubClient;
+ *
+ * $client = new PubSubClient();
+ * $topic = $client->topic($topicId);
+ *
+ * $builder = new MessageBuilder();
+ * $builder = $builder->setData('hello friend!')
+ *     ->addAttribute('from', 'Bob')
+ *     ->addAttribute('to', 'Jane');
+ *
+ * $topic->publish($builder->build());
+ * ```
+ */
+class MessageBuilder
+{
+    use ArrayTrait;
+
+    /**
+     * @var array
+     */
+    private $message;
+
+    /**
+     * @param array $message The initial message data.
+     */
+    public function __construct(array $message = [])
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Set the message data.
+     *
+     * Do not base64-encode the value; If it must be encoded, the client will
+     * do it on your behalf.
+     *
+     * Example:
+     * ```
+     * $builder = $builder->setData('Hello friend!');
+     * ```
+     *
+     * @param string $data The message data field. If this field is empty, the
+     *        message must contain at least one attribute.
+     * @return MessageBuilder
+     */
+    public function setData($data)
+    {
+        return $this->newMessage([
+            'data' => $data
+        ]);
+    }
+
+    /**
+     * Set optional attributes for this message.
+     *
+     * Example:
+     * ```
+     * $builder = $builder->setAttributes([
+     *     'from' => 'Bob'
+     * ]);
+     * ```
+     *
+     * @param array $attributes A set of key/value pairs, where both key and
+     *        value are strings.
+     * @return MessageBuilder
+     */
+    public function setAttributes(array $attributes)
+    {
+        return $this->newMessage([
+            'attributes' => $attributes
+        ]);
+    }
+
+    /**
+     * Add a single attribute to the message.
+     *
+     * Example:
+     * ```
+     * $builder = $builder->addAttribute('to', 'Jane');
+     * ```
+     *
+     * @param string $key The attribute key.
+     * @param string $value The attribute value.
+     * @return MessageBuilder
+     */
+    public function addAttribute($key, $value)
+    {
+        $attributes = [];
+        if (isset($this->message['attributes'])) {
+            $attributes = $this->message['attributes'];
+        }
+
+        $attributes[$key] = $value;
+
+        return $this->newMessage([
+            'attributes' => $attributes
+        ]);
+    }
+
+    /**
+     * Set the message's ordering key.
+     *
+     * Example:
+     * ```
+     * $builder = $builder->setOrderingKey('order');
+     * ```
+     *
+     * @param string $orderingKey The ordering key.
+     * @return MessageBuilder
+     */
+    public function setOrderingKey($orderingKey)
+    {
+        return $this->newMessage([
+            'orderingKey' => $orderingKey
+        ]);
+    }
+
+    /**
+     * Build a message.
+     *
+     * Example:
+     * ```
+     * $message = $builder->build();
+     * ```
+     *
+     * @return Message
+     * @throws \BadMethodCallException If required data is missing.
+     */
+    public function build()
+    {
+        $hasAttributes = isset($this->message['attributes']) && $this->message['attributes'];
+        if (!isset($this->message['data']) && !$hasAttributes) {
+            throw new \BadMethodCallException(
+                'Messages must contain either a non-empty data field or at least one attribute.'
+            );
+        }
+
+        return new Message($this->message);
+    }
+
+    private function newMessage(array $data)
+    {
+        $data = $this->arrayMergeRecursive($this->message, $data);
+
+        return new static($data);
+    }
+}

--- a/PubSub/src/MessageBuilder.php
+++ b/PubSub/src/MessageBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,10 @@ use Google\Cloud\Core\ArrayTrait;
  *
  * This class is immutable and each build method returns a new instance with
  * your changes applied.
+ *
+ * Note that messages are invalid unless they include a data field or at least
+ * one attribute. Both may be provided, but omission of both will result in an
+ * error.
  *
  * Example:
  * ```
@@ -71,8 +75,7 @@ class MessageBuilder
      * $builder = $builder->setData('Hello friend!');
      * ```
      *
-     * @param string $data The message data field. If this field is empty, the
-     *        message must contain at least one attribute.
+     * @param string $data The message data field.
      * @return MessageBuilder
      */
     public function setData($data)

--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -276,14 +276,14 @@ class PubSubClient
      * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create Create Subscription
      *
      * @param string $name A subscription name
-     * @param string $topicName The topic to which the new subscription will be subscribed.
+     * @param Topic|string $topic The topic to which the new subscription will be subscribed.
      * @param array  $options [optional] Please see {@see Google\Cloud\PubSub\Subscription::create()}
      *        for configuration details.
      * @return Subscription
      */
-    public function subscribe($name, $topicName, array $options = [])
+    public function subscribe($name, $topic, array $options = [])
     {
-        $subscription = $this->subscriptionFactory($name, $topicName);
+        $subscription = $this->subscriptionFactory($name, $topic);
         $subscription->create($options);
 
         return $subscription;
@@ -542,20 +542,24 @@ class PubSubClient
      *
      * @codingStandardsIgnoreStart
      * @param string $name The subscription name
-     * @param string $topicName [optional] The topic name
-     * @param array  $info [optional] Information about the subscription. Used
+     * @param Topic|string $topic [optional] The topic name
+     * @param array $info [optional] Information about the subscription. Used
      *        to populate subscriptons with an API result. Should be a
      *        representation of a [Subscription](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions#Subscription).
      * @return Subscription
      * @codingStandardsIgnoreEnd
      */
-    private function subscriptionFactory($name, $topicName = null, array $info = [])
+    private function subscriptionFactory($name, $topic = null, array $info = [])
     {
+        $topic = $topic instanceof Topic
+            ? $topic->name()
+            : $topic;
+
         return new Subscription(
             $this->connection,
             $this->projectId,
             $name,
-            $topicName,
+            $topic,
             $this->encode,
             $info
         );

--- a/PubSub/src/Subscription.php
+++ b/PubSub/src/Subscription.php
@@ -204,6 +204,32 @@ class Subscription
      * @param array $options [optional] {
      *     Configuration Options
      *
+     *     @type int $ackDeadlineSeconds The maximum time after a subscriber
+     *           receives a message before the subscriber should acknowledge the
+     *           message.
+     *     @type bool $enableMessageOrdering If true, messages published with
+     *           the same `orderingKey` in {@see Google\Cloud\PubSub\Message}
+     *           will be delivered to the subscribers in the order in which they
+     *           are received by the Pub/Sub system. Otherwise, they may be
+     *           delivered in any order.
+     *     @type array $expirationPolicy A policy that specifies the conditions
+     *           for resource expiration (i.e., automatic resource deletion).
+     *     @type Duration|string $expirationPolicy.ttl Specifies the
+     *           "time-to-live" duration for an associated resource. The
+     *           resource expires if it is not active for a period of `ttl`. The
+     *           definition of "activity" depends on the type of the associated
+     *           resource. The minimum and maximum allowed values for `ttl`
+     *           depend on the type of the associated resource, as well. If
+     *           `ttl` is not set, the associated resource never expires. If a
+     *           string is provided, it should be as a duration in seconds with
+     *           up to nine fractional digits, terminated by 's', e.g "3.5s".
+     *     @type Duration $messageRetentionDuration How long to retain
+     *           unacknowledged messages in the subscription's backlog, from the
+     *           moment a message is published. If `$retainAckedMessages` is
+     *           true, then this also configures the retention of acknowledged
+     *           messages, and thus configures how far back in time a `Seek`
+     *           can be done. Cannot be more than 7 days or less than 10 minutes.
+     *           **Defaults to** 7 days.
      *     @type string $pushConfig.pushEndpoint A URL locating the endpoint to which
      *           messages should be pushed. For example, a Webhook endpoint
      *           might use "https://example.com/push".
@@ -223,31 +249,8 @@ class Subscription
      *           for the audience field is not supported. More info about the
      *           OIDC JWT token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
      *           Note: if not specified, the Push endpoint URL will be used.
-     *     @type int $ackDeadlineSeconds The maximum time after a subscriber
-     *           receives a message before the subscriber should acknowledge the
-     *           message.
      *     @type bool $retainAckedMessages Indicates whether to retain
      *           acknowledged messages.
-     *     @type Duration|string $messageRetentionDuration How long to retain
-     *           unacknowledged messages in the subscription's backlog, from the
-     *           moment a message is published. If `$retainAckedMessages` is
-     *           true, then this also configures the retention of acknowledged
-     *           messages, and thus configures how far back in time a `Seek`
-     *           can be done. Cannot be more than 7 days or less than 10 minutes.
-     *           If a string is provided, it should be as a duration in seconds
-     *           with up to nine fractional digits, terminated by 's', e.g
-     *           "3.5s". **Defaults to** 7 days.
-     *     @type array $expirationPolicy A policy that specifies the conditions
-     *           for resource expiration (i.e., automatic resource deletion).
-     *     @type Duration|string $expirationPolicy.ttl Specifies the
-     *           "time-to-live" duration for an associated resource. The
-     *           resource expires if it is not active for a period of `ttl`. The
-     *           definition of "activity" depends on the type of the associated
-     *           resource. The minimum and maximum allowed values for `ttl`
-     *           depend on the type of the associated resource, as well. If
-     *           `ttl` is not set, the associated resource never expires. If a
-     *           string is provided, it should be as a duration in seconds with
-     *           up to nine fractional digits, terminated by 's', e.g "3.5s".
      * }
      * @return array An array of subscription info
      * @throws \InvalidArgumentException
@@ -310,6 +313,32 @@ class Subscription
      * @param array $subscription {
      *     The Subscription data.
      *
+     *     @type int $ackDeadlineSeconds The maximum time after a subscriber
+     *           receives a message before the subscriber should acknowledge the
+     *           message.
+     *     @type bool $enableMessageOrdering If true, messages published with
+     *           the same `orderingKey` in {@see Google\Cloud\PubSub\Message}
+     *           will be delivered to the subscribers in the order in which they
+     *           are received by the Pub/Sub system. Otherwise, they may be
+     *           delivered in any order.
+     *     @type array $expirationPolicy A policy that specifies the conditions
+     *           for resource expiration (i.e., automatic resource deletion).
+     *     @type Duration|string $expirationPolicy.ttl Specifies the
+     *           "time-to-live" duration for an associated resource. The
+     *           resource expires if it is not active for a period of `ttl`. The
+     *           definition of "activity" depends on the type of the associated
+     *           resource. The minimum and maximum allowed values for `ttl`
+     *           depend on the type of the associated resource, as well. If
+     *           `ttl` is not set, the associated resource never expires. If a
+     *           string is provided, it should be as a duration in seconds with
+     *           up to nine fractional digits, terminated by 's', e.g "3.5s".
+     *     @type Duration $messageRetentionDuration How long to retain
+     *           unacknowledged messages in the subscription's backlog, from the
+     *           moment a message is published. If `$retainAckedMessages` is
+     *           true, then this also configures the retention of acknowledged
+     *           messages, and thus configures how far back in time a `Seek`
+     *           can be done. Cannot be more than 7 days or less than 10 minutes.
+     *           **Defaults to** 7 days.
      *     @type string $pushConfig.pushEndpoint A URL locating the endpoint to which
      *           messages should be pushed. For example, a Webhook endpoint
      *           might use "https://example.com/push".
@@ -329,29 +358,8 @@ class Subscription
      *           for the audience field is not supported. More info about the
      *           OIDC JWT token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
      *           Note: if not specified, the Push endpoint URL will be used.
-     *     @type int $ackDeadlineSeconds The maximum time after a subscriber
-     *           receives a message before the subscriber should acknowledge the
-     *           message.
      *     @type bool $retainAckedMessages Indicates whether to retain
      *           acknowledged messages.
-     *     @type Duration $messageRetentionDuration How long to retain
-     *           unacknowledged messages in the subscription's backlog, from the
-     *           moment a message is published. If `$retainAckedMessages` is
-     *           true, then this also configures the retention of acknowledged
-     *           messages, and thus configures how far back in time a `Seek`
-     *           can be done. Cannot be more than 7 days or less than 10 minutes.
-     *           **Defaults to** 7 days.
-     *     @type array $expirationPolicy A policy that specifies the conditions
-     *           for resource expiration (i.e., automatic resource deletion).
-     *     @type Duration|string $expirationPolicy.ttl Specifies the
-     *           "time-to-live" duration for an associated resource. The
-     *           resource expires if it is not active for a period of `ttl`. The
-     *           definition of "activity" depends on the type of the associated
-     *           resource. The minimum and maximum allowed values for `ttl`
-     *           depend on the type of the associated resource, as well. If
-     *           `ttl` is not set, the associated resource never expires. If a
-     *           string is provided, it should be as a duration in seconds with
-     *           up to nine fractional digits, terminated by 's', e.g "3.5s".
      * }
      * @param array $options [optional] {
      *     Configuration options.
@@ -555,7 +563,9 @@ class Subscription
      * ```
      * $messages = $subscription->pull();
      *
-     * $subscription->acknowledge($messages[0]);
+     * foreach ($messages as $message) {
+     *     $subscription->acknowledge($message);
+     * }
      * ```
      *
      * @codingStandardsIgnoreStart

--- a/PubSub/tests/Snippet/MessageBuilderTest.php
+++ b/PubSub/tests/Snippet/MessageBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/Snippet/MessageBuilderTest.php
+++ b/PubSub/tests/Snippet/MessageBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub\Tests\Snippet;
+
+use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\MessageBuilder;
+use Google\Cloud\PubSub\PubSubClient;
+use Prophecy\Argument;
+
+/**
+ * @group pubsub
+ */
+class MessageBuilderTest extends SnippetTestCase
+{
+    private $builder;
+
+    public function setUp()
+    {
+        $this->builder = new MessageBuilder;
+    }
+
+    public function testClass()
+    {
+        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection->publishMessage(Argument::any())->willReturn([]);
+
+        $client = TestHelpers::stub(PubSubClient::class);
+        $client->___setProperty('connection', $connection->reveal());
+
+        $snippet = $this->snippetFromClass(MessageBuilder::class);
+        $snippet->replace('$client = new PubSubClient();', '');
+        $snippet->addLocal('client', $client);
+        $snippet->addLocal('topicId', 'test');
+
+        $res = $snippet->invoke('builder');
+        $this->assertEquals([
+            'data' => 'hello friend!',
+            'attributes' => [
+                'from' => 'Bob',
+                'to' => 'Jane'
+            ]
+        ], $res->returnVal()->build()->toArray());
+    }
+
+    public function testSetData()
+    {
+        $snippet = $this->snippetFromMethod(MessageBuilder::class, 'setData');
+        $snippet->addLocal('builder', $this->builder);
+        $res = $snippet->invoke('builder');
+        $this->assertEquals('Hello friend!', $res->returnVal()->build()->toArray()['data']);
+    }
+
+    public function testSetAttributes()
+    {
+        $snippet = $this->snippetFromMethod(MessageBuilder::class, 'setAttributes');
+        $snippet->addLocal('builder', $this->builder);
+        $res = $snippet->invoke('builder');
+        $this->assertEquals(['from' => 'Bob'], $res->returnVal()->setData('foo')->build()->toArray()['attributes']);
+    }
+
+    public function testAddAttribute()
+    {
+        $snippet = $this->snippetFromMethod(MessageBuilder::class, 'addAttribute');
+        $snippet->addLocal('builder', $this->builder);
+        $res = $snippet->invoke('builder');
+        $this->assertEquals(['to' => 'Jane'], $res->returnVal()->setData('foo')->build()->toArray()['attributes']);
+    }
+
+    public function testSetOrderingKey()
+    {
+        $snippet = $this->snippetFromMethod(MessageBuilder::class, 'setOrderingKey');
+        $snippet->addLocal('builder', $this->builder);
+        $res = $snippet->invoke('builder');
+        $this->assertEquals('order', $res->returnVal()->setData('foo')->build()->toArray()['orderingKey']);
+    }
+
+    public function testBuild()
+    {
+        $snippet = $this->snippetFromMethod(MessageBuilder::class, 'build');
+        $snippet->addLocal('builder', $this->builder->setData('hello'));
+        $res = $snippet->invoke('message');
+        $this->assertInstanceOf(Message::class, $res->returnVal());
+    }
+}

--- a/PubSub/tests/Snippet/MessageTest.php
+++ b/PubSub/tests/Snippet/MessageTest.php
@@ -44,7 +44,8 @@ class MessageTest extends SnippetTestCase
             'publishTime' => (new \DateTime())->format('c'),
             'attributes' => [
                 'browser-name' => 'Google Chrome'
-            ]
+            ],
+            'orderingKey' => 'foo'
         ];
 
         $subscription = $this->prophesize(Subscription::class);
@@ -95,6 +96,15 @@ class MessageTest extends SnippetTestCase
 
         $res = $snippet->invoke();
         $this->assertEquals($this->msg['data'], $res->output());
+    }
+
+    public function testOrderingKey()
+    {
+        $snippet = $this->snippetFromMethod(Message::class, 'orderingKey');
+        $snippet->addLocal('message', $this->message);
+
+        $res = $snippet->invoke('orderingKey');
+        $this->assertEquals($this->msg['orderingKey'], $res->returnVal());
     }
 
     public function testAttribute()

--- a/PubSub/tests/System/ManageIAMPoliciesTest.php
+++ b/PubSub/tests/System/ManageIAMPoliciesTest.php
@@ -28,8 +28,7 @@ class ManageIAMPoliciesTest extends PubSubTestCase
      */
     public function testManageTopicIAM($client)
     {
-        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
-        self::$deletionQueue->add($topic);
+        $topic = self::topic($client);
         $this->assertIam($topic->iam());
     }
 
@@ -38,11 +37,7 @@ class ManageIAMPoliciesTest extends PubSubTestCase
      */
     public function testManageSubscriptionIAM($client)
     {
-        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
-        self::$deletionQueue->add($topic);
-
-        $sub = $client->subscribe(uniqid(self::TESTING_PREFIX), $topic->name());
-        self::$deletionQueue->add($sub);
+        list ($topic, $sub) = self::topicAndSubscription($client);
 
         $this->assertIam($sub->iam());
     }

--- a/PubSub/tests/System/PubSubTestCase.php
+++ b/PubSub/tests/System/PubSubTestCase.php
@@ -17,8 +17,9 @@
 
 namespace Google\Cloud\PubSub\Tests\System;
 
-use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\Core\Testing\System\SystemTestCase;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Topic;
 
 class PubSubTestCase extends SystemTestCase
 {
@@ -46,14 +47,46 @@ class PubSubTestCase extends SystemTestCase
         }
 
         $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-        self::$restClient = new PubSubClient([
+        self::$restClient = new PubSubClientRest([
             'keyFilePath' => $keyFilePath,
             'transport' => 'rest'
         ]);
-        self::$grpcClient = new PubSubClient([
+        self::$grpcClient = new PubSubClientGrpc([
             'keyFilePath' => $keyFilePath,
             'transport' => 'grpc'
         ]);
         self::$hasSetUp = true;
     }
+
+    public static function topic(PubSubClient $client, array $config = [])
+    {
+        $topicName = uniqid(self::TESTING_PREFIX);
+        $topic = $client->createTopic($topicName, $config);
+        self::$deletionQueue->add($topic);
+
+        return $topic;
+    }
+
+    public static function subscription(PubSubClient $client, Topic $topic, array $config = [])
+    {
+        $subName = uniqid(self::TESTING_PREFIX);
+        $sub = $client->subscribe($subName, $topic, $config);
+
+        self::$deletionQueue->add($sub);
+
+        return $sub;
+    }
+
+    public static function topicAndSubscription(PubSubClient $client, array $topicConfig = [], array $subConfig = [])
+    {
+        $topic = self::topic($client, $topicConfig);
+        $sub = self::subscription($client, $topic, $subConfig);
+
+        return [$topic, $sub];
+    }
 }
+
+//@codingStandardsIgnoreStart
+class PubSubClientRest extends PubSubClient {}
+class PubSubClientGrpc extends PubSubClient {}
+//@codingStandardsIgnoreEnd

--- a/PubSub/tests/Unit/MessageBuilderTest.php
+++ b/PubSub/tests/Unit/MessageBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub\Tests\Unit;
+
+use Google\Cloud\PubSub\MessageBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group pubsub
+ * @group pubsub-message-builder
+ */
+class MessageBuilderTest extends TestCase
+{
+    public function testSetters()
+    {
+        $expected = [
+            'data' => 'hello',
+            'attributes' => [
+                'foo' => 'bar',
+                'bat' => 'baz'
+            ],
+            'orderingKey' => 'test'
+        ];
+        $builder = new MessageBuilder;
+
+        $builder = $builder->setData($expected['data'])
+            ->setAttributes($expected['attributes'])
+            ->addAttribute('extra', 'ok')
+            ->setOrderingKey($expected['orderingKey']);
+
+        $expected['attributes']['extra'] = 'ok';
+        $this->assertEquals($expected, $builder->build()->toArray());
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testMissingData()
+    {
+        (new MessageBuilder)->build();
+    }
+}

--- a/PubSub/tests/Unit/MessageBuilderTest.php
+++ b/PubSub/tests/Unit/MessageBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/Unit/MessageTest.php
+++ b/PubSub/tests/Unit/MessageTest.php
@@ -39,6 +39,7 @@ class MessageTest extends TestCase
             'attributes' => [
                 'foo' => 'bar'
             ],
+            'orderingKey' => 'foo'
         ], [
             'ackId' => 1234,
             'subscription' => $this->prophesize(Subscription::class)->reveal()
@@ -48,6 +49,11 @@ class MessageTest extends TestCase
     public function testData()
     {
         $this->assertEquals('hello world', $this->message->data());
+    }
+
+    public function testOrderingKey()
+    {
+        $this->assertEquals('foo', $this->message->orderingKey());
     }
 
     public function testAttribute()


### PR DESCRIPTION
replaces #2419. This PR demonstrates using a single batch job for multiple ordering keys RPCs in order to prevent crashes from exhausted shared memory.

Opening as a separate PR so that the changes may be compared.