### PR TITLE
feat: create references to tables from other projects

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -390,7 +390,7 @@ class BigQueryClient
      * @param array $options [optional] Configuration options.
      * @return Job
      */
-    public function startQuery(QueryJobConfiguration $query, array $options = [])
+    public function startQuery(JobConfigurationInterface $query, array $options = [])
     {
         return $this->startJob($query, $options);
     }
@@ -497,8 +497,8 @@ class BigQueryClient
      * point. To see the operations that can be performed on a dataset please
      * see {@see Google\Cloud\BigQuery\Dataset}.
      *
-     * You can specify id of project this dataset belongs to. By default it is the same project id
-     * that was passed to client constructor or obtained from account credentials.
+     * If the dataset is owned by a different project than the project used to authenticate the client,
+     * provide the project ID as the second argument.
      *
      * Example:
      * ```
@@ -606,7 +606,7 @@ class BigQueryClient
      *
      *     @type array $metadata The available options for metadata are outlined
      *           at the [Dataset Resource API docs](
-     *           https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource:-dataset)
+     *           https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets)
      * }
      * @return Dataset
      */

--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -151,8 +151,8 @@ class BigQueryClient
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
-     * Unless otherwise specified, all configuration options will default based
-     * on the [Jobs configuration API documentation](https://goo.gl/vSTbGp)
+     * Unless otherwise specified, all configuration options will default based on the
+     * [query job configuration](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationquery)
      * except for `configuration.query.useLegacySql`, which defaults to `false`
      * in this client.
      *
@@ -193,9 +193,16 @@ class BigQueryClient
      * ```
      *
      * @param string $query A BigQuery SQL query.
-     * @param array $options [optional] Please see the
-     *        [API documentation for Job configuration](https://goo.gl/vSTbGp)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.query Query job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationquery)
+     *           for the available options.
+     * }
      * @return QueryJobConfiguration
      */
     public function query($query, array $options = [])
