### PR TITLE
fix: phpparser syntax error for 8.1 and OOM errors in AppEngineFlexHandlerTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "google/cloud-tools": "^0.12.0",
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
-        "wikimedia/avro": "^1.9"
+        "wikimedia/avro": "^1.9",
+        "monolog/monolog": "<2.3.0"
     },
     "replace": {
         "google/analytics-admin": "0.3.0",


### PR DESCRIPTION
 - Fix `T_READONLY` syntax error when generating docs by setting the emulator to use PHP 8.0 (See https://github.com/nikic/PHP-Parser/issues/799#issuecomment-885599753)
 - Fix OOM errors in `AppEngineFlexHandlerTest` (See https://github.com/Seldaek/monolog/issues/1577)