### PR TITLE
feat: Allow RequestWrapperTrait to use its auth cache when fetching ADC

### DIFF
--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -196,8 +196,8 @@ trait RequestWrapperTrait
         return ApplicationDefaultCredentials::getCredentials(
             $this->scopes,
             $this->authHttpHandler,
-            null,
-            null,
+            $this->authCacheOptions,
+            $this->authCache,
             $this->quotaProject
         );
     }

--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -178,7 +178,7 @@ trait RequestWrapperTrait
             }
         }
 
-        if ($fetcher instanceof FetchAuthTokenCache::class) {
+        if ($fetcher instanceof FetchAuthTokenCache) {
             // The fetcher has already been wrapped in a cache by `ApplicationDefaultCredentials`;
             // no need to wrap it another time.
             return $fetcher;

--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -178,11 +178,17 @@ trait RequestWrapperTrait
             }
         }
 
-        return new FetchAuthTokenCache(
-            $fetcher,
-            $this->authCacheOptions,
-            $this->authCache
-        );
+        if (\is_a($fetcher, FetchAuthTokenCache::class)) {
+            // The fetcher has already been wrapped in a cache by `ApplicationDefaultCredentials`;
+            // no need to wrap it another time.
+            return $fetcher;
+        } else {
+            return new FetchAuthTokenCache(
+                $fetcher,
+                $this->authCacheOptions,
+                $this->authCache
+            );
+        }
     }
 
     /**

--- a/Core/src/RequestWrapperTrait.php
+++ b/Core/src/RequestWrapperTrait.php
@@ -178,7 +178,7 @@ trait RequestWrapperTrait
             }
         }
 
-        if (\is_a($fetcher, FetchAuthTokenCache::class)) {
+        if ($fetcher instanceof FetchAuthTokenCache::class) {
             // The fetcher has already been wrapped in a cache by `ApplicationDefaultCredentials`;
             // no need to wrap it another time.
             return $fetcher;


### PR DESCRIPTION
Motivation: This lets us cache the result of `ApplicationDefaultCredentials::onGce()`, saving us a ping to the metadata server.

Let me know if I'm missing something, or if there was a good reason to provide `null` here.