### PR TITLE
chore: deploy full docs folder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,5 @@ jobs:
           with:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             BRANCH: gh-pages
-            FOLDER: docs/json
-            TARGET_FOLDER: json
+            FOLDER: docs
             CLEAN: false


### PR DESCRIPTION
Fixes the problem of the manifest not being updated. Results in a few extraneous files in the gh-pages branch, but no impact on users.