### PR TITLE
chore: Migrate all synth.py scripts from artman to bazel

### DIFF
--- a/Asset/synth.py
+++ b/Asset/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 
 for version in ['V1', 'V1beta1']:
     lower_version = version.lower()
@@ -29,9 +28,8 @@ for version in ['V1', 'V1beta1']:
     library = gapic.php_library(
         service='asset',
         version=lower_version,
-        config_path=f'artman_cloudasset_{lower_version}.yaml',
-        artman_output_name=f'google-cloud-asset-{lower_version}')
-
+        bazel_target=f'//google/cloud/asset/{lower_version}:google-cloud-asset-{lower_version}-php',
+    )
     # copy all src including partial veneer classes
     s.move(library / 'src')
 

--- a/AutoMl/synth.py
+++ b/AutoMl/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 versions = ["V1beta1", "V1"]
 
 for version in versions:
@@ -29,8 +28,8 @@ for version in versions:
     library = gapic.php_library(
         service='automl',
         version=lower_version,
-        config_path=f'artman_automl_{lower_version}.yaml',
-        artman_output_name=f'google-cloud-automl-{lower_version}')
+        bazel_target=f'//google/cloud/automl/{lower_version}:google-cloud-automl-{lower_version}-php',
+    )
 
     # copy all src including partial veneer classes
     s.move(library / 'src')

--- a/BigQueryDataTransfer/synth.py
+++ b/BigQueryDataTransfer/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
-    service='bigquerydatatransfer',
+    service='bigquery-datatransfer',
     version='v1',
-    config_path='/google/cloud/bigquery/datatransfer/artman_bigquerydatatransfer.yaml',
-    artman_output_name='google-cloud-bigquerydatatransfer-v1')
+    bazel_target='//google/cloud/bigquery/datatransfer/v1:google-cloud-bigquery-datatransfer-v1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Bigtable/synth.py
+++ b/Bigtable/synth.py
@@ -14,28 +14,27 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='bigtable',
     version='v2',
-    config_path='/google/bigtable/artman_bigtable.yaml',
-    artman_output_name='google-cloud-bigtable-v2')
+    bazel_target=f'//google/bigtable/v2:google-cloud-bigtable-v2-php',
+)
 
 # copy all src except handwritten partial veneers
 s.move(library / f'src/V2/Gapic')
 s.move(library / f'src/V2/resources')
 
 # copy proto files to src also
-s.move(library / f'proto/src/Google/Cloud/BigTable', f'src/')
+s.move(library / f'proto/src/Google/Cloud/Bigtable', f'src/')
 s.move(library / f'tests/')
 
 # copy GPBMetadata file to metadata
@@ -45,8 +44,8 @@ s.move(library / f'proto/src/GPBMetadata/Google/Bigtable', f'metadata/')
 admin_library = gapic.php_library(
     service='bigtable-admin',
     version='v2',
-    config_path='/google/bigtable/admin/artman_bigtableadmin.yaml',
-    artman_output_name='google-cloud-bigtable-admin-v2')
+    bazel_target='//google/bigtable/admin/v2:google-cloud-bigtable-admin-v2-php'
+)
 
 # copy all src except handwritten partial veneers
 s.move(admin_library / f'src/V2/Gapic', 'src/Admin/V2/Gapic')

--- a/Billing/synth.py
+++ b/Billing/synth.py
@@ -14,7 +14,6 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
@@ -25,7 +24,9 @@ gapic = gcp.GAPICBazel()
 
 library = gapic.php_library(
     service="billing",
-    version="v1")
+    version="v1",
+    bazel_target='//google/cloud/billing/v1:google-cloud-billing-v1-php',
+)
 
 # copy all src
 s.move(library / f"src/V1")

--- a/Container/synth.py
+++ b/Container/synth.py
@@ -14,21 +14,19 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1_library = gapic.php_library(
     service='container',
     version='v1',
-    config_path='/google/container/artman_container_v1.yaml',
-    artman_output_name='google-cloud-container-v1')
+    bazel_target=f'//google/container/v1:google-cloud-container-v1-php')
 
 # copy all src including partial veneer classes
 s.move(v1_library / 'src')

--- a/Dataproc/synth.py
+++ b/Dataproc/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 for version in ['V1', 'V1beta2']:
@@ -30,7 +29,8 @@ for version in ['V1', 'V1beta2']:
     library = gapic.php_library(
         service='dataproc',
         version=lower_version,
-        artman_output_name=f'google-cloud-dataproc-{lower_version}')
+        bazel_target=f'//google/cloud/dataproc/{lower_version}:google-cloud-dataproc-{lower_version}-php',
+    )
 
     # copy all src including partial veneer classes
     s.move(library / 'src')