@@ -215,8 +222,8 @@ class BigQueryClient
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
-     * Unless otherwise specified, all configuration options will default based
-     * on the [Jobs configuration API documentation](https://goo.gl/vSTbGp)
+     * Unless otherwise specified, all configuration options will default based on the
+     * [query job configuration](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationquery)
      * except for `configuration.query.useLegacySql`, which defaults to `false`
      * in this client.
      *
@@ -224,9 +231,16 @@ class BigQueryClient
      * {@see Google\Cloud\BigQuery\BigQueryClient::query()} for usage examples.
      *
      * @param string $query A BigQuery SQL query.
-     * @param array $options [optional] Please see the
-     *        [API documentation for Job configuration](https://goo.gl/vSTbGp)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.query Query job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationquery)
+     *           for the available options.
+     * }
      * @return QueryJobConfiguration
      */
     public function queryConfig($query, array $options = [])
@@ -304,7 +318,7 @@ class BigQueryClient
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/query Query API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param QueryJobConfiguration $query A BigQuery SQL query configuration.
      * @param array $options [optional] {
@@ -376,7 +390,7 @@ class BigQueryClient
      * @param array $options [optional] Configuration options.
      * @return Job
      */
-    public function startQuery(JobConfigurationInterface $query, array $options = [])
+    public function startQuery(QueryJobConfiguration $query, array $options = [])
     {
         return $this->startJob($query, $options);
     }
@@ -430,8 +444,7 @@ class BigQueryClient
      *     echo $job->id() . PHP_EOL;
      * }
      * ```
-     *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/list Jobs list API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/list Jobs list API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -525,7 +538,7 @@ class BigQueryClient
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/list Datasets list API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list Datasets list API documentation.
      *
      * @codingStandardsIgnoreStart
      * @param array $options [optional] {
@@ -542,7 +555,7 @@ class BigQueryClient
      *           request by label. The syntax is "labels.<name>[:<value>]".
      *           Multiple filters can be ANDed together by connecting with a
      *           space. Example: "labels.department:receiving labels.active".
-     *           See [Filtering datasets using labels](https://cloud.google.com/bigquery/docs/labeling-datasets#filtering_datasets_using_labels)
+     *           See [Filtering datasets using labels](https://cloud.google.com/bigquery/docs/filtering-labels#filtering_datasets_using_labels)
      *           for details.
      * }
      * @codingStandardsIgnoreEnd
@@ -585,15 +598,15 @@ class BigQueryClient
      * $dataset = $bigQuery->createDataset('aDataset');
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/insert Datasets insert API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/insert Datasets insert API documentation.
      *
      * @param string $id The id of the dataset to create.
      * @param array $options [optional] {
      *     Configuration options.
      *
      *     @type array $metadata The available options for metadata are outlined
-     *           at the
-     *           [Dataset Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource)
+     *           at the [Dataset Resource API docs](
+     *           https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource:-dataset)
      * }
      * @return Dataset
      */
@@ -638,7 +651,7 @@ class BigQueryClient
      * echo $job->isComplete(); // true
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param JobConfigurationInterface $config The job configuration.
      * @param array $options [optional] {
@@ -667,7 +680,7 @@ class BigQueryClient
      * $job = $bigQuery->startJob($jobConfig);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param JobConfigurationInterface $config The job configuration.
      * @param array $options [optional] Configuration options.
@@ -778,7 +791,7 @@ class BigQueryClient
      * Create a Numeric object.
      *
      * Numeric represents a value with a data type of
-     * [Numeric](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type).
+     * [Numeric](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_type).
      *
      * It supports a fixed 38 decimal digits of precision and 9 decimal digits of scale, and values
      * are in the range of -99999999999999999999999999999.999999999 to
@@ -830,12 +843,18 @@ class BigQueryClient
      *     ->destinationTable($myTable);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.copy Copy job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationtablecopy)
+     *           for the available options.
+     * }
      * @return CopyJobConfiguration
      */
     public function copy(array $options = [])
@@ -861,12 +880,18 @@ class BigQueryClient
      *     ->destinationUris(['gs://my-bucket/table.csv']);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.extract Extract job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationextract)
+     *           for the available options.
+     * }
      * @return ExtractJobConfiguration
      */
     public function extract(array $options = [])
@@ -892,12 +917,18 @@ class BigQueryClient
      *     ->sourceUris(['gs://my-bucket/table.csv']);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.load Load job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload)
+     *           for the available options.
+     * }
      * @return LoadJobConfiguration
      */
     public function load(array $options = [])

--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -484,9 +484,17 @@ class BigQueryClient
      * point. To see the operations that can be performed on a dataset please
      * see {@see Google\Cloud\BigQuery\Dataset}.
      *
+     * You can specify id of project this dataset belongs to. By default it is the same project id
+     * that was passed to client constructor or obtained from account credentials.
+     *
      * Example:
      * ```
      * $dataset = $bigQuery->dataset('myDatasetId');
+     * ```
+     *
+     * ```
+     * // Reference a dataset from other project.
+     * $dataset = $bigQuery->dataset('samples', 'bigquery-public-data');
      * ```
      *
      * @param string $id The id of the dataset to request.
@@ -817,7 +825,9 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $copyJobConfig = $bigQuery->copy()->sourceTable($otherTable)->destinationTable($myTable);
+     * $copyJobConfig = $bigQuery->copy()
+     *     ->sourceTable($otherTable)
+     *     ->destinationTable($myTable);
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
@@ -846,7 +856,9 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $extractJobConfig = $bigQuery->extract()->sourceTable($table)->destinationUris(['gs://my-bucket/table.csv']);
+     * $extractJobConfig = $bigQuery->extract()
+     *     ->sourceTable($table)
+     *     ->destinationUris(['gs://my-bucket/table.csv']);
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
@@ -875,7 +887,9 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $loadJobConfig = $bigQuery->load()->destinationTable($table)->sourceUris(['gs://my-bucket/table.csv']);
+     * $loadJobConfig = $bigQuery->load()
+     *     ->destinationTable($table)
+     *     ->sourceUris(['gs://my-bucket/table.csv']);
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.

--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -21,7 +21,6 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\BigQuery\Exception\JobException;
-use Google\Cloud\BigQuery\Job;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\Int64;
@@ -491,14 +490,15 @@ class BigQueryClient
      * ```
      *
      * @param string $id The id of the dataset to request.
+     * @param string|null $projectId The id of the project. **Defaults to** current project id.
      * @return Dataset
      */
-    public function dataset($id)
+    public function dataset($id, $projectId = null)
     {
         return new Dataset(
             $this->connection,
             $id,
-            $this->projectId,
+            $projectId ?: $this->projectId,
             $this->mapper,
             [],
             $this->location
@@ -806,5 +806,92 @@ class BigQueryClient
     {
         $resp = $this->connection->getServiceAccount($options + ['projectId' => $this->projectId]);
         return $resp['email'];
+    }
+
+    /**
+     * Returns a copy job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
+     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
+     *
+     * Example:
+     * ```
+     * $copyJobConfig = $bigQuery->copy()->sourceTable($otherTable)->destinationTable($myTable);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     *
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return CopyJobConfiguration
+     */
+    public function copy(array $options = [])
+    {
+        return new CopyJobConfiguration(
+            $this->projectId,
+            $options,
+            $this->location
+        );
+    }
+
+    /**
+     * Returns an extract job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
+     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig = $bigQuery->extract()->sourceTable($table)->destinationUris(['gs://my-bucket/table.csv']);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     *
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return ExtractJobConfiguration
+     */
+    public function extract(array $options = [])
+    {
+        return new ExtractJobConfiguration(
+            $this->projectId,
+            $options,
+            $this->location
+        );
+    }
+
+    /**
+     * Returns a load job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
+     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig = $bigQuery->load()->destinationTable($table)->sourceUris(['gs://my-bucket/table.csv']);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     *
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return LoadJobConfiguration
+     */
+    public function load(array $options = [])
+    {
+        return new LoadJobConfiguration(
+            $this->projectId,
+            $options,
+            $this->location
+        );
     }
 }

--- a/BigQuery/src/Bytes.php
+++ b/BigQuery/src/Bytes.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * Represents a value with a data type of
- * [bytes](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes-type).
+ * [bytes](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes_type).
  *
  * Example:
  * ```

--- a/BigQuery/src/CopyJobConfiguration.php
+++ b/BigQuery/src/CopyJobConfiguration.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a configuration for a copy job. For more information on the
  * available settings please see the
- * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job).
  *
  * Example:
  * ```

--- a/BigQuery/src/Dataset.php
+++ b/BigQuery/src/Dataset.php
@@ -25,7 +25,7 @@ use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
 
 /**
- * [Datasets](https://cloud.google.com/bigquery/what-is-bigquery#datasets) allow
+ * [Datasets](https://cloud.google.com/bigquery/docs/datasets-intro) allow
  * you to organize and control access to your tables.
  */
 class Dataset
@@ -117,7 +117,7 @@ class Dataset
      * $dataset->delete();
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/delete Datasets delete API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete Datasets delete API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -154,11 +154,11 @@ class Dataset
      * ]);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/patch Datasets patch API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/patch Datasets patch API documentation.
      * @see https://cloud.google.com/bigquery/docs/api-performance#patch Patch (Partial Update)
      *
      * @param array $metadata The available options for metadata are outlined
