### PR TITLE
feat: Add support for not equal (1=)

### DIFF
--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -93,6 +93,7 @@ class Query
         '>'  => FieldFilterOperator::GREATER_THAN,
         '>=' => FieldFilterOperator::GREATER_THAN_OR_EQUAL,
         '='  => FieldFilterOperator::EQUAL,
+        '!=' => FieldFilterOperator::NOT_EQUAL,
         '=='  => FieldFilterOperator::EQUAL,
         '==='  => FieldFilterOperator::EQUAL,
         'array-contains' => FieldFilterOperator::ARRAY_CONTAINS,


### PR DESCRIPTION
According to https://firebase.googleblog.com/2020/09/cloud-firestore-not-equal-queries.html - Firestore now supports the not equal operator, so we update Query.php to reflect that change.

 This is my first PR on a public project, so let me know if there's anything wrong.