### PR TITLE
feat(spanner): add support for LCI

### DIFF
--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create Spanner instance
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
       - run: gcloud info

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1210,11 +1210,20 @@ class Grpc implements ConnectionInterface
     private function instanceArray(array &$args, $required = false)
     {
         $argsCopy = $args;
+        if (isset($args['nodeCount'])) {
+            return array_intersect_key([
+                'name' => $this->pluck('name', $args, $required),
+                'config' => $this->pluck('config', $args, $required),
+                'displayName' => $this->pluck('displayName', $args, $required),
+                'nodeCount' => $this->pluck('nodeCount', $args, $required),
+                'state' => $this->pluck('state', $args, $required),
+                'labels' => $this->pluck('labels', $args, $required),
+            ], $argsCopy);
+        }
         return array_intersect_key([
             'name' => $this->pluck('name', $args, $required),
             'config' => $this->pluck('config', $args, $required),
             'displayName' => $this->pluck('displayName', $args, $required),
-            'nodeCount' => $this->pluck('nodeCount', $args, $required),
             'processingUnits' => $this->pluck('processingUnits', $args, $required),
             'state' => $this->pluck('state', $args, $required),
             'labels' => $this->pluck('labels', $args, $required),

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1215,6 +1215,7 @@ class Grpc implements ConnectionInterface
             'config' => $this->pluck('config', $args, $required),
             'displayName' => $this->pluck('displayName', $args, $required),
             'nodeCount' => $this->pluck('nodeCount', $args, $required),
+            'processingUnits' => $this->pluck('processingUnits', $args, $required),
             'state' => $this->pluck('state', $args, $required),
             'labels' => $this->pluck('labels', $args, $required),
         ], $argsCopy);

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -33,6 +33,7 @@ use Google\Cloud\Spanner\Backup;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamInstance;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
+use http\Exception\InvalidArgumentException;
 
 /**
  * Represents a Cloud Spanner instance
@@ -284,10 +285,12 @@ class Instance
      *
      *     @type string $displayName **Defaults to** the value of $name.
      *     @type int $nodeCount **Defaults to** `1`.
+     *     @type int $processingUnits An alternative measurement to `nodeCount` that allows smaller increments.
      *     @type array $labels For more information, see
      *           [Using labels to organize Google Cloud Platform resources](https://cloudplatform.googleblog.com/2015/10/using-labels-to-organize-Google-Cloud-Platform-resources.html).
      * }
      * @return LongRunningOperation<Instance>
+     * @throws \InvalidArgumentException
      * @codingStandardsIgnoreEnd
      */
     public function create(InstanceConfiguration $config, array $options = [])
@@ -295,9 +298,16 @@ class Instance
         $instanceId = InstanceAdminClient::parseName($this->name)['instance'];
         $options += [
             'displayName' => $instanceId,
-            'nodeCount' => self::DEFAULT_NODE_COUNT,
             'labels' => [],
         ];
+
+        if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
+            throw InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
+        }
+
+        if (empty($options['nodeCount'] && empty($options['processingUnits']))) {
+            $options['nodeCount'] = self::DEFAULT_NODE_COUNT;
+        }
 
         // This must always be set to CREATING, so overwrite anything else.
         $options['state'] = State::CREATING;
@@ -362,6 +372,7 @@ class Instance
      *           it appears in UIs. **Defaults to** the value of $name.
      *     @type int $nodeCount The number of nodes allocated to this instance.
      *           **Defaults to** `1`.
+     *     @type int $processingUnits An alternative measurement to `nodeCount` that allows smaller increments.
      *     @type array $labels For more information, see
      *           [Using labels to organize Google Cloud Platform resources](https://goo.gl/xmQnxf).
      * }
@@ -370,6 +381,10 @@ class Instance
      */
     public function update(array $options = [])
     {
+        if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
+            throw InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
+        }
+
         $operation = $this->connection->updateInstance([
             'name' => $this->name,
         ] + $options);

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -297,16 +297,19 @@ class Instance
         $instanceId = InstanceAdminClient::parseName($this->name)['instance'];
         $options += [
             'displayName' => $instanceId,
-            'nodeCount' => null,
-            'processingUnits' => null,
             'labels' => [],
         ];
 
