### PR TITLE
test: set correct location for KeyManager

### DIFF
--- a/BigQuery/tests/System/ManageDatasetsTest.php
+++ b/BigQuery/tests/System/ManageDatasetsTest.php
@@ -120,6 +120,7 @@ class ManageDatasetsTest extends BigQueryTestCase
         $encryption = new KeyManager(
             json_decode(file_get_contents(getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH')), true)
         );
+        $encryption->setLocation(self::$dataset->info()['location']);
 
         $project = $encryption->getProject();
         $encryption->setServiceAccountEmail(sprintf(

--- a/BigQuery/tests/System/ManageModelsTest.php
+++ b/BigQuery/tests/System/ManageModelsTest.php
@@ -46,6 +46,7 @@ class ManageModelsTest extends BigQueryTestCase
         $encryption = new KeyManager(
             json_decode(file_get_contents(getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH')), true)
         );
+        $encryption->setLocation(self::$dataset->info()['location']);
 
         $project = $encryption->getProject();
         $encryption->setServiceAccountEmail(sprintf(


### PR DESCRIPTION
Ensure that keyring and dataset used for system tests have the same location.