### PR TITLE
feat: pass retryAttempt to all retryFunction calls

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -80,7 +80,7 @@ class ExponentialBackoff
                 return call_user_func_array($function, $arguments);
             } catch (\Exception $exception) {
                 if ($this->retryFunction) {
-                    if (!call_user_func($this->retryFunction, $exception)) {
+                    if (!call_user_func($this->retryFunction, $exception, $retryAttempt)) {
                         throw $exception;
                     }
                 }

--- a/Core/src/Retry.php
+++ b/Core/src/Retry.php
@@ -80,7 +80,7 @@ class Retry
                 return $res;
             } catch (\Exception $exception) {
                 if ($this->retryFunction) {
-                    if (!call_user_func($this->retryFunction, $exception)) {
+                    if (!call_user_func($this->retryFunction, $exception, $retryAttempt)) {
                         throw $exception;
                     }
                 }


### PR DESCRIPTION
In my initial PR, I missed a few call locations. This will allow us to pass in the retryAttempt for instrumentation purposes when we override the default retryFunction