### PR TITLE
fix: do not stall on Core\Batch\SysvProcessor#submit() when message queue overflows

### DIFF
--- a/Core/src/Batch/QueueOverflowException.php
+++ b/Core/src/Batch/QueueOverflowException.php
@@ -18,8 +18,9 @@
 namespace Google\Cloud\Core\Batch;
 
 /**
- * Exception thrown in `SysvProcessor#submit()` method when it cannot add an item to the message queue.
- * Possible causes are:
+ * Exception thrown in {@see Google\Cloud\Core\Batch\SysvProcessor::submit()}
+ * method when it cannot add an item to the message queue.
+ * Possible causes include:
  *
  * - batch daemon is not running
  * - no job registered for this queue
@@ -29,6 +30,6 @@ class QueueOverflowException extends \RuntimeException
 {
     public function __construct()
     {
-        parent::__construct('Item queue overflow, probably batch daemon is not running');
+        parent::__construct('Item queue overflow. Check that the batch daemon is running.');
     }
 }

--- a/Core/src/Batch/QueueOverflowException.php
+++ b/Core/src/Batch/QueueOverflowException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Batch;
+
+/**
+ * Exception thrown in `SysvProcessor#submit()` method when it cannot add an item to the message queue.
+ * Possible causes are:
+ *
+ * - batch daemon is not running
+ * - no job registered for this queue
+ * - items are submitted faster than a job can handle them
+ */
+class QueueOverflowException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Item queue overflow, probably batch daemon is not running');
+    }
+}

--- a/Core/src/Batch/SysvProcessor.php
+++ b/Core/src/Batch/SysvProcessor.php
@@ -53,7 +53,9 @@ class SysvProcessor implements ProcessItemInterface
         $result = @msg_send(
             $this->sysvQs[$idNum],
             self::$typeDirect,
-            $item
+            $item,
+            true,
+            false
         );
         if ($result === false) {
             // Try to put the content in a temp file and send the filename.
@@ -67,7 +69,9 @@ class SysvProcessor implements ProcessItemInterface
             $result = @msg_send(
                 $this->sysvQs[$idNum],
                 self::$typeFile,
-                $tempFile
+                $tempFile,
+                true,
+                false
             );
             if ($result === false) {
                 @unlink($tempFile);

--- a/Core/src/Batch/SysvProcessor.php
+++ b/Core/src/Batch/SysvProcessor.php
@@ -75,9 +75,7 @@ class SysvProcessor implements ProcessItemInterface
             );
             if ($result === false) {
                 @unlink($tempFile);
-                throw new \RuntimeException(
-                    "Failed to submit the filename: $tempFile"
-                );
+                throw new QueueOverflowException();
             }
         }
     }

--- a/Core/tests/System/Batch/BatchRunnerTest.php
+++ b/Core/tests/System/Batch/BatchRunnerTest.php
@@ -31,7 +31,6 @@ use PHPUnit\Framework\TestCase;
  */
 class BatchRunnerTest extends TestCase
 {
-    private $items;
     private $runner;
 
     private static $daemon;
@@ -59,7 +58,7 @@ class BatchRunnerTest extends TestCase
         );
         @mkdir(self::$testDir);
         putenv('GOOGLE_CLOUD_BATCH_DAEMON_FAILURE_DIR=' . self::$testDir);
-        $daemon_command = __DIR__
+        $daemon_command = 'exec ' . __DIR__
             . '/../../../bin/google-cloud-batch daemon';
         self::$commandFile = tempnam(
             sys_get_temp_dir(),
@@ -77,7 +76,7 @@ class BatchRunnerTest extends TestCase
             $descriptorSpec = array(
                 0 => array('file', 'php://stdin', 'r'),
                 1 => array('file', 'php://stdout', 'w'),
-                1 => array('file', 'php://stderr', 'w')
+                2 => array('file', 'php://stderr', 'w')
             );
             self::$daemon = proc_open(
                 $daemon_command,

--- a/Core/tests/Unit/Batch/SysvProcessorTest.php
+++ b/Core/tests/Unit/Batch/SysvProcessorTest.php
@@ -56,43 +56,6 @@ class SysvProcessorTest extends TestCase
         putenv('GOOGLE_CLOUD_SYSV_ID');
     }
 
-    private function clearQueue()
-    {
-        while ($this->receive($type, $message, $code)) {
-            if ($type == self::$typeFile) {
-                @unlink(unserialize($message));
-            }
-        }
-    }
-
-    private function queueSize()
-    {
-        return msg_stat_queue($this->queue)['msg_qbytes'];
-    }
-
-    private function send($message, $type = null)
-    {
-        if (!$type) {
-            $type = self::$typeDirect;
-        }
-        $serialize = $type == self::$typeDirect;
-        return @msg_send($this->queue, $type, $message, $serialize, false);
-    }
-
-    private function receive(&$type, &$message, &$errorcode, $unserialize = false)
-    {
-        return @msg_receive(
-            $this->queue,
-            0,
-            $type,
-            8192,
-            $message,
-            $unserialize,
-            MSG_IPC_NOWAIT,
-            $errorcode
-        );
-    }
-
     /**
      * @dataProvider items
      */
@@ -202,5 +165,42 @@ class SysvProcessorTest extends TestCase
             }
         }
         $this->assertFalse($gotAlarm);
