### PR TITLE
fix: correctly decode empty map values

### DIFF
--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -160,6 +160,10 @@ class ValueMapper
                 break;
 
             case 'mapValue':
+                if (empty($value['fields'])) {
+                    return new \stdClass();
+                }
+
                 $res = [];
 
                 foreach ($value['fields'] as $key => $val) {

--- a/Firestore/tests/System/ValueMapperTest.php
+++ b/Firestore/tests/System/ValueMapperTest.php
@@ -78,6 +78,7 @@ class ValueMapperTest extends FirestoreTestCase
             [new GeoPoint(10, -10)],
             [[1, 2, 3, 4]],
             [['foo' => 'bar', 'bat' => [1, 2, 3, 4]]],
+            [(object) []],
             [NAN, function ($val) {
                 return is_nan($val);
             }]

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -144,6 +144,15 @@ class ValueMapperTest extends TestCase
                     $this->assertEquals('world', $val['hello']);
                 }
             ], [
+                [
+                    'mapValue' => [
+                        'fields' => []
+                    ]
+                ],
+                function ($val) {
+                    $this->assertEquals($val, new \stdClass());
+                }
+            ], [
                 ['referenceValue' => 'projects/example_project/databases/(default)/documents/a/b'],
                 function ($val) {
                     $this->assertInstanceOf(DocumentReference::class, $val);


### PR DESCRIPTION
Fix empty map #4250 

First (public) PR here: ran the unit, system and snippet tests successfully and checked `composer style`