### PR TITLE
chore: add simple API compare tool for catching BC breaks

### DIFF
--- a/.github/workflows/bc.yaml
+++ b/.github/workflows/bc.yaml
@@ -23,4 +23,4 @@ jobs:
                 max_attempts: 3
                 command: composer update
             - name: Run Scanner
-              run: dev/google-cloud comparator $GITHUB_REF master
+              run: dev/google-cloud comparator $GITHUB_SHA origin/master

--- a/.github/workflows/bc.yaml
+++ b/.github/workflows/bc.yaml
@@ -1,0 +1,26 @@
+name: Scan for Backwards-Incompatible Changes
+
+on:
+    pull_request:
+
+jobs:
+    scan:
+        name: Scan for Backwards-Incompatible Changes
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Fetch master
+              run: git fetch origin master
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+                ini-values: memory_limit=2048M
+            - name: Install Dependencies
+              uses: nick-invision/retry@v1
+              with:
+                timeout_minutes: 10
+                max_attempts: 3
+                command: composer update
+            - name: Run Scanner
+              run: dev/google-cloud comparator

--- a/.github/workflows/bc.yaml
+++ b/.github/workflows/bc.yaml
@@ -23,4 +23,4 @@ jobs:
                 max_attempts: 3
                 command: composer update
             - name: Run Scanner
-              run: dev/google-cloud comparator
+              run: dev/google-cloud comparator $GITHUB_REF master

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         "phpseclib/phpseclib": "^2",
         "google/cloud-tools": "^0.9.0",
         "opis/closure": "^3.0",
