### PR TITLE
feat: support fflush() and append mode in StreamWrapper

### DIFF
--- a/Storage/src/StreamWrapper.php
+++ b/Storage/src/StreamWrapper.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage;
 
+use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Exception\ServiceException;
 use Google\Cloud\Storage\Bucket;
 use GuzzleHttp\Psr7\CachingStream;
@@ -24,7 +25,7 @@ use GuzzleHttp\Psr7;
 
 /**
  * A streamWrapper implementation for handling `gs://bucket/path/to/file.jpg`.
- * Note that you can only open a file with mode 'r', 'rb', 'rb', 'w', 'wb', or 'wt'.
+ * Note that you can only open a file with mode 'r', 'rb', 'rt', 'w', 'wb', 'wt', 'a', 'ab', or 'at'.
  *
  * See: http://php.net/manual/en/class.streamwrapper.php
  */
@@ -37,8 +38,21 @@ class StreamWrapper
     const DIRECTORY_WRITABLE_MODE = 16895; // 40777 in octal
     const DIRECTORY_READABLE_MODE = 16676; // 40444 in octal
 
+    const TAIL_NAME_SUFFIX = '~';
+
     /**
      * @var resource|null Must be public according to the PHP documentation.
+     *
+     * Contains array of context options in form ['protocol' => ['option' => value]].
+     * Recognized options are:
+     *
+     * chunkSize (int)
+     * encryptionKey (string)
+     * encryptionKeySHA256 (string)
+     * flush (bool) `true`: fflush() will flush output buffer; `false`: fflush() will do nothing
+     * metadata (array)
+     * predefinedAcl (string)
+     * validate (bool)
      */
     public $context;
 
@@ -78,6 +92,31 @@ class StreamWrapper
      * @var StorageObject
      */
     private $object;
