### PR TITLE
feat(spanner): add support for tagging

### DIFF
--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -932,6 +932,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -979,6 +980,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1023,6 +1025,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1067,6 +1070,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1112,6 +1116,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1158,6 +1163,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1203,6 +1209,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1249,6 +1256,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1297,6 +1305,7 @@ class Database
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit Timestamp.
      */

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -425,6 +425,7 @@ class Operation
      */
     public function transaction(Session $session, array $options = [])
     {
+        $createOptions = ['tag' => $this->pluck('tag', $options, false)];
         $options += [
             'singleUse' => false,
             'isRetry' => false
@@ -436,7 +437,7 @@ class Operation
             $res = [];
         }
 
-        return $this->createTransaction($session, $res);
+        return $this->createTransaction($session, $res, $createOptions);
     }
 
     /**
@@ -452,12 +453,15 @@ class Operation
         $res += [
             'id' => null
         ];
+        $options += [
+            'tag' => null
+        ];
 
         $options['isRetry'] = isset($options['isRetry'])
             ? $options['isRetry']
             : false;
 
-        return new Transaction($this, $session, $res['id'], $options['isRetry']);
+        return new Transaction($this, $session, $res['id'], $options['isRetry'], $options['tag']);
     }
 
     /**

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -425,10 +425,11 @@ class Operation
      */
     public function transaction(Session $session, array $options = [])
     {
-        $createOptions = ['tag' => $this->pluck('tag', $options, false)];
+        $transactionTag = $this->pluck('tag', $options, false);
         $options += [
             'singleUse' => false,
-            'isRetry' => false
+            'isRetry' => false,
+            'requestOptions' => ['transactionTag' => $transactionTag]
         ];
 
         if (!$options['singleUse']) {
@@ -437,7 +438,7 @@ class Operation
             $res = [];
         }
 
-        return $this->createTransaction($session, $res, $createOptions);
+        return $this->createTransaction($session, $res, ['tag' => $transactionTag]);
     }
 
     /**

--- a/Spanner/src/Snapshot.php
+++ b/Spanner/src/Snapshot.php
@@ -53,6 +53,11 @@ class Snapshot implements TransactionalReadInterface
      */
     public function __construct(Operation $operation, Session $session, array $options = [])
     {
+        if (isset($options['tag'])) {
+            throw new \InvalidArgumentException(
+                "Cannot set a transaction tag on a read-only transaction."
+            );
+        }
         $this->initialize($operation, $session, $options);
     }
 }

--- a/Spanner/src/Snapshot.php
+++ b/Spanner/src/Snapshot.php
@@ -50,6 +50,7 @@ class Snapshot implements TransactionalReadInterface
      *           the Transaction will be a Single-Use Transaction.
      *     @type Timestamp $readTimestamp The read timestamp.
      * }
+     * @throws \InvalidArgumentException if a tag is specified as this is a read-only transaction.
      */
     public function __construct(Operation $operation, Session $session, array $options = [])
     {

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -593,6 +593,7 @@ class Transaction implements TransactionalReadInterface
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `requestTag` setting will be ignored as it is not supported for commit requests.
      * }
      * @return Timestamp The commit timestamp.
      * @throws \BadMethodCall If the transaction is not active or already used.
@@ -617,11 +618,7 @@ class Transaction implements TransactionalReadInterface
 
         $options['transactionId'] = $this->transactionId;
 
-        if (isset($options['requestOptions']['requestTag'])) {
-            throw new \InvalidArgumentException(
-                "Cannot set a request tag on a commit request."
-            );
-        }
+        unset($options['requestOptions']['requestTag']);
         if (isset($this->tag)) {
             $options['requestOptions']['transactionTag'] = $this->tag;
         }

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -86,6 +86,10 @@ class Transaction implements TransactionalReadInterface
      * @param Session $session The session to use for spanner interactions.
      * @param string $transactionId [optional] The Transaction ID. If no ID is
      *        provided, the Transaction will be a Single-Use Transaction.