--- a/Datastore/synth.py
+++ b/Datastore/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='datastore',
     version='v1',
-    config_path='/google/datastore/artman_datastore.legacy.yaml',
-    artman_output_name='google-cloud-datastore-v1')
+    bazel_target=f'//google/datastore/v1:google-cloud-datastore-v1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Debugger/synth.py
+++ b/Debugger/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='clouddebugger',
     version='v2',
-    config_path='/google/devtools/artman_clouddebugger.yaml',
-    artman_output_name='google-cloud-debugger-v2')
+    bazel_target=f'//google/devtools/clouddebugger/v2:google-cloud-devtools-clouddebugger-v2-php',
+  )
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Dialogflow/synth.py
+++ b/Dialogflow/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='dialogflow',
     version='v2',
-    config_path='/google/cloud/dialogflow/v2/artman_dialogflow_v2.yaml',
-    artman_output_name='google-cloud-dialogflow-v2')
+    bazel_target='//google/cloud/dialogflow/v2:google-cloud-dialogflow-v2-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Dlp/synth.py
+++ b/Dlp/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='dlp',
     version='v2',
-    config_path='/google/privacy/dlp/artman_dlp_v2.yaml',
-    artman_output_name='google-cloud-dlp-v2')
+    bazel_target='//google/privacy/dlp/v2:google-cloud-privacy-dlp-v2-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/ErrorReporting/synth.py
+++ b/ErrorReporting/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='clouderrorreporting',
     version='v1beta1',
-    config_path='/google/devtools/clouderrorreporting/artman_errorreporting.yaml',
-    artman_output_name='google-cloud-error-reporting-v1beta1')
+    bazel_target='//google/devtools/clouderrorreporting/v1beta1:google-cloud-devtools-clouderrorreporting-v1beta1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Firestore/synth.py
+++ b/Firestore/synth.py
@@ -14,29 +14,23 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
-versions = []
-versions.append({'version': 'V1', 'config': '/google/firestore/artman_firestore_v1.yaml'})
-versions.append({'version': 'V1beta1', 'config': '/google/firestore/artman_firestore.yaml'})
-
-for v in versions:
-    ver = v['version']
+for ver in ['V1', 'V1beta1']:
     lower_version = ver.lower()
 
     library = gapic.php_library(
         service='firestore',
         version=lower_version,
-        config_path=v['config'],
-        artman_output_name=f'google-cloud-firestore-{lower_version}')
+        bazel_target=f'//google/firestore/{lower_version}:google-cloud-firestore-{lower_version}-php',
+    )
 
     # copy all src except partial veneer classes
     s.move(library / f'src/{ver}/Gapic')
@@ -53,8 +47,8 @@ for v in versions:
 admin_library = gapic.php_library(
     service='firestore-admin',
     version='v1',
-    config_path='/google/firestore/admin/artman_firestore_v1.yaml',
-    artman_output_name='google-cloud-firestore-admin-v1')
+    bazel_target=f'//google/firestore/admin/v1:google-cloud-firestore-admin-v1-php',
+)
 
 # copy all src
 s.move(admin_library / f'src', 'src/Admin')

--- a/Iot/synth.py
+++ b/Iot/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='iot',
     version='v1',
-    config_path='artman_cloudiot.yaml',
-    artman_output_name='google-cloud-iot-v1')
+    bazel_target='//google/cloud/iot/v1:google-cloud-iot-v1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / f'src')

--- a/Kms/synth.py
+++ b/Kms/synth.py
@@ -14,7 +14,6 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
@@ -23,14 +22,14 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1_library = gapic.php_library(
     service='kms',
     version='v1',
-    config_path='artman_cloudkms.yaml',
-    artman_output_name='google-cloud-kms-v1')
+    bazel_target='//google/cloud/kms/v1:google-cloud-kms-v1-php',
+)
 
 s.copy(v1_library / f'src/')
 s.copy(v1_library / f'proto/src/GPBMetadata/Google/Cloud/Kms', f'metadata')

--- a/Language/synth.py
+++ b/Language/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 
 for version in ['V1', 'V1beta2']:
     lower_version = version.lower()
