### PR TITLE
refactor(spanner): stronger assertions for unit tests

### DIFF
--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -64,7 +64,7 @@ class BatchClientTest extends TestCase
     {
         $time = time();
 
-        $this->connection->createSession(Argument::any())
+        $this->connection->createSession(Argument::withEntry('database', self::DATABASE))
             ->shouldBeCalledTimes(1)
             ->willReturn([
                 'name' => self::SESSION

--- a/Spanner/tests/Unit/InstanceConfigurationTest.php
+++ b/Spanner/tests/Unit/InstanceConfigurationTest.php
@@ -93,7 +93,12 @@ class InstanceConfigurationTest extends TestCase
 
     public function testExists()
     {
-        $this->connection->getInstanceConfig(Argument::any())->willReturn([]);
+        $this->connection->getInstanceConfig(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->configuration->name())
+        ))
+            ->shouldBeCalled()
+            ->willReturn([]);
         $this->configuration->___setProperty('connection', $this->connection->reveal());
 
         $this->assertTrue($this->configuration->exists());
@@ -101,7 +106,12 @@ class InstanceConfigurationTest extends TestCase
 
     public function testExistsDoesntExist()
     {
-        $this->connection->getInstanceConfig(Argument::any())->willThrow(new NotFoundException('', 404));
+        $this->connection->getInstanceConfig(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->configuration->name())
+        ))
+            ->shouldBeCalled()
+            ->willThrow(new NotFoundException('', 404));
         $this->configuration->___setProperty('connection', $this->connection->reveal());
 
         $this->assertFalse($this->configuration->exists());

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -81,7 +81,10 @@ class InstanceTest extends TestCase
     {
         $instance = $this->getDefaultInstance();
 
-        $this->connection->getInstance(Argument::any())
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->instance->name())
+        ))
             ->shouldBeCalledTimes(1)
             ->willReturn($instance);
 
@@ -147,7 +150,10 @@ class InstanceTest extends TestCase
 
     public function testExistsNotFound()
     {
-        $this->connection->getInstance(Argument::any())
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->instance->name())
+        ))
             ->shouldBeCalled()
             ->willThrow(new NotFoundException('foo', 404));
 
@@ -201,7 +207,10 @@ class InstanceTest extends TestCase
     {
         $instance = $this->getDefaultInstance();
 
-        $this->connection->getInstance(Argument::any())
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->instance->name())
+        ))
             ->shouldBeCalledTimes(1)
             ->willReturn($instance);
 
@@ -212,7 +221,10 @@ class InstanceTest extends TestCase
 
     public function testStateIsNull()
     {
-        $this->connection->getInstance(Argument::any())
+        $this->connection->getInstance(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry('name', $this->instance->name())
+        ))
             ->shouldBeCalledTimes(1)
             ->willReturn([]);
 
@@ -326,9 +338,10 @@ class InstanceTest extends TestCase
             ['name' => DatabaseAdminClient::databaseName(self::PROJECT_ID, self::NAME, 'database2')]
         ];
 
-        $this->connection->listDatabases(Argument::any())
+        $this->connection->listDatabases(Argument::withEntry('instance', $this->instance->name()))
             ->shouldBeCalled()
             ->willReturn(['databases' => $databases]);
+
         $this->connection->getDatabase()->shouldNotBeCalled();
 
         $this->instance->___setProperty('connection', $this->connection->reveal());
@@ -356,7 +369,7 @@ class InstanceTest extends TestCase
         ];
 
         $iteration = 0;
