### PR TITLE
fix: anonymous credentials

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "google/auth": "^1.6",
+        "google/auth": "^1.12",
         "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.2",

--- a/Core/src/AnonymousCredentials.php
+++ b/Core/src/AnonymousCredentials.php
@@ -19,12 +19,16 @@ namespace Google\Cloud\Core;
 
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\UpdateMetadataInterface;
+use Google\Auth\GetQuotaProjectInterface;
 
 /**
  * Provides an anonymous set of credentials, which is useful for APIs which do
  * not require authentication.
  */
-class AnonymousCredentials implements FetchAuthTokenInterface, UpdateMetadataInterface
+class AnonymousCredentials implements
+    FetchAuthTokenInterface,
+    UpdateMetadataInterface,
+    GetQuotaProjectInterface
 {
     /**
      * @var array
@@ -80,5 +84,15 @@ class AnonymousCredentials implements FetchAuthTokenInterface, UpdateMetadataInt
         callable $httpHandler = null
     ) {
         return $metadata;
+    }
+
+    /**
+     * Get the quota project used for this API request
+     *
+     * @return string|null
+     */
+    public function getQuotaProject()
+    {
+        return null;
     }
 }

--- a/Core/src/AnonymousCredentials.php
+++ b/Core/src/AnonymousCredentials.php
@@ -71,7 +71,7 @@ class AnonymousCredentials implements
     }
 
     /**
-     * Updates metadata with the authorization token.
+     * This method has no effect for AnonymousCredentials.
      *
      * @param array $metadata metadata hashmap
      * @param string $authUri optional auth uri
@@ -87,7 +87,7 @@ class AnonymousCredentials implements
     }
 
     /**
-     * Get the quota project used for this API request
+     * This method always returns null for AnonymousCredentials.
      *
      * @return string|null
      */

--- a/Core/src/AnonymousCredentials.php
+++ b/Core/src/AnonymousCredentials.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Core;
 
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Auth\UpdateMetadataInterface;
 
 /**
  * Provides an anonymous set of credentials, which is useful for APIs which do
  * not require authentication.
  */
-class AnonymousCredentials implements FetchAuthTokenInterface
+class AnonymousCredentials implements FetchAuthTokenInterface, UpdateMetadataInterface
 {
     /**
      * @var array
@@ -63,5 +64,21 @@ class AnonymousCredentials implements FetchAuthTokenInterface
     public function getLastReceivedToken()
     {
         return $this->token;
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable $httpHandler callback which delivers psr7 request
+     * @return array updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        callable $httpHandler = null
+    ) {
+        return $metadata;
     }
 }

--- a/Core/tests/Unit/AnonymousCredentialsTest.php
+++ b/Core/tests/Unit/AnonymousCredentialsTest.php
@@ -49,4 +49,10 @@ class AnonymousCredentialsTest extends TestCase
     {
         $this->assertEquals($this->token, $this->credentials->getLastReceivedToken());
     }
+
+    public function testUpdateMetadata()
+    {
+        $metadata = ['foo' => 'bar'];
+        $this->assertEquals($metadata, $this->credentials->updateMetadata($metadata));
+    }
 }

--- a/Core/tests/Unit/AnonymousCredentialsTest.php
+++ b/Core/tests/Unit/AnonymousCredentialsTest.php
@@ -55,4 +55,9 @@ class AnonymousCredentialsTest extends TestCase
         $metadata = ['foo' => 'bar'];
         $this->assertEquals($metadata, $this->credentials->updateMetadata($metadata));
     }
+
+    public function testGetQuotaProject()
+    {
+        $this->assertEquals(null, $this->credentials->getQuotaProject());
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.1",
         "google/common-protos": "^1.0",
-        "google/auth": "^1.6",
+        "google/auth": "^1.12",
         "google/crc32": "^0.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Anonymous credentials are being used in `google/cloud`, but they do not implement all the interfaces required by this library.

 - Update `google/auth` to a minimum of `v1.12.0`, which is when `UpdateMetadataInterface` was added.
 - Add `UpdateMetadataInterface` and `GetQuotaProjectInterface` to `AnonymousCredentials`
 - **Note**: `SignBlobInterface` was left off because it doesn't really make sense with `AnonymousCredentials`.