### PR TITLE
feat: Surface  to retryFunction for observation.

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -220,7 +220,7 @@ class RequestWrapper
      *           **Defaults to** `3`.
      *     @type callable $restRetryFunction Sets the conditions for whether or
      *           not a request should attempt to retry. Function signature should
-     *           match: `function (\Exception $ex) : bool`.
+     *           match: `function (\Exception $ex, [$retry_attempt]) : bool`.
      *     @type callable $restDelayFunction Executes a delay, defaults to
      *           utilizing `usleep`. Function signature should match:
      *           `function (int $delay) : void`.
@@ -251,7 +251,7 @@ class RequestWrapper
                 $this->applyHeaders($request),
                 $this->getRequestOptions($options)
             )->then(null, function (\Exception $ex) use ($fn, $retryAttempt, $retryOptions) {
-                $shouldRetry = $retryOptions['retryFunction']($ex);
+                $shouldRetry = $retryOptions['retryFunction']($ex, $retry_attempt);
 
                 if ($shouldRetry === false || $retryAttempt >= $retryOptions['retries']) {
                     throw $this->convertToGoogleException($ex);


### PR DESCRIPTION
Currently, we are using our own retryFunction and track the percentiles of retry attempts for various instrumentation of our app. Since we have moved to purely async behavior we have lost this metrics which has helped us in triage in the past.