-        if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
-            throw new \InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
-        }
+        $nodeCount = $this->pluck('nodeCount', $options, false);
+        $processingUnits = $this->pluck('processingUnits', $options, false);
 
-        if (empty($options['nodeCount'] && empty($options['processingUnits']))) {
+        if (isset($nodeCount) && isset($processingUnits)) {
+            throw new \InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
+        } else if (isset($nodeCount)) {
+            $options['nodeCount'] = $nodeCount;
+        } else if (isset($processingUnits)) {
+            $options['processingUnits'] = $processingUnits;
+        } else {
             $options['nodeCount'] = self::DEFAULT_NODE_COUNT;
         }
 

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -300,16 +300,10 @@ class Instance
             'labels' => [],
         ];
 
-        $nodeCount = $this->pluck('nodeCount', $options, false);
-        $processingUnits = $this->pluck('processingUnits', $options, false);
-
-        if (isset($nodeCount) && isset($processingUnits)) {
+        if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
             throw new \InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
-        } else if (isset($nodeCount)) {
-            $options['nodeCount'] = $nodeCount;
-        } else if (isset($processingUnits)) {
-            $options['processingUnits'] = $processingUnits;
-        } else {
+        }
+        if (empty($options['nodeCount']) && empty($options['processingUnits'])) {
             $options['nodeCount'] = self::DEFAULT_NODE_COUNT;
         }
 

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -33,7 +33,6 @@ use Google\Cloud\Spanner\Backup;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamInstance;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
-use http\Exception\InvalidArgumentException;
 
 /**
  * Represents a Cloud Spanner instance
@@ -298,11 +297,13 @@ class Instance
         $instanceId = InstanceAdminClient::parseName($this->name)['instance'];
         $options += [
             'displayName' => $instanceId,
+            'nodeCount' => null,
+            'processingUnits' => null,
             'labels' => [],
         ];
 
         if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
-            throw InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
+            throw new \InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
         }
 
         if (empty($options['nodeCount'] && empty($options['processingUnits']))) {
@@ -382,7 +383,7 @@ class Instance
     public function update(array $options = [])
     {
         if (isset($options['nodeCount']) && isset($options['processingUnits'])) {
-            throw InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
+            throw new \InvalidArgumentException("Must only set either `nodeCount` or `processingUnits`");
         }
 
         $operation = $this->connection->updateInstance([

--- a/Spanner/tests/System/AdminTest.php
+++ b/Spanner/tests/System/AdminTest.php
@@ -53,8 +53,10 @@ class AdminTest extends SpannerTestCase
         $this->assertEquals(Instance::STATE_READY, $instance->state());
 
         $displayName = uniqid(self::TESTING_PREFIX);
+        $processingUnits = 500;
         $op = $instance->update([
-            'displayName' => $displayName
+            'displayName' => $displayName,
+            'processingUnits' => $processingUnits,
         ]);
 
         $this->assertInstanceOf(LongRunningOperation::class, $op);
@@ -62,6 +64,7 @@ class AdminTest extends SpannerTestCase
 
         $instance = $client->instance(self::INSTANCE_NAME);
         $this->assertEquals($displayName, $instance->info()['displayName']);
+        $this->assertEquals($processingUnits, $instance->info()['processingUnits']);
 
         $requestedFieldNames = ['name', 'state'];
         $expectedInfo = [
@@ -70,6 +73,7 @@ class AdminTest extends SpannerTestCase
             'name' => $instance->name(),
             'displayName' => '',
             'nodeCount' => 0,
+            'processingUnits' => 0,
             'state' => Instance::STATE_READY,
             'config' => ''
         ];

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -189,6 +189,21 @@ class GrpcTest extends TestCase
         ]), $this->lro, null);
     }
 
+    public function testCreateInstanceWithProcessingNodes()
+    {
+        list ($args, $instance) = $this->instance(true, false);
+
+        $this->assertCallCorrect('createInstance', [
+                'projectName' => self::PROJECT,
+                'instanceId' => self::INSTANCE,
+                'processingUnits' => 1000
+            ] + $args, $this->expectResourceHeader(self::INSTANCE, [
+            self::PROJECT,
+            self::INSTANCE,
+            $instance
+        ]), $this->lro, null);
+    }
+
     public function testUpdateInstance()
     {
         list ($args, $instance, $fieldMask) = $this->instance(false);
@@ -1339,7 +1354,7 @@ class GrpcTest extends TestCase
         return call_user_func_array([$method, 'invoke'], $args);
     }
 
-    private function instance($full = true)
+    private function instance($full = true, $nodes = true)
     {
         $args = [
             'name' => self::INSTANCE,
@@ -1347,13 +1362,21 @@ class GrpcTest extends TestCase
         ];
 
         if ($full) {
-            $args = array_merge($args, [
-                'config' => self::CONFIG,
-                'nodeCount' => 1,
-                'processingUnits' => 1000,
-                'state' => State::CREATING,
-                'labels' => []
-            ]);
+            if ($nodes) {
+                $args = array_merge($args, [
+                    'config' => self::CONFIG,
+                    'nodeCount' => 1,
+                    'state' => State::CREATING,
+                    'labels' => []
+                ]);
+            } else {
+                $args = array_merge($args, [
+                    'config' => self::CONFIG,
+                    'processingUnits' => 1000,
+                    'state' => State::CREATING,
+                    'labels' => []
+                ]);
+            }
         }
 
         $mask = [];

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -1350,6 +1350,7 @@ class GrpcTest extends TestCase
             $args = array_merge($args, [
                 'config' => self::CONFIG,
                 'nodeCount' => 1,
+                'processingUnits' => 1000,
                 'state' => State::CREATING,
                 'labels' => []
             ]);

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -194,10 +194,10 @@ class GrpcTest extends TestCase
         list ($args, $instance) = $this->instance(true, false);
 
         $this->assertCallCorrect('createInstance', [
-                'projectName' => self::PROJECT,
-                'instanceId' => self::INSTANCE,
-                'processingUnits' => 1000
-            ] + $args, $this->expectResourceHeader(self::INSTANCE, [
+            'projectName' => self::PROJECT,
+            'instanceId' => self::INSTANCE,
+            'processingUnits' => 1000
+        ] + $args, $this->expectResourceHeader(self::INSTANCE, [
             self::PROJECT,
             self::INSTANCE,
             $instance

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -295,7 +295,13 @@ class InstanceTest extends TestCase
 
     public function testUpdateRaisesInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        if (method_exists($this, 'setExpectedException')) {
+            $expectation = 'setExpectedException';
+        } else {
+            $expectation = 'expectException';
+        }
+        
+        $this->$expectation(\InvalidArgumentException::class);
 
         $this->instance->update(['processingUnits' => 5000, 'nodeCount' => 5]);
     }

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -277,6 +277,29 @@ class InstanceTest extends TestCase
         $this->instance->update(['displayName' => 'bar']);
     }
 
+    public function testUpdateWithProcessingUnits()
+    {
+        $instance = $this->getDefaultInstance();
+
+        $this->connection->updateInstance([
+            'processingUnits' => 500,
+            'name' => $instance['name'],
+        ])->shouldBeCalled()->willReturn([
+            'name' => 'my-operation'
+        ]);
+
+        $this->instance->___setProperty('connection', $this->connection->reveal());
+
+        $this->instance->update(['processingUnits' => 500]);
+    }
+
+    public function testUpdateRaisesInvalidArgument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->instance->update(['processingUnits' => 5000, 'nodeCount' => 5]);
+    }
+
     public function testUpdateWithExistingLabels()
     {
         $instance = $this->getDefaultInstance();

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -293,16 +293,11 @@ class InstanceTest extends TestCase
         $this->instance->update(['processingUnits' => 500]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testUpdateRaisesInvalidArgument()
     {
-        if (method_exists($this, 'setExpectedException')) {
-            $expectation = 'setExpectedException';
-        } else {
-            $expectation = 'expectException';
-        }
-        
-        $this->$expectation(\InvalidArgumentException::class);
-
         $this->instance->update(['processingUnits' => 5000, 'nodeCount' => 5]);
     }
 

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -271,7 +271,13 @@ class SpannerClientTest extends TestCase
      */
     public function testCreateInstanceRaisesInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        if (method_exists($this, 'setExpectedException')) {
+            $expectation = 'setExpectedException';
+        } else {
+            $expectation = 'expectException';
+        }
+        
+        $this->$expectation(\InvalidArgumentException::class);
 
         $config = $this->prophesize(InstanceConfiguration::class);
 

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -268,17 +268,10 @@ class SpannerClientTest extends TestCase
 
     /**
      * @group spanner-admin
+     * @expectedException \InvalidArgumentException
      */
     public function testCreateInstanceRaisesInvalidArgument()
     {
-        if (method_exists($this, 'setExpectedException')) {
-            $expectation = 'setExpectedException';
-        } else {
-            $expectation = 'expectException';
-        }
-        
-        $this->$expectation(\InvalidArgumentException::class);
-
         $config = $this->prophesize(InstanceConfiguration::class);
 
         $this->client->createInstance($config->reveal(), self::INSTANCE, [

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -203,6 +203,87 @@ class SpannerClientTest extends TestCase
     /**
      * @group spanner-admin
      */
+    public function testCreateInstanceWithNodes()
+    {
+        $this->connection->createInstance(Argument::that(function ($arg) {
+            if ($arg['name'] !== InstanceAdminClient::instanceName(self::PROJECT, self::INSTANCE)) {
+                return false;
+            }
+
+            if ($arg['config'] !== InstanceAdminClient::instanceConfigName(self::PROJECT, self::CONFIG)) {
+                return false;
+            }
+
+            return isset($arg['nodeCount']) && $arg['nodeCount'] === 2;
+        }))
+            ->shouldBeCalled()
+            ->willReturn([
+                'name' => 'operations/foo'
+            ]);
+
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $config = $this->prophesize(InstanceConfiguration::class);
+        $config->name()->willReturn(InstanceAdminClient::instanceConfigName(self::PROJECT, self::CONFIG));
+
+        $operation = $this->client->createInstance($config->reveal(), self::INSTANCE, [
+            'nodeCount' => 2
+        ]);
+
+        $this->assertInstanceOf(LongRunningOperation::class, $operation);
+    }
+
+    /**
+     * @group spanner-admin
+     */
+    public function testCreateInstanceWithProcessingUnits()
+    {
+        $this->connection->createInstance(Argument::that(function ($arg) {
+            if ($arg['name'] !== InstanceAdminClient::instanceName(self::PROJECT, self::INSTANCE)) {
+                return false;
+            }
+
+            if ($arg['config'] !== InstanceAdminClient::instanceConfigName(self::PROJECT, self::CONFIG)) {
+                return false;
+            }
+
+            return isset($arg['processingUnits']) && $arg['processingUnits'] === 2000;
+        }))
+            ->shouldBeCalled()
+            ->willReturn([
+                'name' => 'operations/foo'
+            ]);
+
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $config = $this->prophesize(InstanceConfiguration::class);
+        $config->name()->willReturn(InstanceAdminClient::instanceConfigName(self::PROJECT, self::CONFIG));
+
+        $operation = $this->client->createInstance($config->reveal(), self::INSTANCE, [
+            'processingUnits' => 2000
+        ]);
+
+        $this->assertInstanceOf(LongRunningOperation::class, $operation);
+    }
+
+    /**
+     * @group spanner-admin
+     */
+    public function testCreateInstanceRaisesInvalidArgument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $config = $this->prophesize(InstanceConfiguration::class);
+
+        $this->client->createInstance($config->reveal(), self::INSTANCE, [
+            'nodeCount' => 2,
+            'processingUnits' => 2000,
+        ]);
+    }
+
+    /**
+     * @group spanner-admin
+     */
     public function testInstance()
     {
         $i = $this->client->instance('foo');


### PR DESCRIPTION
This PR adds support for low cost instances. By using the new processing units option instead of nodes, users are able to create and manage instances that uses less resources than a single node.

Note: 1000 processing units = 1 node