### PR TITLE
fix!: removes v1beta1

### DIFF
--- a/Asset/synth.py
+++ b/Asset/synth.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICBazel()
 
-for version in ['V1', 'V1beta1']:
+for version in ['V1']:
     lower_version = version.lower()
 
     library = gapic.php_library(
@@ -65,14 +65,6 @@ s.replace(
     '')
 
 # fix year
-s.replace(
-    'src/V1beta1/**/*.php',
-    r'Copyright \d{4}',
-    r'Copyright 2018')
-s.replace(
-    'tests/*/V1beta1/*Test.php',
-    r'Copyright \d{4}',
-    r'Copyright 2018')
 s.replace(
     'src/V1/**/*.php',
     r'Copyright \d{4}',


### PR DESCRIPTION
v1beta1 was shut down and removed [here](https://github.com/googleapis/googleapis/commit/ffae23ed5e42de01b7ffcef16ae3c34cacde7099)

Fixes #3909 