### PR TITLE
fix: correctly set google-cloud-resource-prefix headers

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -694,11 +694,11 @@ class Grpc implements ConnectionInterface
             $this->pluck('sessionTemplate', $args)
         );
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'batchCreateSessions'], [
-            $database,
+            $databaseName,
             $this->pluck('sessionCount', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -707,10 +707,10 @@ class Grpc implements ConnectionInterface
      */
     public function getSession(array $args)
     {
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'getSession'], [
             $this->pluck('name', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -719,10 +719,10 @@ class Grpc implements ConnectionInterface
      */
     public function deleteSession(array $args)
     {
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'deleteSession'], [
             $this->pluck('name', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -737,12 +737,12 @@ class Grpc implements ConnectionInterface
      */
     public function deleteSessionAsync(array $args)
     {
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         $request = new DeleteSessionRequest();
         $request->setName($this->pluck('name', $args));
 
         $transport = $this->spannerClient->getTransport();
-        $opts = $this->addResourcePrefixHeader([], $database);
+        $opts = $this->addResourcePrefixHeader([], $databaseName);
         $opts['credentialsWrapper'] = $this->credentialsWrapper;
 
         return $transport->startUnaryCall(
@@ -764,7 +764,7 @@ class Grpc implements ConnectionInterface
         $args = $this->formatSqlParams($args);
         $args['transaction'] = $this->createTransactionSelector($args);
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         $queryOptions = $this->pluck('queryOptions', $args, false) ?: [];
 
         // Query options precedence is query-level, then environment-level, then client-level.
@@ -784,7 +784,7 @@ class Grpc implements ConnectionInterface
         return $this->send([$this->spannerClient, 'executeStreamingSql'], [
             $this->pluck('session', $args),
             $this->pluck('sql', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -799,13 +799,13 @@ class Grpc implements ConnectionInterface
 
         $args['transaction'] = $this->createTransactionSelector($args);
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'streamingRead'], [
             $this->pluck('session', $args),
             $this->pluck('table', $args),
             $this->pluck('columns', $args),
             $keySet,
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -814,7 +814,7 @@ class Grpc implements ConnectionInterface
      */
     public function executeBatchDml(array $args)
     {
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         $args['transaction'] = $this->createTransactionSelector($args);
 
         $statements = [];
@@ -828,7 +828,7 @@ class Grpc implements ConnectionInterface
             $this->pluck('transaction', $args),
             $statements,
             $this->pluck('seqno', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -854,11 +854,11 @@ class Grpc implements ConnectionInterface
             $options->setPartitionedDml($pdml);
         }
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'beginTransaction'], [
             $this->pluck('session', $args),
             $options,
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -922,11 +922,11 @@ class Grpc implements ConnectionInterface
             $args['singleUseTransaction'] = $options;
         }
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'commit'], [
             $this->pluck('session', $args),
             $mutations,
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -935,11 +935,11 @@ class Grpc implements ConnectionInterface
      */
     public function rollback(array $args)
     {
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'rollback'], [
             $this->pluck('session', $args),
             $this->pluck('transactionId', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -956,11 +956,11 @@ class Grpc implements ConnectionInterface
             $this->pluck('partitionOptions', $args, false) ?: []
         );
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'partitionQuery'], [
             $this->pluck('session', $args),
             $this->pluck('sql', $args),
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 
@@ -979,12 +979,12 @@ class Grpc implements ConnectionInterface
             $this->pluck('partitionOptions', $args, false) ?: []
         );
 
-        $database = $this->pluck('database', $args);
+        $databaseName = $this->pluck('database', $args);
         return $this->send([$this->spannerClient, 'partitionRead'], [
             $this->pluck('session', $args),
             $this->pluck('table', $args),
             $keySet,
-            $this->addResourcePrefixHeader($args, $database)
+            $this->addResourcePrefixHeader($args, $databaseName)
         ]);
     }
 

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -245,10 +245,10 @@ class Grpc implements ConnectionInterface
      */
     public function listInstanceConfigs(array $args)
     {
-        $projectId = $this->pluck('projectId', $args);
+        $projectName = $this->pluck('projectName', $args);
         return $this->send([$this->getInstanceAdminClient(), 'listInstanceConfigs'], [
-            $projectId,
-            $this->addResourcePrefixHeader($args, $projectId)
+            $projectName,
+            $this->addResourcePrefixHeader($args, $projectName)
         ]);
     }
 
@@ -257,10 +257,10 @@ class Grpc implements ConnectionInterface
      */
     public function getInstanceConfig(array $args)
     {
-        $projectId = $this->pluck('projectId', $args);
+        $projectName = $this->pluck('projectName', $args);
         return $this->send([$this->getInstanceAdminClient(), 'getInstanceConfig'], [
             $this->pluck('name', $args),
-            $this->addResourcePrefixHeader($args, $projectId)
+            $this->addResourcePrefixHeader($args, $projectName)
         ]);
     }
 
@@ -269,10 +269,10 @@ class Grpc implements ConnectionInterface
      */
     public function listInstances(array $args)
     {
-        $projectId = $this->pluck('projectId', $args);
+        $projectName = $this->pluck('projectName', $args);
         return $this->send([$this->getInstanceAdminClient(), 'listInstances'], [
-            $projectId,
-            $this->addResourcePrefixHeader($args, $projectId)
+            $projectName,
+            $this->addResourcePrefixHeader($args, $projectName)
         ]);
     }
 
@@ -281,7 +281,7 @@ class Grpc implements ConnectionInterface
      */
     public function getInstance(array $args)
     {
-        $projectId = $this->pluck('projectId', $args);
+        $projectName = $this->pluck('projectName', $args);
 
         if (isset($args['fieldMask'])) {
             $mask = [];
@@ -298,7 +298,7 @@ class Grpc implements ConnectionInterface
 
         return $this->send([$this->getInstanceAdminClient(), 'getInstance'], [
             $this->pluck('name', $args),
-            $this->addResourcePrefixHeader($args, $projectId)
+            $this->addResourcePrefixHeader($args, $projectName)
         ]);
     }
 
@@ -311,7 +311,7 @@ class Grpc implements ConnectionInterface
 
         $instance = $this->instanceObject($args, true);
         $res = $this->send([$this->getInstanceAdminClient(), 'createInstance'], [
-            $this->pluck('projectId', $args),
+            $this->pluck('projectName', $args),
             $this->pluck('instanceId', $args),
             $instance,
             $this->addResourcePrefixHeader($args, $instanceName)
@@ -658,13 +658,13 @@ class Grpc implements ConnectionInterface
      */
     public function createSessionAsync(array $args)
     {
-        $database = $this->pluck('database', $args);
-        $opts = $this->addResourcePrefixHeader([], $database);
+        $databaseName = $this->pluck('database', $args);
+        $opts = $this->addResourcePrefixHeader([], $databaseName);
         $opts['credentialsWrapper'] = $this->credentialsWrapper;
         $transport = $this->spannerClient->getTransport();
 
         $request = new CreateSessionRequest([
-            'database' => $database
+            'database' => $databaseName
         ]);
 
         $session = $this->pluck('session', $args, false);

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -221,7 +221,9 @@ class Instance
             if ($this->info) {
                 $this->connection->getInstance([
                     'name' => $this->name,
-                    'projectId' => $this->projectId,
+                    'projectName' => InstanceAdminClient::projectName(
+                        $this->projectId
+                    ),
                     'fieldMask' => ['name'],
                 ] + $options);
             } else {
@@ -259,7 +261,7 @@ class Instance
     {
         $this->info = $this->connection->getInstance($options + [
             'name' => $this->name,
-            'projectId' => $this->projectId
+            'projectName' => InstanceAdminClient::projectName($this->projectId),
         ]);
 
         return $this->info;
@@ -303,7 +305,7 @@ class Instance
         $operation = $this->connection->createInstance([
             'instanceId' => $instanceId,
             'name' => $this->name,
-            'projectId' => InstanceAdminClient::projectName($this->projectId),
+            'projectName' => InstanceAdminClient::projectName($this->projectId),
             'config' => $config->name()
         ] + $options);
 

--- a/Spanner/src/InstanceConfiguration.php
+++ b/Spanner/src/InstanceConfiguration.php
@@ -170,7 +170,7 @@ class InstanceConfiguration
     {
         $this->info = $this->connection->getInstanceConfig($options + [
             'name' => $this->name,
-            'projectId' => $this->projectId
+            'projectName' => InstanceAdminClient::projectName($this->projectId),
         ]);
 
         return $this->info;

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -131,7 +131,7 @@ class Operation
         $res = $this->connection->commit($this->arrayFilterRemoveNull([
             'mutations' => $mutations,
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session)
+            'database' => $this->getDatabaseNameFromSession($session)
         ]) + $options);
 
         $time = $this->parseTimeString($res['commitTimestamp']);
@@ -153,7 +153,7 @@ class Operation
         $this->connection->rollback([
             'transactionId' => $transactionId,
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session)
+            'database' => $this->getDatabaseNameFromSession($session)
         ] + $options);
     }
 
@@ -187,7 +187,7 @@ class Operation
             return $this->connection->executeStreamingSql([
                 'sql' => $sql,
                 'session' => $session->name(),
-                'database' => $this->getFullyQualifiedDatabaseName($session)
+                'database' => $this->getDatabaseNameFromSession($session)
             ] + $options);
         };
 
@@ -282,7 +282,7 @@ class Operation
 
         $res = $this->connection->executeBatchDml([
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session),
+            'database' => $this->getDatabaseNameFromSession($session),
             'transactionId' => $transaction->id(),
             'statements' => $stmts
         ] + $options);
@@ -333,7 +333,7 @@ class Operation
                 'session' => $session->name(),
                 'columns' => $columns,
                 'keySet' => $this->flattenKeySet($keySet),
-                'database' => $this->getFullyQualifiedDatabaseName($session)
+                'database' => $this->getDatabaseNameFromSession($session)
             ] + $options);
         };
 
@@ -569,7 +569,7 @@ class Operation
 
         $res = $this->connection->partitionQuery([
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session),
+            'database' => $this->getDatabaseNameFromSession($session),
             'transactionId' => $transactionId,
             'sql' => $sql
         ] + $options);
@@ -625,7 +625,7 @@ class Operation
 
         $res = $this->connection->partitionRead([
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session),
+            'database' => $this->getDatabaseNameFromSession($session),
             'transactionId' => $transactionId,
             'table' => $table,
             'columns' => $columns,
@@ -679,7 +679,7 @@ class Operation
 
         return $this->connection->beginTransaction($options + [
             'session' => $session->name(),
-            'database' => $this->getFullyQualifiedDatabaseName($session)
+            'database' => $this->getDatabaseNameFromSession($session)
         ]);
     }
 
@@ -710,12 +710,9 @@ class Operation
         return $this->arrayFilterRemoveNull($keys);
     }
 
-    private function getFullyQualifiedDatabaseName($session)
+    private function getDatabaseNameFromSession(Session $session)
     {
-        $info = $session->info();
-        return GapicSpannerClient::databaseName(
-            $info['projectId'], $info['instance'], $info['database'],
-        );
+        return $session->info()['databaseName'];
     }
 
     /**

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -131,7 +131,7 @@ class Operation
         $res = $this->connection->commit($this->arrayFilterRemoveNull([
             'mutations' => $mutations,
             'session' => $session->name(),
-            'database' => $session->info()['database']
+            'database' => $this->getFullyQualifiedDatabaseName($session)
         ]) + $options);
 
         $time = $this->parseTimeString($res['commitTimestamp']);
@@ -153,7 +153,7 @@ class Operation
         $this->connection->rollback([
             'transactionId' => $transactionId,
             'session' => $session->name(),
-            'database' => $session->info()['database']
+            'database' => $this->getFullyQualifiedDatabaseName($session)
         ] + $options);
     }
 
@@ -187,7 +187,7 @@ class Operation
             return $this->connection->executeStreamingSql([
                 'sql' => $sql,
                 'session' => $session->name(),
-                'database' => $session->info()['database']
+                'database' => $this->getFullyQualifiedDatabaseName($session)
             ] + $options);
         };
 
@@ -282,7 +282,7 @@ class Operation
 
         $res = $this->connection->executeBatchDml([
             'session' => $session->name(),
-            'database' => $session->info()['database'],
+            'database' => $this->getFullyQualifiedDatabaseName($session),
             'transactionId' => $transaction->id(),
             'statements' => $stmts
         ] + $options);
@@ -333,7 +333,7 @@ class Operation
                 'session' => $session->name(),
                 'columns' => $columns,
                 'keySet' => $this->flattenKeySet($keySet),
-                'database' => $session->info()['database']
+                'database' => $this->getFullyQualifiedDatabaseName($session)
             ] + $options);
         };
 
@@ -569,7 +569,7 @@ class Operation
 
         $res = $this->connection->partitionQuery([
             'session' => $session->name(),
-            'database' => $session->info()['database'],
+            'database' => $this->getFullyQualifiedDatabaseName($session),
             'transactionId' => $transactionId,
             'sql' => $sql
         ] + $options);
@@ -625,7 +625,7 @@ class Operation
 
         $res = $this->connection->partitionRead([
             'session' => $session->name(),
-            'database' => $session->info()['database'],
+            'database' => $this->getFullyQualifiedDatabaseName($session),
             'transactionId' => $transactionId,
             'table' => $table,
             'columns' => $columns,
@@ -679,7 +679,7 @@ class Operation
 
         return $this->connection->beginTransaction($options + [
             'session' => $session->name(),
-            'database' => $session->info()['database']
+            'database' => $this->getFullyQualifiedDatabaseName($session)
         ]);
     }
 
@@ -708,6 +708,14 @@ class Operation
         }
 
         return $this->arrayFilterRemoveNull($keys);
+    }
+
+    private function getFullyQualifiedDatabaseName($session)
+    {
+        $info = $session->info();
+        return GapicSpannerClient::databaseName(
+            $info['projectId'], $info['instance'], $info['database'],
+        );
     }
 
     /**

--- a/Spanner/src/Session/Session.php
+++ b/Spanner/src/Session/Session.php
@@ -34,6 +34,21 @@ class Session
     /**
      * @var string
      */
+    private $projectId;
+
+    /**
+     * @var string
+     */
+    private $instance;
+
+    /**
+     * @var string
+     */
+    private $database;
+
+    /**
+     * @var string
+     */
     private $databaseName;
 
     /**
@@ -61,6 +76,9 @@ class Session
         $name
     ) {
         $this->connection = $connection;
+        $this->projectId = $projectId;
+        $this->instance = $instance;
+        $this->database = $database;
         $this->databaseName = SpannerClient::databaseName(
             $projectId,
             $instance,
@@ -77,11 +95,14 @@ class Session
     /**
      * Return info on the session.
      *
-     * @return array An array containing the `databaseName` and session `name` keys.
+     * @return array An array containing the `projectId`, `instance`, `database`, 'databaseName' and session `name` keys.
      */
     public function info()
     {
         return [
+            'projectId' => $this->projectId,
+            'instance' => $this->instance,
+            'database' => $this->database,
             'databaseName' => $this->databaseName,
             'name' => $this->name
         ];
@@ -164,6 +185,9 @@ class Session
     {
         return [
             'connection' => get_class($this->connection),
+            'projectId' => $this->projectId,
+            'instance' => $this->instance,
+            'database' => $this->database,
             'databaseName' => $this->databaseName,
             'name' => $this->name,
         ];

--- a/Spanner/src/Session/Session.php
+++ b/Spanner/src/Session/Session.php
@@ -95,7 +95,8 @@ class Session
     /**
      * Return info on the session.
      *
-     * @return array An array containing the `projectId`, `instance`, `database`, 'databaseName' and session `name` keys.
+     * @return array An array containing the `projectId`, `instance`, `database`, 'databaseName' and session `name`
+     *         keys.
      */
     public function info()
     {

--- a/Spanner/src/Session/Session.php
+++ b/Spanner/src/Session/Session.php
@@ -62,7 +62,9 @@ class Session
     ) {
         $this->connection = $connection;
         $this->databaseName = SpannerClient::databaseName(
-            $projectId, $instance, $database
+            $projectId,
+            $instance,
+            $database
         );
         $this->name = SpannerClient::sessionName(
             $projectId,

--- a/Spanner/src/Session/Session.php
+++ b/Spanner/src/Session/Session.php
@@ -34,17 +34,7 @@ class Session
     /**
      * @var string
      */
-    private $projectId;
-
-    /**
-     * @var string
-     */
-    private $instance;
-
-    /**
-     * @var string
-     */
-    private $database;
+    private $databaseName;
 
     /**
      * @var string
@@ -71,23 +61,26 @@ class Session
         $name
     ) {
         $this->connection = $connection;
-        $this->projectId = $projectId;
-        $this->instance = $instance;
-        $this->database = $database;
-        $this->name = $name;
+        $this->databaseName = SpannerClient::databaseName(
+            $projectId, $instance, $database
+        );
+        $this->name = SpannerClient::sessionName(
+            $projectId,
+            $instance,
+            $database,
+            $name
+        );
     }
 
     /**
      * Return info on the session.
      *
-     * @return array An array containing the `projectId`, `instance`, `database` and session `name` keys.
+     * @return array An array containing the `databaseName` and session `name` keys.
      */
     public function info()
     {
         return [
-            'projectId' => $this->projectId,
-            'instance' => $this->instance,
-            'database' => $this->database,
+            'databaseName' => $this->databaseName,
             'name' => $this->name
         ];
     }
@@ -103,9 +96,7 @@ class Session
         try {
             $this->connection->getSession($options + [
                 'name' => $this->name(),
-                'database' => SpannerClient::databaseName(
-                     $this->projectId, $this->instance, $this->database,
-                 )
+                'database' => $this->databaseName
             ]);
 
             return true;
@@ -124,9 +115,7 @@ class Session
     {
         $this->connection->deleteSession($options + [
             'name' => $this->name(),
-            'database' => SpannerClient::databaseName(
-                 $this->projectId, $this->instance, $this->database,
-             )
+            'database' => $this->databaseName
         ]);
     }
 
@@ -137,12 +126,7 @@ class Session
      */
     public function name()
     {
-        return SpannerClient::sessionName(
-            $this->projectId,
-            $this->instance,
-            $this->database,
-            $this->name
-        );
+        return $this->name;
     }
 
     /**
@@ -178,9 +162,7 @@ class Session
     {
         return [
             'connection' => get_class($this->connection),
-            'projectId' => $this->projectId,
-            'instance' => $this->instance,
-            'database' => $this->database,
+            'databaseName' => $this->databaseName,
             'name' => $this->name,
         ];
     }

--- a/Spanner/src/Session/Session.php
+++ b/Spanner/src/Session/Session.php
@@ -103,7 +103,9 @@ class Session
         try {
             $this->connection->getSession($options + [
                 'name' => $this->name(),
-                'database' => $this->database
+                'database' => SpannerClient::databaseName(
+                     $this->projectId, $this->instance, $this->database,
+                 )
             ]);
 
             return true;
@@ -122,7 +124,9 @@ class Session
     {
         $this->connection->deleteSession($options + [
             'name' => $this->name(),
-            'database' => $this->database
+            'database' => SpannerClient::databaseName(
+                 $this->projectId, $this->instance, $this->database,
+             )
         ]);
     }
 

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -301,7 +301,7 @@ class SpannerClient
                     return $this->instanceConfiguration($config['name'], $config);
                 },
                 [$this->connection, 'listInstanceConfigs'],
-                ['projectId' => InstanceAdminClient::projectName($this->projectId)] + $options,
+                ['projectName' => InstanceAdminClient::projectName($this->projectId)] + $options,
                 [
                     'itemsKey' => 'instanceConfigs',
                     'resultLimit' => $resultLimit
@@ -431,7 +431,7 @@ class SpannerClient
                     return $this->instance($name, $instance);
                 },
                 [$this->connection, 'listInstances'],
-                ['projectId' => InstanceAdminClient::projectName($this->projectId)] + $options,
+                ['projectName' => InstanceAdminClient::projectName($this->projectId)] + $options,
                 [
                     'itemsKey' => 'instances',
                     'resultLimit' => $resultLimit

--- a/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
+++ b/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
@@ -63,7 +63,8 @@ class BatchSnapshotTest extends SnippetTestCase
         $this->session = $this->prophesize(Session::class);
         $this->session->name()->willReturn(self::SESSION);
         $this->session->info()->willReturn($sessData + [
-            'name' => self::SESSION
+            'name' => self::SESSION,
+            'databaseName' => self::DATABASE
         ]);
 
         $this->time = time();

--- a/Spanner/tests/Snippet/BatchDmlResultTest.php
+++ b/Spanner/tests/Snippet/BatchDmlResultTest.php
@@ -91,7 +91,7 @@ class BatchDmlResultTest extends SnippetTestCase
             'projects/test-project/instances/my-instance/databases/my-database/sessions/foo'
         );
         $session->info()->willReturn([
-            'database' => 'projects/test-project/instances/my-instance/databases/my-database'
+            'databaseName' => 'projects/test-project/instances/my-instance/databases/my-database'
         ]);
         $session->setExpiration(Argument::any())->willReturn(null);
 

--- a/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
+++ b/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
@@ -472,7 +472,9 @@ class TransactionalReadMethodsTest extends SnippetTestCase
         $this->session->info()->willReturn($sessData + [
             'name' => self::SESSION,
             'databaseName' => SpannerGapicClient::databaseName(
-                self::PROJECT, self::INSTANCE, self::DATABASE
+                self::PROJECT,
+                self::INSTANCE,
+                self::DATABASE
             )
         ]);
 

--- a/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
+++ b/Spanner/tests/Snippet/TransactionalReadMethodsTest.php
@@ -470,7 +470,10 @@ class TransactionalReadMethodsTest extends SnippetTestCase
         $sessData = SpannerGapicClient::parseName(self::SESSION, 'session');
         $this->session->name()->willReturn(self::SESSION);
         $this->session->info()->willReturn($sessData + [
-            'name' => self::SESSION
+            'name' => self::SESSION,
+            'databaseName' => SpannerGapicClient::databaseName(
+                self::PROJECT, self::INSTANCE, self::DATABASE
+            )
         ]);
 
         return \Google\Cloud\Core\Testing\TestHelpers::stub(BatchSnapshot::class, [

--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -77,8 +77,7 @@ class BatchClientTest extends TestCase
                     return false;
                 }
 
-                $db = explode('/', self::DATABASE);
-                return $args['database'] === array_pop($db);
+                return $args['database'] === self::DATABASE;
             })
         ))->shouldBeCalled()->willReturn([
             'id' => self::TRANSACTION,

--- a/Spanner/tests/Unit/Batch/BatchSnapshotTest.php
+++ b/Spanner/tests/Unit/Batch/BatchSnapshotTest.php
@@ -60,7 +60,8 @@ class BatchSnapshotTest extends TestCase
         $this->session = $this->prophesize(Session::class);
         $this->session->name()->willReturn(self::SESSION);
         $this->session->info()->willReturn($sessData + [
-            'name' => self::SESSION
+            'name' => self::SESSION,
+            'databaseName' => self::DATABASE
         ]);
 
         $this->timestamp = new Timestamp(new \DateTime());
@@ -86,7 +87,6 @@ class BatchSnapshotTest extends TestCase
 
     public function testPartitionRead()
     {
-        $db = explode('/', self::DATABASE);
         $table = 'table';
         $keySet = new KeySet(['all' =>  true]);
         $columns = ['a', 'b'];
@@ -98,7 +98,7 @@ class BatchSnapshotTest extends TestCase
 
         $this->connection->partitionRead(Argument::allOf(
             Argument::withEntry('session', self::SESSION),
-            Argument::withEntry('database', array_pop($db)),
+            Argument::withEntry('database', self::DATABASE),
             Argument::withEntry('transactionId', self::TRANSACTION),
             Argument::withEntry('table', $table),
             Argument::withEntry('columns', $columns),
@@ -131,7 +131,6 @@ class BatchSnapshotTest extends TestCase
 
     public function testPartitionQuery()
     {
-        $db = explode('/', self::DATABASE);
         $sql = 'SELECT 1=1';
         $opts = [
             'parameters' => [
@@ -143,7 +142,7 @@ class BatchSnapshotTest extends TestCase
 
         $this->connection->partitionQuery(Argument::allOf(
             Argument::withEntry('session', self::SESSION),
-            Argument::withEntry('database', array_pop($db)),
+            Argument::withEntry('database', self::DATABASE),
             Argument::withEntry('transactionId', self::TRANSACTION),
             Argument::withEntry('sql', $sql),
             Argument::withEntry('params', $opts['parameters']),
@@ -176,7 +175,6 @@ class BatchSnapshotTest extends TestCase
 
     public function testExecuteQueryPartition()
     {
-        $db = explode('/', self::DATABASE);
         $token = 'token';
         $sql = 'SELECT 1=1';
         $opts = [
@@ -190,7 +188,7 @@ class BatchSnapshotTest extends TestCase
         $this->connection->executeStreamingSql(Argument::allOf(
             Argument::withEntry('partitionToken', $token),
             Argument::withEntry('session', self::SESSION),
-            Argument::withEntry('database', array_pop($db)),
+            Argument::withEntry('database', self::DATABASE),
             Argument::withEntry('transaction', ['id' => self::TRANSACTION]),
             Argument::withEntry('sql', $sql),
             Argument::withEntry('params', $opts['parameters']),
@@ -206,9 +204,7 @@ class BatchSnapshotTest extends TestCase
 
     public function testExecuteReadPartition()
     {
-        $db = explode('/', self::DATABASE);
         $token = 'token';
-        $db = explode('/', self::DATABASE);
         $table = 'table';
         $keySet = new KeySet(['all' =>  true]);
         $columns = ['a', 'b'];
@@ -221,7 +217,7 @@ class BatchSnapshotTest extends TestCase
         $this->connection->streamingRead(Argument::allOf(
             Argument::withEntry('partitionToken', $token),
             Argument::withEntry('session', self::SESSION),
-            Argument::withEntry('database', array_pop($db)),
+            Argument::withEntry('database', self::DATABASE),
             Argument::withEntry('transaction', ['id' => self::TRANSACTION]),
             Argument::withEntry('table', $table),
             Argument::withEntry('columns', $columns),

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -98,7 +98,7 @@ class GrpcTest extends TestCase
     public function testListInstanceConfigs()
     {
         $this->assertCallCorrect('listInstanceConfigs', [
-            'projectId' => self::PROJECT
+            'projectName' => self::PROJECT
         ], $this->expectResourceHeader(self::PROJECT, [
             self::PROJECT
         ]));
@@ -108,7 +108,7 @@ class GrpcTest extends TestCase
     {
         $this->assertCallCorrect('getInstanceConfig', [
             'name' => self::CONFIG,
-            'projectId' => self::PROJECT
+            'projectName' => self::PROJECT
         ], $this->expectResourceHeader(self::PROJECT, [
             self::CONFIG
         ]));
@@ -117,7 +117,7 @@ class GrpcTest extends TestCase
     public function testListInstances()
     {
         $this->assertCallCorrect('listInstances', [
-            'projectId' => self::PROJECT
+            'projectName' => self::PROJECT
         ], $this->expectResourceHeader(self::PROJECT, [
             self::PROJECT
         ]));
@@ -127,7 +127,7 @@ class GrpcTest extends TestCase
     {
         $this->assertCallCorrect('getInstance', [
             'name' => self::INSTANCE,
-            'projectId' => self::PROJECT
+            'projectName' => self::PROJECT
         ], $this->expectResourceHeader(self::PROJECT, [
             self::INSTANCE
         ]));
@@ -145,7 +145,7 @@ class GrpcTest extends TestCase
         $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
         $this->assertCallCorrect('getInstance', [
             'name' => self::INSTANCE,
-            'projectId' => self::PROJECT,
+            'projectName' => self::PROJECT,
             'fieldMask' => $fieldNames
         ], $this->expectResourceHeader(self::PROJECT, [
             self::INSTANCE,
@@ -161,7 +161,7 @@ class GrpcTest extends TestCase
         $fieldMask = $this->serializer->decodeMessage(new FieldMask, ['paths' => $mask]);
         $this->assertCallCorrect('getInstance', [
             'name' => self::INSTANCE,
-            'projectId' => self::PROJECT,
+            'projectName' => self::PROJECT,
             'fieldMask' => $fieldNames
         ], $this->expectResourceHeader(self::PROJECT, [
             self::INSTANCE,
@@ -174,7 +174,7 @@ class GrpcTest extends TestCase
         list ($args, $instance) = $this->instance();
 
         $this->assertCallCorrect('createInstance', [
-            'projectId' => self::PROJECT,
+            'projectName' => self::PROJECT,
             'instanceId' => self::INSTANCE
         ] + $args, $this->expectResourceHeader(self::INSTANCE, [
             self::PROJECT,

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -452,7 +452,14 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn([
@@ -460,7 +467,14 @@ class DatabaseTest extends TestCase
             ]);
 
         $this->connection->deleteSession(Argument::allOf(
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE)),
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
             Argument::withEntry('name', $this->session->name())
         ))
             ->shouldBeCalled();
@@ -525,7 +539,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -559,7 +580,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -578,14 +606,28 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['commitTimestamp' => '2017-01-09T18:05:22.534799Z']);
@@ -610,14 +652,28 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
         $this->connection->rollback(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled();
 
@@ -633,7 +689,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -661,7 +724,14 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalledTimes(3)
             ->willReturn(['id' => self::TRANSACTION]);
@@ -669,7 +739,14 @@ class DatabaseTest extends TestCase
         $it = 0;
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalledTimes(3)
             ->will(function () use (&$it, $abort) {
@@ -710,7 +787,14 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalledTimes(Database::MAX_RETRIES + 1)
             ->willReturn(['id' => self::TRANSACTION]);
@@ -718,7 +802,14 @@ class DatabaseTest extends TestCase
         $it = 0;
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalledTimes(Database::MAX_RETRIES + 1)
             ->will(function () use (&$it, $abort) {
@@ -742,7 +833,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -760,7 +858,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -1168,7 +1273,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->deleteSession(Argument::allOf(
             Argument::withEntry('name', $this->session->name()),
-            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
+            Argument::withEntry(
+                'database',
+                DatabaseAdminClient::databaseName(
+                    self::PROJECT,
+                    self::INSTANCE,
+                    self::DATABASE
+                )
+            )
         ))
             ->shouldBeCalled()
             ->willReturn([]);

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -165,7 +165,7 @@ class DatabaseTest extends TestCase
         $this->database->___setProperty('connection', $this->connection->reveal());
 
         $this->assertEquals(Database::STATE_READY, $this->database->state());
-        
+
         // Make sure the request only is sent once.
         $this->database->state();
     }
@@ -185,9 +185,9 @@ class DatabaseTest extends TestCase
             ->willReturn(['name' => 'operations/foo']);
 
         $this->database->___setProperty('connection', $this->connection->reveal());
-        
+
         $op = $this->database->createBackup(self::BACKUP, $expireTime);
-        
+
         $this->assertInstanceOf(LongRunningOperation::class, $op);
     }
 
@@ -201,7 +201,7 @@ class DatabaseTest extends TestCase
                 'name' => DatabaseAdminClient::backupName(self::PROJECT, self::INSTANCE, 'backup2'),
             ]
         ];
-            
+
         $expectedFilter = "database:".$this->database->name();
         $this->connection->listBackups(Argument::withEntry('filter', $expectedFilter))
             ->shouldBeCalled()
@@ -340,7 +340,7 @@ class DatabaseTest extends TestCase
             ]);
 
         $this->instance->___setProperty('connection', $this->connection->reveal());
-        
+
         $op = $this->database->restore($backupName);
         $this->assertInstanceOf(LongRunningOperation::class, $op);
     }
@@ -361,7 +361,7 @@ class DatabaseTest extends TestCase
             ->willReturn([
             'name' => 'my-operation'
             ]);
-    
+
         $this->instance->___setProperty('connection', $this->connection->reveal());
 
         $op = $this->database->restore($backupObj);
@@ -452,7 +452,7 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn([
@@ -460,7 +460,7 @@ class DatabaseTest extends TestCase
             ]);
 
         $this->connection->deleteSession(Argument::allOf(
-            Argument::withEntry('database', self::DATABASE),
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE)),
             Argument::withEntry('name', $this->session->name())
         ))
             ->shouldBeCalled();
@@ -525,7 +525,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -559,7 +559,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -578,14 +578,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['commitTimestamp' => '2017-01-09T18:05:22.534799Z']);
@@ -610,14 +610,14 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
         $this->connection->rollback(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled();
 
@@ -633,7 +633,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -661,7 +661,7 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalledTimes(3)
             ->willReturn(['id' => self::TRANSACTION]);
@@ -669,7 +669,7 @@ class DatabaseTest extends TestCase
         $it = 0;
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalledTimes(3)
             ->will(function () use (&$it, $abort) {
@@ -710,7 +710,7 @@ class DatabaseTest extends TestCase
 
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalledTimes(Database::MAX_RETRIES + 1)
             ->willReturn(['id' => self::TRANSACTION]);
@@ -718,7 +718,7 @@ class DatabaseTest extends TestCase
         $it = 0;
         $this->connection->commit(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalledTimes(Database::MAX_RETRIES + 1)
             ->will(function () use (&$it, $abort) {
@@ -742,7 +742,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -760,7 +760,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('session', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -1168,7 +1168,7 @@ class DatabaseTest extends TestCase
     {
         $this->connection->deleteSession(Argument::allOf(
             Argument::withEntry('name', $this->session->name()),
-            Argument::withEntry('database', self::DATABASE)
+            Argument::withEntry('database', DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE))
         ))
             ->shouldBeCalled()
             ->willReturn([]);

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -474,7 +474,7 @@ class DatabaseTest extends TestCase
                     self::INSTANCE,
                     self::DATABASE
                 )
-            )
+            ),
             Argument::withEntry('name', $this->session->name())
         ))
             ->shouldBeCalled();

--- a/Spanner/tests/Unit/InstanceConfigurationTest.php
+++ b/Spanner/tests/Unit/InstanceConfigurationTest.php
@@ -83,7 +83,7 @@ class InstanceConfigurationTest extends TestCase
 
         $this->connection->getInstanceConfig([
             'name' => InstanceAdminClient::instanceConfigName(self::PROJECT_ID, self::NAME),
-            'projectId' => self::PROJECT_ID
+            'projectName' => InstanceAdminClient::projectName(self::PROJECT_ID)
         ])->shouldBeCalled()->willReturn($info);
 
         $this->configuration->___setProperty('connection', $this->connection->reveal());
@@ -94,7 +94,10 @@ class InstanceConfigurationTest extends TestCase
     public function testExists()
     {
         $this->connection->getInstanceConfig(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->configuration->name())
         ))
             ->shouldBeCalled()
@@ -107,7 +110,10 @@ class InstanceConfigurationTest extends TestCase
     public function testExistsDoesntExist()
     {
         $this->connection->getInstanceConfig(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->configuration->name())
         ))
             ->shouldBeCalled()
@@ -123,7 +129,7 @@ class InstanceConfigurationTest extends TestCase
 
         $this->connection->getInstanceConfig([
             'name' => InstanceAdminClient::instanceConfigName(self::PROJECT_ID, self::NAME),
-            'projectId' => self::PROJECT_ID
+            'projectName' => InstanceAdminClient::projectName(self::PROJECT_ID)
         ])->shouldBeCalledTimes(1)->willReturn($info);
 
         $this->configuration->___setProperty('connection', $this->connection->reveal());

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -86,7 +86,10 @@ class InstanceTest extends TestCase
         $instance = $this->getDefaultInstance();
 
         $this->connection->getInstance(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->instance->name())
         ))
             ->shouldBeCalledTimes(1)
@@ -126,7 +129,10 @@ class InstanceTest extends TestCase
     {
         $this->connection->getInstance(Argument::allOf(
             Argument::withEntry('name', $this->instance->name()),
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('fieldMask', ['name'])
         ))
             ->shouldBeCalledTimes(1)
@@ -134,7 +140,10 @@ class InstanceTest extends TestCase
 
         $this->connection->getInstance(Argument::allOf(
             Argument::withEntry('name', $this->instance->name()),
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::not(Argument::withKey('fieldMask'))
         ))
             ->shouldBeCalledTimes(2)
@@ -155,7 +164,10 @@ class InstanceTest extends TestCase
     public function testExistsNotFound()
     {
         $this->connection->getInstance(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->instance->name())
         ))
             ->shouldBeCalled()
@@ -172,7 +184,10 @@ class InstanceTest extends TestCase
 
         $this->connection->getInstance(Argument::allOf(
             Argument::withEntry('name', $this->instance->name()),
-            Argument::withEntry('projectId', self::PROJECT_ID)
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            )
         ))
             ->shouldBeCalledTimes(1)
             ->willReturn($instance);
@@ -194,7 +209,10 @@ class InstanceTest extends TestCase
         $requestedFieldNames = ["name", 'node_count'];
         $this->connection->getInstance(Argument::allOf(
             Argument::withEntry('name', $this->instance->name()),
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('fieldMask', $requestedFieldNames)
         ))
             ->shouldBeCalledTimes(1)
@@ -212,7 +230,10 @@ class InstanceTest extends TestCase
         $instance = $this->getDefaultInstance();
 
         $this->connection->getInstance(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->instance->name())
         ))
             ->shouldBeCalledTimes(1)
@@ -226,7 +247,10 @@ class InstanceTest extends TestCase
     public function testStateIsNull()
     {
         $this->connection->getInstance(Argument::allOf(
-            Argument::withEntry('projectId', self::PROJECT_ID),
+            Argument::withEntry(
+                'projectName',
+                InstanceAdminClient::projectName(self::PROJECT_ID)
+            ),
             Argument::withEntry('name', $this->instance->name())
         ))
             ->shouldBeCalledTimes(1)
@@ -341,7 +365,7 @@ class InstanceTest extends TestCase
                 'name' => 'my-operation'
             ]);
         $this->instance->___setProperty('connection', $this->connection->reveal());
-        
+
         $op = $this->instance->createDatabaseFromBackup('restore-database', $backupName);
         $this->assertInstanceOf(LongRunningOperation::class, $op);
     }
@@ -359,7 +383,7 @@ class InstanceTest extends TestCase
                 'name' => 'my-operation'
             ]);
         $this->instance->___setProperty('connection', $this->connection->reveal());
-        
+
         $op = $this->instance->createDatabaseFromBackup('restore-database', $backupObject);
         $this->assertInstanceOf(LongRunningOperation::class, $op);
     }
@@ -479,7 +503,7 @@ class InstanceTest extends TestCase
         $this->connection->listBackupOperations(Argument::withEntry('instance', $this->instance->name()))
             ->shouldBeCalled()
             ->willReturn(['operations' => $operations]);
-        
+
         $this->instance->___setProperty('connection', $this->connection->reveal());
 
         $bkpOps = $this->instance->backupOperations();
@@ -498,13 +522,13 @@ class InstanceTest extends TestCase
             ['name' => 'operation1'],
             ['name' => 'operation2']
         ];
-        
+
         $this->connection->listDatabaseOperations(Argument::withEntry('instance', $this->instance->name()))
             ->shouldBeCalled()
             ->willReturn(['operations' => $operations]);
-        
+
         $this->instance->___setProperty('connection', $this->connection->reveal());
-        
+
         $dbOps = $this->instance->databaseOperations();
 
         $this->assertInstanceOf(ItemIterator::class, $dbOps);

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner\Tests\Unit;
 
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Batch\ReadPartition;
 use Google\Cloud\Spanner\Database;
@@ -45,7 +46,7 @@ class OperationTest extends TestCase
 
     const SESSION = 'my-session-id';
     const TRANSACTION = 'my-transaction-id';
-    const DATABASE = 'my-database';
+    const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const TIMESTAMP = '2017-01-09T18:05:22.534799Z';
 
     private $connection;
@@ -65,7 +66,7 @@ class OperationTest extends TestCase
 
         $session = $this->prophesize(Session::class);
         $session->name()->willReturn(self::SESSION);
-        $session->info()->willReturn(['database' => self::DATABASE]);
+        $session->info()->willReturn(['databaseName' => self::DATABASE]);
         $this->session = $session->reveal();
     }
 

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -92,7 +92,7 @@ class SpannerClientTest extends TestCase
     public function testInstanceConfigurations()
     {
         $this->connection->listInstanceConfigs(
-            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+            Argument::withEntry('projectName', InstanceAdminClient::projectName(self::PROJECT))
         )
             ->shouldBeCalled()
             ->willReturn([
@@ -144,7 +144,7 @@ class SpannerClientTest extends TestCase
         ];
 
         $this->connection->listInstanceConfigs(
-            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+            Argument::withEntry('projectName', InstanceAdminClient::projectName(self::PROJECT))
         )
             ->shouldBeCalledTimes(2)
             ->willReturn($firstCall, $secondCall);
@@ -224,7 +224,7 @@ class SpannerClientTest extends TestCase
     public function testInstances()
     {
         $this->connection->listInstances(
-            Argument::withEntry('projectId', InstanceAdminClient::projectName(self::PROJECT))
+            Argument::withEntry('projectName', InstanceAdminClient::projectName(self::PROJECT))
         )
             ->shouldBeCalled()
             ->willReturn([


### PR DESCRIPTION
Currently many of the google-cloud-resource-prefix headers are being set to IDs rather than the fully qualified names that are expected. This PR ensures the google-cloud-resource-prefix headers are being correctly set as fully qualified names.