+
+    /**
+     * @var array Context options passed to stream_open(), used for append mode and flushing.
+     */
+    private $options = [];
+
+    /**
+     * @var bool `true`: fflush() will flush output buffer and redirect output to the "tail" object.
+     */
+    private $flushing = false;
+
+    /**
+     * @var string|null Content type for composed object. Will be filled on first composing.
+     */
+    private $contentType = null;
+
+    /**
+     * @var bool `true`: writing the "tail" object, next fflush() or fclose() will compose.
+     */
+    private $composing = false;
+
+    /**
+     * @var bool `true`: data has been written to the stream.
+     */
+    private $dirty = false;
 
     /**
      * Ensure we close the stream when this StreamWrapper is destroyed.
@@ -139,7 +178,7 @@ class StreamWrapper
      * download the file to see if it can be opened.
      *
      * @param string $path The path of the resource to open
-     * @param string $mode The fopen mode. Currently only supports ('r', 'rb', 'rt', 'w', 'wb', 'wt')
+     * @param string $mode The fopen mode. Currently supports ('r', 'rb', 'rt', 'w', 'wb', 'wt', 'a', 'ab', 'at')
      * @param int $flags Bitwise options STREAM_USE_PATH|STREAM_REPORT_ERRORS|STREAM_MUST_SEEK
      * @param string $openedPath Will be set to the path on success if STREAM_USE_PATH option is set
      * @return bool
@@ -157,6 +196,13 @@ class StreamWrapper
             if (array_key_exists($this->protocol, $contextOptions)) {
                 $options = $contextOptions[$this->protocol] ?: [];
             }
+
+            if (isset($options['flush'])) {
+                $this->flushing = (bool)$options['flush'];
+                unset($options['flush']);
+            }
+
+            $this->options = $options;
         }
 
         if ($mode == 'w') {
@@ -165,6 +211,24 @@ class StreamWrapper
                 $this->bucket->getStreamableUploader(
                     $this->stream,
                     $options + ['name' => $this->file]
+                )
+            );
+        } elseif ($mode == 'a') {
+            try {
+                $info = $this->bucket->object($this->file)->info();
+                $this->composing = ($info['size'] > 0);
+            } catch (NotFoundException $e) {
+            }
+
+            $this->stream = new WriteStream(null, $options);
+            $name = $this->file;
+            if ($this->composing) {
+                $name .= self::TAIL_NAME_SUFFIX;
+            }
+            $this->stream->setUploader(
+                $this->bucket->getStreamableUploader(
+                    $this->stream,
+                    $options + ['name' => $name]
                 )
             );
         } elseif ($mode == 'r') {
@@ -213,7 +277,9 @@ class StreamWrapper
      */
     public function stream_write($data)
     {
-        return $this->stream->write($data);
+        $result = $this->stream->write($data);
+        $this->dirty = $this->dirty || (bool)$result;
+        return $result;
     }
 
     /**
@@ -249,6 +315,18 @@ class StreamWrapper
     {
         if (isset($this->stream)) {
             $this->stream->close();
+        }
+
+        if ($this->composing) {
+            if ($this->dirty) {
+                $this->compose();
+                $this->dirty = false;
+            }
+            try {
+                $this->bucket->object($this->file . self::TAIL_NAME_SUFFIX)->delete();
+            } catch (NotFoundException $e) {
+            }
+            $this->composing = false;
         }
     }
 
@@ -529,6 +607,43 @@ class StreamWrapper
     }
 
     /**
+     * Callback handler for fflush() function.
+     *
+     * @return bool
+     */
+    public function stream_flush()
+    {
+        if (!$this->flushing) {
+            return false;
+        }
+
+        if (!$this->dirty) {
+            return true;
+        }
+
+        if (isset($this->stream)) {
+            $this->stream->close();
+        }
+
+        if ($this->composing) {
+            $this->compose();
+        }
+
+        $options = $this->options;
+        $this->stream = new WriteStream(null, $options);
+        $this->stream->setUploader(
+            $this->bucket->getStreamableUploader(
+                $this->stream,
+                $options + ['name' => $this->file . self::TAIL_NAME_SUFFIX]
+            )
+        );
+        $this->composing = true;
+        $this->dirty = false;
+
+        return true;
+    }
+
+    /**
      * Parse the URL and set protocol, filename and bucket.
      *
      * @param  string $path URL to open
@@ -714,5 +829,15 @@ class StreamWrapper
 
         // Otherwise, assume only the project/bucket owner can use the bucket.
         return 'private';
+    }
+
+    private function compose()
+    {
+        if (!isset($this->contentType)) {
+            $info = $this->bucket->object($this->file)->info();
+            $this->contentType = $info['contentType'] ?: 'application/octet-stream';
+        }
+        $options = ['destination' => ['contentType' => $this->contentType]];
+        $this->bucket->compose([$this->file, $this->file . self::TAIL_NAME_SUFFIX], $this->file, $options);
     }
 }

--- a/Storage/src/StreamWrapper.php
+++ b/Storage/src/StreamWrapper.php
@@ -44,15 +44,9 @@ class StreamWrapper
      * @var resource|null Must be public according to the PHP documentation.
      *
      * Contains array of context options in form ['protocol' => ['option' => value]].
-     * Recognized options are:
+     * Options used by StreamWrapper:
      *
-     * chunkSize (int)
-     * encryptionKey (string)
-     * encryptionKeySHA256 (string)
      * flush (bool) `true`: fflush() will flush output buffer; `false`: fflush() will do nothing
-     * metadata (array)
-     * predefinedAcl (string)
-     * validate (bool)
      */
     public $context;
 

