### PR TITLE
fix: exclude generated client from debug dump

### DIFF
--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -249,4 +249,19 @@ class Grpc implements ConnectionInterface
 
         return $args;
     }
+
+    /**
+     * @access private
+     * @codeCoverageIgnore
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'serializer' => get_class($this->serializer),
+            'firestore' => get_class($this->firestore),
+            'resourcePrefixHeader' => $this->resourcePrefixHeader,
+            'isUsingEmulator' => $this->isUsingEmulator
+        ];
+    }
 }


### PR DESCRIPTION
Recursion in protobuf messages causing out of memory errors when printed is a known issue. This change fixes #2581 by not printing the details of the generated client in traces and `print_r`. A similar pattern is used throughout Spanner for the same reasons.