### PR TITLE
feat: add support for signed post policies

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1372,7 +1372,7 @@ class Bucket
      *
      * Example:
      * ```
-     * $policy = $bucket->postPolicy(new \DateTime('tomorrow'), $objectName, [
+     * $policy = $bucket->generateSignedPostPolicyV4(new \DateTime('tomorrow'), $objectName, [
      *     'conditions' => [
      *         ['content-length-range', 0, 255]
      *     ],
@@ -1433,7 +1433,7 @@ class Bucket
      * }
      * @return array
      */
-    public function postPolicy($expires, $objectName, array $options = [])
+    public function generateSignedPostPolicyV4($expires, $objectName, array $options = [])
     {
         // May be overridden for testing.
         $signingHelper = $this->pluck('helper', $options, false)

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1368,9 +1368,11 @@ class Bucket
      * documents to allow visitors to a website to upload files to Google Cloud
      * Storage without giving them direct write access.
      *
+     * Google Cloud PHP does not support v2 post policies.
+     *
      * Example:
      * ```
-     * $policy = $bucket->uploadPolicy(new \DateTime('tomorrow'), $objectName, [
+     * $policy = $bucket->postPolicy(new \DateTime('tomorrow'), $objectName, [
      *     'conditions' => [
      *         ['content-length-range', 0, 255]
      *     ],

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1362,6 +1362,91 @@ class Bucket
     }
 
     /**
+     * Create a signed upload policy for uploading objects.
+     *
+     * This method generates and signs a policy document. You can use policy
+     * documents to allow visitors to a website to upload files to Google Cloud
+     * Storage without giving them direct write access.
+     *
+     * Example:
+     * ```
+     * $policy = $bucket->uploadPolicy(new \DateTime('tomorrow'), $objectName, [
+     *     'conditions' => [
+     *         ['content-length-range', 0, 255]
+     *     ],
+     *     'fields' => [
+     *          'x-goog-meta-hello' => 'world',
+     *          'success_action_redirect' => 'https://google.com'
+     *     ]
+     * ]);
+     *
+     * echo '<form action="' . $policy['url'] . '" method="post" enctype="multipart/form-data">';
+     * foreach ($policy['fields'] as $name => $value) {
+     *     echo '<input type="hidden" name="' . $name . '" value="' . $value . '">';
+     * }
+     *
+     * echo 'Upload a file!<br>';
+     * echo '<input type="file" name="file">';
+     * echo '<button type="submit">Submit!</button>';
+     * echo '</form>';
+     * ```
+     *
+     * @see https://cloud.google.com/storage/docs/xml-api/post-object#policydocument Policy Documents
+     *
+     * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
+     *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
+     *        [http://php.net/datetimeimmutable](`\DateTimeImmutable`), or a
+     *        UNIX timestamp as an integer.
+     * @param string $objectName The path to the file in Google Cloud Storage,
+     *        relative to the bucket.
+     * @param array $options [optional] {
+     *     Configuration options
+     *
+     *     @type string $bucketBoundHostname The hostname for the bucket, for
+     *           instance `cdn.example.com`. May be used for Google Cloud Load
+     *           Balancers or for custom bucket CNAMEs. **Defaults to**
+     *           `storage.googleapis.com`.
+     *     @type array $conditions A list of arrays containing policy matching
+     *           conditions (e.g. `eq`, `starts-with`, `content-length-range`).
+     *     @type array $fields Additional form fields (do not include
+     *           `x-goog-signature`, `file`, `policy` or fields with an
+     *           `x-ignore` prefix), given as key/value pairs.
+     *     @type bool $forceOpenssl If true, OpenSSL will be used regardless of
+     *           whether phpseclib is available. **Defaults to** `false`.
+     *     @type array $keyFile Keyfile data to use in place of the keyfile with
+     *           which the client was constructed. If `$options.keyFilePath` is
+     *           set, this option is ignored.
+     *     @type string $keyFilePath A path to a valid Keyfile to use in place
+     *           of the keyfile with which the client was constructed.
+     *     @type string $scheme Either `http` or `https`. Only used if a custom
+     *           hostname is provided via `$options.bucketBoundHostname`. If a
+     *           custom bucketBoundHostname is provided, **defaults to** `http`.
+     *           In all other cases, **defaults to** `https`.
+     *     @type string|array $scopes One or more authentication scopes to be
+     *           used with a key file. This option is ignored unless
+     *           `$options.keyFile` or `$options.keyFilePath` is set.
+     *     @type bool $virtualHostedStyle If `true`, URL will be of form
+     *           `mybucket.storage.googleapis.com`. If `false`,
+     *           `storage.googleapis.com/mybucket`. **Defaults to** `false`.
+     * }
+     * @return array
+     */
+    public function postPolicy($expires, $objectName, array $options = [])
+    {
+        // May be overridden for testing.
+        $signingHelper = $this->pluck('helper', $options, false)
+            ?: SigningHelper::getHelper();
+
+        $resource = sprintf('/%s/%s', $this->identity['bucket'], $objectName);
+        return $signingHelper->v4PostPolicy(
+            $this->connection,
+            $expires,
+            $resource,
+            $options
+        );
+    }
+
+    /**
      * Determines if an object name is required.
      *
      * @param mixed $data

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1431,7 +1431,8 @@ class Bucket
      *           `mybucket.storage.googleapis.com`. If `false`,
      *           `storage.googleapis.com/mybucket`. **Defaults to** `false`.
      * }
-     * @return array
+     * @return array An associative array, containing (string) `uri` and
+     *        (array) `fields` keys.
      */
     public function generateSignedPostPolicyV4($expires, $objectName, array $options = [])
     {

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Storage;
 
 use Google\Auth\CredentialsLoader;
 use Google\Auth\SignBlobInterface;
+use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\JsonTrait;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
@@ -30,6 +31,7 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
  */
 class SigningHelper
 {
+    use ArrayTrait;
     use JsonTrait;
 
     const DEFAULT_URL_SIGNING_VERSION = 'v2';
@@ -423,6 +425,13 @@ class SigningHelper
         $conditions = $options['conditions'];
         foreach ($options['fields'] as $key => $value) {
             $conditions[] = [$key => $value];
+        }
+
+        foreach ($conditions as &$condition) {
+            if (is_array($condition) && !$this->isAssoc($condition)) {
+                $end = array_pop($condition);
+                $condition[] = addslashes($end);
+            }
         }
 
         $conditions = array_merge($conditions, [

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -131,7 +131,7 @@ class SigningHelper
         list($credentials, $options) = $this->getSigningCredentials($connection, $options);
 
         $expires = $this->normalizeExpiration($expires);
-        list($bucket, $resource) = $this->normalizeResource($resource);
+        list($resource, $bucket) = $this->normalizeResource($resource);
         $options = $this->normalizeOptions($options);
         $headers = $this->normalizeHeaders($options['headers']);
 
@@ -227,7 +227,7 @@ class SigningHelper
         list($credentials, $options) = $this->getSigningCredentials($connection, $options);
 
         $expires = $this->normalizeExpiration($expires);
-        list($bucket, $resource) = $this->normalizeResource($resource);
+        list($resource, $bucket) = $this->normalizeResource($resource);
         $options = $this->normalizeOptions($options);
 
         $time = $options['timestamp'];
@@ -359,6 +359,115 @@ class SigningHelper
     }
 
     /**
+     * Create an HTTP POST policy using v4 signing.
+     *
+     * @param ConnectionInterface $connection A Connection to Google Cloud Storage.
+     * @param Timestamp|\DateTimeInterface|int $expires The signed URL
+     *        expiration.
+     * @param string $resource The URI to the storage resource, preceded by a
+     *        leading slash.
+     * @param array $options Configuration options. See
+     *        {@see Google\Cloud\Storage\Bucket::postPolicy()} for details.
+     * @return array An associative array, containing (string) `uri` and
+     *        (array) `fields` keys.
+     */
+    public function v4PostPolicy(
+        ConnectionInterface $connection,
+        $expires,
+        $resource,
+        array $options = []
+    ) {
+        list($credentials, $options) = $this->getSigningCredentials($connection, $options);
+
+        $expires = $this->normalizeExpiration($expires);
+        list($resource, $bucket, $object) = $this->normalizeResource($resource);
+        $object = trim($object, '/');
+
+        $options = $this->normalizeOptions($options) + [
+            'fields' => [],
+            'conditions' => [],
+            'successActionRedirect' => null,
+            'successActionStatus' => null
+        ];
+
+        $time = $options['timestamp'];
+        $requestTimestamp = $time->format(self::V4_TIMESTAMP_FORMAT);
+        $requestDatestamp = $time->format(self::V4_DATESTAMP_FORMAT);
+        $expiration = \DateTimeImmutable::createFromFormat('U', $expires);
+        $expirationTimestamp = str_replace(
+            '+00:00',
+            'Z',
+            $expiration->format(\DateTime::RFC3339)
+        );
+
+        $clientEmail = $credentials->getClientName();
+        $credentialScope = sprintf('%s/auto/storage/goog4_request', $requestDatestamp);
+        $credential = sprintf('%s/%s', $clientEmail, $credentialScope);
+
+        if ($options['virtualHostedStyle']) {
+            $options['bucketBoundHostname'] = sprintf(
+                '%s.storage.googleapis.com',
+                $bucket
+            );
+        }
+
+        $fields = $options['fields'];
+
+        $fields = array_merge($fields, [
+            'key' => $object,
+            'x-goog-algorithm' => self::V4_ALGO_NAME,
+            'x-goog-credential' => $credential,
+            'x-goog-date' => $requestTimestamp
+        ]);
+
+        $conditions = $options['conditions'];
+        foreach ($options['fields'] as $key => $value) {
+            $conditions[] = [$key => $value];
+        }
+
+        $conditions = array_merge($conditions, [
+            ['key' => $object],
+            ['x-goog-date' => $requestTimestamp],
+            ['x-goog-credential' => $credential],
+            ['x-goog-algorithm' => self::V4_ALGO_NAME],
+        ]);
+
+        $policy = [
+            'conditions' => $conditions,
+            'expiration' => $expirationTimestamp
+        ];
+
+        $stringToSign = base64_encode(json_encode($policy, JSON_UNESCAPED_SLASHES));
+
+        $signature = bin2hex(base64_decode($credentials->signBlob($stringToSign, [
+            'forceOpenssl' => $options['forceOpenssl']
+        ])));
+
+        $fields['x-goog-signature'] = $signature;
+        $fields['policy'] = $stringToSign;
+
+        // Construct the modified resource name. If a custom hostname is provided,
+        // this will remove the bucket name from the resource.
+        $resource = $this->normalizeUriPath($options['bucketBoundHostname'], '/' . $bucket, true);
+
+        $scheme = $this->chooseScheme(
+            $options['scheme'],
+            $options['bucketBoundHostname'],
+            $options['virtualHostedStyle']
+        );
+
+        return [
+            'url' => sprintf(
+                '%s://%s%s',
+                $scheme,
+                $options['bucketBoundHostname'],
+                $resource,
+            ),
+            'fields' => $fields
+        ];
+    }
+
+    /**
      * Creates a canonical request hash for a V4 Signed URL.
      *
      * NOTE: While in most cases `PHP_EOL` is preferable to a system-specific
@@ -456,8 +565,9 @@ class SigningHelper
      *
      * @param string $resource The resource identifier. In form
      *        `[/]$bucket/$object`.
-     * @return array A list, where index 0 is the bucket and index 1 is the
-     *         resource, with pieces encoded and prefixed with a forward slash.
+     * @return array A list, where index 0 is the resource path, with pieces
+     *        encoded and prefixed with a forward slash, index 1 is the bucket
+     *        name, and index 2 is the object name, relative to the bucket.
      */
     private function normalizeResource($resource)
     {
@@ -468,9 +578,13 @@ class SigningHelper
 
         $bucket = $pieces[0];
 
+        $relative = $pieces;
+        array_shift($relative);
+
         return [
+            '/' . implode('/', $pieces),
             $bucket,
-            '/' . implode('/', $pieces)
+            '/' . implode('/', $relative),
         ];
     }
 
@@ -613,7 +727,7 @@ class SigningHelper
      * @param string $resource The GCS resource path (i.e. /bucket/object).
      * @return string
      */
-    private function normalizeUriPath($bucketBoundHostname, $resource)
+    private function normalizeUriPath($bucketBoundHostname, $resource, $withTrailingSlash = false)
     {
         if ($bucketBoundHostname !== self::DEFAULT_DOWNLOAD_HOST) {
             $resourceParts = explode('/', trim($resource, '/'));
@@ -627,7 +741,11 @@ class SigningHelper
             }
         }
 
-        return $resource;
+        $resource = rtrim($resource, '/');
+
+        return $withTrailingSlash
+            ? $resource . '/'
+            : $resource;
     }
 
     /**
@@ -691,12 +809,14 @@ class SigningHelper
             $credentials = $rw->getCredentialsFetcher();
         }
 
+        //@codeCoverageIgnoreStart
         if (!($credentials instanceof SignBlobInterface)) {
             throw new \RuntimeException(sprintf(
                 'Credentials object is of type `%s` and is not valid for signing.',
                 get_class($credentials)
             ));
         }
+        //@codeCoverageIgnoreEnd
 
         unset(
             $options['keyFilePath'],

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -413,9 +413,7 @@ class SigningHelper
             );
         }
 
-        $fields = $options['fields'];
-
-        $fields = array_merge($fields, [
+        $fields = array_merge($options['fields'], [
             'key' => $object,
             'x-goog-algorithm' => self::V4_ALGO_NAME,
             'x-goog-credential' => $credential,

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -461,7 +461,7 @@ class SigningHelper
                 '%s://%s%s',
                 $scheme,
                 $options['bucketBoundHostname'],
-                $resource,
+                $resource
             ),
             'fields' => $fields
         ];

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -393,7 +393,7 @@ class SigningHelper
         $time = $options['timestamp'];
         $requestTimestamp = $time->format(self::V4_TIMESTAMP_FORMAT);
         $requestDatestamp = $time->format(self::V4_DATESTAMP_FORMAT);
-        $expiration = \DateTimeImmutable::createFromFormat('U', $expires);
+        $expiration = \DateTimeImmutable::createFromFormat('U', (string) $expires);
         $expirationTimestamp = str_replace(
             '+00:00',
             'Z',

--- a/Storage/src/SigningHelper.php
+++ b/Storage/src/SigningHelper.php
@@ -422,14 +422,8 @@ class SigningHelper
             'x-goog-date' => $requestTimestamp
         ]);
 
-        // foreach ($fields as $key => $value) {
-        //     $key = $this->applyPostPolicyEscapingRules($key);
-        //     $value = $this->applyPostPolicyEscapingRules($value);
-        //     $fields[$key] = $value;
-        // }
-
         $conditions = $options['conditions'];
-        foreach (array_reverse($options['fields']) as $key => $value) {
+        foreach ($options['fields'] as $key => $value) {
             $conditions[] = [$key => $value];
         }
 
@@ -921,7 +915,7 @@ class SigningHelper
             return $input;
         }
 
-        $output = addslashes($input);
+        $output = preg_replace('/[\\\]{1,}/', '\\\\', $input);
         $output = str_replace(PHP_EOL, '\n', $output);
         $output = preg_replace('/[\t]+/', '\t', $output);
 

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -642,7 +642,6 @@ class BucketTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(Bucket::class, 'signedUrl');
         $snippet->addLocal('bucket', $this->bucket);
-        $snippet->addUse(Timestamp::class);
 
         list($pkey, $pub) = $this->getKeyPair();
         $kf = [
@@ -673,7 +672,6 @@ class BucketTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(Bucket::class, 'signedUrl', 1);
         $snippet->addLocal('bucket', $this->bucket);
-        $snippet->addUse(Timestamp::class);
 
         list($pkey, $pub) = $this->getKeyPair();
         $kf = [
@@ -697,6 +695,39 @@ class BucketTest extends SnippetTestCase
         $res = $snippet->invoke('url');
         $this->assertContains('https://storage.googleapis.com/my-bucket', $res->returnVal());
         $this->assertContains('X-Goog-Signature=', $res->returnVal());
+    }
+
+    public function testUploadPolicy()
+    {
+        $objectName = 'foo.txt';
+
+        $snippet = $this->snippetFromMethod(Bucket::class, 'uploadPolicy');
+        $snippet->addLocal('bucket', $this->bucket);
+        $snippet->addLocal('objectName', $objectName);
+
+        list($pkey, $pub) = $this->getKeyPair();
+        $kf = [
+            'private_key' => $pkey,
+            'client_email' => 'test@example.com'
+        ];
+
+        $rw = $this->prophesize(RequestWrapper::class);
+        $rw->keyFile()->willReturn($kf);
+
+        $creds = $this->prophesize(ServiceAccountCredentials::class);
+        $creds->signBlob(Argument::any(), Argument::any())->willReturn('foo');
+        $creds->getClientName()->willReturn($kf['client_email']);
+        $rw->getCredentialsFetcher()->willReturn($creds->reveal());
+
+        $conn = $this->prophesize(Rest::class);
+        $conn->requestWrapper()->willReturn($rw->reveal());
+
+        $this->bucket->___setProperty('connection', $conn->reveal());
+
+        $res = $snippet->invoke('policy');
+
+        $this->assertContains('https://storage.googleapis.com/my-bucket', $res->returnVal()['url']);
+        $this->assertEquals($objectName, $res->returnVal()['fields']['key']);
     }
 
     private function assertSnippetBuildsNotification($snippet, $expectedArgs)

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -697,11 +697,11 @@ class BucketTest extends SnippetTestCase
         $this->assertContains('X-Goog-Signature=', $res->returnVal());
     }
 
-    public function testPostPolicy()
+    public function testGgenerateSignedPostPolicyV4()
     {
         $objectName = 'foo.txt';
 
-        $snippet = $this->snippetFromMethod(Bucket::class, 'postPolicy');
+        $snippet = $this->snippetFromMethod(Bucket::class, 'generateSignedPostPolicyV4');
         $snippet->addLocal('bucket', $this->bucket);
         $snippet->addLocal('objectName', $objectName);
 

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -697,11 +697,11 @@ class BucketTest extends SnippetTestCase
         $this->assertContains('X-Goog-Signature=', $res->returnVal());
     }
 
-    public function testUploadPolicy()
+    public function testPostPolicy()
     {
         $objectName = 'foo.txt';
 
-        $snippet = $this->snippetFromMethod(Bucket::class, 'uploadPolicy');
+        $snippet = $this->snippetFromMethod(Bucket::class, 'postPolicy');
         $snippet->addLocal('bucket', $this->bucket);
         $snippet->addLocal('objectName', $objectName);
 

--- a/Storage/tests/System/PostPolicyTest.php
+++ b/Storage/tests/System/PostPolicyTest.php
@@ -106,7 +106,8 @@ class PostPolicyTest extends StorageTestCase
             ["foo
             "],
             ["é"],
-            ["hello\world"]
+            ["hello\world"],
+            ["	"] // tab
         ];
     }
 

--- a/Storage/tests/System/PostPolicyTest.php
+++ b/Storage/tests/System/PostPolicyTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\System;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7;
+
+/**
+ * @group storage
+ * @group storage-postpolicy
+ */
+class PostPolicyTest extends StorageTestCase
+{
+    private $guzzle;
+
+    public function setUp()
+    {
+        $this->guzzle = new Client;
+    }
+
+    public function testUploadPolicy()
+    {
+        $filename = $this->createFilename();
+        $content = 'helloworld';
+        $policy = self::$bucket->postPolicy(time() + 3600, $filename);
+        $res = $this->uploadWithPolicy($policy, $content);
+        self::$deletionQueue->add($this->getObject($filename));
+
+        $this->assertEquals(204, $res->getStatusCode());
+        $this->assertEquals($content, $this->getUploadedFileContents($filename));
+    }
+
+    public function testUploadPolicySuccessActionRedirect()
+    {
+        $filename = $this->createFilename();
+        $content = 'helloworld';
+        $location = 'https://google.com';
+        $policy = self::$bucket->postPolicy(time() + 3600, $filename, [
+            'fields' => [
+                'success_action_redirect' => $location
+            ]
+        ]);
+        $res = $this->uploadWithPolicy($policy, $content);
+        self::$deletionQueue->add($this->getObject($filename));
+
+        $this->assertEquals(303, $res->getStatusCode());
+        $this->assertStringStartsWith(
+            $location . '?bucket=' . self::$bucket->name(),
+            $res->getHeaderLine('Location')
+        );
+    }
+
+    public function testUploadPolicyInvalidField()
+    {
+        $filename = $this->createFilename();
+        $policy = self::$bucket->postPolicy(time() + 3600, $filename, [
+            'fields' => [
+                'x-goog-random' => 'foo'
+            ]
+        ]);
+        $res = $this->uploadWithPolicy($policy);
+        self::$deletionQueue->add($this->getObject($filename));
+
+        $this->assertEquals(400, $res->getStatusCode());
+    }
+
+    public function testUploadPolicyEscapingSequence()
+    {
+        $filename = $this->createFilename();
+        $content = "foo\n";
+        $policy = self::$bucket->postPolicy(time() + 3600, $filename, [
+            'conditions' => [
+                ['starts-with', '$key', "foo\n"]
+            ]
+        ]);
+        $res = $this->uploadWithPolicy($policy, $content);
+        self::$deletionQueue->add($this->getObject($filename));
+
+        $this->assertEquals(203, $res->getStatusCode());
+    }
+
+    private function uploadWithPolicy(array $policy, $content = '')
+    {
+        $fields = [];
+        $fields[] = [
+            'name' => 'file',
+            'contents' => Psr7\stream_for($content ?: uniqid(self::TESTING_PREFIX))
+        ];
+
+        foreach ($policy['fields'] as $key => $val) {
+            $fields[] = [
+                'name' => $key,
+                'contents' => $val
+            ];
+        }
+
+        return $this->guzzle->request('POST', $policy['url'], [
+            'multipart' => $fields,
+            'allow_redirects' => false,
+            'http_errors' => false
+        ]);
+    }
+
+    private function getUploadedFileContents($filename)
+    {
+        $object = self::$bucket->object($filename);
+        return $object->downloadAsString();
+    }
+
+    private function getObject($filename)
+    {
+        return self::$bucket->object($filename);
+    }
+
+    private function createFilename()
+    {
+        return uniqid(self::TESTING_PREFIX) . '.txt';
+    }
+}

--- a/Storage/tests/Unit/ConformanceTest.php
+++ b/Storage/tests/Unit/ConformanceTest.php
@@ -179,7 +179,7 @@ class ConformanceTest extends TestCase
         foreach (self::$cases['postPolicyV4Tests'] as $case) {
             $desc = $case['description'];
 
-            if ($desc !== 'POST Policy Cache-Control File Header') continue;
+            // if ($desc !== 'POST Policy Cache-Control File Header') continue;
 
             $out[$case['description']] = [$case];
             unset($case['description']);

--- a/Storage/tests/Unit/ConformanceTest.php
+++ b/Storage/tests/Unit/ConformanceTest.php
@@ -175,8 +175,6 @@ class ConformanceTest extends TestCase
         foreach (self::$cases['postPolicyV4Tests'] as $case) {
             $desc = $case['description'];
 
-            // if ($desc !== 'POST Policy Cache-Control File Header') continue;
-
             $out[$case['description']] = [$case];
             unset($case['description']);
 

--- a/Storage/tests/Unit/ConformanceTest.php
+++ b/Storage/tests/Unit/ConformanceTest.php
@@ -142,10 +142,6 @@ class ConformanceTest extends TestCase
         $decodedPolicy = base64_decode($policy['fields']['policy']);
         $this->assertEquals($testdata['policyOutput']['fields'], $policy['fields']);
         $this->assertEquals($testdata['policyOutput']['url'], $policy['url']);
-        // $this->assertEquals(
-        //     $testdata['policyOutput']['expectedDecodedPolicy'],
-        //     $decodedPolicy
-        // );
     }
 
     public function signedUrlConformanceCases()

--- a/Storage/tests/Unit/ConformanceTest.php
+++ b/Storage/tests/Unit/ConformanceTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  * @group storage
  * @group storage-conformance
  */
-class StorageConformanceTest extends TestCase
+class ConformanceTest extends TestCase
 {
     private static $cases;
 
@@ -133,7 +133,7 @@ class StorageConformanceTest extends TestCase
             'conditions' => $conditions,
         ];
 
-        $policy = $bucket->postPolicy(
+        $policy = $bucket->generateSignedPostPolicyV4(
             $expiration,
             $testdata['policyInput']['object'],
             $hostnameOptions + $options
@@ -142,10 +142,10 @@ class StorageConformanceTest extends TestCase
         $decodedPolicy = base64_decode($policy['fields']['policy']);
         $this->assertEquals($testdata['policyOutput']['fields'], $policy['fields']);
         $this->assertEquals($testdata['policyOutput']['url'], $policy['url']);
-        $this->assertEquals(
-            $testdata['policyOutput']['expectedDecodedPolicy'],
-            $decodedPolicy
-        );
+        // $this->assertEquals(
+        //     $testdata['policyOutput']['expectedDecodedPolicy'],
+        //     $decodedPolicy
+        // );
     }
 
     public function signedUrlConformanceCases()
@@ -178,6 +178,8 @@ class StorageConformanceTest extends TestCase
         $out = [];
         foreach (self::$cases['postPolicyV4Tests'] as $case) {
             $desc = $case['description'];
+
+            if ($desc !== 'POST Policy Cache-Control File Header') continue;
 
             $out[$case['description']] = [$case];
             unset($case['description']);

--- a/Storage/tests/Unit/SigningHelperTest.php
+++ b/Storage/tests/Unit/SigningHelperTest.php
@@ -343,6 +343,34 @@ class SigningHelperTest extends TestCase
         $this->assertEquals($expected ?: $bucketBoundHostname, $parts['host']);
     }
 
+    /**
+     * @dataProvider hostnames
+     */
+    public function testCnameStillWorks($bucketBoundHostname, $expected = null)
+    {
+        $credentials = $this->createCredentialsMock();
+        $expires = time() + 2;
+        $resource = $this->createResource();
+        $return = base64_encode('SIGNATURE');
+
+        $credentials->signBlob(Argument::type('string'), Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($return);
+
+        $url = $this->helper->v4Sign(
+            $this->mockConnection($credentials->reveal()),
+            $expires,
+            $resource,
+            self::GENERATION,
+            [
+                'cname' => $bucketBoundHostname
+            ]
+        );
+
+        $parts = parse_url($url);
+        $this->assertEquals($expected ?: $bucketBoundHostname, $parts['host']);
+    }
+
     public function hostnames()
     {
         return [
@@ -477,7 +505,7 @@ class SigningHelperTest extends TestCase
             $this->$expectation($exception);
         }
 
-        $res = $this->helper->normalizeProxy('normalizeOptions', [$options]);
+        $res = $this->helper->proxyPrivateMethodCall('normalizeOptions', [$options]);
 
         if (!$exception) {
             $expectedKeys = array_keys($expected ?: $options);
@@ -519,7 +547,7 @@ class SigningHelperTest extends TestCase
      */
     public function testNormalizeOptionsInvalidTimestamps($timestamp)
     {
-        $this->helper->normalizeProxy('normalizeOptions', [
+        $this->helper->proxyPrivateMethodCall('normalizeOptions', [
             ['timestamp' => $timestamp]
         ]);
     }
@@ -540,7 +568,7 @@ class SigningHelperTest extends TestCase
      */
     public function testNormalizeHeaders(array $input, array $expected)
     {
-        $res = $this->helper->normalizeProxy('normalizeHeaders', [$input]);
+        $res = $this->helper->proxyPrivateMethodCall('normalizeHeaders', [$input]);
 
         $this->assertEquals($expected, $res);
     }
@@ -602,7 +630,7 @@ class SigningHelperTest extends TestCase
      */
     public function testNormalizeUriPath($resource, $bucketBoundHostname, $expected)
     {
-        $res = $this->helper->normalizeProxy('normalizeUriPath', [
+        $res = $this->helper->proxyPrivateMethodCall('normalizeUriPath', [
             $bucketBoundHostname,
             $resource
         ]);
@@ -636,7 +664,7 @@ class SigningHelperTest extends TestCase
             ], [
                 '/bucket',
                 'example.com',
-                '/'
+                ''
             ],
         ];
     }
@@ -668,6 +696,73 @@ class SigningHelperTest extends TestCase
         $this->assertEquals('/bar.gif', $parts['path']);
     }
 
+    /**
+     * @dataProvider keyfiles
+     */
+    public function testGetSigningCredentialsWithKeyfile($input, $keyfile, $name)
+    {
+        $scopes = ['foo'];
+
+        $rw = $this->prophesize(RequestWrapper::class);
+        $rw->scopes()->shouldBeCalled()->willReturn($scopes);
+        $conn = $this->mockConnection($this->createCredentialsMock(), $rw);
+
+        $res = $this->helper->proxyPrivateMethodCall('getSigningCredentials', [
+            $conn,
+            [
+                $name => $input
+            ]
+        ]);
+
+        $this->assertInstanceOf(ServiceAccountCredentials::class, $res[0]);
+        $this->assertEquals($keyfile['client_email'], $res[0]->getClientName());
+    }
+
+    /**
+     * @dataProvider keyfiles
+     */
+    public function testGetSigningCredentialsWithKeyfileCustomScopes($input, $keyfile, $name)
+    {
+        $scopes = ['foo'];
+        $conn = $this->mockConnection($this->createCredentialsMock());
+
+        $res = $this->helper->proxyPrivateMethodCall('getSigningCredentials', [
+            $conn,
+            [
+                $name => $input,
+                'scopes' => $scopes
+            ]
+        ]);
+
+        $auth = TestHelpers::getPrivateProperty($res[0], 'auth');
+        $this->assertEquals($scopes[0], $auth->getScope());
+    }
+
+    public function keyfiles()
+    {
+        $keyfilePath = __DIR__ . '/data/signed-url-v4-service-account.json';
+        $keyfile = json_decode(file_get_contents($keyfilePath), true);
+        return [
+            [$keyfilePath, $keyfile, 'keyFilePath'],
+            [$keyfile, $keyfile, 'keyFile']
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetSigningCredentialsInvalidKeyfilePath()
+    {
+        $conn = $this->mockConnection();
+
+        $res = $this->helper->proxyPrivateMethodCall('getSigningCredentials', [
+            $conn,
+            [
+                'keyFilePath' => '/wow/i/hope/this/path/never/exists.json'
+            ]
+        ]);
+    }
+
     private function createCredentialsMock()
     {
         $credentials = $this->prophesize(ServiceAccountCredentials::class);
@@ -681,11 +776,17 @@ class SigningHelperTest extends TestCase
         return sprintf('/%s/%s', $bucket ?: self::BUCKET, $object ?: self::OBJECT);
     }
 
-    private function mockConnection($credentials)
+    private function mockConnection($credentials = null, $rw = null)
     {
+        $rw = $rw ?: $this->prophesize(RequestWrapper::class);
+
+        if ($credentials) {
+            $rw->getCredentialsFetcher()->willReturn($credentials);
+        } else {
+            $rw->getCredentialsFetcher()->shouldNotBeCalled();
+        }
+
         $conn = $this->prophesize(Rest::class);
-        $rw = $this->prophesize(RequestWrapper::class);
-        $rw->getCredentialsFetcher()->willReturn($credentials);
         $conn->requestWrapper()->willReturn($rw->reveal());
 
         return $conn->reveal();
@@ -715,7 +816,7 @@ class SigningHelperStub extends SigningHelper
             : \Closure::bind($callPrivate, null, new SigningHelper);
     }
 
-    public function normalizeProxy($method, array $args)
+    public function proxyPrivateMethodCall($method, array $args)
     {
         $parent = new SigningHelper;
         $cb = function () use ($method) {

--- a/Storage/tests/Unit/StorageConformanceTest.php
+++ b/Storage/tests/Unit/StorageConformanceTest.php
@@ -133,7 +133,7 @@ class StorageConformanceTest extends TestCase
             'conditions' => $conditions,
         ];
 
-        $policy = $bucket->uploadPolicy(
+        $policy = $bucket->postPolicy(
             $expiration,
             $testdata['policyInput']['object'],
             $hostnameOptions + $options

--- a/Storage/tests/Unit/StorageConformanceTest.php
+++ b/Storage/tests/Unit/StorageConformanceTest.php
@@ -22,10 +22,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
- * @group storage-signed-url
  * @group storage-conformance
  */
-class SignedUrlConformanceTest extends TestCase
+class StorageConformanceTest extends TestCase
 {
     private static $cases;
 
@@ -41,6 +40,7 @@ class SignedUrlConformanceTest extends TestCase
     }
 
     /**
+     * @group storage-conformance-signed-url
      * @dataProvider signedUrlConformanceCases
      */
     public function testSignedUrlConformance(array $testdata)
@@ -58,19 +58,7 @@ class SignedUrlConformanceTest extends TestCase
             $testdata['queryParams'] = $testdata['queryParameters'];
         }
 
-        if (isset($testdata['urlStyle'])) {
-            switch ($testdata['urlStyle']) {
-                case 'VIRTUAL_HOSTED_STYLE':
-                    $testdata['virtualHostedStyle'] = true;
-                    break;
-
-                case 'BUCKET_BOUND_HOSTNAME':
-                    break;
-
-                default:
-                    throw new \Exception('url style ' . $testdata['urlStyle'] . ' not implemented.');
-            }
-        }
+        $hostnameOptions = $this->getHostnameOptions($testdata);
 
         $instanceMethodName = $testdata['method'] === 'POST'
             ? 'signedUploadUrl'
@@ -90,11 +78,74 @@ class SignedUrlConformanceTest extends TestCase
             $testdata['bucketBoundDomain']
         );
 
-        $signedUrl = $signingObject->$instanceMethodName($expiration, $testdata + [
+        $signedUrl = $signingObject->$instanceMethodName($expiration, $hostnameOptions + $testdata + [
             'version' => 'v4'
         ]);
 
         $this->assertEquals($expectedUrl, $signedUrl);
+    }
+
+    /**
+     * @group storage-conformance-post-policy
+     * @dataProvider postPolicyConformanceCases
+     */
+    public function testPostPolicy(array $testdata)
+    {
+        $testdata['policyInput'] = $testdata['policyInput'] + [
+            'conditions' => [],
+            'fields' => []
+        ];
+
+        $client = new StorageClient([
+            'keyFilePath' => __DIR__ . '/data/signed-url-v4-service-account.json'
+        ]);
+
+        $generationTimestamp = \DateTimeImmutable::createFromFormat(
+            \DateTime::RFC3339,
+            $testdata['policyInput']['timestamp']
+        );
+        $bucket = $client->bucket($testdata['policyInput']['bucket']);
+
+        $expiration = $generationTimestamp->format('U') + $testdata['policyInput']['expiration'];
+
+        $hostnameOptions = $this->getHostnameOptions($testdata['policyInput']);
+
+        $conditions = [];
+        foreach ($testdata['policyInput']['conditions'] as $key => $condition) {
+            if ($key === 'startsWith') {
+                $key = 'starts-with';
+            }
+
+            if ($key === 'contentLengthRange') {
+                $key = 'content-length-range';
+            }
+
+            if (!is_array($condition)) {
+                $condition = [$condition];
+            }
+
+            $conditions[] = array_merge([$key], $condition);
+        }
+
+        $options = [
+            'timestamp' => $generationTimestamp,
+            'fields' => $testdata['policyInput']['fields'],
+            'conditions' => $conditions,
+        ];
+
+        $policy = $bucket->uploadPolicy(
+            $expiration,
+            $testdata['policyInput']['object'],
+            $hostnameOptions + $options
+        );
+
+        $decodedPolicy = base64_decode($policy['fields']['policy']);
+        $this->assertEquals($testdata['policyOutput']['fields'], $policy['fields']);
+        $this->assertEquals($testdata['policyOutput']['url'], $policy['url']);
+        $this->assertEquals(
+            $testdata['policyOutput']['expectedDecodedPolicy'],
+            $decodedPolicy
+        );
     }
 
     public function signedUrlConformanceCases()
@@ -127,6 +178,8 @@ class SignedUrlConformanceTest extends TestCase
         $out = [];
         foreach (self::$cases['postPolicyV4Tests'] as $case) {
             $desc = $case['description'];
+
+            $out[$case['description']] = [$case];
             unset($case['description']);
 
             if (isset($case['urlStyle']) && $case['urlStyle'] === 'BUCKET_BOUND_HOSTNAME') {
@@ -139,5 +192,31 @@ class SignedUrlConformanceTest extends TestCase
         }
 
         return $out;
+    }
+
+    private function getHostnameOptions(array $testdata)
+    {
+        $options = [];
+        $options['virtualHostedStyle'] = false;
+        if (isset($testdata['urlStyle'])) {
+            switch ($testdata['urlStyle']) {
+                case 'VIRTUAL_HOSTED_STYLE':
+                    $options['virtualHostedStyle'] = true;
+                    break;
+
+                case 'BUCKET_BOUND_HOSTNAME':
+                    $options['bucketBoundHostname'] = $testdata['bucketBoundHostname'];
+                    break;
+
+                default:
+                    throw new \Exception('url style ' . $testdata['urlStyle'] . ' not implemented.');
+            }
+        }
+
+        if (isset($testdata['scheme'])) {
+            $options['scheme'] = $testdata['scheme'];
+        }
+
+        return $options;
     }
 }

--- a/Storage/tests/Unit/data/signed-url-v4-testdata.json
+++ b/Storage/tests/Unit/data/signed-url-v4-testdata.json
@@ -513,14 +513,14 @@
         "fields" : {
           "key": "$test-object-é",
           "success_action_redirect": "http://www.google.com/",
+          "x-goog-meta": "$test-object-é-metadata",
           "x-goog-algorithm": "GOOG4-RSA-SHA256",
           "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
           "x-goog-date": "20200123T043530Z",
-          "x-goog-meta": "$test-object-é-metadata",
-          "x-goog-signature": "5e62f731d1e5e0935c9157dd059b61d7a9076f0dc953f60534486fdef2f74e54b41c2c35cb441b2fa36e0b93aae0a8b61ae73d003772238e8792415356eb1bf61c8e01043b8d44941e6d535d27e516b89f4055e65ebd0127a92a38f90ccc350a31ae9796567b6585f988c6aa78708ab4969a574c73da0b7eba77af2467bcd5852a8ac712c0abeee85034507cc602543493c9570f1922590cfea66c823ab03740bc64c321320b577d6c0a704f9832c5da8c5a9ba89437e1d0022924802b9d5bb7918f1cc5927666d9a34284c6e11242b3244e51080e751fcf55d871d0e749c04e71e64aba145e07da9dbcba6374865b4446033fb2f15ff0c297c8896ddb1b4688",
-          "policy": "eyJjb25kaXRpb25zIjpbeyJ4LWdvb2ctbWV0YSI6IiR0ZXN0LW9iamVjdC1cdTAwZTktbWV0YWRhdGEifSx7InN1Y2Nlc3NfYWN0aW9uX3JlZGlyZWN0IjoiaHR0cDovL3d3dy5nb29nbGUuY29tLyJ9LHsia2V5IjoiJHRlc3Qtb2JqZWN0LVx1MDBlOSJ9LHsieC1nb29nLWRhdGUiOiIyMDIwMDEyM1QwNDM1MzBaIn0seyJ4LWdvb2ctY3JlZGVudGlhbCI6InRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9zdG9yYWdlL2dvb2c0X3JlcXVlc3QifSx7IngtZ29vZy1hbGdvcml0aG0iOiJHT09HNC1SU0EtU0hBMjU2In1dLCJleHBpcmF0aW9uIjoiMjAyMC0wMS0yM1QwNDozNTo0MFoifQ=="
+          "x-goog-signature": "05eb19ea4ece513cbb2bc6a92c9bc82de6be46943fb4703df3f7b26e6033f90a194e2444e6c3166e9585ca468b5727702aa2696e5cca54677c047f7734119ea0d635404d6a5e577b737ffd5414059cd1b508aa99cfad592d9228f1bf47d7df3ffd73bcae6af6d8d83f7f50b4ccbf6e6c0798d2d9923a7e18c8888e2519fcf09d174b7015581a7de021964eeb9d27293213686d80d825332819c4e98d4ab2c5237f352840993e22a02a41d827ce6a4a294e84a33bf051519fdcbf982f2ad932f58714608c4b5a1f89d5e322d194f5e29fa4160fce771008320ac4e659adeead36aa07fe26a96e52e809436b7bd169256d6613c135148fdee6926caaef65817dc2",
+          "policy": "eyJjb25kaXRpb25zIjpbeyJzdWNjZXNzX2FjdGlvbl9yZWRpcmVjdCI6Imh0dHA6Ly93d3cuZ29vZ2xlLmNvbS8ifSx7IngtZ29vZy1tZXRhIjoiJHRlc3Qtb2JqZWN0LVx1MDBlOS1tZXRhZGF0YSJ9LHsia2V5IjoiJHRlc3Qtb2JqZWN0LVx1MDBlOSJ9LHsieC1nb29nLWRhdGUiOiIyMDIwMDEyM1QwNDM1MzBaIn0seyJ4LWdvb2ctY3JlZGVudGlhbCI6InRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9zdG9yYWdlL2dvb2c0X3JlcXVlc3QifSx7IngtZ29vZy1hbGdvcml0aG0iOiJHT09HNC1SU0EtU0hBMjU2In1dLCJleHBpcmF0aW9uIjoiMjAyMC0wMS0yM1QwNDozNTo0MFoifQ=="
         },
-        "expectedDecodedPolicy": "{\"conditions\":[{\"x-goog-meta\":\"$test-object-\u00e9-metadata\"},{\"success_action_redirect\":\"http://www.google.com/\"},{\"key\":\"$test-object-\u00e9\"},{\"x-goog-date\":\"20200123T043530Z\"},{\"x-goog-credential\":\"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"},{\"x-goog-algorithm\":\"GOOG4-RSA-SHA256\"}],\"expiration\":\"2020-01-23T04:35:40Z\"}"
+        "expectedDecodedPolicy": "{\"conditions\":[{\"success_action_redirect\":\"http://www.google.com/\"},{\"x-goog-meta\":\"$test-object-\u00e9-metadata\"},{\"key\":\"$test-object-\u00e9\"},{\"x-goog-date\":\"20200123T043530Z\"},{\"x-goog-credential\":\"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"},{\"x-goog-algorithm\":\"GOOG4-RSA-SHA256\"}],\"expiration\":\"2020-01-23T04:35:40Z\"}"
       }
     }
   ]

--- a/Storage/tests/Unit/data/signed-url-v4-testdata.json
+++ b/Storage/tests/Unit/data/signed-url-v4-testdata.json
@@ -494,6 +494,34 @@
         },
         "expectedDecodedPolicy": "{\"conditions\":[{\"success_action_redirect\":\"http://www.google.com/\"},{\"key\":\"test-object\"},{\"x-goog-date\":\"20200123T043530Z\"},{\"x-goog-credential\":\"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"},{\"x-goog-algorithm\":\"GOOG4-RSA-SHA256\"}],\"expiration\":\"2020-01-23T04:35:40Z\"}"
       }
+    },
+    {
+      "description": "POST Policy Character Escaping",
+      "policyInput": {
+        "scheme": "https",
+        "bucket": "rsaposttest-1579902671-6ldm6caw4se52vrx",
+        "object": "$test-object-é",
+        "expiration": 10,
+        "timestamp": "2020-01-23T04:35:30Z",
+        "fields": {
+          "success_action_redirect": "http://www.google.com/",
+          "x-goog-meta": "$test-object-é-metadata"
+        }
+      },
+      "policyOutput": {
+        "url": "https://storage.googleapis.com/rsaposttest-1579902671-6ldm6caw4se52vrx/",
+        "fields" : {
+          "key": "$test-object-é",
+          "success_action_redirect": "http://www.google.com/",
+          "x-goog-algorithm": "GOOG4-RSA-SHA256",
+          "x-goog-credential": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request",
+          "x-goog-date": "20200123T043530Z",
+          "x-goog-meta": "$test-object-é-metadata",
+          "x-goog-signature": "5e62f731d1e5e0935c9157dd059b61d7a9076f0dc953f60534486fdef2f74e54b41c2c35cb441b2fa36e0b93aae0a8b61ae73d003772238e8792415356eb1bf61c8e01043b8d44941e6d535d27e516b89f4055e65ebd0127a92a38f90ccc350a31ae9796567b6585f988c6aa78708ab4969a574c73da0b7eba77af2467bcd5852a8ac712c0abeee85034507cc602543493c9570f1922590cfea66c823ab03740bc64c321320b577d6c0a704f9832c5da8c5a9ba89437e1d0022924802b9d5bb7918f1cc5927666d9a34284c6e11242b3244e51080e751fcf55d871d0e749c04e71e64aba145e07da9dbcba6374865b4446033fb2f15ff0c297c8896ddb1b4688",
+          "policy": "eyJjb25kaXRpb25zIjpbeyJ4LWdvb2ctbWV0YSI6IiR0ZXN0LW9iamVjdC1cdTAwZTktbWV0YWRhdGEifSx7InN1Y2Nlc3NfYWN0aW9uX3JlZGlyZWN0IjoiaHR0cDovL3d3dy5nb29nbGUuY29tLyJ9LHsia2V5IjoiJHRlc3Qtb2JqZWN0LVx1MDBlOSJ9LHsieC1nb29nLWRhdGUiOiIyMDIwMDEyM1QwNDM1MzBaIn0seyJ4LWdvb2ctY3JlZGVudGlhbCI6InRlc3QtaWFtLWNyZWRlbnRpYWxzQGR1bW15LXByb2plY3QtaWQuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20vMjAyMDAxMjMvYXV0by9zdG9yYWdlL2dvb2c0X3JlcXVlc3QifSx7IngtZ29vZy1hbGdvcml0aG0iOiJHT09HNC1SU0EtU0hBMjU2In1dLCJleHBpcmF0aW9uIjoiMjAyMC0wMS0yM1QwNDozNTo0MFoifQ=="
+        },
+        "expectedDecodedPolicy": "{\"conditions\":[{\"x-goog-meta\":\"$test-object-\u00e9-metadata\"},{\"success_action_redirect\":\"http://www.google.com/\"},{\"key\":\"$test-object-\u00e9\"},{\"x-goog-date\":\"20200123T043530Z\"},{\"x-goog-credential\":\"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request\"},{\"x-goog-algorithm\":\"GOOG4-RSA-SHA256\"}],\"expiration\":\"2020-01-23T04:35:40Z\"}"
+      }
     }
   ]
 }


### PR DESCRIPTION
note: this PR is based off of #2720, and that PR must be merged first. When reviewing, you may find it more convenient to view the [comparison between those two branches](https://github.com/jdpedrie/google-cloud-php/compare/storage-conformance...jdpedrie:post-policies) rather than the pull request diff.

This change does not include system tests yet.