### PR TITLE
fix: add support for reading Bigtable key value of zero

### DIFF
--- a/Bigtable/src/ChunkFormatter.php
+++ b/Bigtable/src/ChunkFormatter.php
@@ -285,7 +285,7 @@ class ChunkFormatter implements \IteratorAggregate
             'A new row cannot have existing state.'
         );
         $this->isError(
-            !$chunk->getRowKey(),
+            $chunk->getRowKey() === '',
             'A row key must be set.'
         );
         $this->isError(


### PR DESCRIPTION
Although it's possible to write a row key of value "0" to Bigtable, the PHP Bigtable client currently doesn't support reading such rows. The reason is because there is currently a validation check that uses the ! operator, and the boolean value of "0" in PHP happens to be `false`.  

This change would instead use a strict value check for an empty row key string. 