### PR TITLE
feat: implement JsonSerializable

### DIFF
--- a/Core/src/Blob.php
+++ b/Core/src/Blob.php
@@ -38,7 +38,7 @@ use Psr\Http\Message\StreamInterface;
  * echo (string) $blob;
  * ```
  */
-class Blob
+class Blob implements \JsonSerializable
 {
     /**
      * @var mixed
@@ -79,5 +79,16 @@ class Blob
     public function __toString()
     {
         return (string) $this->value;
+    }
+
+    /**
+     * Implement JsonSerializable by returning a base64 encoded string of the blob
+     *
+     * @return string
+     * @access private
+     */
+    public function jsonSerialize()
+    {
+        return base64_encode((string) $this->value);
     }
 }

--- a/Core/src/GeoPoint.php
+++ b/Core/src/GeoPoint.php
@@ -33,7 +33,7 @@ use InvalidArgumentException;
  * $point = new GeoPoint(37.423147, -122.085015);
  * ```
  */
-class GeoPoint
+class GeoPoint implements \JsonSerializable
 {
     /**
      * @var float
@@ -203,5 +203,23 @@ class GeoPoint
         return $allowNull && $value === null
             ? $value
             : (float) $value;
+    }
+
+    /**
+     * Implement JsonSerializable by representing GeoPoint as a JSON-object:
+     *
+     * ```
+     * {
+     *   latitude: 31.778333
+     *   longitude: 35.229722
+     * }
+     * ```
+     *
+     * @return object
+     * @access private
+     */
+    public function jsonSerialize()
+    {
+        return (object) $this->point();
     }
 }

--- a/Core/src/Int64.php
+++ b/Core/src/Int64.php
@@ -26,7 +26,7 @@ namespace Google\Cloud\Core;
  * $int64 = new Int64('9223372036854775807');
  * ```
  */
-class Int64
+class Int64 implements \JsonSerializable
 {
     /**
      * @var string
@@ -62,6 +62,17 @@ class Int64
      * @access private
      */
     public function __toString()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Implement JsonSerializable by returning the 64 bit integer as a string
+     *
+     * @return string
+     * @access private
+     */
+    public function jsonSerialize()
     {
         return $this->value;
     }

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -37,7 +37,7 @@ namespace Google\Cloud\Core;
  * echo (string) $timestamp;
  * ```
  */
-class Timestamp
+class Timestamp implements \JsonSerializable
 {
     use TimeTrait;
 
@@ -146,5 +146,16 @@ class Timestamp
     public function formatForApi()
     {
         return $this->formatTimeAsArray($this->value, $this->nanoSeconds());
+    }
+
+    /**
+     * Implement JsonSerializable by returning a ISO 8601 formatted string
+     *
+     * @return string
+     * @access private
+     */
+    public function jsonSerialize()
+    {
+        return $this->formatAsString();
     }
 }

--- a/Core/tests/Unit/BlobTest.php
+++ b/Core/tests/Unit/BlobTest.php
@@ -35,4 +35,10 @@ class BlobTest extends TestCase
         $this->assertEquals($this->data, (string) $blob->get());
         $this->assertEquals($this->data, (string) $blob);
     }
+
+    public function testJsonEncode()
+    {
+        $blob = new Blob($this->data);
+        $this->assertEquals('"Zm9vYmFy"', json_encode($blob));  // base64
+    }
 }

--- a/Core/tests/Unit/GeoPointTest.php
+++ b/Core/tests/Unit/GeoPointTest.php
@@ -93,6 +93,12 @@ class GeoPointTest extends TestCase
         ], $point->point());
     }
 
+    public function testJsonEncode()
+    {
+        $point = new GeoPoint(1.1, 2.2);
+        $this->assertEquals('{"latitude":1.1,"longitude":2.2}', json_encode($point));
+    }
+
     public function methods()
     {
         return [

--- a/Core/tests/Unit/Int64Test.php
+++ b/Core/tests/Unit/Int64Test.php
@@ -40,4 +40,11 @@ class Int64Test extends TestCase
 
         $this->assertEquals($int, (string) $int64);
     }
+
+    public function testJsonEncode()
+    {
+        $int64 = new Int64('123');
+
+        $this->assertEquals('"123"', json_encode($int64));
+    }
 }

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -51,6 +51,11 @@ class TimestampTest extends TestCase
         );
     }
 
+    public function testJsonEncode()
+    {
+        $this->assertEquals(sprintf('"%s"', $this->dt->format(Timestamp::FORMAT)), json_encode($this->ts));
+    }
+
     public function testCast()
     {
         $this->assertEquals(


### PR DESCRIPTION
### JsonSerializible
Implements `\JsonSerializible` for 
- Google\Cloud\Core\Blob
- Google\Cloud\Core\Int64
- Google\Cloud\Core\GeoPoint
- Google\Cloud\Core\Timestamp

This makes it easy to fetch data from the Firestore en directly json_encode it. See #2698 

### Example
First create a document in firestore with for example a geopoint.
 
```php
$data = $client->document(SOME_ID)->data();
echo json_encode($data);
```

will show something like

```json
{
  "latitude": 1.1,
  "longitude": 2.2
}
```