### PR TITLE
feat(spanner): add commit stats support

### DIFF
--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -131,6 +131,20 @@ class Operation
 
     /**
      * @internal
+     *
+     * Commit all enqueued mutations.
+     *
+     * @codingStandardsIgnoreStart
+     * @param Session $session The session ID to use for the commit.
+     * @param array $mutations A list of mutations to apply.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type string $transactionId The ID of the transaction.
+     *     @type bool $returnCommitStats If true, return the full response.
+     *           **Defaults to** `false`.
+     * }
+     * @return [Timestamp, CommitResponse] An array with the commit timestamp and the commit response.
      */
     public function commitWithResponse(Session $session, array $mutations, array $options = [])
     {

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -119,13 +119,16 @@ class Operation
      *     Configuration options.
      *
      *     @type string $transactionId The ID of the transaction.
+     *     @type bool $returnCommitStats If true, return the full response.
+     *           **Defaults to** `false`.
      * }
-     * @return Timestamp The commit Timestamp.
+     * @return Timestamp|array The commit Timestamp or the entire response.
      */
     public function commit(Session $session, array $mutations, array $options = [])
     {
         $options += [
-            'transactionId' => null
+            'transactionId' => null,
+            'returnCommitStats' => false
         ];
 
         $res = $this->connection->commit($this->arrayFilterRemoveNull([
@@ -133,6 +136,10 @@ class Operation
             'session' => $session->name(),
             'database' => $this->getDatabaseNameFromSession($session)
         ]) + $options);
+
+        if ($options['returnCommitStats']) {
+            return $res;
+        }
 
         $time = $this->parseTimeString($res['commitTimestamp']);
         return new Timestamp($time[0], $time[1]);

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -144,7 +144,8 @@ class Operation
      *     @type bool $returnCommitStats If true, return the full response.
      *           **Defaults to** `false`.
      * }
-     * @return [Timestamp, CommitResponse] An array with the commit timestamp and the commit response.
+     * @return array An array containing {@see Google\Cloud\Spanner\Timestamp}
+     *               at index 0 and the commit response as an array at index 1.
      */
     public function commitWithResponse(Session $session, array $mutations, array $options = [])
     {

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -122,13 +122,20 @@ class Operation
      *     @type bool $returnCommitStats If true, return the full response.
      *           **Defaults to** `false`.
      * }
-     * @return Timestamp|array The commit Timestamp or the entire response.
+     * @return Timestamp The commit Timestamp.
      */
     public function commit(Session $session, array $mutations, array $options = [])
     {
+        return $this->commitWithResponse($session, $mutations, $options)[0];
+    }
+
+    /**
+     * @internal
+     */
+    public function commitWithResponse(Session $session, array $mutations, array $options = [])
+    {
         $options += [
-            'transactionId' => null,
-            'returnCommitStats' => false
+            'transactionId' => null
         ];
 
         $res = $this->connection->commit($this->arrayFilterRemoveNull([
@@ -137,12 +144,8 @@ class Operation
             'database' => $this->getDatabaseNameFromSession($session)
         ]) + $options);
 
-        if ($options['returnCommitStats']) {
-            return $res;
-        }
-
         $time = $this->parseTimeString($res['commitTimestamp']);
-        return new Timestamp($time[0], $time[1]);
+        return [new Timestamp($time[0], $time[1]), $res];
     }
 
     /**

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -67,7 +67,7 @@ class Transaction implements TransactionalReadInterface
     use TransactionalReadTrait;
 
     /**
-     * @var array
+     * @var CommitStats
      */
     private $commitStats = [];
 

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -110,6 +110,12 @@ class Transaction implements TransactionalReadInterface
      * `return_commit_stats` => true. If commit is called multiple times, only the commitStats for the last commit will
      * be available.
      *
+     * Example:
+     * ```
+     * $transaction->commit(["returnCommitStats" => true]);
+     * $commitStats = $transaction->getCommitStats();
+     * ```
+     *
      * @return array The commit stats
      */
     public function getCommitStats()

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -18,7 +18,6 @@
 namespace Google\Cloud\Spanner;
 
 use Google\Cloud\Core\Exception\AbortedException;
-use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 
@@ -107,7 +106,9 @@ class Transaction implements TransactionalReadInterface
     }
 
     /**
-     * Get the commit stats for this transaction.
+     * Get the commit stats for this transaction. Commit stats are only available after commit has been called with
+     * `return_commit_stats` => true. If commit is called multiple times, only the commitStats for the last commit will
+     * be available.
      *
      * @return array The commit stats
      */
@@ -546,7 +547,7 @@ class Transaction implements TransactionalReadInterface
      *     @type array $mutations An array of mutations to commit. May be used
      *           instead of or in addition to enqueing mutations separately.
      *     @type bool $returnCommitStats If true, commit statistics will be
