### PR TITLE
docs: update table of contents

### DIFF
--- a/docs/toc.json
+++ b/docs/toc.json
@@ -1,21 +1,5 @@
 {
     "guides": [{
-        "title": "Authentication",
-        "id": "authentication",
-        "edit": "https://github.com/googleapis/google-cloud-common/edit/master/authentication/readme.md",
-        "contents": [
-            "https://raw.githubusercontent.com/googleapis/google-cloud-common/master/authentication/readme.md",
-            "authentication.md"
-        ]
-    }, {
-        "title": "FAQ",
-        "id": "faq",
-        "edit": "https://github.com/googleapis/google-cloud-common/edit/master/faq/readme.md",
-        "contents": [
-            "https://raw.githubusercontent.com/googleapis/google-cloud-common/master/faq/readme.md",
-            "faq.md"
-        ]
-    }, {
         "title": "Troubleshooting",
         "id": "troubleshooting",
         "edit": "https://github.com/googleapis/google-cloud-common/edit/master/troubleshooting/readme.md",
@@ -26,8 +10,8 @@
     }, {
         "title": "Contributing",
         "id": "contributing",
-        "edit": "https://github.com/googleapis/google-cloud-common/edit/master/contributing/readme.md",
-        "contents": "https://raw.githubusercontent.com/googleapis/google-cloud-common/master/contributing/readme.md"
+        "edit": "https://github.com/googleapis/google-cloud-php/edit/master/CONTRIBUTING.md",
+        "contents": "https://raw.githubusercontent.com/googleapis/google-cloud-php/master/CONTRIBUTING.md"
     }],
     "services": []
 }


### PR DESCRIPTION
Related to #3135.

I updated the docs site to change the table of contents authentication guide to something more current. This removes obsolete links from the table of contents.