+     * @param bool $isRetry Whether the transaction will automatically retry or not.
+     * @param string $tag A transaction tag. Requests made using this transaction will
+     *        use this as the transaction tag.
+     * @throws \InvalidArgumentException if a tag is specified on a single-use transaction.
      */
     public function __construct(
         Operation $operation,
@@ -419,11 +423,14 @@ class Transaction implements TransactionalReadInterface
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
+     *         been set when creating the transaction.
      * }
      * @return int The number of rows modified.
      */
     public function executeUpdate($sql, array $options = [])
     {
+        unset($options['requestOptions']['transactionTag']);
         if (isset($this->tag)) {
             $options += [
                 'requestOptions' => []
@@ -514,12 +521,15 @@ class Transaction implements TransactionalReadInterface
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
+     *         been set when creating the transaction.
      * }
      * @return BatchDmlResult
      * @throws \InvalidArgumentException If any statement is missing the `sql` key.
      */
     public function executeUpdateBatch(array $statements, array $options = [])
     {
+        unset($options['requestOptions']['transactionTag']);
         if (isset($this->tag)) {
             $options += [
                 'requestOptions' => []

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -256,6 +256,8 @@ trait TransactionalReadTrait
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
+     *         been set when creating the transaction.
      * }
      * @codingStandardsIgnoreEnd
      * @return Result
@@ -274,6 +276,7 @@ trait TransactionalReadTrait
 
         $options['transaction'] = $selector[0];
 
+        unset($options['requestOptions']['transactionTag']);
         if (isset($this->tag)) {
             $options += [
                 'requestOptions' => []
@@ -317,6 +320,8 @@ trait TransactionalReadTrait
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
+     *         been set when creating the transaction.
      * }
      * @return Result
      */
@@ -332,6 +337,7 @@ trait TransactionalReadTrait
 
         $options['transaction'] = $selector[0];
 
+        unset($options['requestOptions']['transactionTag']);
         if (isset($this->tag)) {
             $options += [
                 'requestOptions' => []

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -68,6 +68,11 @@ trait TransactionalReadTrait
     private $seqno = 1;
 
     /**
+     * @var string
+     */
+    private $tag = null;
+
+    /**
      * Run a query.
      *
      * Google Cloud PHP will infer parameter types for all primitive types and
@@ -269,6 +274,13 @@ trait TransactionalReadTrait
 
         $options['transaction'] = $selector[0];
 
+        if (isset($this->tag)) {
+            $options += [
+                'requestOptions' => []
+            ];
+            $options['requestOptions']['transactionTag'] = $this->tag;
+        }
+
         return $this->operation->execute($this->session, $sql, $options);
     }
 
@@ -319,6 +331,13 @@ trait TransactionalReadTrait
         $selector = $this->transactionSelector($options, $this->options);
 
         $options['transaction'] = $selector[0];
+
+        if (isset($this->tag)) {
+            $options += [
+                'requestOptions' => []
+            ];
+            $options['requestOptions']['transactionTag'] = $this->tag;
+        }
 
         return $this->operation->read($this->session, $table, $keySet, $columns, $options);
     }

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -65,6 +65,7 @@ class DatabaseTest extends TestCase
     const SESSION = 'my-session';
     const TRANSACTION = 'my-transaction';
     const BACKUP = 'my-backup';
+    const TRANSACTION_TAG = 'my-transaction-tag';
 
     private $connection;
     private $instance;
@@ -613,7 +614,10 @@ class DatabaseTest extends TestCase
                     self::INSTANCE,
                     self::DATABASE
                 )
-            )
+            ),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+            ])
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
@@ -627,7 +631,10 @@ class DatabaseTest extends TestCase
                     self::INSTANCE,
                     self::DATABASE
                 )
-            )
+            ),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+            ])
         ))
             ->shouldBeCalled()
             ->willReturn(['commitTimestamp' => '2017-01-09T18:05:22.534799Z']);
@@ -640,7 +647,7 @@ class DatabaseTest extends TestCase
             $hasTransaction = true;
 
             $t->commit();
-        });
+        }, ['tag' => self::TRANSACTION_TAG]);
 
         $this->assertTrue($hasTransaction);
     }
@@ -840,14 +847,17 @@ class DatabaseTest extends TestCase
                     self::INSTANCE,
                     self::DATABASE
                 )
-            )
+            ),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+            ])
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);
 
         $this->refreshOperation($this->database, $this->connection->reveal());
 
-        $t = $this->database->transaction();
+        $t = $this->database->transaction(['tag' => self::TRANSACTION_TAG]);
         $this->assertInstanceOf(Transaction::class, $t);
     }
 

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -291,7 +291,8 @@ class OperationTest extends TestCase
     {
         $this->connection->beginTransaction(Argument::allOf(
             Argument::withEntry('database', self::DATABASE),
-            Argument::withEntry('session', $this->session->name())
+            Argument::withEntry('session', $this->session->name(),
+            Argument::withEntry('requestOptions', ['transactionTag' => self::TRANSACTION_TAG]))
         ))
             ->shouldBeCalled()
             ->willReturn(['id' => self::TRANSACTION]);

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -47,6 +47,7 @@ class OperationTest extends TestCase
 
     const SESSION = 'my-session-id';
     const TRANSACTION = 'my-transaction-id';
+    const TRANSACTION_TAG = 'my-transaction-tag';
     const DATABASE = 'projects/my-awesome-project/instances/my-instance/databases/my-database';
     const TIMESTAMP = '2017-01-09T18:05:22.534799Z';
 
@@ -297,7 +298,7 @@ class OperationTest extends TestCase
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $t = $this->operation->transaction($this->session);
+        $t = $this->operation->transaction($this->session, ['tag' => self::TRANSACTION_TAG]);
         $this->assertInstanceOf(Transaction::class, $t);
         $this->assertEquals(self::TRANSACTION, $t->id());
     }

--- a/Spanner/tests/Unit/SnapshotTest.php
+++ b/Spanner/tests/Unit/SnapshotTest.php
@@ -53,6 +53,18 @@ class SnapshotTest extends TestCase
         );
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testTagError()
+    {
+        new Snapshot(
+            $this->prophesize(Operation::class)->reveal(),
+            $this->prophesize(Session::class)->reveal(),
+            ['tag' => 'transaction-tag']
+        );
+    }
+
     public function testTypeIsPreAllocated()
     {
         $this->assertEquals(Snapshot::TYPE_PRE_ALLOCATED, $this->snapshot->type());

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -498,7 +498,7 @@ class TransactionTest extends TestCase
 
         $this->transaction->___setProperty('operation', $operation->reveal());
 
-        $this->transaction->commit();
+        $this->transaction->commit(['requestOptions' => ['requestTag' => 'unused']]);
     }
 
     public function testCommitWithReturnCommitStats()
@@ -534,14 +534,6 @@ class TransactionTest extends TestCase
     {
         $this->transaction->___setProperty('state', 'foo');
         $this->transaction->commit();
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testCommitRequestTagError()
-    {
-        $this->transaction->commit(['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
     }
 
     public function testRollback()

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -251,11 +251,11 @@ class TransactionTest extends TestCase
     {
         $sql = 'UPDATE foo SET bar = @bar';
         $this->connection->executeStreamingSql(Argument::allOf(
-                Argument::withEntry('seqno', 1),
-                Argument::withEntry('requestOptions', [
-                    'transactionTag' => self::TRANSACTION_TAG,
-                    'requestTag' => self::REQUEST_TAG
-                ])
+            Argument::withEntry('seqno', 1),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
+            ])
         ))->shouldBeCalled()->willReturn($this->resultGenerator(true));
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
@@ -344,7 +344,10 @@ class TransactionTest extends TestCase
         ]);
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $res = $this->transaction->executeUpdateBatch($this->bdmlStatements(), ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
+        $res = $this->transaction->executeUpdateBatch(
+            $this->bdmlStatements(),
+            ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]
+        );
 
         $this->assertInstanceOf(BatchDmlResult::class, $res);
         $this->assertNull($res->error());
@@ -382,7 +385,10 @@ class TransactionTest extends TestCase
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
         $statements = $this->bdmlStatements();
-        $res = $this->transaction->executeUpdateBatch($statements, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
+        $res = $this->transaction->executeUpdateBatch(
+            $statements,
+            ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]
+        );
 
         $this->assertEquals([1,2], $res->rowCounts());
         $this->assertEquals($err, $res->error()['status']);

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -52,6 +52,8 @@ class TransactionTest extends TestCase
     const INSTANCE = 'my-instance';
     const SESSION = 'my-session';
     const TRANSACTION = 'my-transaction';
+    const TRANSACTION_TAG = 'my-transaction-tag';
+    const REQUEST_TAG = 'my-request-tag';
 
     private $connection;
     private $instance;
@@ -81,6 +83,8 @@ class TransactionTest extends TestCase
             $this->operation,
             $this->session,
             self::TRANSACTION,
+            false,
+            self::TRANSACTION_TAG
         ];
 
         $props = [
@@ -89,8 +93,25 @@ class TransactionTest extends TestCase
 
         $this->transaction = TestHelpers::stub(Transaction::class, $args, $props);
 
-        unset($args[2]);
+        $args = [
+            $this->operation,
+            $this->session,
+        ];
         $this->singleUseTransaction = TestHelpers::stub(Transaction::class, $args, $props);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSingleUseTagError()
+    {
+        new Transaction(
+            $this->operation,
+            $this->session,
+            null,
+            false,
+            self::TRANSACTION_TAG
+        );
     }
 
     public function testInsert()
@@ -197,7 +218,7 @@ class TransactionTest extends TestCase
 
         $this->connection->executeStreamingSql(Argument::allOf(
             Argument::withEntry('transaction', ['id' => self::TRANSACTION]),
-            Argument::withEntry('sql', $sql)
+            Argument::withEntry('sql', $sql),
         ))->shouldBeCalled()->willReturn($this->resultGenerator());
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
@@ -213,11 +234,15 @@ class TransactionTest extends TestCase
         $sql = 'UPDATE foo SET bar = @bar';
         $this->connection->executeStreamingSql(Argument::allOf(
             Argument::withEntry('sql', $sql),
-            Argument::withEntry('transactionId', self::TRANSACTION)
+            Argument::withEntry('transactionId', self::TRANSACTION),
+            Argument::withEntry('requestOptions', [
+                'requestTag' => self::REQUEST_TAG,
+                'transactionTag' => self::TRANSACTION_TAG
+            ])
         ))->shouldBeCalled()->willReturn($this->resultGenerator(true));
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $res = $this->transaction->executeUpdate($sql);
+        $res = $this->transaction->executeUpdate($sql, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
         $this->assertEquals(1, $res);
     }
@@ -225,30 +250,45 @@ class TransactionTest extends TestCase
     public function testDmlSeqno()
     {
         $sql = 'UPDATE foo SET bar = @bar';
-        $this->connection->executeStreamingSql(Argument::withEntry('seqno', 1))
-            ->shouldBeCalled()
-            ->willReturn($this->resultGenerator(true));
+        $this->connection->executeStreamingSql(Argument::allOf(
+                Argument::withEntry('seqno', 1),
+                Argument::withEntry('requestOptions', [
+                    'transactionTag' => self::TRANSACTION_TAG,
+                    'requestTag' => self::REQUEST_TAG
+                ])
+        ))->shouldBeCalled()->willReturn($this->resultGenerator(true));
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $this->transaction->executeUpdate($sql);
+        $this->transaction->executeUpdate($sql, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
-        $this->connection->executeStreamingSql(Argument::withEntry('seqno', 2))
-            ->shouldBeCalled()
-            ->willReturn($this->resultGenerator(true));
-
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $this->transaction->executeUpdate($sql);
-
-        $this->connection->executeBatchDml(Argument::withEntry('seqno', 3))
-            ->shouldBeCalled()
-            ->willReturn([
-                'resultSets' => []
-            ]);
+        $this->connection->executeStreamingSql(Argument::allOf(
+            Argument::withEntry('seqno', 2),
+            Argument::withEntry('requestOptions', [
+                'requestTag' => self::REQUEST_TAG,
+                'transactionTag' => self::TRANSACTION_TAG
+            ])
+        ))->shouldBeCalled()->willReturn($this->resultGenerator(true));
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $this->transaction->executeUpdateBatch([
-            ['sql' => 'SELECT 1']
+        $this->transaction->executeUpdate($sql, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
+
+        $this->connection->executeBatchDml(Argument::allOf(
+            Argument::withEntry('seqno', 3),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
+            ])
+        ))->shouldBeCalled()->willReturn([
+            'resultSets' => []
         ]);
+
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->transaction->executeUpdateBatch(
+            [
+                ['sql' => 'SELECT 1'],
+            ],
+            ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]
+        );
     }
 
     public function testExecuteUpdateBatch()
@@ -280,6 +320,10 @@ class TransactionTest extends TestCase
                         ]
                     ]
                 ]
+            ]),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
             ])
         ))->shouldBeCalled()->willReturn([
             'resultSets' => [
@@ -300,7 +344,7 @@ class TransactionTest extends TestCase
         ]);
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $res = $this->transaction->executeUpdateBatch($this->bdmlStatements());
+        $res = $this->transaction->executeUpdateBatch($this->bdmlStatements(), ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
         $this->assertInstanceOf(BatchDmlResult::class, $res);
         $this->assertNull($res->error());
@@ -315,26 +359,30 @@ class TransactionTest extends TestCase
             'details' => []
         ];
 
-        $this->connection->executeBatchDml(Argument::withEntry('session', $this->session->name()))
-            ->shouldBeCalled()
-            ->willReturn([
-                'resultSets' => [
-                    [
-                        'stats' => [
-                            'rowCountExact' => 1
-                        ]
-                    ], [
-                        'stats' => [
-                            'rowCountExact' => 2
-                        ]
+        $this->connection->executeBatchDml(Argument::allOf(
+            Argument::withEntry('session', $this->session->name()),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
+            ])
+        ))->shouldBeCalled()->willReturn([
+            'resultSets' => [
+                [
+                    'stats' => [
+                        'rowCountExact' => 1
                     ]
-                ],
-                'status' => $err
-            ]);
+                ], [
+                    'stats' => [
+                        'rowCountExact' => 2
+                    ]
+                ]
+            ],
+            'status' => $err
+        ]);
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
         $statements = $this->bdmlStatements();
-        $res = $this->transaction->executeUpdateBatch($statements);
+        $res = $this->transaction->executeUpdateBatch($statements, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
         $this->assertEquals([1,2], $res->rowCounts());
         $this->assertEquals($err, $res->error()['status']);
@@ -381,11 +429,15 @@ class TransactionTest extends TestCase
         $sql = 'UPDATE foo SET bar = @bar';
         $this->connection->executeStreamingSql(Argument::allOf(
             Argument::withEntry('sql', $sql),
-            Argument::withEntry('transactionId', self::TRANSACTION)
+            Argument::withEntry('transactionId', self::TRANSACTION),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
+            ])
         ))->shouldBeCalled()->willReturn($this->resultGenerator());
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
-        $res = $this->transaction->executeUpdate($sql);
+        $res = $this->transaction->executeUpdate($sql, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
         $this->assertEquals(1, $res);
     }
@@ -399,12 +451,21 @@ class TransactionTest extends TestCase
             Argument::withEntry('transaction', ['id' => self::TRANSACTION]),
             Argument::withEntry('table', $table),
             Argument::withEntry('keySet', ['all' => true]),
-            Argument::withEntry('columns', ['ID'])
+            Argument::withEntry('columns', ['ID']),
+            Argument::withEntry('requestOptions', [
+                'transactionTag' => self::TRANSACTION_TAG,
+                'requestTag' => self::REQUEST_TAG
+            ])
         ))->shouldBeCalled()->willReturn($this->resultGenerator());
 
         $this->refreshOperation($this->transaction, $this->connection->reveal());
 
-        $res = $this->transaction->read($table, new KeySet(['all' => true]), ['ID']);
+        $res = $this->transaction->read(
+            $table,
+            new KeySet(['all' => true]),
+            ['ID'],
+            ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]
+        );
 
         $this->assertInstanceOf(Result::class, $res);
         $rows = iterator_to_array($res->rows());
@@ -421,7 +482,12 @@ class TransactionTest extends TestCase
         $operation->commitWithResponse(
             $this->session,
             $mutations,
-            ['transactionId' => self::TRANSACTION]
+            [
+                'transactionId' => self::TRANSACTION,
+                'requestOptions' => [
+                    'transactionTag' => self::TRANSACTION_TAG
+                ]
+            ]
         )->shouldBeCalled()->willReturn($this->commitResponseWithCommitStats());
 
         $this->transaction->___setProperty('operation', $operation->reveal());
@@ -439,7 +505,13 @@ class TransactionTest extends TestCase
         $operation->commitWithResponse(
             $this->session,
             $mutations,
-            ['transactionId' => self::TRANSACTION, 'returnCommitStats' => true]
+            [
+                'transactionId' => self::TRANSACTION,
+                'returnCommitStats' => true,
+                'requestOptions' => [
+                    'transactionTag' => self::TRANSACTION_TAG
+                ]
+            ]
         )->shouldBeCalled()->willReturn($this->commitResponseWithCommitStats());
 
         $this->transaction->___setProperty('operation', $operation->reveal());
@@ -456,6 +528,14 @@ class TransactionTest extends TestCase
     {
         $this->transaction->___setProperty('state', 'foo');
         $this->transaction->commit();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCommitRequestTagError()
+    {
+        $this->transaction->commit(['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
     }
 
     public function testRollback()


### PR DESCRIPTION
Supersedes #3928

This PR adds supports the following:
1. Set a transaction tag on a read-write transaction which will be used for all request including `BeginTransaction`.
2. Set a request tag on methods which use the following request types:
    - `ExecuteSqlRequest`
    - `ExecuteBatchDmlRequest`
    - `ReadRequest`


The following is not supported:
- Set a transaction tag on read-only or single-use transactions.
- Set a request tag on a `CommitRequest`.
- Set a transaction tag on PDML.
- Set a request tag on batched mutation methods as the mutations that will be sent as part of a `CommitRequest`.

Example usage is shown below:
```
$spanner = new SpannerClient();
$instance = $spanner->instance($instanceId);
$database = $instance->database($databaseId);
$database->runTransaction(function (Transaction $t) use ($spanner) {
    $t->executeUpdate('SELECT 1', [
        'requestOptions' => ['requestTag' => 'app=cart,env=dev,action=list']
    ]);
    $t->executeUpdate('UPDATE foo SET bar='baz' WHERE TRUE', [
        'requestOptions' => ['requestTag' => 'app=cart,env=dev,action=update']
    ]);
    $t->commit();
}, ['tag' => 'app=cart,env=dev']);
```