### PR TITLE
fix: preserve empty arrays when using set() with merge enabled

### DIFF
--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -847,7 +847,7 @@ class WriteBatch
         foreach ($fields as $key => $val) {
             $currentPath = $path->child($key);
 
-            if (is_array($val) && $this->isAssoc($val)) {
+            if (is_array($val) && !empty($val) && $this->isAssoc($val)) {
                 $output = array_merge(
                     $output,
                     $this->encodeFieldPaths($val, $currentPath)

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -269,17 +269,23 @@ class WriteBatchTest extends TestCase
     public function testSetMerge($name, $ref)
     {
         $this->batch->set($ref, [
-            'hello' => 'world'
+            'hello' => 'world',
+            'foobar' => ['foo' => 'bar'],
+            'emptiness' => []
         ], ['merge' => true]);
 
         $this->commitAndAssert([
             'database' => sprintf('projects/%s/databases/%s', self::PROJECT, self::DATABASE),
             'writes' => [
                 [
-                    'updateMask' => ['fieldPaths' => ['hello']],
+                    'updateMask' => ['fieldPaths' => ['emptiness', 'foobar.foo', 'hello']],
                     'update' => [
                         'name' => $name,
-                        'fields' => ['hello' => ['stringValue' => 'world']]
+                        'fields' => [
+                            'hello' => ['stringValue' => 'world'],
+                            'foobar' => ['mapValue' => ['fields' => ['foo' => ['stringValue' => 'bar']]]],
+                            'emptiness' => ['arrayValue' => ['values' => []]]
+                        ]
                     ]
                 ]
             ]


### PR DESCRIPTION
When we want to set a document with the "merge" flag enabled, an empty arrays fields are not set because their path is removed. I'm not sure if the current behavior is correct, I suppose it's not.