-     *        at the [Dataset Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource)
+     *        at the [Dataset Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets)
      * @param array $options [optional] Configuration options.
      */
     public function update(array $metadata, array $options = [])
@@ -216,7 +216,7 @@ class Dataset
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/list Tables list API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list Tables list API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -266,14 +266,14 @@ class Dataset
      * $table = $dataset->createTable('aTable');
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/insert Tables insert API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert Tables insert API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
      *
      *     @type array $metadata The available options for metadata are outlined
      *           at the
-     *           [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
+     *           [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables)
      * }
      * @return Table
      */
@@ -351,7 +351,7 @@ class Dataset
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/models/list Models list API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/models/list Models list API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -431,7 +431,7 @@ class Dataset
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/routines/list List Routines API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/list List Routines API documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -490,11 +490,11 @@ class Dataset
      * ]);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/routines/insert Insert Routines API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/routines/insert Insert Routines API documentation.
      *
      * @param string $id The routine ID.
      * @param array $metadata The available options for metadata are outlined at the
-     *        [Routine Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/routines#resource).
+     *        [Routine Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/routines).
      *        Omit `routineReference` as it is computed and appended by the
      *        client.
      * @param array $options [optional] Configuration options.
@@ -526,7 +526,7 @@ class Dataset
      * echo $info['selfLink'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource Datasets resource documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets Datasets resource documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array
@@ -550,7 +550,7 @@ class Dataset
      * echo $info['selfLink'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/get Datasets get API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/get Datasets get API documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array

--- a/BigQuery/src/Date.php
+++ b/BigQuery/src/Date.php
@@ -19,7 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 /**
  * Represents a value with a data type of
- * [Date](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#date-type).
+ * [Date](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#date_type).
  *
  * Example:
  * ```

--- a/BigQuery/src/ExtractJobConfiguration.php
+++ b/BigQuery/src/ExtractJobConfiguration.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a configuration for an extract job. For more information on the
  * available settings please see the
- * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job).
  *
  * Example:
  * ```

--- a/BigQuery/src/InsertResponse.php
+++ b/BigQuery/src/InsertResponse.php
@@ -80,7 +80,7 @@ class InsertResponse
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll#response
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll#response-body
      * Tabledata insertAll API response documentation.
      *
      * @return array
@@ -111,7 +111,7 @@ class InsertResponse
      * print_r($info['insertErrors']);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll#response
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll#response-body
      * Tabledata insertAll API response documentation.
      *
      * @return array

--- a/BigQuery/src/Job.php
+++ b/BigQuery/src/Job.php
@@ -23,7 +23,7 @@ use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 
 /**
- * [Jobs](https://cloud.google.com/bigquery/docs/reference/v2/jobs) are objects
+ * [Jobs](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job) are objects
  * that manage asynchronous tasks such as running queries, loading data, and
  * exporting data.
  */
@@ -127,7 +127,7 @@ class Job
      * echo 'Job successfully cancelled.';
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/cancel Jobs cancel API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel Jobs cancel API documentation.
      *
      * @param array $options [optional] Configuration options.
      */
@@ -156,7 +156,7 @@ class Job
      * $queryResults = $job->queryResults();
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/getQueryResults
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults
      * Jobs getQueryResults API documentation.
      *
      * @param array $options [optional] {
@@ -271,7 +271,7 @@ class Job
      * echo $info['statistics']['startTime'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs#resource Jobs resource documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/Job Jobs resource documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array
@@ -296,7 +296,7 @@ class Job
      * echo $job->isComplete(); // true
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/get Jobs get API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get Jobs get API documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array

--- a/BigQuery/src/LoadJobConfiguration.php
+++ b/BigQuery/src/LoadJobConfiguration.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Represents a configuration for a load job. For more information on the
  * available settings please see the
- * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job).
  *
  * Example:
  * ```

--- a/BigQuery/src/Model.php
+++ b/BigQuery/src/Model.php
@@ -90,7 +90,7 @@ class Model
      * echo $info['modelType'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/models#resource Model resource documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/models Model resource documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array
@@ -220,7 +220,7 @@ class Model
      * @see https://cloud.google.com/bigquery/docs/api-performance#patch Patch (Partial Update)
      *
      * @param array $metadata The available options for metadata are outlined
-     *        at the [Model Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/models#resource)
+     *        at the [Model Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/models)
      * @param array $options [optional] Configuration options.
      *
      * @return array
@@ -253,7 +253,7 @@ class Model
      * $extractJobConfig = $model->extract($destinationObject);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $destination The destination object. May be
      *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to
@@ -261,7 +261,7 @@ class Model
      *        `gs://{bucket-name}/{object-name}`.
      * @param array $options [optional] Please see the
      *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/Job)
      *        for the available options.
      * @return ExtractJobConfiguration
      */

--- a/BigQuery/src/Numeric.php
+++ b/BigQuery/src/Numeric.php
@@ -19,7 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 /**
  * Represents a value with a data type of
- * [Numeric](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type).
+ * [Numeric](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_type).
  *
  * It supports a fixed 38 decimal digits of precision and 9 decimal digits of scale, and values
  * are in the range of -99999999999999999999999999999.999999999 to

--- a/BigQuery/src/QueryJobConfiguration.php
+++ b/BigQuery/src/QueryJobConfiguration.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a configuration for a query job. For more information on the
  * available settings please see the
- * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job).
  *
  * Example:
  * ```
@@ -221,8 +221,6 @@ class QueryJobConfiguration implements JobConfigurationInterface
      * ```
      * $query->maximumBillingTier(1);
      * ```
-     *
-     * @see https://cloud.google.com/bigquery/pricing#high-compute High-Compute queries
      *
      * @param int $maximumBillingTier The maximum billing tier.
      * @return QueryJobConfiguration
@@ -457,7 +455,7 @@ class QueryJobConfiguration implements JobConfigurationInterface
      * $query->useQueryCache(true);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/querying-data#query-caching Query Caching
+     * @see https://cloud.google.com/bigquery/docs/cached-results Using cached results
      *
      * @param bool $useQueryCache Whether or not to use the query cache.
      * @return QueryJobConfiguration

--- a/BigQuery/src/QueryResults.php
+++ b/BigQuery/src/QueryResults.php
@@ -25,7 +25,7 @@ use Google\Cloud\Core\Iterator\PageIterator;
 
 /**
  * QueryResults represent the result of a BigQuery SQL query. Read more at the
- * [Query Response API Documentation](https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#response).
+ * [Query Response API Documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#response-body)
  *
  * This class should be not instantiated directly, but as a result of
  * calling {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
@@ -247,7 +247,7 @@ class QueryResults implements \IteratorAggregate
      * echo $info['totalBytesProcessed'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/getQueryResults#response
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults#response-body
      * Jobs getQueryResults API response documentation.
      *
      * @return array
@@ -265,7 +265,7 @@ class QueryResults implements \IteratorAggregate
      * $queryResults->reload();
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/getQueryResults
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults
      * Jobs getQueryResults API documentation.
      *
      * @param array $options [optional] {

--- a/BigQuery/src/Table.php
+++ b/BigQuery/src/Table.php
@@ -138,7 +138,7 @@ class Table
      * $table->delete();
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/delete Tables delete API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete Tables delete API documentation.
      *
      * @param array $options [optional] Configuration options.
      */
@@ -169,11 +169,11 @@ class Table
      * ]);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/patch Tables patch API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/patch Tables patch API documentation.
      * @see https://cloud.google.com/bigquery/docs/api-performance#patch Patch (Partial Update)
      *
      * @param array $metadata The available options for metadata are outlined
-     *        at the [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
+     *        at the [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables)
      * @param array $options [optional] Configuration options.
      */
     public function update(array $metadata, array $options = [])
@@ -204,7 +204,7 @@ class Table
      * }
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/list Tabledata list API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/list Tabledata list API Documentation.
      *
      * @param array $options [optional] {
      *     Configuration options.
@@ -265,7 +265,7 @@ class Table
      * echo $job->isComplete(); // true
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @deprecated Use {@see Google\Cloud\BigQuery\BigQueryClient::runJob()}.
      * @param JobConfigurationInterface $config The job configuration.
@@ -295,7 +295,7 @@ class Table
      * $job = $table->startJob($jobConfig);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @deprecated Use {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}.
      * @param JobConfigurationInterface $config The job configuration.
@@ -339,13 +339,19 @@ class Table
      * $copyJobConfig = $sourceTable->copy($destinationTable);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param Table $destination The destination table.
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.copy Copy job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationtablecopy)
+     *           for the available options.
+     * }
      * @return CopyJobConfiguration
      */
     public function copy(Table $destination, array $options = [])