--- a/Storage/tests/System/StreamWrapper/AppendTest.php
+++ b/Storage/tests/System/StreamWrapper/AppendTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\System\StreamWrapper;
+
+use Google\Cloud\Storage\StreamWrapper;
+
+/**
+ * @group storage
+ * @group storage-stream-wrapper
+ * @group storage-stream-wrapper-append
+ */
+class AppendTest extends StreamWrapperTestCase
+{
+    private static $fileName = 'append.txt';
+    private $fileUrl;
+    private $tailFileUrl;
+
+    public function setUp()
+    {
+        $this->fileUrl = self::generateUrl(self::$fileName);
+        $this->tailFileUrl = $this->fileUrl . StreamWrapper::TAIL_NAME_SUFFIX;
+    }
+
+    public static function tearDownAfterCLass()
+    {
+        $url = static::generateUrl(self::$fileName);
+        unlink($url);
+        unlink($url . StreamWrapper::TAIL_NAME_SUFFIX);
+    }
+
+    public function testNonExistent()
+    {
+        unlink($this->fileUrl);
+        unlink($this->tailFileUrl);
+        $content = 'hello';
+        $f = fopen($this->fileUrl, 'a');
+        $this->assertEquals(strlen($content), fwrite($f, $content));
+        fclose($f);
+        $this->assertTrue(file_exists($this->fileUrl));
+        $this->assertFalse(file_exists($this->tailFileUrl));
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertEquals(strlen($content), $info['size']);
+        $this->assertArrayNotHasKey('componentCount', $info);
+        $this->assertEquals($content, file_get_contents($this->fileUrl));
+    }
+
+    /**
+     * @depends testNonExistent
+     */
+    public function testSimple()
+    {
+        $append = ' world';
+        $content = 'hello' . $append;
+        $f = fopen($this->fileUrl, 'a');
+        $this->assertEquals(strlen($append), fwrite($f, $append));
+        fclose($f);
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertEquals(strlen($content), $info['size']);
+        $this->assertArrayHasKey('componentCount', $info);
+        $this->assertEquals(2, $info['componentCount']);
+        $this->assertEquals($content, file_get_contents($this->fileUrl));
+        $this->assertFalse(file_exists($this->tailFileUrl));
+    }
+
+    /**
+     * @depends testSimple
+     */
+    public function testComposed()
+    {
+        $append = '!';
+        $content = 'hello world' . $append;
+        $f = fopen($this->fileUrl, 'a');
+        $this->assertEquals(strlen($append), fwrite($f, $append));
+        fclose($f);
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertEquals(strlen($content), $info['size']);
+        $this->assertArrayHasKey('componentCount', $info);
+        $this->assertEquals(3, $info['componentCount']);
+        $this->assertEquals($content, file_get_contents($this->fileUrl));
+        $this->assertFalse(file_exists($this->tailFileUrl));
+    }
+}

