### PR TITLE
ci(spanner): fix UNAUTHENTICATED emulator errors

### DIFF
--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -35,10 +35,9 @@ jobs:
       - run: gcloud spanner instances create google-cloud-php-system-tests --config=emulator-config --description="Test Instance" --nodes=1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: pecl
           extensions: bcmath, grpc
 
       - name: Install dependencies

--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -38,7 +38,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          extensions: bcmath, grpc
+          tools: pecl
+          extensions: bcmath, grpc-1.37.1
 
       - name: Install dependencies
         run: |

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -83,6 +83,8 @@ class ValueMapper
     {
         $paramTypes = [];
 
+        // DO NOT MERGE
+        // This change is to force the emulator action to trigger.
         foreach ($parameters as $key => $value) {
             if (is_null($value) && !isset($types[$key])) {
                 throw new \BadMethodCallException(sprintf(

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -83,8 +83,6 @@ class ValueMapper
     {
         $paramTypes = [];
 
-        // DO NOT MERGE
-        // This change is to force the emulator action to trigger.
         foreach ($parameters as $key => $value) {
             if (is_null($value) && !isset($types[$key])) {
                 throw new \BadMethodCallException(sprintf(


### PR DESCRIPTION
This PR pins the `grpc` version installed for the Spanner emulator Github action to 1.37.1 to prevent `UNAUTHENTICATED` errors. This was discussed in https://github.com/googleapis/google-cloud-php/issues/3911.

Successful emulator run: https://github.com/googleapis/google-cloud-php/pull/4112/checks?check_run_id=2846226392