@@ -374,16 +380,22 @@ class Table
      * $extractJobConfig = $table->extract($destinationObject);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $destination The destination object. May be
      *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to
      *        a Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.extract Extract job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationextract)
+     *           for the available options.
+     * }
      * @return ExtractJobConfiguration
      */
     public function extract($destination, array $options = [])
@@ -415,13 +427,19 @@ class Table
      * $loadJobConfig = $table->load(fopen('/path/to/my/data.csv', 'r'));
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|resource|StreamInterface $data The data to load.
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.load Load job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload)
+     *           for the available options.
+     * }
      * @return LoadJobConfiguration
      */
     public function load($data, array $options = [])
@@ -455,16 +473,22 @@ class Table
      * $loadJobConfig = $table->loadFromStorage($object);
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $object The object to load data from. May be
      *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
-     * @param array $options [optional] Please see the
-     *        [upstream API documentation for Job configuration]
-     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     *        for the available options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $configuration Job configuration. Please see the
+     *           [API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration)
+     *           for the available options.
+     *     @type array $configuration.load Load job configuration. Please see the
+     *           [documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload)
+     *           for the available options.
+     * }
      * @return LoadJobConfiguration
      */
     public function loadFromStorage($object, array $options = [])
@@ -507,7 +531,7 @@ class Table
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll Tabledata insertAll API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll Tabledata insertAll API Documentation.
      * @see https://cloud.google.com/bigquery/streaming-data-into-bigquery Streaming data into BigQuery.
      *
      * @param array $row Key/value set of data matching the table's schema.
