### PR TITLE
Fix broken logs-correlation on GAE flex environment

### DIFF
--- a/Core/src/Report/GAEFlexMetadataProvider.php
+++ b/Core/src/Report/GAEFlexMetadataProvider.php
@@ -18,12 +18,20 @@
 namespace Google\Cloud\Core\Report;
 
 /**
- * An MetadataProvider for GAE Flex.
+ * A MetadataProvider for GAE Flex.
  */
 class GAEFlexMetadataProvider extends GAEMetadataProvider
 {
     protected function getTraceValue($server)
     {
-        return substr($server['HTTP_X_CLOUD_TRACE_CONTEXT'], 0, 32);
+        $traceId = substr($server['HTTP_X_CLOUD_TRACE_CONTEXT'], 0, 32);
+        if (isset($server['GOOGLE_CLOUD_PROJECT'])) {
+            return sprintf(
+                'projects/%s/traces/%s',
+                $server['GOOGLE_CLOUD_PROJECT'],
+                $traceId
+            );
+        }
+        return $traceId;
     }
 }

--- a/Core/src/Report/GAEStandardMetadataProvider.php
+++ b/Core/src/Report/GAEStandardMetadataProvider.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Core\Report;
 
 /**
- * An MetadataProvider for GAE Standard.
+ * A MetadataProvider for GAE Standard.
  */
 class GAEStandardMetadataProvider extends GAEMetadataProvider
 {


### PR DESCRIPTION
For GAE Flexible environment, trace value was not being generated correctly, due to which custom app logs were not being correlated with `nginx.request` logs in the logs viewer.

Now both `GAEFlexMetadataProvider` and `GAEStandardMetadataProvider` classes are practically identical. We can eliminate them and move the implementation of `getTraceValue` method to `GAEMetadataProvider` making it a concrete class, although it will require changes on multiple places across the project. Let me know if this is ok and I can do it too.