### PR TITLE
Correctly serialize evaluated expressions

### DIFF
--- a/Debugger/src/Breakpoint.php
+++ b/Debugger/src/Breakpoint.php
@@ -476,7 +476,9 @@ class Breakpoint
             'stackFrames' => array_map(function ($sf) {
                 return $sf->info();
             }, $this->stackFrames),
-            'evaluatedExpressions' => $this->evaluatedExpressions
+            'evaluatedExpressions' => array_map(function ($exp) {
+                return $exp->info();
+            }, $this->evaluatedExpressions),
         ];
         if ($this->labels) {
             $info['labels'] = $this->labels;


### PR DESCRIPTION
When serializing the `Breakpoint` object the `evaluatedExpressions` were not being properly serialized. They need to be converted to a serializable format before running `json_encode()` on them, so we need to run the `info()` function on each of them, the same way that we are doing for the `stackFrames`

Fixes #2971 