### PR TITLE
fix: add IAM to StorageClient by default

### DIFF
--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -96,7 +96,10 @@ class StorageClient
     public function __construct(array $config = [])
     {
         if (!isset($config['scopes'])) {
-            $config['scopes'] = [self::FULL_CONTROL_SCOPE];
+            $config['scopes'] = [
+                'https://www.googleapis.com/auth/iam',
+                self::FULL_CONTROL_SCOPE,
+            ];
         }
 
         $this->connection = new Rest($this->configureAuthentication($config) + [


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/3289

Adds IAM permission by default to ensure `signBlob` works when using Metadata credentials.

[NodeJS has similar scope defaults](https://github.com/googleapis/nodejs-storage/blob/master/src/storage.ts#L418)