-        "swaggest/json-schema": "^0.12.0"
+        "swaggest/json-schema": "^0.12.0",
+        "gitonomy/gitlib": "^1"
     },
     "replace": {
         "google/cloud-asset": "1.2.1",

--- a/dev/google-cloud
+++ b/dev/google-cloud
@@ -19,6 +19,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Google\Cloud\Dev\AddComponent\Command\AddComponent;
+use Google\Cloud\Dev\ApiComparator\Command as ApiComparator;
 use Google\Cloud\Dev\ComponentIntegration\Command\ComponentIntegration;
 use Google\Cloud\Dev\ComponentManager;
 use Google\Cloud\Dev\Credentials\Command as Credentials;
@@ -48,4 +49,5 @@ $app->add(new Docs($rootDirectory));
 $app->add(new Release($rootDirectory));
 $app->add(new ReleaseBuilder($rootDirectory));
 $app->add(new Split($rootDirectory, $componentManager));
+$app->add(new ApiComparator($rootDirectory));
 $app->run();

--- a/dev/src/ApiComparator/Command.php
+++ b/dev/src/ApiComparator/Command.php
@@ -111,17 +111,8 @@ class Command extends GoogleCloudCommand
 
     private function getClassMethods(array $nodes)
     {
+        $methodFindingTraverser = new MethodFindingTraverser();
         $traverser = new NodeTraverser;
-        $methodFindingTraverser = new class extends NodeVisitorAbstract {
-            public $methods = [];
-
-            function enterNode(Node $node) {
-                if ($node instanceof ClassMethod) {
-                    $this->methods[] = $node;
-                    return NodeTraverser::DONT_TRAVERSE_CHILDREN;
-                }
-            }
-        };
         $traverser->addVisitor($methodFindingTraverser);
         $traverser->addVisitor(new NameResolver());
 

--- a/dev/src/ApiComparator/Command.php
+++ b/dev/src/ApiComparator/Command.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\ApiComparator;
+
+use Gitonomy\Git\Diff\File;
+use Gitonomy\Git\Repository;
+use Google\Cloud\Dev\Command\GoogleCloudCommand;
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitorAbstract;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Detect backwards-incompatible changes in php class signatures.
+ */
+class Command extends GoogleCloudCommand
+{
+    private $parser;
+
+    protected function configure()
+    {
+        $this->setName('comparator')
+            ->setDescription('Test the current git ref against master for backwards-compatibility breaks.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->parser = new \PhpParser\Parser(new \PhpParser\Lexer);
+
+        $repo = new Repository($this->rootPath);
+        $commit = $repo->getHeadCommit();
+        $rev = $commit->getRevision();
+
+        $diff = $repo->getDiff('master..' . $rev);
+        $files = array_filter($diff->getFiles(), function ($file) {
+            return $file->getOldName() === $file->getNewName() && strpos($file->getNewName(), '.php') !== false;
+        });
+
+        if (empty($files)) {
+            return;
+        }
+
+        $passed = true;
+        $results = [];
+        foreach ($files as $file) {
+            $result = new FileResult($file->getNewName());
+            $result->setResults($this->compareFile($file));
+
+            if ($passed) {
+                $passed = $result->passed();
+            }
+
+            $results[] = $result;
+        }
+
+        if (!$passed) {
+            $output->writeln("<error>Backwards-incompatible changes found!</error>");
+            foreach ($results as $result) {
+                if ($result->passed()) {
+                    continue;
+                }
+                $output->writeln($result->toString());
+            }
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function compareFile(File $file)
+    {
+        $oldContent = $file->getOldBlob()->getContent();
+        $newContent = $file->getNewBlob()->getContent();
+
+        $oldContentMethods = $this->getClassMethods($this->parser->parse($oldContent));
+        $newContentMethods = $this->getClassMethods($this->parser->parse($newContent));
+
+        $results = [];
+        foreach ($oldContentMethods as $method) {
+            $result = $this->compareMethod($file->getNewName(), $method, $newContentMethods);
+            if ($result) {
+                $results[] = $result;
+            }
+        }
+
+        return $results;
+    }
+
+    private function getClassMethods(array $nodes)
+    {
+        $traverser = new NodeTraverser;
+        $methodFindingTraverser = new class extends NodeVisitorAbstract {
+            public $methods = [];
+
+            function enterNode(Node $node) {
+                if ($node instanceof ClassMethod) {
+                    $this->methods[] = $node;
+                    return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                }
+            }
+        };
+        $traverser->addVisitor($methodFindingTraverser);
+        $traverser->addVisitor(new NameResolver());
+
+        $traverser->traverse($nodes);
+
+        return $methodFindingTraverser->methods;
+    }
+
+    private function compareMethod($file, ClassMethod $method, array $newMethods)
+    {
+        $name = $method->name;
+
+        $newMethodMatches = array_filter($newMethods, function (ClassMethod $newMethod) use ($name) {
+            return $name === $newMethod->name;
+        });
+
+        if (!$newMethodMatches) {
+            return sprintf(
+                "Method %s was removed from file %s",
+                $name,
+                $file
+            );
+        }
+
+        $newMethod = current($newMethodMatches);
+        if ($method->isPublic() && !$newMethod->isPublic()) {
+            return sprintf(
+                "Method %s in file %s is no longer public",
+                $name,
+                $file
+            );
+        }
+
+        return $this->compareMethodParams($file, $method, $newMethod);
+    }
+
+    private function compareMethodParams($file, ClassMethod $method, ClassMethod $newMethod)
+    {
+        $methodArgs = $method->getParams();
+        $newMethodArgs = $newMethod->getParams();
+
+        if (count($methodArgs) > count($newMethodArgs)) {
+            return sprintf(
+                "Argument(s) removed from method %s in file %s",
+                $method->name,
+                $file
+            );
+        }
+
+        foreach ($methodArgs as $i => $arg) {
+            $newMethodArg = $newMethodArgs[$i];
+
+            $oldType = $arg->type;
+            $newType = $newMethodArg->type;
+            if ($newType !== null) {
+                if ($oldType === null) {
+                    return sprintf(
+                        "Argument %s in method %s in file %s has restricted its type.",
+                        $arg->name,
+                        $method->name,
+                        $file
+                    );
+                }
+
+                if ($newType instanceof FullyQualified) {
+                    if (!($oldType instanceof FullyQualified)) {
+                        return sprintf(
+                            "Argument %s in method %s in file %s has changed type",
+                            $arg->name,
+                            $method->name,
+                            $file
+                        );
+                    }
+
+                    if (!is_a($oldType->toString(), $newType->toString())) {
+                        return sprintf(
+                            "Argument %s in method %s in file %s has restricted its type",
+                            $arg->name,
+                            $method->name,
+                            $file
+                        );
+                    }
+                }
+
+                if (is_string($newType) && $newType !== $oldType) {
+                    return sprintf(
+                        "Argument %s in method %s in file %s has changed type",
+                        $arg->name,
+                        $method->name,
+                        $file
+                    );
+                }
+            }
+        }
+    }
+}

--- a/dev/src/ApiComparator/Command.php
+++ b/dev/src/ApiComparator/Command.php
@@ -55,7 +55,7 @@ class Command extends GoogleCloudCommand
 
         $diff = $repo->getDiff($input->getArgument('base') . '..' . $input->getArgument('head'));
         $files = array_filter($diff->getFiles(), function ($file) {
-            return $file->getOldName() === $file->getNewName() && strpos($file->getNewName(), '.php') !== false;
+            return $file->getOldName() && $file->getNewName() && strpos($file->getNewName(), '.php') !== false;
         });
 
         if (empty($files)) {

--- a/dev/src/ApiComparator/Command.php
+++ b/dev/src/ApiComparator/Command.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitorAbstract;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -39,7 +40,9 @@ class Command extends GoogleCloudCommand
     protected function configure()
     {
         $this->setName('comparator')
-            ->setDescription('Test the current git ref against master for backwards-compatibility breaks.');
+            ->setDescription('Test the current git ref against master for backwards-compatibility breaks.')
+            ->addArgument('head', InputArgument::REQUIRED, "The git HEAD ref")
+            ->addArgument('base', InputArgument::REQUIRED, "The base ref");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -50,7 +53,7 @@ class Command extends GoogleCloudCommand
         $commit = $repo->getHeadCommit();
         $rev = $commit->getRevision();
 
-        $diff = $repo->getDiff('master..' . $rev);
+        $diff = $repo->getDiff($input->getArgument('base') . '..' . $input->getArgument('head'));
         $files = array_filter($diff->getFiles(), function ($file) {
             return $file->getOldName() === $file->getNewName() && strpos($file->getNewName(), '.php') !== false;
         });

--- a/dev/src/ApiComparator/FileResult.php
+++ b/dev/src/ApiComparator/FileResult.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\ApiComparator;
+
+/**
+ * A collection class for the backwards compatibility test of a file.
+ */
+class FileResult
+{
+    private $name;
+    private $results = [];
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function setResults(array $result)
+    {
+        $this->results = $result;
+    }
+
+    public function passed()
+    {
+        return !(bool) $this->results;
+    }
+
+    public function toString()
+    {
+        if (empty($this->results)) {
+            return '';
+        }
+
+        $out = $this->name . PHP_EOL . "--------------------" . PHP_EOL;
+
+        $out .= count($this->results) . " backwards-incompatible change(s) found!" . PHP_EOL . PHP_EOL;
+        foreach ($this->results as $result) {
+            $out .= $result . PHP_EOL;
+        }
+
+        return $out;
+    }
+}

--- a/dev/src/ApiComparator/MethodFindingTraverser.php
+++ b/dev/src/ApiComparator/MethodFindingTraverser.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\ApiComparator;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Traverse an AST and find class methods.
+ */
+class MethodFindingTraverser extends NodeVisitorAbstract
+{
+    public $methods = [];
+
+    function enterNode(Node $node) {
+        if ($node instanceof ClassMethod) {
+            $this->methods[] = $node;
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+    }
+}


### PR DESCRIPTION
Sample run: https://github.com/jdpedrie/google-cloud-php/runs/800818099?check_suite_focus=true

Intended to catch obvious backwards-incompatible changes. There may be false positives, but I'm hoping to iterate on this as needed. It may make sense to limit it to generated code since that's where we often see breaking changes.

I initially wanted to use [`roave/backward-compatibility-check`](https://github.com/Roave/BackwardCompatibilityCheck), but it would require a number of other changes to the library.