### PR TITLE
test: allow changing location for KeyManager

### DIFF
--- a/Core/src/Testing/System/KeyManager.php
+++ b/Core/src/Testing/System/KeyManager.php
@@ -26,18 +26,22 @@ use GuzzleHttp\Psr7\Request;
  */
 class KeyManager
 {
+    const DEFAULT_LOCATION = 'us-west1';
+
     private $keyFile;
     private $serviceAccountEmail;
     private $projectId;
     private $requestWrapper;
+    private $location;
 
-    public function __construct(array $keyFile, $serviceAccountEmail = null, $projectId = null)
+    public function __construct(array $keyFile, $serviceAccountEmail = null, $projectId = null, $location = null)
     {
         $this->keyFile = $keyFile;
         $this->serviceAccountEmail = $serviceAccountEmail
             ?: $keyFile['client_email'];
         $this->projectId = $projectId
             ?: $keyFile['project_id'];
+        $this->setLocation($location ?: self::DEFAULT_LOCATION);
 
         $this->requestWrapper = new RequestWrapper([
             'keyFile' => $this->keyFile,
@@ -53,6 +57,18 @@ class KeyManager
     public function setServiceAccountEmail($serviceAccountEmail)
     {
         $this->serviceAccountEmail = $serviceAccountEmail;
+    }
+
+    /**
+     * Set keyring location.
+     *
+     * Location name may be in upper or lower case.
+     *
+     * @param string $location
+     */
+    public function setLocation($location)
+    {
+        $this->location = strtolower($location);
     }
 
     /**
@@ -110,8 +126,9 @@ class KeyManager
                 new Request(
                     'POST',
                     sprintf(
-                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/us-west1/keyRings?keyRingId=%s',
+                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/%s/keyRings?keyRingId=%s',
                         $this->projectId,
+                        $this->location,
                         $keyRingId
                     )
                 )
@@ -133,8 +150,7 @@ class KeyManager
         $name = null;
 
         try {
-            $uri = 'https://cloudkms.googleapis.com/v1/projects/%s/' .
-                'locations/us-west1/keyRings/%s/cryptoKeys?cryptoKeyId=%s';
+            $uri = 'https://cloudkms.googleapis.com/v1/projects/%s/locations/%s/keyRings/%s/cryptoKeys?cryptoKeyId=%s';
 
             $response = $this->requestWrapper->send(
                 new Request(
@@ -142,6 +158,7 @@ class KeyManager
                     sprintf(
                         $uri,
                         $this->projectId,
+                        $this->location,
                         $keyRingId,
                         $cryptoKeyId
                     ),
@@ -153,8 +170,9 @@ class KeyManager
             $name = json_decode((string) $response->getBody(), true)['name'];
         } catch (ConflictException $ex) {
             $name = sprintf(
-                'projects/%s/locations/us-west1/keyRings/%s/cryptoKeys/%s' ,
+                'projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s' ,
                 $this->projectId,
+                $this->location,
                 $keyRingId,
                 $cryptoKeyId
             );
@@ -174,13 +192,14 @@ class KeyManager
         ];
 
         $uri = 'https://cloudkms.googleapis.com/v1/projects/%s/locations/' .
-            'us-west1/keyRings/%s/cryptoKeys/%s:setIamPolicy';
+            '%s/keyRings/%s/cryptoKeys/%s:setIamPolicy';
         $this->requestWrapper->send(
             new Request(
                 'POST',
                 sprintf(
                     $uri,
                     $this->projectId,
+                    $this->location,
                     $keyRingId,
                     $cryptoKeyId
                 ),


### PR DESCRIPTION
`Core\Testing\System\KeyManager` (used in `BigQuery` and `Storage` system tests) uses hardcoded keyring location `us-west1`. This leads to error 400 when created dataset or bucket uses different location (e. g. `us`).
This PR adds a way to set correct location for `KeyManager`.