@@ -29,7 +28,8 @@ for version in ['V1', 'V1beta2']:
     library = gapic.php_library(
         service='language',
         version=lower_version,
-        artman_output_name=f'google-cloud-language-{lower_version}')
+        bazel_target=f'//google/cloud/language/{lower_version}:google-cloud-language-{lower_version}-php'
+    )
 
     # copy all src including partial veneer classes
     s.move(library / 'src')

--- a/Logging/synth.py
+++ b/Logging/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='logging',
     version='v2',
-    config_path='/google/logging/artman_logging.yaml',
-    artman_output_name='google-cloud-logging-v2')
+    bazel_target='//google/logging/v2:google-cloud-logging-v2-php'
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Monitoring/synth.py
+++ b/Monitoring/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='monitoring',
     version='v3',
-    config_path='/google/monitoring/artman_monitoring.yaml',
-    artman_output_name='google-cloud-monitoring-v3')
+    bazel_target='//google/monitoring/v3:google-cloud-monitoring-v3-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/OsLogin/synth.py
+++ b/OsLogin/synth.py
@@ -14,25 +14,26 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1beta = gapic.php_library(
     service='oslogin',
     version='v1beta',
-    artman_output_name='google-cloud-os-login-v1beta')
+    bazel_target='//google/cloud/oslogin/v1beta:google-cloud-oslogin-v1beta-php'
+)
 
 v1 = gapic.php_library(
     service='oslogin',
     version='v1',
-    artman_output_name='google-cloud-os-login-v1')
+    bazel_target='//google/cloud/oslogin/v1:google-cloud-oslogin-v1-php'
+)
 
 # copy all src
 s.move(v1beta / f'src/V1beta')

--- a/PubSub/synth.py
+++ b/PubSub/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='pubsub',
     version='v1',
-    config_path='/google/pubsub/artman_pubsub.yaml',
-    artman_output_name='google-cloud-pubsub-v1')
+    bazel_target='//google/pubsub/v1:google-cloud-pubsub-v1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Recommender/synth.py
+++ b/Recommender/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='recommender',
     version='v1',
-    config_path=f'/google/cloud/recommender/v1/artman_recommender_v1.yaml',
-    artman_output_name=f'google-cloud-recommender-v1')
+    bazel_target='//google/cloud/recommender/v1:google-cloud-recommender-v1-php',
+)
 
 # copy all src
 s.move(library / f'src/V1')

--- a/Redis/synth.py
+++ b/Redis/synth.py
@@ -14,20 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1beta1_library = gapic.php_library(
     service='redis',
     version='v1beta1',
-    artman_output_name='google-cloud-redis-v1beta1')
+    bazel_target='//google/cloud/redis/v1beta1:google-cloud-redis-v1beta1-php',
+)
 
 # copy all src except partial veneer classes
 s.move(v1beta1_library / f'src/V1beta1/Gapic')
@@ -43,7 +43,8 @@ s.move(v1beta1_library / f'proto/src/GPBMetadata/Google/Cloud/Redis', f'metadata
 v1_library = gapic.php_library(
     service='redis',
     version='v1',
-    artman_output_name='google-cloud-redis-v1')
+    bazel_target='//google/cloud/redis/v1:google-cloud-redis-v1-php',
+)
 
 # copy all src except partial veneer classes
 s.move(v1_library / f'src/V1/Gapic')

--- a/Scheduler/synth.py
+++ b/Scheduler/synth.py
@@ -14,24 +14,23 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
-for version in ['V1', 'V1Beta1']:
+for version in ['V1', 'V1beta1']:
     lower_version = version.lower()
 
     library = gapic.php_library(
         service='scheduler',
         version=lower_version,
-        config_path=f'/google/cloud/scheduler/artman_cloudscheduler_{lower_version}.yaml',
-        artman_output_name=f'google-cloud-cloudscheduler-{lower_version}')
+        bazel_target=f'//google/cloud/scheduler/{lower_version}:google-cloud-scheduler-{lower_version}-php',
+    )
 
     # copy all src
     s.move(library / f'src/{version}')

--- a/SecretManager/synth.py
+++ b/SecretManager/synth.py
@@ -23,16 +23,17 @@ logging.basicConfig(level=logging.DEBUG)
 gapic = gcp.GAPICBazel()
 
 for version in ['v1', 'v1beta1']:
-    kwargs = {}
     if version is 'v1beta1':