--- a/Storage/tests/System/StreamWrapper/FlushTest.php
+++ b/Storage/tests/System/StreamWrapper/FlushTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\System\StreamWrapper;
+
+use Google\Cloud\Storage\StreamWrapper;
+
+/**
+ * @group storage
+ * @group storage-stream-wrapper
+ * @group storage-stream-wrapper-flush
+ */
+class FlushTest extends StreamWrapperTestCase
+{
+    private static $fileName = 'flush.txt';
+    private static $binFileName = 'flush';
+    private $fileUrl;
+    private $tailFileUrl;
+    private $binFileUrl;
+    private $tailBinFileUrl;
+
+    public function setUp()
+    {
+        $this->fileUrl = self::generateUrl(self::$fileName);
+        $this->tailFileUrl = $this->fileUrl . StreamWrapper::TAIL_NAME_SUFFIX;
+        $this->binFileUrl = self::generateUrl(self::$binFileName);
+        $this->tailBinFileUrl = $this->binFileUrl . StreamWrapper::TAIL_NAME_SUFFIX;
+        unlink($this->fileUrl);
+    }
+
+    public function tearDown()
+    {
+        unlink($this->fileUrl);
+        unlink($this->tailFileUrl);
+        unlink($this->binFileUrl);
+        unlink($this->tailBinFileUrl);
+    }
+
+    public function testFlushOff()
+    {
+        $f = fopen($this->fileUrl, 'w');
+        fwrite($f, 'hello');
+        $this->assertFalse(fflush($f));
+        fwrite($f, ' world');
+        fclose($f);
+
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertArrayNotHasKey('componentCount', $info);
+        $this->assertEquals('hello world', file_get_contents($this->fileUrl));
+    }
+
+    public function testFlushOnAndCalled()
+    {
+        $ctx = stream_context_create(['gs' => ['flush' => true]]);
+        $f = fopen($this->fileUrl, 'w', false, $ctx);
+        fwrite($f, 'hello');
+        $this->assertTrue(fflush($f));
+        fwrite($f, ' world');
+        $this->assertTrue(fflush($f));
+        fwrite($f, '!');
+        fclose($f);
+
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertArrayHasKey('componentCount', $info);
+        $this->assertEquals(3, $info['componentCount']);
+        $this->assertEquals('hello world!', file_get_contents($this->fileUrl));
+        $this->assertFalse(file_exists($this->tailFileUrl));
+    }
+
+    public function testFlushOnAndNotCalled()
+    {
+        $ctx = stream_context_create(['gs' => ['flush' => true]]);
+        $f = fopen($this->fileUrl, 'w', false, $ctx);
+        fwrite($f, 'hello');
+        fwrite($f, ' world');
+        fwrite($f, '!');
+        fclose($f);
+
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertArrayNotHasKey('componentCount', $info);
+        $this->assertEquals('hello world!', file_get_contents($this->fileUrl));
+        $this->assertFalse(file_exists($this->tailFileUrl));
+    }
+
+    public function testFlushEmptyBuffer()
+    {
+        $ctx = stream_context_create(['gs' => ['flush' => true]]);
+        $f = fopen($this->fileUrl, 'w', false, $ctx);
+        $this->assertTrue(fflush($f));
+        fwrite($f, 'hello');
+        fflush($f);
+        fflush($f);
+        fwrite($f, ' world');
+        fclose($f);
+
+        $info = static::$bucket->object(self::$fileName)->info();
+        $this->assertArrayHasKey('componentCount', $info);
+        $this->assertEquals(2, $info['componentCount']);
+        $this->assertFalse(file_exists($this->tailFileUrl));
+    }
+
+    public function testFlushNoContentType()
+    {
+        $ctx = stream_context_create(['gs' => ['flush' => true]]);
+        $f = fopen($this->binFileUrl, 'w', false, $ctx);
+        fwrite($f, '0');
+        fflush($f);
+        fwrite($f, '1');
+        fclose($f);
+
+        $info = static::$bucket->object(self::$binFileName)->info();
+        $this->assertArrayHasKey('componentCount', $info);
+        $this->assertEquals(2, $info['componentCount']);
+        $this->assertEquals('application/octet-stream', $info['contentType']);
+        $this->assertFalse(file_exists($this->tailBinFileUrl));
+    }
+}

--- a/Storage/tests/Unit/StreamWrapperTest.php
+++ b/Storage/tests/Unit/StreamWrapperTest.php
@@ -84,7 +84,7 @@ class StreamWrapperTest extends TestCase
      */
     public function testUnknownOpenMode()
     {
-        $fp = @fopen('gs://my_bucket/existing_file.txt', 'a');
+        $fp = @fopen('gs://my_bucket/existing_file.txt', 'x');
         $this->assertFalse($fp);
     }
 


### PR DESCRIPTION
Closing #924.

Adds «a» (append) open mode for StreamWrapper. Example:
```php
$file = fopen('gs://my-bucket/my-object', 'a');
```
Adds an option to flush stream buffer using `fflush()` function. By default this function does nothing and returns false. Flushing is enabled by passing a stream context with `flush` option set to `true`. Example:
```php
$ctx = stream_context_create(['gs' => ['flush' => true]]);
$file = fopen('gs://my-bucket/my-object', 'w', false, $ctx);
fwrite($file, 'hello');
fflush($file); // my-object now contains 'hello'
fwrite($file, ' world');
fclose($file);
```
Both features are implemented using composite objects. When a non-empty object is opened for append or `fflush()` called current stream is closed and a «tail» object is created in the same bucket. All following data is written to this new object. When `fflush()` is called or the stream is closed the «tail» is appended to the main object. The «tail» name is the main object name with «~» suffix, e. g. `my-object~`.