### PR TITLE
fix: remove redundant extension from lock file name

### DIFF
--- a/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
+++ b/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
@@ -37,8 +37,8 @@ class FileBreakpointStorage implements BreakpointStorageInterface
     /**
      * Create a new FileBreakpointStorage instance.
      *
-     * @param string $filename [optional] The full path to the storage file.
-     *      **Defaults to** a temporary file in the system's temp directory.
+     * @param string $filename [optional] The name of the file to create in the
+     *        systems temp directory. **Defaults to** `debugger-breakpoints`.
      */
     public function __construct($filename = null)
     {

--- a/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
+++ b/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
@@ -44,7 +44,7 @@ class FileBreakpointStorage implements BreakpointStorageInterface
     {
         $filename = $filename ?: self::DEFAULT_FILENAME;
         $this->filename = implode(DIRECTORY_SEPARATOR, [sys_get_temp_dir(), $filename]);
-        $this->lockFilename = $filename . '.lock';
+        $this->lockFilename = $filename;
     }
 
     /**

--- a/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
+++ b/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
@@ -38,7 +38,7 @@ class FileBreakpointStorage implements BreakpointStorageInterface
      * Create a new FileBreakpointStorage instance.
      *
      * @param string $filename [optional] The name of the file to create in the
-     *        systems temp directory. **Defaults to** `debugger-breakpoints`.
+     *        system's temp directory. **Defaults to** `debugger-breakpoints`.
      */
     public function __construct($filename = null)
     {


### PR DESCRIPTION
Closes: https://github.com/googleapis/google-cloud-php/issues/2068