### PR TITLE
feat(spanner): add support for Point In Time Restore (PITR)

### DIFF
--- a/Spanner/src/Backup.php
+++ b/Spanner/src/Backup.php
@@ -159,11 +159,20 @@ class Backup
      *              as the create time of the backup.
      *     }
      * @return LongRunningOperation<Backup>
+     * @throws \InvalidArgumentException
      */
     public function create($database, \DateTimeInterface $expireTime, array $options = [])
     {
         if (isset($options['versionTime'])) {
-            $options['versionTime'] = $this->pluck('versionTime', $options)->format('Y-m-d\TH:i:s.u\Z');
+            if (!($options['versionTime'] instanceof \DateTimeInterface)) {
+                throw new \InvalidArgumentException(
+                    'Optional argument `versionTime` must be a DateTimeInterface, got ' .
+                    (is_object($options['versionTime'])
+                        ? get_class($options['versionTime'])
+                        : gettype($options['versionTime']))
+                );
+            }
+            $options['versionTime'] = $options['versionTime']->format('Y-m-d\TH:i:s.u\Z');
         }
         $operation = $this->connection->createBackup([
             'instance' => $this->instance->name(),

--- a/Spanner/src/Backup.php
+++ b/Spanner/src/Backup.php
@@ -151,12 +151,20 @@ class Backup
      *        with microseconds granularity that must be at least 6 hours and
      *        at most 366 days. Once the expireTime has passed, the backup is
      *        eligible to be automatically deleted by Cloud Spanner.
-     * @param array $options [optional] Configuration Options.
+     * @param array $options [optional] {
+     *         Configuration Options.
      *
+     *         @type \DateTimeInterface $versionTime The version time for the externally
+     *              consistent copy of the database. If not present, it will be the same
+     *              as the create time of the backup.
+     *     }
      * @return LongRunningOperation<Backup>
      */
     public function create($database, \DateTimeInterface $expireTime, array $options = [])
     {
+        if (isset($options['versionTime'])) {
+            $options['versionTime'] = $this->pluck('versionTime', $options)->format('Y-m-d\TH:i:s.u\Z');
+        }
         $operation = $this->connection->createBackup([
             'instance' => $this->instance->name(),
             'backupId' => DatabaseAdminClient::parseName($this->name)['backup'],

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -476,6 +476,9 @@ class Grpc implements ConnectionInterface
     {
         $backup = $this->pluck('backup', $args);
         $backup['expireTime'] = $this->formatTimestampForApi($this->pluck('expireTime', $backup));
+        if (isset($args['versionTime'])) {
+            $backup['versionTime'] = $this->formatTimestampForApi($this->pluck('versionTime', $args));
+        }
         $backupInfo = $this->serializer->decodeMessage(new Backup(), $backup);
 
         $instanceName = $this->pluck('instance', $args);

--- a/Spanner/tests/Unit/BackupTest.php
+++ b/Spanner/tests/Unit/BackupTest.php
@@ -56,13 +56,14 @@ class BackupTest extends TestCase
     private $lroCallables;
     private $expireTime;
     private $createTime;
+    private $versionTime;
     private $backup;
 
 
     public function setUp()
     {
         $this->checkAndSkipGrpcTests();
-        
+
         $this->connection = $this->prophesize(ConnectionInterface::class);
         $this->instance = $this->prophesize(Instance::class);
         $this->database = $this->prophesize(Database::class);
@@ -75,6 +76,7 @@ class BackupTest extends TestCase
         $this->lroCallables = [];
         $this->expireTime = new \DateTime("+ 7 hours");
         $this->createTime = $this->expireTime;
+        $this->versionTime = new \DateTime("- 2 hours");
 
         $args=[
            $this->connection->reveal(),
@@ -105,7 +107,8 @@ class BackupTest extends TestCase
             Argument::withEntry('backupId', self::BACKUP),
             Argument::withEntry('backup', [
                 'database' => DatabaseAdminClient::databaseName(self::PROJECT_ID, self::INSTANCE, self::DATABASE),
-                'expireTime' => $this->expireTime->format('Y-m-d\TH:i:s.u\Z')
+                'expireTime' => $this->expireTime->format('Y-m-d\TH:i:s.u\Z'),
+                'versionTime' => $this->versionTime->format('Y-m-d\TH:i:s.u\Z')
             ])
         ))
             ->shouldBeCalled()
@@ -114,7 +117,9 @@ class BackupTest extends TestCase
             ]);
 
         $this->backup->___setProperty('connection', $this->connection->reveal());
-        $op = $this->backup->create(self::DATABASE, $this->expireTime);
+        $op = $this->backup->create(self::DATABASE, $this->expireTime, [
+            'versionTime' => $this->versionTime,
+        ]);
         $this->assertInstanceOf(LongRunningOperation::class, $op);
     }
 
@@ -122,7 +127,7 @@ class BackupTest extends TestCase
     {
         $this->connection->deleteBackup(Argument::withEntry('name', $this->backup->name()))
             ->shouldBeCalled();
-        
+
         $this->backup->___setProperty('connection', $this->connection->reveal());
 
         $this->backup->delete();
@@ -133,7 +138,8 @@ class BackupTest extends TestCase
         $res = [
             'name' => $this->backup->name(),
             'expireTime' => $this->expireTime->format('Y-m-d\TH:i:s.u\Z'),
-            'createTime' => $this->createTime->format('Y-m-d\TH:i:s.u\Z')
+            'createTime' => $this->createTime->format('Y-m-d\TH:i:s.u\Z'),
+            'versionTime' => $this->versionTime->format('Y-m-d\TH:i:s.u\Z')
         ];
 
         $this->connection->getBackup(Argument::withEntry('name', $this->backup->name()))
@@ -143,7 +149,7 @@ class BackupTest extends TestCase
         $this->backup->___setProperty('connection', $this->connection->reveal());
 
         $info = $this->backup->info();
-        
+
         $this->assertEquals($res, $info);
 
         // Make sure the request only is sent once.
@@ -155,7 +161,8 @@ class BackupTest extends TestCase
         $res = [
             'name' => $this->backup->name(),
             'expireTime' => $this->expireTime->format('Y-m-d\TH:i:s.u\Z'),
-            'createTime' => $this->createTime->format('Y-m-d\TH:i:s.u\Z')
+            'createTime' => $this->createTime->format('Y-m-d\TH:i:s.u\Z'),
+            'versionTime' => $this->versionTime->format('Y-m-d\TH:i:s.u\Z')
         ];
 
         $this->connection->getBackup(Argument::withEntry('name', $this->backup->name()))
@@ -163,7 +170,7 @@ class BackupTest extends TestCase
             ->willReturn($res);
 
         $this->backup->___setProperty('connection', $this->connection->reveal());
-        
+
         $info = $this->backup->reload();
 
         $this->assertEquals($res, $info);

--- a/Spanner/tests/Unit/BackupTest.php
+++ b/Spanner/tests/Unit/BackupTest.php
@@ -108,8 +108,8 @@ class BackupTest extends TestCase
             Argument::withEntry('backup', [
                 'database' => DatabaseAdminClient::databaseName(self::PROJECT_ID, self::INSTANCE, self::DATABASE),
                 'expireTime' => $this->expireTime->format('Y-m-d\TH:i:s.u\Z'),
-                'versionTime' => $this->versionTime->format('Y-m-d\TH:i:s.u\Z')
-            ])
+            ]),
+            Argument::withEntry('versionTime', $this->versionTime->format('Y-m-d\TH:i:s.u\Z'))
         ))
             ->shouldBeCalled()
             ->willReturn([


### PR DESCRIPTION
This PR adds support for PITR. It allows users to specify the timestamp for a consistent copy of a database when creating a new backup.

Sample code:
```
$operation = $backup->create($database->name(), $expireTime, [
   "versionTime" => $versionTime,
]);
$operation->pollUntilComplete();
```