### PR TITLE
fix: adds quota project doc to language, debugger and bigtable

### DIFF
--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -101,6 +101,8 @@ class BigtableClient
      *           See the `build` method on {@see Google\ApiCore\Transport\GrpcTransport}
      *           and {@see Google\ApiCore\Transport\RestTransport} for the
      *           supported options.
+     *     @type string $quotaProject Specifies a user project to bill for
+     *           access charges associated with the request.
      * }
      * @throws ValidationException
      */

--- a/Debugger/src/DebuggerClient.php
+++ b/Debugger/src/DebuggerClient.php
@@ -85,6 +85,8 @@ class DebuggerClient
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      *     @type array $scopes Scopes to be used for the request.
+     *     @type string $quotaProject Specifies a user project to bill for
+     *           access charges associated with the request.
      * }
      */
     public function __construct(array $config = [])

--- a/Language/src/LanguageClient.php
+++ b/Language/src/LanguageClient.php
@@ -98,6 +98,8 @@ class LanguageClient
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      *     @type array $scopes Scopes to be used for the request.
+     *     @type string $quotaProject Specifies a user project to bill for
+     *           access charges associated with the request.
      * }
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
`LanguageClient` and `DebuggerClient` both use `RequestWrapper`, and so should have `quotaProject` mentioned in their constructor parameters

`Bigtable` uses GAPIC, so I'm not as sure where this stands

fixes #3253 
