### PR TITLE
feat: add maintain() method for CacheSessionPool

### DIFF
--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -885,12 +885,12 @@ class CacheSessionPool implements SessionPoolInterface
 
             $len = count($queue);
             for ($expiredPos = 0; $expiredPos < $len; $expiredPos++) {
-                if ($queue[$expiredPos]['expires'] <= $now) {
+                if ($queue[$expiredPos]['expires'] > $now) {
                     break;
                 }
             }
             for ($oldPos = $expiredPos; $oldPos < $len; $oldPos++) {
-                if ($queue[$oldPos]['expires'] <= $oldThreshold) {
+                if ($queue[$oldPos]['expires'] > $oldThreshold) {
                     break;
                 }
             }
@@ -898,7 +898,7 @@ class CacheSessionPool implements SessionPoolInterface
             if (isset($prevMaintainTime)) {
                 $freshThreshold = $prevMaintainTime + self::SESSION_EXPIRATION_SECONDS;
                 for (; $freshPos >= 0; $freshPos--) {
-                    if ($queue[$freshPos]['expires'] > $freshThreshold) {
+                    if ($queue[$freshPos]['expires'] <= $freshThreshold) {
                         break;
                     }
                 }

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -884,12 +884,24 @@ class CacheSessionPool implements SessionPoolInterface
             $prevMaintainTime = isset($data['maintainTime']) ? $data['maintainTime'] : null;
 
             $len = count($queue);
-            for ($expiredPos = 0; $expiredPos < $len and $queue[$expiredPos]['expires'] <= $now; $expiredPos++);
-            for ($oldPos = $expiredPos; $oldPos < $len and $queue[$oldPos]['expires'] <= $oldThreshold; $oldPos++);
+            for ($expiredPos = 0; $expiredPos < $len; $expiredPos++) {
+                if ($queue[$expiredPos]['expires'] <= $now) {
+                    break;
+                }
+            }
+            for ($oldPos = $expiredPos; $oldPos < $len; $oldPos++) {
+                if ($queue[$oldPos]['expires'] <= $oldThreshold) {
+                    break;
+                }
+            }
             $freshPos = $len - 1;
             if (isset($prevMaintainTime)) {
                 $freshThreshold = $prevMaintainTime + self::SESSION_EXPIRATION_SECONDS;
-                for (; $freshPos >= 0 and $queue[$freshPos]['expires'] > $freshThreshold; $freshPos--);
+                for (; $freshPos >= 0; $freshPos--) {
+                    if ($queue[$freshPos]['expires'] > $freshThreshold) {
+                        break;
+                    }
+                }
             }
             $freshCount = $len - 1 - $freshPos;
             $oldQueue = array_splice($queue, $expiredPos, ($oldPos - $expiredPos));
@@ -955,7 +967,6 @@ class CacheSessionPool implements SessionPoolInterface
         try {
             $this->database->execute('SELECT 1', ['session' => $session])->rows()->current();
             return true;
-
         } catch (NotFoundException $e) {
             return false;
         }

--- a/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
@@ -50,7 +50,7 @@ class CacheSessionPoolTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
         putenv('GOOGLE_CLOUD_SYSV_ID=U');
-        $this->time = 1000000000;//time();
+        $this->time = time();
         MockValues::initialize();
         $this->cacheKey = sprintf(self::CACHE_KEY_TEMPLATE, self::PROJECT_ID, self::INSTANCE_NAME, self::DATABASE_NAME);
     }


### PR DESCRIPTION
Adds a public method for `Spanner\Session\CacheSessionPool` to maintain cached sessions and keep them alive.
Related to issue #2411. Implementation details are described [here](https://docs.google.com/document/d/1rBpvz3tGGysmsM5qoXxo5y-tI6hSquMMY0zKnb11gm8/edit?usp=sharing).