-        kwargs = {
-           'bazel_target': '//google/cloud/secrets/v1beta1:google-cloud-secretmanager-v1beta1-php'
-        }
-
+        bazel_target = '//google/cloud/secrets/v1beta1:google-cloud-secretmanager-v1beta1-php'
+        service='secrets'
+    else:
+        bazel_target = '//google/cloud/secretmanager/v1:google-cloud-secretmanager-v1-php'
+        service='secretmanager'
     library = gapic.php_library(
-        service='secretmanager' if version is 'v1' else 'secrets',
+        service=service,
         version=version,
-        **kwargs)
+        bazel_target=bazel_target,
+    )
 
     # copy all src
     s.move(library / f'src')

--- a/SecurityCenter/synth.py
+++ b/SecurityCenter/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 for version in ['V1', 'V1p1beta1']:
@@ -29,7 +28,8 @@ for version in ['V1', 'V1p1beta1']:
     library = gapic.php_library(
         service='securitycenter',
         version=lower_version,
-        artman_output_name=f'google-cloud-securitycenter-{lower_version}')
+        bazel_target=f'//google/cloud/securitycenter/{lower_version}:google-cloud-securitycenter-{lower_version}-php',
+    )
 
     # copy all src
     s.move(library / f'src/{version}')
@@ -39,7 +39,7 @@ for version in ['V1', 'V1p1beta1']:
     s.move(library / f'tests/')
 
     # copy GPBMetadata file to metadata
-    s.move(library / f'proto/src/GPBMetadata/Google/Cloud/SecurityCenter', f'metadata/')
+    s.move(library / f'proto/src/GPBMetadata/Google/Cloud/Securitycenter', f'metadata/')
 
 # document and utilize apiEndpoint instead of serviceAddress
 s.replace(

--- a/ServiceDirectory/synth.py
+++ b/ServiceDirectory/synth.py
@@ -24,7 +24,9 @@ gapic = gcp.GAPICBazel()
 
 library = gapic.php_library(
     service="servicedirectory",
-    version="v1beta1")
+    version="v1beta1",
+    bazel_target='//google/cloud/servicedirectory/v1beta1:google-cloud-servicedirectory-v1beta1-php',
+)
 
 # copy all src
 s.move(library / f"src/V1beta1")

--- a/Spanner/synth.py
+++ b/Spanner/synth.py
@@ -14,7 +14,6 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
@@ -22,14 +21,14 @@ import re
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='spanner',
     version='v1',
-    config_path='/google/spanner/artman_spanner.yaml',
-    artman_output_name='google-cloud-spanner-v1')
+    bazel_target='//google/spanner/v1:google-cloud-spanner-v1-php',
+)
 
 # copy all src except handwritten partial veneers
 s.move(library / f'src/V1/Gapic')
@@ -46,8 +45,8 @@ s.move(library / f'proto/src/GPBMetadata/Google/Spanner', f'metadata/')
 admin_library = gapic.php_library(
     service='spanner-admin-database',
     version='v1',
-    config_path='/google/spanner/admin/database/artman_spanner_admin_database.yaml',
-    artman_output_name='google-cloud-spanner-admin-database-v1')
+    bazel_target='//google/spanner/admin/database/v1:google-cloud-admin-database-v1-php',
+)
 
 # copy all src except handwritten partial veneers
 s.move(admin_library / f'src/V1/Gapic', 'src/Admin/Database/V1/Gapic')
@@ -64,8 +63,8 @@ s.move(admin_library / f'proto/src/GPBMetadata/Google/Spanner', f'metadata/')
 admin_library = gapic.php_library(
     service='spanner-admin-instance',
     version='v1',
-    config_path='/google/spanner/admin/instance/artman_spanner_admin_instance.yaml',
-    artman_output_name='google-cloud-spanner-admin-instance-v1')
+    bazel_target='//google/spanner/admin/instance/v1:google-cloud-admin-instance-v1-php',
+)
 
 # copy all src except handwritten partial veneers
 s.move(admin_library / f'src/V1/Gapic', 'src/Admin/Instance/V1/Gapic')
