### PR TITLE
Add support for Guzzle 7.x

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
         "google/auth": "^1.6",
-        "guzzlehttp/guzzle": "^5.3|^6.0",
+        "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "^1.1|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "guzzlehttp/guzzle": "^5.3|^6.0",
+        "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*",


### PR DESCRIPTION
Greetings 👋 ,

[Guzzle 7.0 has been released](https://github.com/guzzle/guzzle/releases). This PR widens the version constraint to be able to use it with the `google/cloud` library.

This is a non-breaking change by itself, but https://github.com/googleapis/google-auth-library-php/pull/256 and https://github.com/GoogleCloudPlatform/php-tools/pull/80 are needed to make the change effective.

```
❯ composer why guzzlehttp/guzzle
google/cloud        dev-guzzle7  requires  guzzlehttp/guzzle (^5.3|^6.0|^7.0)
google/auth         v1.9.0       requires  guzzlehttp/guzzle (~5.3.1|~6.0)
google/cloud-tools  v0.9.1       requires  guzzlehttp/guzzle (~5.3|~6.0)
```

:octocat: 