### PR TITLE
feat: add support for IN queries with documents IDs

### DIFF
--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -355,7 +355,11 @@ class Query
         }
 
         if ($escapedPathString === self::DOCUMENT_ID) {
-            $value = $this->createDocumentReference($basePath, $value);
+            $value = $operator === FieldFilterOperator::IN
+                ? array_map(function ($value) use ($basePath) {
+                    return $this->createDocumentReference($basePath, $value);
+                }, (array)$value)
+                : $this->createDocumentReference($basePath, $value);
         }
 
         if ((is_float($value) && is_nan($value)) || is_null($value)) {

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -355,11 +355,13 @@ class Query
         }
 
         if ($escapedPathString === self::DOCUMENT_ID) {
-            $value = $operator === FieldFilterOperator::IN
-                ? array_map(function ($value) use ($basePath) {
+            if ($operator === FieldFilterOperator::IN) {
+                $value = array_map(function ($value) use ($basePath) {
                     return $this->createDocumentReference($basePath, $value);
-                }, (array)$value)
-                : $this->createDocumentReference($basePath, $value);
+                }, (array) $value);
+            } else {
+                $value = $this->createDocumentReference($basePath, $value);
+            }
         }
 
         if ((is_float($value) && is_nan($value)) || is_null($value)) {

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -116,7 +116,10 @@ class QueryTest extends FirestoreTestCase
         $docs = self::$client->collection($name)->where('foos', 'in', [['bar', 'foo']])->documents()->rows();
         $this->assertEmpty($docs);
 
-        $docs = self::$client->collection($name)->where(FieldPath::documentId(), 'in', [$doc1->id(), $doc2->id()])->documents()->rows();
+        $docs = self::$client->collection($name)
+            ->where(FieldPath::documentId(), 'in', [$doc1->id(), $doc2->id()])
+            ->documents()
+            ->rows();
         $this->assertCount(2, $docs);
         $doc_ids = array_map(function ($doc) {
             return $doc->id();

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\System;
 
+use Google\Cloud\Firestore\FieldPath;
+
 /**
  * @group firestore
  * @group firestore-query
@@ -113,6 +115,14 @@ class QueryTest extends FirestoreTestCase
 
         $docs = self::$client->collection($name)->where('foos', 'in', [['bar', 'foo']])->documents()->rows();
         $this->assertEmpty($docs);
+
+        $docs = self::$client->collection($name)->where(FieldPath::documentId(), 'in', [$doc1->id(), $doc2->id()])->documents()->rows();
+        $this->assertCount(2, $docs);
+        $doc_ids = array_map(function ($doc) {
+            return $doc->id();
+        }, $docs);
+        $this->assertContains($doc1->id(), $doc_ids);
+        $this->assertContains($doc2->id(), $doc_ids);
     }
 
     public function testSnapshotCursors()

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -376,6 +376,42 @@ class QueryTest extends TestCase
         ]);
     }
 
+    /**
+     * @dataProvider whereDocument
+     */
+    public function testWhereDocumentIdIn($document, $expected)
+    {
+        $this->runAndAssert(function (Query $q) use ($document) {
+            $res = $q->where(FieldPath::documentId(), 'in', [$document]);
+
+            return $res;
+        }, [
+            'parent' => self::QUERY_PARENT,
+            'structuredQuery' => [
+                'from' => $this->queryFrom(),
+                'where' => [
+                    'fieldFilter' => [
+                        'field' => [
+                            'fieldPath' => '__name__'
+                        ],
+                        'op' => FieldFilterOperator::IN,
+                        'value' => [
+                            'arrayValue' => [
+                                'values' => [
+                                    [
+                                        'referenceValue' => is_string($expected)
+                                            ? $expected
+                                            : $expected->name()
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+
     public function whereDocument()
     {
         $name = FirestoreGapicClient::documentPathName(self::PROJECT, self::DATABASE, self::COLLECTION . '/a/b/c');


### PR DESCRIPTION
I was looking for a way to query several documents by document IDs using `IN` query.
It turned out that the PHP library doesn't support that at all. Please consider adding this.
Please let me know if any style updates are necessary.