-        $this->connection->listDatabases(Argument::any())
+        $this->connection->listDatabases(Argument::withEntry('instance', $this->instance->name()))
             ->shouldBeCalledTimes(2)
             ->willReturn(['databases' => [$databases[0]], 'nextPageToken' => 'foo'], ['databases' => [$databases[1]]]);
 

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -71,7 +71,7 @@ class InstanceTest extends TestCase
 
     public function testInfo()
     {
-        $this->connection->getInstance()->shouldNotBeCalled();
+        $this->connection->getInstance(Argument::any())->shouldNotBeCalled();
 
         $this->instance->___setProperty('info', ['foo' => 'bar']);
         $this->assertEquals('bar', $this->instance->info()['foo']);
@@ -342,7 +342,7 @@ class InstanceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(['databases' => $databases]);
 
-        $this->connection->getDatabase()->shouldNotBeCalled();
+        $this->connection->getDatabase(Argument::any())->shouldNotBeCalled();
 
         $this->instance->___setProperty('connection', $this->connection->reveal());
 

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -255,7 +255,10 @@ class OperationTest extends TestCase
 
     public function testTransaction()
     {
-        $this->connection->beginTransaction(Argument::any())
+        $this->connection->beginTransaction(Argument::allOf(
+            Argument::withEntry('database', self::DATABASE),
+            Argument::withEntry('session', $this->session->name())
+        ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
@@ -268,7 +271,10 @@ class OperationTest extends TestCase
 
     public function testSnapshot()
     {
-        $this->connection->beginTransaction(Argument::any())
+        $this->connection->beginTransaction(Argument::allOf(
+            Argument::withEntry('database', self::DATABASE),
+            Argument::withEntry('session', $this->session->name())
+        ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
@@ -295,7 +301,10 @@ class OperationTest extends TestCase
 
     public function testSnapshotWithTimestamp()
     {
-        $this->connection->beginTransaction(Argument::any())
+        $this->connection->beginTransaction(Argument::allOf(
+            Argument::withEntry('database', self::DATABASE),
+            Argument::withEntry('session', $this->session->name())
+        ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION, 'readTimestamp' => self::TIMESTAMP]);
 

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -54,6 +54,7 @@ class SpannerClientTest extends TestCase
     const CONFIG = 'conf';
 
     private $client;
+    private $connection;
 
     public function setUp()
     {
@@ -90,7 +91,9 @@ class SpannerClientTest extends TestCase
      */
     public function testInstanceConfigurations()
     {
-        $this->connection->listInstanceConfigs(Argument::any())
+        $this->connection->listInstanceConfigs(
+            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+        )
             ->shouldBeCalled()
             ->willReturn([
                 'instanceConfigs' => [
@@ -140,7 +143,9 @@ class SpannerClientTest extends TestCase
             ]
         ];
 
-        $this->connection->listInstanceConfigs(Argument::any())
+        $this->connection->listInstanceConfigs(
+            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+        )
             ->shouldBeCalledTimes(2)
             ->willReturn($firstCall, $secondCall);
 
@@ -218,7 +223,9 @@ class SpannerClientTest extends TestCase
      */
     public function testInstances()
     {
-        $this->connection->listInstances(Argument::any())
+        $this->connection->listInstances(
+            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+        )
             ->shouldBeCalled()
             ->willReturn([
                 'instances' => [

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -54,6 +54,7 @@ class TransactionTest extends TestCase
     private $instance;
     private $session;
     private $database;
+    private $operation;
 
     private $transaction;
     private $singleUseTransaction;
@@ -311,7 +312,7 @@ class TransactionTest extends TestCase
             'details' => []
         ];
 
-        $this->connection->executeBatchDml(Argument::any())
+        $this->connection->executeBatchDml(Argument::withEntry('session', $this->session->name()))
             ->shouldBeCalled()
             ->willReturn([
                 'resultSets' => [
@@ -432,7 +433,7 @@ class TransactionTest extends TestCase
 
     public function testRollback()
     {
-        $this->connection->rollback(Argument::any())
+        $this->connection->rollback(Argument::withEntry('session', $this->session->name()))
             ->shouldBeCalled();
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());

--- a/Spanner/tests/Unit/TransactionTypeTest.php
+++ b/Spanner/tests/Unit/TransactionTypeTest.php
@@ -66,7 +66,9 @@ class TransactionTypeTest extends TestCase
 
         $this->connection = $this->getConnStub();
 
-        $this->connection->createSession(Argument::any())
+        $this->connection->createSession(
+            Argument::withEntry('database', SpannerClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE)
+        ))
             ->willReturn(['name' => SpannerClient::sessionName(
                 self::PROJECT,
                 self::INSTANCE,

--- a/Spanner/tests/Unit/TransactionTypeTest.php
+++ b/Spanner/tests/Unit/TransactionTypeTest.php
@@ -67,8 +67,8 @@ class TransactionTypeTest extends TestCase
         $this->connection = $this->getConnStub();
 
         $this->connection->createSession(
-            Argument::withEntry('database', SpannerClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE)
-        ))
+            Argument::withEntry('database', SpannerClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+        )
             ->willReturn(['name' => SpannerClient::sessionName(
                 self::PROJECT,
                 self::INSTANCE,


### PR DESCRIPTION
replace Argument::any() tokens with Argument::allOf() and Argument::withEntry()