### PR TITLE
feat: allow array-of-arrays value for "in" query filter

### DIFF
--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -362,13 +362,17 @@ class Query
                 ]
             ];
         } else {
+            $encodedValue = ($operator == FieldFilterOperator::IN
+                ? $this->valueMapper->encodeMultiValue((array)$value)
+                : $this->valueMapper->encodeValue($value)
+            );
             $filter = [
                 'fieldFilter' => [
                     'field' => [
                         'fieldPath' => $escapedPathString,
                     ],
                     'op' => $operator,
-                    'value' => $this->valueMapper->encodeValue($value)
+                    'value' => $encodedValue
                 ]
             ];
         }

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -362,10 +362,10 @@ class Query
                 ]
             ];
         } else {
-            $encodedValue = ($operator == FieldFilterOperator::IN
+            $encodedValue = $operator === FieldFilterOperator::IN
                 ? $this->valueMapper->encodeMultiValue((array)$value)
-                : $this->valueMapper->encodeValue($value)
-            );
+                : $this->valueMapper->encodeValue($value);
+
             $filter = [
                 'fieldFilter' => [
                     'field' => [

--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -334,4 +334,22 @@ class ValueMapper
 
         return ['mapValue' => ['fields' => $out]];
     }
+
+    /**
+     * Encode a list of Google Cloud PHP values as a Firestore value.
+     *
+     * The list is treated as an ArrayValue with one exception: indexed arrays are allowed as top level items.
+     * This is needed to properly encode values for "in" query filters.
+     *
+     * @param array $values
+     * @return array [Value](https://firebase.google.com/docs/firestore/reference/rpc/google.firestore.v1beta1#value)
+     */
+    public function encodeMultiValue(array $values)
+    {
+        return [
+            'arrayValue' => [
+                'values' => array_map([$this, 'encodeValue'], $values),
+            ],
+        ];
+    }
 }

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -90,6 +90,31 @@ class QueryTest extends FirestoreTestCase
         $this->assertEquals($res->name(), $doc->name());
     }
 
+    public function testWhereInArray()
+    {
+        $name = $this->query->name();
+        $doc1 = $this->insertDoc([
+            'foos' => ['foo', 'bar'],
+        ]);
+        $doc2 = $this->insertDoc([
+            'foos' => ['foo'],
+        ]);
+
+        $docs = self::$client->collection($name)->where('foos', 'in', [['foo']])->documents()->rows();
+        $this->assertCount(1, $docs);
+        $this->assertEquals($doc2->name(), $docs[0]->name());
+
+        $docs = self::$client->collection($name)->where('foos', 'in', [['bar']])->documents()->rows();
+        $this->assertEmpty($docs);
+
+        $docs = self::$client->collection($name)->where('foos', 'in', [['foo', 'bar']])->documents()->rows();
+        $this->assertCount(1, $docs);
+        $this->assertEquals($doc1->name(), $docs[0]->name());
+
+        $docs = self::$client->collection($name)->where('foos', 'in', [['bar', 'foo']])->documents()->rows();
+        $this->assertEmpty($docs);
+    }
+
     public function testSnapshotCursors()
     {
         $collection = self::$client->collection(uniqid(self::COLLECTION_NAME));

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -363,4 +363,32 @@ class ValueMapperTest extends TestCase
             ['a']
         ]]);
     }
+
+    public function multiValues()
+    {
+        return [
+            [[]],
+            [['foo', 'bar']],
+            [[['foo'], ['bar', 'baz'], 'qux']],
+        ];
+    }
+
+    /**
+     * @dataProvider multiValues
+     * @param array $values
+     */
+    public function testEncodeValidMultiValues($values)
+    {
+        $encoded = $this->mapper->encodeMultiValue($values);
+        $decoded = $this->mapper->decodeValues(['key' => $encoded]);
+        $this->assertEquals($values, $decoded['key']);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testEncodeInvalidMultiValue()
+    {
+        $this->mapper->encodeMultiValue([[['foo']]]);
+    }
 }


### PR DESCRIPTION
IN query filter [allows](https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any) an array of arrays as its value, this could be written as
```php
$containsQuery = $citiesRef->where('regions', 'in', [['west_coast'], ['east_coast']]);
```
But currently this code throws an exception. RPC reference [says](https://firebase.google.com/docs/firestore/reference/rpc/google.firestore.v1#google.firestore.v1.Value) that an array value "Cannot directly contain another array value", and `Firestore\ValueMapper` [checks it](https://github.com/googleapis/google-cloud-php/blob/master/Firestore/src/ValueMapper.php#L261-L263). But if we remove that check, this code works fine, and a query returns exactly what is expected.

This PR adds a "pseudotype" MultiValue, which is encoded like an ArrayValue, but allows indexed arrays as top-level items. `Firestore\Query#where()` method encodes value as a MultiValue for "in" operator, or as an ordinary Value otherwise.