### PR TITLE
fix: issue with isComplete function causing an error when an array is not returned

### DIFF
--- a/BigQuery/src/Job.php
+++ b/BigQuery/src/Job.php
@@ -258,7 +258,7 @@ class Job
      */
     public function isComplete(array $options = [])
     {
-        return $this->info($options)['status']['state'] === 'DONE';
+        return isset($this->info($options)['status']['state']) && $this->info($options)['status']['state'] === 'DONE';
     }
 
     /**


### PR DESCRIPTION
fix: issue with isComplete function causing an error when an array is not returned

`ErrorException: Undefined index: status in /var/www/code/vendor/google/cloud-bigquery/src/Job.php:261`