### PR TITLE
feat: add getPrivateProperty test helper

### DIFF
--- a/Core/src/Testing/TestHelpers.php
+++ b/Core/src/Testing/TestHelpers.php
@@ -241,6 +241,23 @@ class TestHelpers
     }
 
     /**
+     * Get the value of a private property.
+     *
+     * @param mixed $class The class
+     * @param string $property The property name.
+     * @return mixed
+     */
+    public static function getPrivateProperty($class, $property)
+    {
+        $className = get_class($class);
+        $c = \Closure::bind(function ($class) use ($property) {
+            return $class->$property;
+        }, null, $className);
+
+        return $c($class);
+    }
+
+    /**
      * Determine the path of the project root based on where the composer
      * autoloader is located.
      *


### PR DESCRIPTION
We have `StubTrait::___getProperty()`, but it only works for classes which we create. This allows us to grab private properties from any object for testing, and is used by #2532.