+    }
+
+    private function clearQueue()
+    {
+        while ($this->receive($type, $message, $code)) {
+            if ($type == self::$typeFile) {
+                @unlink(unserialize($message));
+            }
+        }
+    }
+
+    private function queueSize()
+    {
+        return msg_stat_queue($this->queue)['msg_qbytes'];
+    }
+
+    private function send($message, $type = null)
+    {
+        if (!$type) {
+            $type = self::$typeDirect;
+        }
+        $serialize = $type == self::$typeDirect;
+        return @msg_send($this->queue, $type, $message, $serialize, false);
+    }
+
+    private function receive(&$type, &$message, &$errorcode, $unserialize = false)
+    {
+        return @msg_receive(
+            $this->queue,
+            0,
+            $type,
+            8192,
+            $message,
+            $unserialize,
+            MSG_IPC_NOWAIT,
+            $errorcode
+        );
     }
 }

--- a/Core/tests/Unit/Batch/SysvProcessorTest.php
+++ b/Core/tests/Unit/Batch/SysvProcessorTest.php
@@ -38,7 +38,7 @@ class SysvProcessorTest extends TestCase
     public function setUp()
     {
         putenv('GOOGLE_CLOUD_SYSV_ID=U');
-        if (! $this->isSysvIPCLOaded()) {
+        if (! $this->isSysvIPCLoaded()) {
             $this->markTestSkipped(
                 'Skipping because SystemV IPC extensions are not loaded'
             );
@@ -50,7 +50,9 @@ class SysvProcessorTest extends TestCase
 
     public function tearDown()
     {
-        $this->clearQueue();
+        if ($this->isSysvIPCLoaded()) {
+            $this->clearQueue();
+        }
         putenv('GOOGLE_CLOUD_SYSV_ID');
     }
 

--- a/Core/tests/Unit/Batch/SysvProcessorTest.php
+++ b/Core/tests/Unit/Batch/SysvProcessorTest.php
@@ -170,6 +170,8 @@ class SysvProcessorTest extends TestCase
      * Test that submit() method does not stall.
      *
      * @depends testQueueOverflowDirect
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /Failed to submit the filename/
      */
     public function testQueueOverflowFile()
     {
@@ -182,9 +184,6 @@ class SysvProcessorTest extends TestCase
         do {
             $result = @$this->send('12345678');
         } while ($result);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/Failed to submit the filename/');
 
         $gotAlarm = false;
         pcntl_signal(SIGALRM, function ($n, $i) use (&$gotAlarm) {

--- a/Core/tests/Unit/Batch/SysvProcessorTest.php
+++ b/Core/tests/Unit/Batch/SysvProcessorTest.php
@@ -135,8 +135,7 @@ class SysvProcessorTest extends TestCase
      * Test that submit() method does not stall.
      *
      * @depends testQueueOverflowDirect
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /Failed to submit the filename/
+     * @expectedException \Google\Cloud\Core\Batch\QueueOverflowException
      */
     public function testQueueOverflowFile()
     {

--- a/Core/tests/Unit/Batch/SysvProcessorTest.php
+++ b/Core/tests/Unit/Batch/SysvProcessorTest.php
@@ -32,6 +32,8 @@ class SysvProcessorTest extends TestCase
     use SysvTrait;
 
     private $submitter;
+    private $processor;
+    private $queue;
 
     public function setUp()
     {
@@ -42,11 +44,51 @@ class SysvProcessorTest extends TestCase
             );
         }
         $this->processor = new SysvProcessor();
+        $this->queue = msg_get_queue($this->getSysvKey(1));
+        $this->clearQueue();
     }
 
     public function tearDown()
     {
+        $this->clearQueue();
         putenv('GOOGLE_CLOUD_SYSV_ID');
+    }
+
+    private function clearQueue()
+    {
+        while ($this->receive($type, $message, $code)) {
+            if ($type == self::$typeFile) {
+                @unlink(unserialize($message));
+            }
+        }
+    }
+
+    private function queueSize()
+    {
+        return msg_stat_queue($this->queue)['msg_qbytes'];
+    }
+
+    private function send($message, $type = null)
+    {
+        if (!$type) {
+            $type = self::$typeDirect;
+        }
+        $serialize = $type == self::$typeDirect;
+        return @msg_send($this->queue, $type, $message, $serialize, false);
+    }
+
+    private function receive(&$type, &$message, &$errorcode, $unserialize = false)
+    {
+        return @msg_receive(
+            $this->queue,
+            0,
+            $type,
+            8192,
+            $message,
+            $unserialize,
+            MSG_IPC_NOWAIT,
+            $errorcode
+        );
     }
 
     /**
@@ -55,17 +97,7 @@ class SysvProcessorTest extends TestCase
     public function testSubmit($item, $exptectedType)
     {
         $this->processor->submit($item, 1);
-        $q = msg_get_queue($this->getSysvKey(1));
-        $result = msg_receive(
-            $q,
-            0,
-            $type,
-            8192,
-            $message,
-            true,
-            MSG_IPC_NOWAIT,
-            $errorcode
-        );
+        $result = $this->receive($type, $message, $errorCode, true);
         $this->assertTrue($result);
         $this->assertEquals($exptectedType, $type);
         if ($type === self::$typeDirect) {
@@ -85,5 +117,89 @@ class SysvProcessorTest extends TestCase
             ['item', self::$typeDirect],
             [str_repeat('x', 8193), self::$typeFile]
         ];
+    }
+
+    /**
+     * Message queue has no room for a "direct" message, but has enough room for a file path.
+     * Test that submit() method does not stall.
+     */
+    public function testQueueOverflowDirect()
+    {
+        $queueSize = $this->queueSize();
+        $item = str_repeat('a', 8160);
+        while ($queueSize >= 9000) {
+            $this->send($item);
+            $queueSize -= 8192;
+        }
+        if ($queueSize > 1000) {
+            $this->send(str_repeat('b', $queueSize - 1000));
+        }
+
+        $gotAlarm = false;
+        pcntl_signal(SIGALRM, function ($n, $i) use (&$gotAlarm) {
+            $gotAlarm = true;
+        });
+        try {
+            pcntl_alarm(2);
+            $this->processor->submit($item, 1);
+        } finally {
+            pcntl_signal_dispatch();
+            pcntl_signal(SIGALRM, SIG_IGN);
+            if (!$gotAlarm) {
+                sleep(3);
+            }
+        }
+
+        $this->assertFalse($gotAlarm);
+        $gotTypeFile = false;
+        while ($this->receive($type, $message, $code)) {
+            if ($type == self::$typeFile) {
+                $gotTypeFile = true;
+                $fileName = unserialize($message);
+                $this->assertFileExists($fileName);
+                $fileContent = unserialize(file_get_contents($fileName));
+                @unlink($fileName);
+                $this->assertEquals($item, $fileContent);
+            }
+        }
+        $this->assertTrue($gotTypeFile);
+    }
+
+    /**
+     * Message queue has no room even for a file path.
+     * Test that submit() method does not stall.
+     *
+     * @depends testQueueOverflowDirect
+     */
+    public function testQueueOverflowFile()
+    {
+        $queueSize = $this->queueSize();
+        $item = str_repeat('a', 8160);
+        while ($queueSize >= 8192) {
+            $this->send($item);
+            $queueSize -= 8192;
+        }
+        do {
+            $result = @$this->send('12345678');
+        } while ($result);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/Failed to submit the filename/');
+
+        $gotAlarm = false;
+        pcntl_signal(SIGALRM, function ($n, $i) use (&$gotAlarm) {
+            $gotAlarm = true;
+        });
+        try {
+            pcntl_alarm(2);
+            $this->processor->submit($item, 1);
+        } finally {
+            pcntl_signal_dispatch();
+            pcntl_signal(SIGALRM, SIG_IGN);
+            if (!$gotAlarm) {
+                sleep(3);
+            }
+        }
+        $this->assertFalse($gotAlarm);
     }
 }


### PR DESCRIPTION
Relates to issue #1336.

`SysvProcessor#submit()` method now uses non-blocking `msg_send()` calls. When the item queue is full (e. g. batch daemon not running) an exception will be thrown.
