### PR TITLE
feat: add support for ramsey/uuid v4

### DIFF
--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.35",
-        "ramsey/uuid": "~3"
+        "ramsey/uuid": "^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/BigQuery/src/JobConfigurationTrait.php
+++ b/BigQuery/src/JobConfigurationTrait.php
@@ -151,6 +151,6 @@ trait JobConfigurationTrait
      */
     protected function generateJobId()
     {
-        return (string) Uuid::uuid4();
+        return Uuid::uuid4()->toString();
     }
 }

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -7,7 +7,7 @@
         "ext-grpc": "*",
         "google/cloud-core": "^1.35",
         "google/gax": "^1.1",
-        "ramsey/uuid": "~3"
+        "ramsey/uuid": "^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.35",
-        "ramsey/uuid": "~3",
+        "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.1"
     },
      "require-dev": {

--- a/Trace/src/Trace.php
+++ b/Trace/src/Trace.php
@@ -163,6 +163,6 @@ class Trace
      */
     private function generateTraceId()
     {
-        return str_replace('-', '', Uuid::uuid4());
+        return str_replace('-', '', Uuid::uuid4()->toString());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*",
-        "ramsey/uuid": "~3",
+        "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.1",
         "google/common-protos": "^1.0",
         "google/auth": "^1.6",


### PR DESCRIPTION
Greetings 👋

### Changes

- Replaced `"ramsey/uuid": "~3"` with `"ramsey/uuid": "^3.0|^4.0"` (`^` instead of `~` to match the other definitions)
- Replaced occurrences of `(string)` or implicit casts with `->toString()` (it's defined in the `UuidInterface` for both versions)

I searched the usages with full-text searches for `ramsey` and `uuid`, I hope I didn't miss anything 🤞

:octocat: