### PR TITLE
ci: add project id for Datastore tests

### DIFF
--- a/.github/emulator/start-emulator.sh
+++ b/.github/emulator/start-emulator.sh
@@ -1,11 +1,8 @@
 #!/bin/sh -eux
 
-EMULATOR=$1
-shift
 docker pull -q gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators
 CONTAINER=`docker run \
   -d \
   -p 8085:8085 \
-  gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators $EMULATOR start --host-port=0.0.0.0:8085 "$@"`
+  gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators $1 start --host-port=0.0.0.0:8085 --project=emulator-project`
 sleep 10
-docker logs $CONTAINER

--- a/.github/emulator/start-emulator.sh
+++ b/.github/emulator/start-emulator.sh
@@ -6,3 +6,4 @@ CONTAINER=`docker run \
   -p 8085:8085 \
   gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators $1 start --host-port=0.0.0.0:8085 --project=emulator-project`
 sleep 10
+docker logs $CONTAINER

--- a/.github/emulator/start-emulator.sh
+++ b/.github/emulator/start-emulator.sh
@@ -1,8 +1,11 @@
 #!/bin/sh -eux
 
+EMULATOR=$1
+shift
 docker pull -q gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators
-docker run \
+CONTAINER=`docker run \
   -d \
   -p 8085:8085 \
-  gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators $1 start --host-port=0.0.0.0:8085
+  gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators gcloud beta emulators $EMULATOR start --host-port=0.0.0.0:8085 "$@"`
 sleep 10
+docker logs $CONTAINER

--- a/.github/workflows/datastore-emulator-system-tests.yaml
+++ b/.github/workflows/datastore-emulator-system-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./.github/emulator/start-emulator.sh datastore --project=emulator-project
+      - run: ./.github/emulator/start-emulator.sh datastore
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/datastore-emulator-system-tests.yaml
+++ b/.github/workflows/datastore-emulator-system-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./.github/emulator/start-emulator.sh datastore
+      - run: ./.github/emulator/start-emulator.sh datastore --project=emulator-project
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Related to #2721.

Datastore emulator did not start because project id was not provided. This PR adds `--project` parameter to `start-emulator.sh`.