### PR TITLE
fix: Message::publishTime return type is nullable

### DIFF
--- a/PubSub/src/Message.php
+++ b/PubSub/src/Message.php
@@ -198,7 +198,7 @@ class Message
      * $time = $message->publishTime();
      * ```
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function publishTime()
     {


### PR DESCRIPTION
My phpstan was bugging me when I was using the return type of the `publishMessage` function on a `Message` object and checked for `null`. The docblock says that this is not possible, while the code clearly shows that it is.