### PR TITLE
ci: fix Bigtable testing

### DIFF
--- a/.github/workflows/bigtable-emulator-system-tests.yaml
+++ b/.github/workflows/bigtable-emulator-system-tests.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run system tests
         run: |
-          Bigtable/vendor/bin/phpunit -c Bigtable/phpunit-system.xml.dist
+          Bigtable/vendor/bin/phpunit -c Bigtable/phpunit-system.xml.dist --group bigtable
         env:
           BIGTABLE_EMULATOR_HOST: localhost:8085
           GOOGLE_CLOUD_PROJECT: my-project-id


### PR DESCRIPTION
Adds `--group bigtable` parameter to skip `BigtableInstanceAdminClientTest`.