### PR TITLE
feat: deprecate v1beta1 client

### DIFF
--- a/Firestore/src/V1beta1/Gapic/FirestoreGapicClient.php
+++ b/Firestore/src/V1beta1/Gapic/FirestoreGapicClient.php
@@ -103,6 +103,9 @@ use Google\Protobuf\Timestamp;
  * a parseName method to extract the individual identifiers contained within formatted names
  * that are returned by the API.
  *
+ * @deprecated This version is deprecated and will be removed in a future
+ *     release. Please use {@see Google\Cloud\Firestore\V1\FirestoreClient}
+ *     instead.
  * @experimental
  */
 class FirestoreGapicClient

--- a/docs/contents/cloud-firestore.json
+++ b/docs/contents/cloud-firestore.json
@@ -49,15 +49,5 @@
             "title": "FirestoreAdminClient",
             "type": "firestore/admin/v1/firestoreadminclient"
         }]
-    }, {
-        "title": "v1beta1",
-        "type": "firestore/v1beta1/readme",
-        "patterns": [
-          "firestore/v1beta1/\\w{1,}"
-        ],
-        "nav": [{
-            "title": "FirestoreClient",
-            "type": "firestore/v1beta1/firestoreclient"
-        }]
     }]
 }


### PR DESCRIPTION
We don't generate updates to this client anymore, so synth change isn't needed.