### PR TITLE
feat(spanner): deserialize response & metadata in operation lists

### DIFF
--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.36.1",
+        "google/cloud-core": "^1.35",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.35",
+        "google/cloud-core": "^1.36.1",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -439,7 +439,7 @@ class Grpc implements ConnectionInterface
             $this->pluck('databaseId', $args),
             $this->addResourcePrefixHeader($args, $instanceName)
         ]);
-        
+
         return $this->operationToArray($res, $this->serializer, $this->lroResponseMappers);
     }
 
@@ -451,7 +451,7 @@ class Grpc implements ConnectionInterface
         $backup = $this->pluck('backup', $args);
         $backup['expireTime'] = $this->formatTimestampForApi($this->pluck('expireTime', $backup));
         $backupInfo = $this->serializer->decodeMessage(new Backup(), $backup);
-        
+
         $backupName = $backupInfo->getName();
         $updateMask = $this->serializer->decodeMessage(new FieldMask(), $this->pluck('updateMask', $args));
         return $this->send([$this->getDatabaseAdminClient(), 'updateBackup'], [
@@ -469,7 +469,7 @@ class Grpc implements ConnectionInterface
         $backup = $this->pluck('backup', $args);
         $backup['expireTime'] = $this->formatTimestampForApi($this->pluck('expireTime', $backup));
         $backupInfo = $this->serializer->decodeMessage(new Backup(), $backup);
-        
+
         $instanceName = $this->pluck('instance', $args);
         $res = $this->send([$this->getDatabaseAdminClient(), 'createBackup'], [
             $instanceName,

--- a/Spanner/tests/System/BackupTest.php
+++ b/Spanner/tests/System/BackupTest.php
@@ -43,7 +43,7 @@ class BackupTest extends SpannerTestCase
     protected static $dbName2;
 
     protected static $project;
-    
+
     private static $hasSetUp = false;
 
     public static function setUpBeforeClass()
@@ -61,7 +61,7 @@ class BackupTest extends SpannerTestCase
         $op->pollUntilComplete();
 
         $db1 = self::getDatabaseInstance(self::$dbName1);
-        
+
         self::$deletionQueue->add(function () use ($db1) {
             $db1->drop();
         });
@@ -115,7 +115,7 @@ class BackupTest extends SpannerTestCase
         $expireTime = new \DateTime('+7 hours');
 
         $backup = self::$instance->backup(self::$backupId1);
-        
+
         self::$createTime1 = gmdate('"Y-m-d\TH:i:s\Z"');
         $op = $backup->create(self::$dbName1, $expireTime);
         self::$backupOperationName = $op->name();
@@ -140,7 +140,7 @@ class BackupTest extends SpannerTestCase
     {
         $backupId = uniqid(self::BACKUP_PREFIX);
         $expireTime = new \DateTime('-2 hours');
-        
+
         $backup = self::$instance->backup($backupId);
 
         $e = null;
@@ -175,7 +175,7 @@ class BackupTest extends SpannerTestCase
     {
         $backup = self::$instance->backup(self::$backupId1);
         $backup->reload();
-        
+
         $this->assertEquals(self::$backupId1, DatabaseAdminClient::parseName($backup->info()['name'])['backup']);
         $this->assertEquals(self::$dbName1, DatabaseAdminClient::parseName($backup->info()['database'])['database']);
         $this->assertTrue(is_string($backup->info()['expireTime']));
@@ -183,13 +183,13 @@ class BackupTest extends SpannerTestCase
         $this->assertEquals(Backup::STATE_READY, $backup->state());
         $this->assertTrue($backup->info()['sizeBytes'] > 0);
     }
-        
+
     public function testUpdateExpirationTime()
     {
         $backup = self::$instance->backup(self::$backupId1);
 
         $currentExpireTime = $backup->info()['expireTime'];
-       
+
         $newExpireTime = new \DateTime('+10 days');
 
         $backup->updateExpireTime($newExpireTime);
@@ -211,7 +211,7 @@ class BackupTest extends SpannerTestCase
             $backup->updateExpireTime($newExpireTime);
         } catch (BadRequestException $e) {
         }
-        
+
         $this->assertInstanceOf(BadRequestException::class, $e);
         $backup->reload();
 
@@ -222,7 +222,7 @@ class BackupTest extends SpannerTestCase
     public function testListAllBackups()
     {
         $allBackups = iterator_to_array(self::$instance->backups(), false);
-        
+
         $backupNames = [];
         foreach ($allBackups as $b) {
             $backupNames[] = $b->name();
@@ -241,7 +241,7 @@ class BackupTest extends SpannerTestCase
     public function testListAllBackupsReady()
     {
         $backups = iterator_to_array(self::$instance->backups(['filter'=>'state:READY']));
-        
+
         $backupNames = [];
         foreach ($backups as $b) {
             $backupNames[] = $b->name();
@@ -254,9 +254,9 @@ class BackupTest extends SpannerTestCase
     {
         $database = self::$instance->database(self::$dbName1);
         $backups = iterator_to_array($database->backups());
-        
+
         $this->assertTrue(count($backups) > 0);
-        
+
         foreach ($backups as $b) {
             $this->assertEquals($database->name(), $b->info()['database']);
         }
@@ -265,9 +265,9 @@ class BackupTest extends SpannerTestCase
     public function testListAllBackupsCreatedAfterTimestamp()
     {
         $filter = sprintf("create_time >= %s", self::$createTime2);
-        
+
         $backups = iterator_to_array(self::$instance->backups(['filter'=>$filter]));
-        
+
         $backupNames = [];
         foreach ($backups as $b) {
             $backupNames[] = $b->name();
@@ -299,9 +299,9 @@ class BackupTest extends SpannerTestCase
         $filter = "size_bytes > " . $size;
 
         $backups = iterator_to_array(self::$instance->backups(['filter' => $filter]));
-        
+
         $backupNames = [];
-        
+
         foreach ($backups as $b) {
             $backupNames[] = $b->name();
         }
@@ -315,7 +315,7 @@ class BackupTest extends SpannerTestCase
         $backupsfirstPage = self::$instance->backups(['pageSize' => 1]);
         $page = $backupsfirstPage->iterateByPage()->current();
         $this->assertEquals(1, count($page));
-        
+
         $backupsSecondPage = self::$instance->backups(
             ['pageToken' => $backupsfirstPage->nextResultToken(), 'pageSize' => 1]
         );
@@ -329,7 +329,7 @@ class BackupTest extends SpannerTestCase
     public function testListAllBackupOperations()
     {
         $backupOps = iterator_to_array($this::$instance->backupOperations());
-        
+
         $backupOpsNames = array_map(function ($bOp) {
             return $bOp->name();
         }, $backupOps);
@@ -342,7 +342,7 @@ class BackupTest extends SpannerTestCase
     {
         $backupId = uniqid(self::BACKUP_PREFIX);
         $expireTime = new \DateTime('+7 hours');
-        
+
         $backup = self::$instance->backup($backupId);
 
         $op = $backup->create(self::$dbName1, $expireTime);
@@ -358,9 +358,9 @@ class BackupTest extends SpannerTestCase
     public function testDeleteNonExistantBackup()
     {
         $backup = self::$instance->backup("does_not_exis");
-        
+
         $this->assertFalse($backup->exists());
-        
+
         $backup->delete();
     }
 
@@ -375,7 +375,7 @@ class BackupTest extends SpannerTestCase
         self::$restoreOperationName = $op->name();
         $op->pollUntilComplete();
         $restoredDb = $this::$instance->database($restoreDbName);
-        
+
         self::$deletionQueue->add(function () use ($restoredDb) {
             $restoredDb->drop();
         });
@@ -394,14 +394,14 @@ class BackupTest extends SpannerTestCase
         $this->assertContainsOnlyInstancesOf(LongRunningOperation::class, $databaseOps);
         $this->assertTrue(in_array(self::$restoreOperationName, $databaseOpsNames));
     }
-    
+
     public function testRestoreBackupToAnExistingDatabase()
     {
         $existingDb = self::$instance->database(self::$dbName2);
         $this->assertTrue($existingDb->exists());
 
         $this->expectException(ConflictException::class);
-        
+
         $this::$instance->createDatabaseFromBackup(
             self::$dbName2,
             self::fullyQualifiedBackupName(self::$backupId1)


### PR DESCRIPTION
Deserialize responses and metadata returned by Instance#backupOperations() and Instance#databaseOperations().
Required for issue [#1050](https://github.com/GoogleCloudPlatform/php-docs-samples/issues/1050).