### PR TITLE
docs: fix typo for CacheSessionPool config

### DIFF
--- a/Spanner/README.md
+++ b/Spanner/README.md
@@ -87,8 +87,8 @@ $spanner = new SpannerClient([
 $sessionPool = new CacheSessionPool(
     $sessionCache,
     [
-        'minSession' => 10,
-        'maxSession' => 10  // Here it will create 10 sessions under the cover.
+        'minSessions' => 10,
+        'maxSessions' => 10  // Here it will create 10 sessions under the cover.
     ]
 );
 


### PR DESCRIPTION
`maxSessions` and `minSessions` should be correct.
http://googleapis.github.io/google-cloud-php/#/docs/cloud-spanner/v1.24.0/spanner/session/cachesessionpool