@@ -574,7 +598,7 @@ class Table
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/insertAll Tabledata insertAll API Documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll Tabledata insertAll API Documentation.
      * @see https://cloud.google.com/bigquery/streaming-data-into-bigquery Streaming data into BigQuery.
      *
      * @param array $rows The rows to insert. Each item in the array must
@@ -592,7 +616,7 @@ class Table
      *           exist. **Defaults to** `false`.
      *     @type array $tableMetadata Metadata to apply to table to be created. The
      *           full set of metadata are outlined at the
-     *           [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource).
+     *           [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
      *           Only applies when `autoCreate` is `true`.
      *     @type int $maxRetries The maximum number of times to attempt creating the
      *           table in the case of failure. Please note, each retry attempt
@@ -660,7 +684,7 @@ class Table
      * echo $info['selfLink'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables#resource Tables resource documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables Tables resource documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array
@@ -684,7 +708,7 @@ class Table
      * echo $info['selfLink'];
      * ```
      *
-     * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/get Tables get API documentation.
+     * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/get Tables get API documentation.
      *
      * @param array $options [optional] Configuration options.
      * @return array

--- a/BigQuery/src/Time.php
+++ b/BigQuery/src/Time.php
@@ -19,7 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 /**
  * Represents a value with a data type of
- * [Time](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time-type).
+ * [Time](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time_type).
  *
  * Example:
  * ```

--- a/BigQuery/src/Timestamp.php
+++ b/BigQuery/src/Timestamp.php
@@ -19,7 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 /**
  * Represents a value with a data type of
- * [Timestamp](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type).
+ * [Timestamp](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type).
  *
  * Example:
  * ```

--- a/BigQuery/tests/Snippet/BigQueryClientTest.php
+++ b/BigQuery/tests/Snippet/BigQueryClientTest.php
@@ -332,9 +332,22 @@ class BigQueryClientTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'dataset');
         $snippet->addLocal('bigQuery', $this->client);
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $res = $snippet->invoke('dataset');
+        $dataset = $snippet->invoke('dataset')->returnVal();
 
-        $this->assertInstanceOf(Dataset::class, $res->returnVal());
+        $this->assertInstanceOf(Dataset::class, $dataset);
+        $this->assertEquals(self::PROJECT_ID, $dataset->identity()['projectId']);
+    }
+
+    public function testDatasetWithProjectId()
+    {
+        $snippet = $this->snippetFromMethod(BigQueryClient::class, 'dataset', 1);
+        $snippet->addLocal('bigQuery', $this->client);
+        $this->client->___setProperty('connection', $this->connection->reveal());
+        $dataset = $snippet->invoke('dataset')->returnVal();
+
+        $this->assertInstanceOf(Dataset::class, $dataset);
+        $this->assertEquals('samples', $dataset->id());
+        $this->assertEquals('bigquery-public-data', $dataset->identity()['projectId']);
     }
 
     public function testDatasets()

--- a/BigQuery/tests/System/BigQueryTestCase.php
+++ b/BigQuery/tests/System/BigQueryTestCase.php
@@ -57,11 +57,11 @@ class BigQueryTestCase extends SystemTestCase
         self::$hasSetUp = true;
     }
 
-    protected static function createTable(Dataset $dataset, $name, array $options = [])
+    protected static function createTable(Dataset $dataset, $name = null, array $options = [])
     {
         if (!isset($options['schema'])) {
             $options['schema']['fields'] = json_decode(file_get_contents(__DIR__ . '/data/table-schema.json'), true);
         }
-        return $dataset->createTable(uniqid(self::TESTING_PREFIX), $options);
+        return $dataset->createTable($name ?: uniqid(self::TESTING_PREFIX), $options);
     }
 }

--- a/BigQuery/tests/System/LoadDataAndQueryTest.php
+++ b/BigQuery/tests/System/LoadDataAndQueryTest.php
@@ -354,7 +354,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $loadJobConfig = self::$table->load($data)
             ->sourceFormat('NEWLINE_DELIMITED_JSON');
 
-        $job = self::$table->startJob($loadJobConfig);
+        $job = self::$client->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -430,7 +430,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
             ])
             ->sourceFormat('NEWLINE_DELIMITED_JSON');
 
-        $job = $table->startJob($loadJobConfig);
+        $job = self::$client->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -461,7 +461,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
         $loadJobConfig = self::$table->loadFromStorage($object)
             ->sourceFormat('NEWLINE_DELIMITED_JSON');
-        $job = self::$table->startJob($loadJobConfig);
+        $job = self::$client->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -500,7 +500,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         ]);
         $loadJobConfig = $table->loadFromStorage(self::US_STATES_ORC_DATA)
             ->sourceFormat('ORC');
-        $job = self::$table->runJob($loadJobConfig, [
+        $job = self::$client->runJob($loadJobConfig, [
             'maxRetries' => 8
         ]);
 
@@ -574,7 +574,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
             ->rangePartitioning($partitioning)
             ->sourceFormat('NEWLINE_DELIMITED_JSON');
 
-        $job = $table->startJob($loadJobConfig);
+        $job = self::$client->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -600,7 +600,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
             ->destinationTable($queryTable)
             ->rangePartitioning($partitioning);
 
-        $job = $table->startJob($queryJobConfig);
+        $job = self::$client->startJob($queryJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();

--- a/BigQuery/tests/System/RegionalizationTest.php
+++ b/BigQuery/tests/System/RegionalizationTest.php
@@ -56,7 +56,7 @@ class RegionalizationTest extends BigQueryTestCase
             ->table(uniqid(self::TESTING_PREFIX));
         $copyConfig = self::$tableAsia->copy($targetTable)
             ->location(self::LOCATION_ASIA);
-        $results = self::$tableAsia->runJob($copyConfig);
+        $results = self::$client->runJob($copyConfig);
 
         $this->assertArrayNotHasKey(
             'errorResult',
@@ -77,7 +77,7 @@ class RegionalizationTest extends BigQueryTestCase
             ->table(uniqid(self::TESTING_PREFIX));
         $copyConfig = self::$tableAsia->copy($targetTable)
             ->location(self::LOCATION_US);
-        self::$tableAsia->runJob($copyConfig);
+        self::$client->runJob($copyConfig);
     }
 
     public function testExtractJobSucceedsInAsia()
@@ -86,7 +86,7 @@ class RegionalizationTest extends BigQueryTestCase
         $extractConfig = self::$tableAsia->extract($object)
             ->destinationFormat('NEWLINE_DELIMITED_JSON')
             ->location(self::LOCATION_ASIA);
-        $results = self::$tableAsia->runJob($extractConfig);
+        $results = self::$client->runJob($extractConfig);
 
         $this->assertArrayNotHasKey(
             'errorResult',
@@ -104,7 +104,7 @@ class RegionalizationTest extends BigQueryTestCase
         $extractConfig = self::$tableAsia->extract($object)
             ->destinationFormat('NEWLINE_DELIMITED_JSON')
             ->location(self::LOCATION_US);
-        self::$tableAsia->runJob($extractConfig);
+        self::$client->runJob($extractConfig);
     }
 
     public function testLoadJobSucceedsInAsia()
@@ -114,7 +114,7 @@ class RegionalizationTest extends BigQueryTestCase
         )
             ->sourceFormat('NEWLINE_DELIMITED_JSON')
             ->location(self::LOCATION_ASIA);
-        $results = self::$tableAsia->runJob($loadConfig);
+        $results = self::$client->runJob($loadConfig);
 
         $this->assertArrayNotHasKey(
             'errorResult',
@@ -134,7 +134,7 @@ class RegionalizationTest extends BigQueryTestCase
             ->sourceFormat('NEWLINE_DELIMITED_JSON')
             ->createDisposition('CREATE_NEVER')
             ->location(self::LOCATION_US);
-        self::$tableAsia->runJob($loadConfig);
+        self::$client->runJob($loadConfig);
     }
 
     public function testRunQuerySucceedsInAsia()

--- a/BigQuery/tests/Unit/BigQueryClientTest.php
+++ b/BigQuery/tests/Unit/BigQueryClientTest.php
@@ -20,10 +20,13 @@ namespace Google\Cloud\BigQuery\Tests\Unit;
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Bytes;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Date;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\JobConfigurationInterface;
+use Google\Cloud\BigQuery\LoadJobConfiguration;
 use Google\Cloud\BigQuery\Numeric;
 use Google\Cloud\BigQuery\QueryJobConfiguration;
 use Google\Cloud\BigQuery\QueryResults;
@@ -306,7 +309,19 @@ class BigQueryClientTest extends TestCase
     {
         $client = $this->getClient();
         $client->___setProperty('connection', $this->connection->reveal());
-        $this->assertInstanceOf(Dataset::class, $client->dataset(self::DATASET_ID));
+        $dataset = $client->dataset(self::DATASET_ID);
+        $this->assertInstanceOf(Dataset::class, $dataset);
+        $this->assertEquals(self::PROJECT_ID, $dataset->identity()['projectId']);
+    }
+
+    public function testGetsDatasetWithOtherProjectId()
+    {
+        $projectId = 'otherProjectId';
+        $client = $this->getClient();
+        $client->___setProperty('connection', $this->connection->reveal());
+        $dataset = $client->dataset(self::DATASET_ID, $projectId);
+        $this->assertInstanceOf(Dataset::class, $dataset);
+        $this->assertEquals($projectId, $dataset->identity()['projectId']);
     }
 
     public function testGetsDatasetsWithNoResults()
@@ -606,5 +621,41 @@ class BigQueryClientTest extends TestCase
         $serviceAccount = $client->getServiceAccount();
 
         $this->assertEquals($expectedEmail, $serviceAccount);
+    }
+
+    public function testCopy()
+    {
+        $jobConfig = $this->getClient()->copy([
+            'location' => 'world',
+        ]);
+        $this->assertInstanceOf(CopyJobConfiguration::class, $jobConfig);
+        $config = $jobConfig->toArray();
+        $this->assertEquals(self::PROJECT_ID, $config['projectId']);
+        $this->assertEquals(self::PROJECT_ID, $config['jobReference']['projectId']);
+        $this->assertEquals('world', $config['location']);
+    }
+
+    public function testExtract()
+    {
+        $jobConfig = $this->getClient()->extract([
+            'location' => 'world',
+        ]);
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $jobConfig);
+        $config = $jobConfig->toArray();
+        $this->assertEquals(self::PROJECT_ID, $config['projectId']);
+        $this->assertEquals(self::PROJECT_ID, $config['jobReference']['projectId']);
+        $this->assertEquals('world', $config['location']);
+    }
+
+    public function testLoad()
+    {
+        $jobConfig = $this->getClient()->load([
+            'location' => 'world',
+        ]);
+        $this->assertInstanceOf(LoadJobConfiguration::class, $jobConfig);
+        $config = $jobConfig->toArray();
+        $this->assertEquals(self::PROJECT_ID, $config['projectId']);
+        $this->assertEquals(self::PROJECT_ID, $config['jobReference']['projectId']);
+        $this->assertEquals('world', $config['location']);
     }
 }


### PR DESCRIPTION
Added optional `projectId` argument for `BigQueryClient#dataset()` method. Added `copy()`, `extract()`, and `load()` methods for `BigQueryClient` creating job configurations.

Closes #1512.