### PR TITLE
fix: fix check for user provided MD5 hash

### DIFF
--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -495,7 +495,7 @@ class Rest implements ConnectionInterface
     private function chooseValidationMethod(array $args)
     {
         // If the user provided a hash, skip hashing.
-        if (isset($args['metadata']['md5']) || isset($args['metadata']['crc32c'])) {
+        if (isset($args['metadata']['md5Hash']) || isset($args['metadata']['crc32c'])) {
             return false;
         }
 

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -417,7 +417,7 @@ class RestTest extends TestCase
                 true,
                 false
             ], [
-                ['validate' => 'md5', 'metadata' => ['md5' => 'foo']],
+                ['validate' => 'md5', 'metadata' => ['md5Hash' => 'foo']],
                 true,
                 true,
                 false


### PR DESCRIPTION
The check for a user provided MD5 hash contains a typo which causes a new hash to be generated even if the user already provided one.

Fixes #2969