### PR TITLE
feat(spanner): add emulator support

### DIFF
--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -131,6 +131,8 @@ class SpannerClient
      */
     public function __construct(array $config = [])
     {
+        $emulatorHost = getenv('SPANNER_EMULATOR_HOST');
+
         $this->requireGrpc();
         $config += [
             'scopes' => [
@@ -138,7 +140,9 @@ class SpannerClient
                 self::ADMIN_SCOPE
             ],
             'returnInt64AsObject' => false,
-            'projectIdRequired' => true
+            'projectIdRequired' => true,
+            'hasEmulator' => (bool) $emulatorHost,
+            'emulatorHost' => $emulatorHost
         ];
 
         $this->connection = new Grpc($this->configureAuthentication($config));

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -57,6 +57,17 @@ use Psr\Http\StreamInterface;
  * $spanner = new SpannerClient();
  * ```
  *
+ * ```
+ * // Using a Spanner Emulator
+ * use Google\Cloud\Spanner\SpannerClient;
+ *
+ * // Be sure to use the port specified when starting the emulator.
+ * // `9010` is used as an example only.
+ * putenv('SPANNER_EMULATOR_HOST=localhost:9010');
+ *
+ * $spanner = new SpannerClient();
+ * ```
+ *
  * @method resumeOperation() {
  *     Resume a Long Running Operation
  *

--- a/Spanner/tests/Snippet/SpannerClientTest.php
+++ b/Spanner/tests/Snippet/SpannerClientTest.php
@@ -267,4 +267,12 @@ class SpannerClientTest extends SnippetTestCase
         $res = $snippet->invoke('operation');
         $this->assertInstanceOf(LongRunningOperation::class, $res->returnVal());
     }
+
+    public function testEmulator()
+    {
+        $snippet = $this->snippetFromClass(SpannerClient::class, 1);
+        $res = $snippet->invoke('spanner');
+        $this->assertInstanceOf(SpannerClient::class, $res->returnVal());
+        $this->assertEquals('localhost:9010', getenv('SPANNER_EMULATOR_HOST'));
+    }
 }


### PR DESCRIPTION
Add support for emulators.

To use an emulator, set the environment variable to the host:port of the emulator:
e.g. `$ export SPANNER_EMULATOR_HOST=localhost:9010`

Avoid using http schemes in the emulator host as it can cause the gRPC DNS resolver to endlessly attempt to resolve.