### PR TITLE
feat: add keepalive setting in data client

### DIFF
--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -119,7 +119,7 @@ class BigtableClient
             // Sets 30s as Google Frontends allows keepalive pings at 30s
             'grpc.keepalive_time_ms' => 30000,
             // Conservative timeout at 10s
-            'grpc.max_receive_message_length' => -1
+            'grpc.keepalive_timeout_ms' => 10000,
         ];
 
         $this->projectId = $this->pluck('projectId', $config, false)

--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -119,7 +119,7 @@ class BigtableClient
             // Sets 30s as Google Frontends allows keepalive pings at 30s
             'grpc.keepalive_time_ms' => 30000,
             // Conservative timeout at 10s
-            'grpc.keepalive_timeout_ms' => 10000,
+            'grpc.keepalive_timeout_ms' => 10000
         ];
 
         $this->projectId = $this->pluck('projectId', $config, false)

--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -115,6 +115,10 @@ class BigtableClient
         // Workaround for large messages.
         $config['transportConfig']['grpc']['stubOpts'] += [
             'grpc.max_send_message_length' => -1,
+            'grpc.max_receive_message_length' => -1,
+            // Sets 30s as Google Frontends allows keepalive pings at 30s
+            'grpc.keepalive_time_ms' => 30000,
+            // Conservative timeout at 10s
             'grpc.max_receive_message_length' => -1
         ];
 


### PR DESCRIPTION
Sets KeepAlive timer to 30s (Google Frontends are configured limits keepalive calls at 30s by default. If used below 30s, grpc automatically increases keepalive time by 2x after too_many_ping commands).

Sets KeepAliveTimeout to 10s (conservative)