### PR TITLE
fix: tell github to always treat php files as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,4 @@
 /codecov.yml export-ignore
 /.github export-ignore
 /*/.github export-ignore
-*.php text
+*.php diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 /codecov.yml export-ignore
 /.github export-ignore
 /*/.github export-ignore
+*.php text


### PR DESCRIPTION
Speculative fix for https://github.com/googleapis/synthtool/issues/918