### PR TITLE
ci: add empty key file and env vars for emulator workflows

### DIFF
--- a/.github/emulator/example-key.json
+++ b/.github/emulator/example-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "emulator-project",
+  "private_key_id": "1",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n\n-----END PRIVATE KEY-----\n",
+  "client_email": "example@example.com",
+  "client_id": "1",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/example%40example.com"
+}

--- a/.github/workflows/bigtable-emulator-system-tests.yaml
+++ b/.github/workflows/bigtable-emulator-system-tests.yaml
@@ -33,4 +33,5 @@ jobs:
           Bigtable/vendor/bin/phpunit -c Bigtable/phpunit-system.xml.dist --group bigtable
         env:
           BIGTABLE_EMULATOR_HOST: localhost:8085
-          GOOGLE_CLOUD_PROJECT: my-project-id
+          GOOGLE_CLOUD_PHP_TESTS_KEY_PATH: '.github/emulator/example-key.json'
+          GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH: '.github/emulator/example-key.json'

--- a/.github/workflows/datastore-emulator-system-tests.yaml
+++ b/.github/workflows/datastore-emulator-system-tests.yaml
@@ -33,3 +33,5 @@ jobs:
           Datastore/vendor/bin/phpunit -c Datastore/phpunit-system.xml.dist
         env:
           DATASTORE_EMULATOR_HOST: localhost:8085
+          GOOGLE_CLOUD_PHP_TESTS_KEY_PATH: '.github/emulator/example-key.json'
+          GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH: '.github/emulator/example-key.json'

--- a/.github/workflows/firestore-emulator-system-tests.yaml
+++ b/.github/workflows/firestore-emulator-system-tests.yaml
@@ -33,3 +33,5 @@ jobs:
           Firestore/vendor/bin/phpunit -c Firestore/phpunit-system.xml.dist --exclude-group gapic
         env:
           FIRESTORE_EMULATOR_HOST: localhost:8085
+          GOOGLE_CLOUD_PHP_TESTS_KEY_PATH: '.github/emulator/example-key.json'
+          GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH: '.github/emulator/example-key.json'

--- a/.github/workflows/pubsub-emulator-system-tests.yaml
+++ b/.github/workflows/pubsub-emulator-system-tests.yaml
@@ -34,3 +34,5 @@ jobs:
         env:
           PUBSUB_EMULATOR_HOST: localhost:8085
           PROJECT_ID: my-project-id
+          GOOGLE_CLOUD_PHP_TESTS_KEY_PATH: '.github/emulator/example-key.json'
+          GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH: '.github/emulator/example-key.json'


### PR DESCRIPTION
Related to #2721.

Adds a fake key file and sets `GOOGLE_CLOUD_PHP_TESTS_KEY_PATH` and `GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH` required for system tests with emulators.
