### PR TITLE
test: run PubSub system tests against emulator

### DIFF
--- a/.github/emulator/pubsub.sh
+++ b/.github/emulator/pubsub.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -eux
+
+docker pull -q gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators
+docker run \
+  -d \
+  -p 8085:8085 \
+  gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
+sleep 10

--- a/.github/workflows/pubsub-emulator-system-tests.yaml
+++ b/.github/workflows/pubsub-emulator-system-tests.yaml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'PubSub/**'
+  pull_request:
+    paths:
+      - 'PubSub/**'
+name: Run PubSub System Tests With Emulator
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: ./.github/emulator/pubsub.sh
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: pecl
+          extensions: grpc
+
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-suggest -d PubSub/
+
+      - name: Run system tests
+        run: |
+          PubSub/vendor/bin/phpunit -c PubSub/phpunit-system.xml.dist --exclude-group gapic
+        env:
+          PUBSUB_EMULATOR_HOST: localhost:8085
+          PROJECT_ID: my-project-id

--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - 'Spanner/**'
-name: Run Spanner integration tests against service emulator
+name: Run Spanner System Tests With Emulator
 jobs:
   php-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@ava12 this pattern should work for other services as well. I think it would be worthwhile to extend this to other test suites which have emulators available, though not a high priority.