### PR TITLE
chore: update require version for google/cloud-core

### DIFF
--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.35",
+        "google/cloud-core": "^1.36.2",
         "google/gax": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This will ensure the proper google/cloud-core version is used to enable proper LRO encoding updated in #2837 