-     *           returned and accessible via `commitStats`.
+     *           returned and accessible via {@see Google\Cloud\Spanner\Transaction::getCommitStats()}.
      *           **Defaults to** `false`.
      * }
      * @return Timestamp The commit timestamp.

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -571,8 +571,7 @@ class Transaction implements TransactionalReadInterface
         }
 
         $options += [
-            'mutations' => [],
-            'returnCommitStats' => false
+            'mutations' => []
         ];
 
         $options['mutations'] += $this->mutations;
@@ -583,13 +582,12 @@ class Transaction implements TransactionalReadInterface
 
         $options[$t[1]] = $t[0];
 
-        if ($options['returnCommitStats']) {
-            $res = $this->operation->commitWithResponse($this->session, $this->pluck('mutations', $options), $options);
+        $res = $this->operation->commitWithResponse($this->session, $this->pluck('mutations', $options), $options);
+        if (isset($res[1]['commitStats'])) {
             $this->commitStats = $res[1]['commitStats'];
-            return $res[0];
         }
 
-        return $this->operation->commit($this->session, $this->pluck('mutations', $options), $options);
+        return $res[0];
     }
 
     /**

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -398,12 +398,12 @@ class TransactionTest extends SnippetTestCase
 
     public function testGetCommitStats()
     {
-        $expectedCommitStats = ['mutation_count' => 4];
+        $expectedCommitStats = new CommitStats(['mutation_count' => 4]);
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 'commitTimestamp' => (new Timestamp(new \DateTime))->formatAsString(),
-                'commitStats' => new CommitStats($expectedCommitStats),
+                'commitStats' => $expectedCommitStats,
             ]);
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -32,6 +32,7 @@ use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
 use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
+use Google\Cloud\Spanner\V1\CommitResponse\CommitStats;
 use Prophecy\Argument;
 
 /**

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -395,6 +395,25 @@ class TransactionTest extends SnippetTestCase
         $snippet->invoke();
     }
 
+    public function testGetCommitStats()
+    {
+        $expectedCommitStats = ['mutation_count' => 4];
+        $this->connection->commit(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'commitTimestamp' => (new Timestamp(new \DateTime))->formatAsString(),
+                'commitStats' => new CommitStats($expectedCommitStats),
+        ]);
+
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Transaction::class, 'getCommitStats');
+        $snippet->addLocal('transaction', $this->transaction);
+
+        $res = $snippet->invoke();
+        $this->assertEquals($expectedCommitStats, $res->returnVal());
+    }
+
     public function testState()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'state');

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -403,7 +403,7 @@ class TransactionTest extends SnippetTestCase
             ->willReturn([
                 'commitTimestamp' => (new Timestamp(new \DateTime))->formatAsString(),
                 'commitStats' => new CommitStats($expectedCommitStats),
-        ]);
+            ]);
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
 

--- a/Spanner/tests/Snippet/TransactionTest.php
+++ b/Spanner/tests/Snippet/TransactionTest.php
@@ -411,7 +411,7 @@ class TransactionTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Transaction::class, 'getCommitStats');
         $snippet->addLocal('transaction', $this->transaction);
 
-        $res = $snippet->invoke();
+        $res = $snippet->invoke('commitStats');
         $this->assertEquals($expectedCommitStats, $res->returnVal());
     }
 

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -149,15 +149,16 @@ class OperationTest extends TestCase
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $res = $this->operation->commit($this->session, $mutations, [
+        $res = $this->operation->commitWithResponse($this->session, $mutations, [
             'transactionId' => 'foo',
             'returnCommitStats' => true
         ]);
 
+        $this->assertInstanceOf(Timestamp::class, $res[0]);
         $this->assertEquals([
             'commitTimestamp' => self::TIMESTAMP,
             'commitStats' => ['mutationCount' => 1]
-        ], $res);
+        ], $res[1]);
     }
 
     public function testCommitWithExistingTransaction()

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -33,6 +33,7 @@ use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
+use Google\Cloud\Spanner\V1\CommitResponse;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -127,6 +128,36 @@ class OperationTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Timestamp::class, $res);
+    }
+
+    public function testCommitWithReturnCommitStats()
+    {
+        $mutations = [
+            $this->operation->mutation(Operation::OP_INSERT, 'Posts', [
+                'foo' => 'bar'
+            ])
+        ];
+
+        $this->connection->commit(Argument::allOf(
+            Argument::withEntry('mutations', $mutations),
+            Argument::withEntry('transactionId', 'foo'),
+            Argument::withEntry('returnCommitStats', true)
+        ))->shouldBeCalled()->willReturn([
+            'commitTimestamp' => self::TIMESTAMP,
+            'commitStats' => ['mutationCount' => 1]
+        ]);
+
+        $this->operation->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->operation->commit($this->session, $mutations, [
+            'transactionId' => 'foo',
+            'returnCommitStats' => true
+        ]);
+
+        $this->assertEquals([
+            'commitTimestamp' => self::TIMESTAMP,
+            'commitStats' => ['mutationCount' => 1]
+        ], $res);
     }
 
     public function testCommitWithExistingTransaction()

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner\Tests\Unit;
 
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\BatchDmlResult;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeySet;
@@ -28,6 +29,7 @@ use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Tests\OperationRefreshTrait;
 use Google\Cloud\Spanner\Tests\ResultGeneratorTrait;
 use Google\Cloud\Spanner\Tests\StubCreationTrait;
+use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -41,6 +43,7 @@ class TransactionTest extends TestCase
     use OperationRefreshTrait;
     use ResultGeneratorTrait;
     use StubCreationTrait;
+    use TimeTrait;
 
     const TIMESTAMP = '2017-01-09T18:05:22.534799Z';
 
@@ -437,16 +440,13 @@ class TransactionTest extends TestCase
             $this->session,
             $mutations,
             ['transactionId' => self::TRANSACTION, 'returnCommitStats' => true]
-        )->shouldBeCalled()->willReturn([
-                'commitTimestamp' => self::TIMESTAMP,
-                'commitStats' => ['mutationCount' => 1]
-        ]);
+        )->shouldBeCalled()->willReturn($this->commitResponseWithCommitStats());
 
         $this->transaction->___setProperty('operation', $operation->reveal());
 
         $this->transaction->commit(['returnCommitStats' => true]);
 
-        $this->assertEquals(['mutationCount' => 1], $this->transaction->commitStats);
+        $this->assertEquals(['mutationCount' => 1], $this->transaction->getCommitStats());
     }
 
     /**
@@ -523,6 +523,19 @@ class TransactionTest extends TestCase
     private function commitResponse()
     {
         return ['commitTimestamp' => self::TIMESTAMP];
+    }
+
+    private function commitResponseWithCommitStats()
+    {
+        $time = $this->parseTimeString(self::TIMESTAMP);
+        $timestamp = new Timestamp($time[0], $time[1]);
+        return [
+            $timestamp,
+            [
+                'commitTimestamp' => self::TIMESTAMP,
+                'commitStats' => ['mutationCount' => 1]
+            ]
+        ];
     }
 
     private function assertTimestampIsCorrect($res)

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -421,7 +421,7 @@ class TransactionTest extends TestCase
         $operation->commit(
             $this->session,
             $mutations,
-            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => false]
+            ['transactionId' => self::TRANSACTION]
         )->shouldBeCalled();
 
         $this->transaction->___setProperty('operation', $operation->reveal());

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -418,11 +418,11 @@ class TransactionTest extends TestCase
         $mutations = $this->transaction->___getProperty('mutations');
 
         $operation = $this->prophesize(Operation::class);
-        $operation->commit(
+        $operation->commitWithResponse(
             $this->session,
             $mutations,
             ['transactionId' => self::TRANSACTION]
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($this->commitResponseWithCommitStats());
 
         $this->transaction->___setProperty('operation', $operation->reveal());
 

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -415,9 +415,11 @@ class TransactionTest extends TestCase
         $mutations = $this->transaction->___getProperty('mutations');
 
         $operation = $this->prophesize(Operation::class);
-        $operation->commit($this->session, $mutations,
-            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => false])
-            ->shouldBeCalled();
+        $operation->commit(
+            $this->session,
+            $mutations,
+            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => false]
+        )->shouldBeCalled();
 
         $this->transaction->___setProperty('operation', $operation->reveal());
 
@@ -431,13 +433,14 @@ class TransactionTest extends TestCase
         $mutations = $this->transaction->___getProperty('mutations');
 
         $operation = $this->prophesize(Operation::class);
-        $operation->commit($this->session, $mutations,
-            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => true])
-            ->shouldBeCalled()
-            ->willReturn([
-              'commitTimestamp' => self::TIMESTAMP,
-              'commitStats' => ['mutationCount' => 1]
-          ]);;
+        $operation->commit(
+            $this->session,
+            $mutations,
+            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => true]
+        )->shouldBeCalled()->willReturn([
+                'commitTimestamp' => self::TIMESTAMP,
+                'commitStats' => ['mutationCount' => 1]
+        ]);
 
         $this->transaction->___setProperty('operation', $operation->reveal());
 

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -433,7 +433,7 @@ class TransactionTest extends TestCase
         $mutations = $this->transaction->___getProperty('mutations');
 
         $operation = $this->prophesize(Operation::class);
-        $operation->commit(
+        $operation->commitWithResponse(
             $this->session,
             $mutations,
             ['transactionId' => self::TRANSACTION, 'returnCommitStats' => true]


### PR DESCRIPTION
This PR adds support for commit stats.

When calling `commit()` on a transaction, you can get commit statistics by specifying the `returnCommitStats` option. Example code:
```
$transaction->commit(['returnCommitStats' => true]);
$commitStats = $transaction->getCommitStats();
```

Currently, the commit stats only contains `mutation_count` which is the total number of mutations for the transaction. Knowing the `mutation_count` value can help you maximize the number of mutations in a transaction and minimize the number of API round trips. You can also monitor this value to prevent transactions from exceeding the system [limit](http://cloud.google.com/spanner/quotas#limits_for_creating_reading_updating_and_deleting_data).