@@ -110,11 +109,11 @@ s.replace(
 s.replace(
     'tests/Unit/Admin/Database/*/*.php',
     r'namespace Google\\Cloud\\Spanner\\Admin\\Database\\Tests\\Unit',
-    'namespace Google\\Cloud\\Spanner\\Tests\\Unit\\Admin\\Database')
+    r'namespace Google\\Cloud\\Spanner\\Tests\\Unit\\Admin\\Database')
 s.replace(
     'tests/Unit/Admin/Instance/*/*.php',
     r'namespace Google\\Cloud\\Spanner\\Admin\\Instance\\Tests\\Unit',
-    'namespace Google\\Cloud\\Spanner\\Tests\\Unit\\Admin\\Instance')
+    r'namespace Google\\Cloud\\Spanner\\Tests\\Unit\\Admin\\Instance')
 
 # fix test group
 s.replace(

--- a/Speech/synth.py
+++ b/Speech/synth.py
@@ -14,14 +14,13 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 for version in ['V1', 'V1p1beta1']:
@@ -30,7 +29,8 @@ for version in ['V1', 'V1p1beta1']:
     library = gapic.php_library(
         service='speech',
         version=lower_version,
-        artman_output_name=f'google-cloud-speech-{lower_version}')
+        bazel_target=f'//google/cloud/speech/{lower_version}:google-cloud-speech-{lower_version}-php',
+    )
 
     # copy all src except partial veneer classes
     s.move(library / f'src/{version}/Gapic')

--- a/Talent/synth.py
+++ b/Talent/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='talent',
     version='v4beta1',
-    config_path='/google/cloud/talent/artman_talent_v4beta1.yaml',
-    artman_output_name='google-cloud-talent-v4beta1')
+    bazel_target='//google/cloud/talent/v4beta1:google-cloud-talent-v4beta1-php'
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Tasks/synth.py
+++ b/Tasks/synth.py
@@ -14,22 +14,21 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 
 for version in ['V2', 'V2beta2', 'V2beta3']:
     lower_version = version.lower()
     library = gapic.php_library(
         service='tasks',
         version=lower_version,
-        config_path=f'artman_cloudtasks_{lower_version}.yaml',
-        artman_output_name=f'google-cloud-tasks-{lower_version}')
+        bazel_target=f'//google/cloud/tasks/{lower_version}:google-cloud-tasks-{lower_version}-php',
+    )
 
     # copy all src including partial veneer classes
     s.move(library / 'src')

--- a/TextToSpeech/synth.py
+++ b/TextToSpeech/synth.py
@@ -14,20 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
-v1_library = gapic._generate_code(
-    'texttospeech', 'v1', 'php',
-    config_path='artman_texttospeech_v1.yaml',
-    artman_output_name='google-cloud-texttospeech-v1')
+v1_library = gapic.php_library(
+    service='texttospeech',
+    version='v1',
+    bazel_target='//google/cloud/texttospeech/v1:google-cloud-texttospeech-v1-php',
+)
 
 s.copy(v1_library / f'src/')
 s.copy(v1_library / f'proto/src/GPBMetadata/Google/Cloud/Texttospeech', f'metadata')

--- a/Trace/synth.py
+++ b/Trace/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='cloudtrace',
     version='v2',
-    config_path='/google/devtools/cloudtrace/artman_cloudtrace_v2.yaml',
-    artman_output_name='google-cloud-trace-v2')
+    bazel_target='//google/devtools/cloudtrace/v2:google-cloud-devtools-cloudtrace-v2-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')

--- a/Translate/synth.py
+++ b/Translate/synth.py
@@ -20,13 +20,14 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1_library = gapic.php_library(
     service='translate',
     version='v3',
-    artman_output_name='google-cloud-translate-v3')
+    bazel_target='//google/cloud/translate/v3:google-cloud-translation-v3-php',
+)
 
 # copy all src except partial veneer classes
 s.move(v1_library / f'src/')

--- a/VideoIntelligence/synth.py
+++ b/VideoIntelligence/synth.py
@@ -14,29 +14,23 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 for version in ['V1', 'V1beta2']:
     lower_version = version.lower()
 
-    if version == 'V1':
-        extension = '.legacy.yaml'
-    else:
-        extension = '.yaml'
-
     library = gapic.php_library(
         service='videointelligence',
         version=lower_version,
-        config_path=f'/google/cloud/videointelligence/artman_videointelligence_{lower_version}{extension}',
-        artman_output_name=f'google-cloud-video-intelligence-{lower_version}')
+        bazel_target=f'//google/cloud/videointelligence/{lower_version}:google-cloud-videointelligence-{lower_version}-php',
+    )
 
     # copy all src including partial veneer classes
     s.move(library / 'src')

