### PR TITLE
test: add missing option in RestTest::insertObjectProvider

### DIFF
--- a/Logging/src/Connection/Grpc.php
+++ b/Logging/src/Connection/Grpc.php
@@ -17,18 +17,18 @@
 
 namespace Google\Cloud\Logging\Connection;
 
+use Google\ApiCore\Serializer;
 use Google\Cloud\Core\GrpcRequestWrapper;
 use Google\Cloud\Core\GrpcTrait;
 use Google\Cloud\Logging\Logger;
 use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\V2\ConfigServiceV2Client;
-use Google\Cloud\Logging\V2\LoggingServiceV2Client;
-use Google\Cloud\Logging\V2\MetricsServiceV2Client;
-use Google\ApiCore\Serializer;
 use Google\Cloud\Logging\V2\LogEntry;
+use Google\Cloud\Logging\V2\LoggingServiceV2Client;
 use Google\Cloud\Logging\V2\LogMetric;
 use Google\Cloud\Logging\V2\LogSink;
-use Google\Cloud\Logging\V2\LogSink_VersionFormat;
+use Google\Cloud\Logging\V2\LogSink\VersionFormat;
+use Google\Cloud\Logging\V2\MetricsServiceV2Client;
 
 /**
  * Implementation of the
@@ -39,9 +39,9 @@ class Grpc implements ConnectionInterface
     use GrpcTrait;
 
     private static $versionFormatMap = [
-        LogSink_VersionFormat::VERSION_FORMAT_UNSPECIFIED => 'VERSION_FORMAT_UNSPECIFIED',
-        LogSink_VersionFormat::V1 => 'V1',
-        LogSink_VersionFormat::V2 => 'V2'
+        VersionFormat::VERSION_FORMAT_UNSPECIFIED => 'VERSION_FORMAT_UNSPECIFIED',
+        VersionFormat::V1 => 'V1',
+        VersionFormat::V2 => 'V2'
     ];
 
     /**

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -264,6 +264,7 @@ class RestTest extends TestCase
                 [
                     'data' => $tempFile,
                     'name' => 'file.txt',
+                    'resumable' => true,
                     'predefinedAcl' => 'private',
                     'metadata' => ['contentType' => 'text/plain'],
                     'validate' => 'md5'


### PR DESCRIPTION
Hello,

While working in a PR to add support for async uploads in GCS, I ran across this missing data piece in the `dataProvider` for `testInsert` object. This comes into play because the `resumable` and `streamable` options are used to determine which Uploader to use. I broke this off as a separate PR for considerations since a better solution might be needed/implemented.

Thanks for your consideration,
-Rolf