### PR TITLE
fix: StorageClient accepting custom endpoints via the "apiEndpoint" options

### DIFF
--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -44,8 +44,13 @@ class Rest implements ConnectionInterface
     use UriTrait;
 
     const BASE_URI = 'https://storage.googleapis.com/storage/v1/';
-    const UPLOAD_URI = 'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o{?query*}';
-    const DOWNLOAD_URI = 'https://storage.googleapis.com/storage/v1/b/{bucket}/o/{object}{?query*}';
+    const UPLOAD_PATH = 'b/{bucket}/o{?query*}';
+    const DOWNLOAD_PATH = 'b/{bucket}/o/{object}{?query*}';
+
+    /**
+     * @var string
+     */
+    private $apiEndpoint;
 
     /**
      * @var string
@@ -64,10 +69,10 @@ class Rest implements ConnectionInterface
 
         $this->setRequestWrapper(new RequestWrapper($config));
 
-        $apiEndpoint = $this->getApiEndpoint(self::BASE_URI, $config);
+        $this->apiEndpoint = $this->getApiEndpoint(self::BASE_URI, $config);
         $this->setRequestBuilder(new RequestBuilder(
             $config['serviceDefinitionPath'],
-            $apiEndpoint
+            $this->apiEndpoint
         ));
 
         $this->projectId = $this->pluck('projectId', $config, false);
@@ -278,7 +283,7 @@ class Rest implements ConnectionInterface
         return new $uploaderClass(
             $this->requestWrapper,
             $args['data'],
-            $this->expandUri(self::UPLOAD_URI, $uriParams),
+            $this->expandUri($this->apiEndpoint . self::UPLOAD_PATH, $uriParams),
             $args['uploaderOptions']
         );
     }
@@ -471,7 +476,7 @@ class Rest implements ConnectionInterface
             'restDelayFunction' => null
         ]);
 
-        $uri = $this->expandUri(self::DOWNLOAD_URI, [
+        $uri = $this->expandUri($this->apiEndpoint . self::DOWNLOAD_PATH, [
             'bucket' => $args['bucket'],
             'object' => $args['object'],
             'query' => [

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -63,9 +63,11 @@ class Rest implements ConnectionInterface
         ];
 
         $this->setRequestWrapper(new RequestWrapper($config));
+
+        $apiEndpoint = $this->getApiEndpoint(self::BASE_URI, $config);
         $this->setRequestBuilder(new RequestBuilder(
             $config['serviceDefinitionPath'],
-            self::BASE_URI
+            $apiEndpoint
         ));
 
         $this->projectId = $this->pluck('projectId', $config, false);


### PR DESCRIPTION
Fix storage client ignoring the "apiEndpoint" option.

The `RestTrait` implementation (which is shared between multiple `Rest` implementations) supports customising our base endpoint and is already in use in `\Google\Cloud\BigQuery\Connection\Rest` for this exact use case.