### PR TITLE
chore: update synth to fix relative cloud.google.com links

### DIFF
--- a/Asset/synth.py
+++ b/Asset/synth.py
@@ -102,3 +102,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/AutoMl/synth.py
+++ b/AutoMl/synth.py
@@ -140,3 +140,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/BigQueryDataTransfer/synth.py
+++ b/BigQueryDataTransfer/synth.py
@@ -108,3 +108,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Bigtable/synth.py
+++ b/Bigtable/synth.py
@@ -150,3 +150,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Container/synth.py
+++ b/Container/synth.py
@@ -72,13 +72,6 @@ s.replace(
     r'Copyright \d{4}',
     'Copyright 2018')
 
-# fix documentation links
-s.replace(
-    '**/*.php',
-    r"\(\/compute\/docs",
-    '(https://cloud.google.com/compute/docs'
-)
-
 # Fix class references in gapic samples
 for version in ['V1']:
     pathExpr = 'src/' + version + '/Gapic/ClusterManagerGapicClient.php'
@@ -126,3 +119,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Dataproc/synth.py
+++ b/Dataproc/synth.py
@@ -121,16 +121,9 @@ s.replace(
 
 ### [END] protoc backwards compatibility fixes
 
-# fix documentation links
+# fix relative cloud.google.com links
 s.replace(
-    '**/*.php',
-    r"\(\/compute\/docs",
-    '(https://cloud.google.com/compute/docs'
-)
-
-# fix documentation links
-s.replace(
-    '**/*.php',
-    r"\(\/dataproc\/docs",
-    '(https://cloud.google.com/dataproc/docs'
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
 )

--- a/Datastore/synth.py
+++ b/Datastore/synth.py
@@ -112,3 +112,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Debugger/synth.py
+++ b/Debugger/synth.py
@@ -100,3 +100,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Dialogflow/synth.py
+++ b/Dialogflow/synth.py
@@ -115,3 +115,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Dlp/synth.py
+++ b/Dlp/synth.py
@@ -108,3 +108,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/ErrorReporting/synth.py
+++ b/ErrorReporting/synth.py
@@ -97,3 +97,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Firestore/synth.py
+++ b/Firestore/synth.py
@@ -143,3 +143,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Iot/synth.py
+++ b/Iot/synth.py
@@ -93,3 +93,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Kms/synth.py
+++ b/Kms/synth.py
@@ -99,3 +99,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Language/synth.py
+++ b/Language/synth.py
@@ -118,3 +118,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Logging/synth.py
+++ b/Logging/synth.py
@@ -104,3 +104,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Monitoring/synth.py
+++ b/Monitoring/synth.py
@@ -130,3 +130,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/OsLogin/synth.py
+++ b/OsLogin/synth.py
@@ -109,3 +109,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/PubSub/synth.py
+++ b/PubSub/synth.py
@@ -108,3 +108,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Recommender/synth.py
+++ b/Recommender/synth.py
@@ -98,3 +98,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Redis/synth.py
+++ b/Redis/synth.py
@@ -135,3 +135,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Scheduler/synth.py
+++ b/Scheduler/synth.py
@@ -158,3 +158,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/SecretManager/synth.py
+++ b/SecretManager/synth.py
@@ -104,3 +104,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/SecurityCenter/synth.py
+++ b/SecurityCenter/synth.py
@@ -113,3 +113,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Spanner/synth.py
+++ b/Spanner/synth.py
@@ -218,3 +218,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Speech/synth.py
+++ b/Speech/synth.py
@@ -124,3 +124,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Talent/synth.py
+++ b/Talent/synth.py
@@ -113,3 +113,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Tasks/synth.py
+++ b/Tasks/synth.py
@@ -176,3 +176,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/TextToSpeech/synth.py
+++ b/TextToSpeech/synth.py
@@ -86,3 +86,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Trace/synth.py
+++ b/Trace/synth.py
@@ -114,3 +114,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Translate/synth.py
+++ b/Translate/synth.py
@@ -96,3 +96,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/VideoIntelligence/synth.py
+++ b/VideoIntelligence/synth.py
@@ -114,3 +114,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/Vision/synth.py
+++ b/Vision/synth.py
@@ -98,3 +98,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/WebRisk/synth.py
+++ b/WebRisk/synth.py
@@ -112,3 +112,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)

--- a/WebSecurityScanner/synth.py
+++ b/WebSecurityScanner/synth.py
@@ -98,3 +98,10 @@ s.replace(
 )
 
 ### [END] protoc backwards compatibility fixes
+
+# fix relative cloud.google.com links
+s.replace(
+    "src/**/V*/**/*.php",
+    r"(.{0,})\]\((/.{0,})\)",
+    r"\1](https://cloud.google.com\2)"
+)


### PR DESCRIPTION
This change should fix bad markdown links throughout our generated protos.