--- a/Vision/synth.py
+++ b/Vision/synth.py
@@ -14,20 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 v1_library = gapic.php_library(
     service='vision',
     version='v1',
-    artman_output_name='google-cloud-vision-v1')
+    bazel_target=f'//google/cloud/vision/v1:google-cloud-vision-v1-php',
+)
 
 # copy all src except partial veneer classes
 s.move(v1_library / f'src/V1/Gapic')

--- a/WebRisk/synth.py
+++ b/WebRisk/synth.py
@@ -14,20 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='webrisk',
     version='v1beta1',
-    artman_output_name='google-cloud-webrisk-v1beta1')
+    bazel_target=f'//google/cloud/webrisk/v1beta1:google-cloud-webrisk-v1beta1-php',
+)
 
 # copy all src including partial veneer classes
 s.move(library / 'src')
@@ -37,7 +37,7 @@ s.move(library / 'proto/src/Google/Cloud/WebRisk', 'src/')
 s.move(library / 'tests/')
 
 # copy GPBMetadata file to metadata
-s.move(library / 'proto/src/GPBMetadata/Google/Cloud/WebRisk', 'metadata/')
+s.move(library / 'proto/src/GPBMetadata/Google/Cloud/Webrisk', 'metadata/')
 
 # document and utilize apiEndpoint instead of serviceAddress
 s.replace(

--- a/WebSecurityScanner/synth.py
+++ b/WebSecurityScanner/synth.py
@@ -14,21 +14,20 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import os
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 library = gapic.php_library(
     service='websecurityscanner',
     version='v1beta',
-    config_path=f'/google/cloud/websecurityscanner/artman_websecurityscanner_v1beta.yaml',
-    artman_output_name=f'google-cloud-websecurityscanner-v1beta')
+    bazel_target=f'//google/cloud/websecurityscanner/v1beta:google-cloud-websecurityscanner-v1beta-php',
+)
 
 # copy all src
 s.move(library / f'src/V1beta')


### PR DESCRIPTION
This change depends on a pending change in googleapis repository and a pending change in synthtool https://github.com/googleapis/synthtool/pull/459.

All the migrated synth.py scripts were tested with the following results:


Client Name (subfodler) | Generator | Comments
-- | -- | --
Asset | Bazel |  
AutoMl | Bazel | With fix in service.yaml
BigQuery | N/A |  
BigQueryDataTransfer | Bazel | Experimental annotation for methods removed
Bigtable | Bazel | With BigTable -> Bigtable case fix in synth.py
Billing | Bazel |  
CommonProtos | N/A |  
Container | Bazel |  
Core | N/A |  
Dataproc | Bazel | Lots of changes, seems like current ones are still from gapic_yaml v1
Datastore | Bazel | Retry Params are like in gapic_yaml_legacy
Debugger | Bazel |  
dev | N/A |  
Dialogflow | Bazel | google.longrunning.Operations is missing in *clieng_config.php files, but same is true for artman
Dlp | Bazel | Abunch of breaking changes, but same is for artman
docs | N/A |  
ErrorReporting | Bazel |  
Firestore | Bazel |  
Iot | Bazel | License year in the client classe is changed from 2018 to 2020
Kms | Bazel | Bethods like cryptoKeyPathName are removed, but same is for artman
Language | Bazel | Some comments changes, look safe
Logging | Bazel | Lots of breaking changes, but same with artman
Monitoring | Bazel |  
OsLogin | Bazel | Experimental tag removed, but same with artman
PubSub | Bazel | Some resource names changes, but same with artman
Recommender | Bazel |  
Redis | Bazel |  
Scheduler | Bazel | V1beta1 case bug fix, and related changes in V1beta1 package
SecretManager | Bazel | Comments changes, but look safe
SecurityCenter | Bazel | Service yaml fix, plus some additions, plus SecurityCenter Securitycenter case fix in synth.py
ServiceDirectory | Bazel |  
Spanner | Bazel | Fixed missing r'' fix in synth.py for replacements
Speech | Bazel | Experimental removed from client class, but same with artman
src | N/A |  
Storage | N/A |  
Talent | Bazel | Breaking changes, but same with artman
Tasks | Bazel |  
tests | N/A |  
TextToSpeech | Bazel |  
Trace | Bazel |  
Translate | Bazel |  
VideoIntelligence | Bazel | Required change in BUILD.bazel file to use legacy gapic for v1
Vision | Bazel |  
WebRisk | Bazel | WebRisk -> Webrisk case fix for GPBMetadata path
WebSecurityScanner | Bazel |  


