### PR TITLE
feat: Upgrade Guzzlehttp/psr7 version

### DIFF
--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.43",
         "ramsey/uuid": "^3.0|^4.0"
     },
     "require-dev": {

--- a/BigQuery/src/Bytes.php
+++ b/BigQuery/src/Bytes.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\BigQuery;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -45,7 +45,7 @@ class Bytes implements ValueInterface
      */
     public function __construct($value)
     {
-        $this->value = Psr7\stream_for($value);
+        $this->value = Utils::streamFor($value);
     }
 
     /**

--- a/BigQuery/src/Connection/Rest.php
+++ b/BigQuery/src/Connection/Rest.php
@@ -25,7 +25,7 @@ use Google\Cloud\Core\RestTrait;
 use Google\Cloud\Core\Upload\AbstractUploader;
 use Google\Cloud\Core\Upload\MultipartUploader;
 use Google\Cloud\Core\UriTrait;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * Implementation of the
@@ -280,7 +280,7 @@ class Rest implements ConnectionInterface
             'jobReference' => []
         ];
 
-        $args['data'] = Psr7\stream_for($args['data']);
+        $args['data'] = Utils::streamFor($args['data']);
         $args['metadata'] = $this->pluckArray([
             'labels',
             'dryRun',

--- a/BigQuery/tests/System/LoadDataAndQueryTest.php
+++ b/BigQuery/tests/System/LoadDataAndQueryTest.php
@@ -21,7 +21,7 @@ use Google\Cloud\BigQuery\BigNumeric;
 use Google\Cloud\BigQuery\Geography;
 use Google\Cloud\BigQuery\Numeric;
 use Google\Cloud\Core\ExponentialBackoff;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * @group bigquery
@@ -408,7 +408,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         return [
             [$data],
             [fopen(__DIR__ . '/data/table-data.json', 'r')],
-            [Psr7\stream_for($data)]
+            [Utils::streamFor($data)]
         ];
     }
 

--- a/BigQuery/tests/Unit/BytesTest.php
+++ b/BigQuery/tests/Unit/BytesTest.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\BigQuery\Tests\Unit;
 
 use Google\Cloud\BigQuery\Bytes;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,7 +47,7 @@ class BytesTest extends TestCase
         return [
             [$this->value],
             [$fh],
-            [Psr7\stream_for($this->value)]
+            [Utils::streamFor($this->value)]
         ];
     }
 

--- a/BigQuery/tests/Unit/Connection/RestTest.php
+++ b/BigQuery/tests/Unit/Connection/RestTest.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Upload\AbstractUploader;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -9,7 +9,7 @@
         "google/auth": "^1.12",
         "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
         "guzzlehttp/promises": "^1.3",
-        "guzzlehttp/psr7": "^1.2",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*"
     },

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "google/auth": "^1.12",
+        "google/auth": "^1.18",
         "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7|^2.0",
@@ -18,7 +18,7 @@
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",
-        "google/gax": "^1.1",
+        "google/gax": "^1.9",
         "opis/closure": "^3",
         "google/common-protos": "^1.0"
     },

--- a/Core/src/Blob.php
+++ b/Core/src/Blob.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Core;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -52,7 +52,7 @@ class Blob
      */
     public function __construct($value)
     {
-        $this->value = Psr7\stream_for($value);
+        $this->value = Utils::streamFor($value);
     }
 
     /**

--- a/Core/src/RequestBuilder.php
+++ b/Core/src/RequestBuilder.php
@@ -17,7 +17,6 @@
 
 namespace Google\Cloud\Core;
 
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\RequestInterface;

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -25,7 +25,7 @@ use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\Core\RequestWrapperTrait;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -304,7 +304,7 @@ class RequestWrapper
             }
         }
 
-        return Psr7\modify_request($request, ['set_headers' => $headers]);
+        return Utils::modifyRequest($request, ['set_headers' => $headers]);
     }
 
     /**

--- a/Core/src/Upload/AbstractUploader.php
+++ b/Core/src/Upload/AbstractUploader.php
@@ -19,7 +19,7 @@ namespace Google\Cloud\Core\Upload;
 
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\UriTrait;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -96,7 +96,7 @@ abstract class AbstractUploader
         array $options = []
     ) {
         $this->requestWrapper = $requestWrapper;
-        $this->data = Psr7\stream_for($data);
+        $this->data = Utils::streamFor($data);
         $this->uri = $uri;
         $this->metadata = isset($options['metadata']) ? $options['metadata'] : [];
         $this->chunkSize = isset($options['chunkSize']) ? $options['chunkSize'] : null;

--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -23,7 +23,6 @@ use Google\Cloud\Core\Exception\UploadException;
 use Google\Cloud\Core\JsonTrait;
 use Google\Cloud\Core\RequestWrapper;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;

--- a/Core/src/UriTrait.php
+++ b/Core/src/UriTrait.php
@@ -17,7 +17,8 @@
 
 namespace Google\Cloud\Core;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\UriInterface;
 use Rize\UriTemplate;
 
@@ -59,6 +60,6 @@ trait UriTrait
             }
         }
 
-        return Psr7\uri_for($uri)->withQuery(Psr7\build_query($query));
+        return Utils::uriFor($uri)->withQuery(Query::build($query));
     }
 }

--- a/Core/tests/Unit/Upload/MultipartUploaderTest.php
+++ b/Core/tests/Unit/Upload/MultipartUploaderTest.php
@@ -20,14 +20,13 @@ namespace Google\Cloud\Core\Tests\Unit\Upload;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Upload\MultipartUploader;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * @group core
@@ -38,7 +37,7 @@ class MultipartUploaderTest extends TestCase
     public function testUploadsData()
     {
         $requestWrapper = $this->prophesize(RequestWrapper::class);
-        $stream = Psr7\stream_for('abcd');
+        $stream = Utils::streamFor('abcd');
         $successBody = '{"canI":"kickIt"}';
         $response = new Response(200, [], $successBody);
 
@@ -59,7 +58,7 @@ class MultipartUploaderTest extends TestCase
     public function testUploadsAsyncData()
     {
         $requestWrapper = $this->prophesize(RequestWrapper::class);
-        $stream = Psr7\stream_for('abcd');
+        $stream = Utils::streamFor('abcd');
         $successBody = '{"canI":"kickIt"}';
         $response = new Response(200, [], $successBody);
         $promise = Promise\promise_for($response);

--- a/Core/tests/Unit/Upload/ResumableUploaderTest.php
+++ b/Core/tests/Unit/Upload/ResumableUploaderTest.php
@@ -20,9 +20,8 @@ namespace Google\Cloud\Core\Tests\Unit\Upload;
 use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Upload\ResumableUploader;
-use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -41,7 +40,7 @@ class ResumableUploaderTest extends TestCase
     public function setUp()
     {
         $this->requestWrapper = $this->prophesize(RequestWrapper::class);
-        $this->stream = Psr7\stream_for('abcd');
+        $this->stream = Utils::streamFor('abcd');
         $this->successBody = '{"canI":"kickIt"}';
     }
 

--- a/Core/tests/Unit/Upload/SignedUrlUploaderTest.php
+++ b/Core/tests/Unit/Upload/SignedUrlUploaderTest.php
@@ -20,12 +20,11 @@ namespace Google\Cloud\Core\Tests\Unit\Upload;
 use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,7 +40,7 @@ class SignedUrlUploaderTest extends TestCase
     public function setUp()
     {
         $this->requestWrapper = $this->prophesize(RequestWrapper::class);
-        $this->stream = Psr7\stream_for('abcd');
+        $this->stream = Utils::streamFor('abcd');
         $this->successBody = '{"canI":"kickIt"}';
     }
 

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.43",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Datastore/src/Blob.php
+++ b/Datastore/src/Blob.php
@@ -18,8 +18,6 @@
 namespace Google\Cloud\Datastore;
 
 use Google\Cloud\Core\Blob as CoreBlob;
-use GuzzleHttp\Psr7;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * Represents a Blob value.

--- a/Datastore/tests/Unit/BlobTest.php
+++ b/Datastore/tests/Unit/BlobTest.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Datastore\Tests\Unit;
 
 use Google\Cloud\Datastore\Blob;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,7 +45,7 @@ class BlobTest extends TestCase
 
     public function testBlobStreamInterface()
     {
-        $blob = new Blob(Psr7\stream_for('hello world'));
+        $blob = new Blob(Utils::streamFor('hello world'));
         $this->assertEquals('hello world', (string) $blob);
     }
 

--- a/Datastore/tests/Unit/Connection/RestTest.php
+++ b/Datastore/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Datastore\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Datastore/tests/Unit/EntityTest.php
+++ b/Datastore/tests/Unit/EntityTest.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Datastore\Tests\Unit;
 use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
-use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/Language/tests/Unit/Connection/RestTest.php
+++ b/Language/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Language\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Logging/tests/Unit/Connection/RestTest.php
+++ b/Logging/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Logging\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/PubSub/tests/Unit/Connection/RestTest.php
+++ b/PubSub/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\PubSub\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.43",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Spanner/src/Bytes.php
+++ b/Spanner/src/Bytes.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Spanner;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -50,7 +50,7 @@ class Bytes implements ValueInterface
      */
     public function __construct($value)
     {
-        $this->value = Psr7\stream_for($value);
+        $this->value = Utils::streamFor($value);
     }
 
     /**

--- a/Speech/tests/Unit/Connection/RestTest.php
+++ b/Speech/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Speech\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.43",
         "google/crc32": "^0.1.0"
     },
     "require-dev": {

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -32,7 +32,8 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\Connection\IamBucket;
 use Google\Cloud\Storage\SigningHelper;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\MimeType;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -1070,7 +1071,7 @@ class Bucket
         ];
 
         if (!isset($options['destination']['contentType'])) {
-            $options['destination']['contentType'] = Psr7\mimetype_from_filename($name);
+            $options['destination']['contentType'] = MimeType::fromFilename($name);
         }
 
         if ($options['destination']['contentType'] === null) {
@@ -1266,7 +1267,7 @@ class Bucket
     {
         $file = $file ?: '__tempfile';
         $uploader = $this->getResumableUploader(
-            Psr7\stream_for(''),
+            Utils::streamFor(''),
             ['name' => $file]
         );
         try {

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -29,8 +29,9 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\StorageClient;
 use Google\CRC32\Builtin;
 use Google\CRC32\CRC32;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\MimeType;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -322,7 +323,7 @@ class Rest implements ConnectionInterface
             'userProject' => null,
         ];
 
-        $args['data'] = Psr7\stream_for($args['data']);
+        $args['data'] = Utils::streamFor($args['data']);
 
         if ($args['resumable'] === null) {
             $args['resumable'] = $args['data']->getSize() > AbstractUploader::RESUMABLE_LIMIT;
@@ -334,7 +335,7 @@ class Rest implements ConnectionInterface
 
         $validate = $this->chooseValidationMethod($args);
         if ($validate === 'md5') {
-            $args['metadata']['md5Hash'] = base64_encode(Psr7\hash($args['data'], 'md5', true));
+            $args['metadata']['md5Hash'] = base64_encode(Utils::hash($args['data'], 'md5', true));
         } elseif ($validate === 'crc32') {
             $args['metadata']['crc32c'] = $this->crcFromStream($args['data']);
         }
@@ -343,7 +344,7 @@ class Rest implements ConnectionInterface
         unset($args['name']);
         $args['contentType'] = isset($args['metadata']['contentType'])
             ? $args['metadata']['contentType']
-            : Psr7\mimetype_from_filename($args['metadata']['name']);
+            : MimeType::fromFilename($args['metadata']['name']);
 
         $uploaderOptionKeys = [
             'restOptions',
@@ -505,7 +506,7 @@ class Rest implements ConnectionInterface
         ]);
 
         return [
-            new Request('GET', Psr7\uri_for($uri)),
+            new Request('GET', Utils::uriFor($uri)),
             $requestOptions
         ];
     }

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -23,7 +23,7 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -611,9 +611,9 @@ class StorageObject
      */
     public function downloadToFile($path, array $options = [])
     {
-        $destination = Psr7\stream_for(fopen($path, 'w'));
+        $destination = Utils::streamFor(fopen($path, 'w'));
 
-        Psr7\copy_to_stream(
+        Utils::copyToStream(
             $this->downloadAsStream($options),
             $destination
         );

--- a/Storage/src/StreamWrapper.php
+++ b/Storage/src/StreamWrapper.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Exception\ServiceException;
 use Google\Cloud\Storage\Bucket;
 use GuzzleHttp\Psr7\CachingStream;
-use GuzzleHttp\Psr7;
 
 /**
  * A streamWrapper implementation for handling `gs://bucket/path/to/file.jpg`.

--- a/Storage/tests/Snippet/StorageObjectTest.php
+++ b/Storage/tests/Snippet/StorageObjectTest.php
@@ -29,8 +29,8 @@ use Google\Cloud\Storage\Connection\Rest;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -262,7 +262,7 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(Psr7\stream_for('test'));
+            ->willReturn(Utils::streamFor('test'));
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 
@@ -278,7 +278,7 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(Psr7\stream_for('test'));
+            ->willReturn(Utils::streamFor('test'));
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 
@@ -294,7 +294,7 @@ class StorageObjectTest extends SnippetTestCase
 
         $this->connection->downloadObject(Argument::any())
             ->shouldBeCalled()
-            ->willReturn(Psr7\stream_for('test'));
+            ->willReturn(Utils::streamFor('test'));
 
         $this->object->___setProperty('connection', $this->connection->reveal());
 
@@ -317,7 +317,7 @@ class StorageObjectTest extends SnippetTestCase
                 'object' => 'my-object'
             ])
             ->shouldBeCalled()
-            ->willReturn(Psr7\stream_for('test'));
+            ->willReturn(Utils::streamFor('test'));
         $this->object->___setProperty('connection', $this->connection->reveal());
 
         $res = $snippet->invoke();
@@ -331,7 +331,7 @@ class StorageObjectTest extends SnippetTestCase
         $this->connection->downloadObjectAsync(Argument::any())
             ->shouldBeCalled()
             ->willReturn(
-                Promise\promise_for(Psr7\stream_for('test'))
+                Promise\promise_for(Utils::streamFor('test'))
             );
 
         $this->object->___setProperty('connection', $this->connection->reveal());
@@ -353,7 +353,7 @@ class StorageObjectTest extends SnippetTestCase
         $this->connection->downloadObjectAsync(Argument::any())
             ->shouldBeCalled()
             ->willReturn(
-                Promise\promise_for(Psr7\stream_for('test'))
+                Promise\promise_for(Utils::streamFor('test'))
             );
 
         $this->object->___setProperty('connection', $this->connection->reveal());

--- a/Storage/tests/System/PostPolicyTest.php
+++ b/Storage/tests/System/PostPolicyTest.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Storage\Tests\System;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * @group storage
@@ -116,7 +116,7 @@ class PostPolicyTest extends StorageTestCase
         $fields = [];
         $fields[] = [
             'name' => 'file',
-            'contents' => Psr7\stream_for($content ?: uniqid(self::TESTING_PREFIX))
+            'contents' => Utils::streamFor($content ?: uniqid(self::TESTING_PREFIX))
         ];
 
         foreach ($policy['fields'] as $key => $val) {

--- a/Storage/tests/System/UploadObjectsTest.php
+++ b/Storage/tests/System/UploadObjectsTest.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Storage\Tests\System;
 
 use Google\CRC32\CRC32;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * @group storage
@@ -68,7 +68,7 @@ class UploadObjectsTest extends StorageTestCase
 
     public function testUploadsObjectFromStream()
     {
-        $stream = Psr7\stream_for('somedata');
+        $stream = Utils::streamFor('somedata');
         $options = ['name' => uniqid(self::TESTING_PREFIX)];
         $object = self::$bucket->upload($stream, $options);
 

--- a/Storage/tests/Unit/BucketTest.php
+++ b/Storage/tests/Unit/BucketTest.php
@@ -37,7 +37,6 @@ use Google\Cloud\Storage\SigningHelper;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -27,9 +27,9 @@ use Google\Cloud\Storage\Connection\Rest;
 use Google\CRC32\CRC32;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
@@ -287,9 +287,9 @@ class RestTest extends TestCase
 
     public function insertObjectProvider()
     {
-        $tempFile = Psr7\stream_for(fopen('php://temp', 'r+'));
+        $tempFile = Utils::streamFor(fopen('php://temp', 'r+'));
         $tempFile->write(str_repeat('0', 5000001));
-        $logoFile = Psr7\stream_for(fopen(__DIR__ . '/../data/logo.svg', 'r'));
+        $logoFile = Utils::streamFor(fopen(__DIR__ . '/../data/logo.svg', 'r'));
 
         $crc32c = CRC32::create(CRC32::CASTAGNOLI);
         $crc32c->update((string) $logoFile);
@@ -307,7 +307,7 @@ class RestTest extends TestCase
                 ResumableUploader::class,
                 'text/plain',
                 [
-                    'md5Hash' => base64_encode(Psr7\hash($tempFile, 'md5', true)),
+                    'md5Hash' => base64_encode(Utils::hash($tempFile, 'md5', true)),
                     'name' => 'file.txt'
                 ],
                 ['crc32c']

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -27,7 +27,7 @@ use Google\Cloud\Storage\HmacKey;
 use Google\Cloud\Storage\Lifecycle;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StreamWrapper;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -148,7 +148,7 @@ class StorageClientTest extends TestCase
     public function testSignedUrlUploader()
     {
         $uri = 'http://example.com';
-        $data = Psr7\stream_for('hello world');
+        $data = Utils::streamFor('hello world');
 
         $uploader = $this->client->signedUrlUploader($uri, $data);
         $this->assertInstanceOf(SignedUrlUploader::class, $uploader);

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -31,7 +31,7 @@ use Google\Cloud\Storage\SigningHelper;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -414,7 +414,7 @@ class StorageObjectTest extends TestCase
         $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = self::OBJECT;
-        $stream = Psr7\stream_for($string = 'abcdefg');
+        $stream = Utils::streamFor($string = 'abcdefg');
         $this->connection->downloadObject([
                 'bucket' => $bucket,
                 'object' => $object,
@@ -443,7 +443,7 @@ class StorageObjectTest extends TestCase
         $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = self::OBJECT;
-        $stream = Psr7\stream_for($string = 'abcdefg');
+        $stream = Utils::streamFor($string = 'abcdefg');
         $this->connection->downloadObject([
                 'bucket' => $bucket,
                 'object' => $object,
@@ -470,7 +470,7 @@ class StorageObjectTest extends TestCase
     {
         $bucket = 'bucket';
         $object = self::OBJECT;
-        $stream = Psr7\stream_for($string = 'abcdefg');
+        $stream = Utils::streamFor($string = 'abcdefg');
         $this->connection->downloadObject([
             'bucket' => $bucket,
             'object' => $object,
@@ -491,7 +491,7 @@ class StorageObjectTest extends TestCase
         $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = self::OBJECT;
-        $stream = Psr7\stream_for($string = 'abcdefg');
+        $stream = Utils::streamFor($string = 'abcdefg');
         $this->connection->downloadObject([
             'bucket' => $bucket,
             'object' => $object,
@@ -522,7 +522,7 @@ class StorageObjectTest extends TestCase
         $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = self::OBJECT;
-        $stream = Psr7\stream_for($string = 'abcdefg');
+        $stream = Utils::streamFor($string = 'abcdefg');
         $this->connection->downloadObjectAsync([
             'bucket' => $bucket,
             'object' => $object,

--- a/Storage/tests/Unit/StreamWrapperTest.php
+++ b/Storage/tests/Unit/StreamWrapperTest.php
@@ -23,7 +23,7 @@ use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
 use Google\Cloud\Storage\StreamWrapper;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\BufferStream;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
 
@@ -453,7 +453,7 @@ class StreamWrapperTest extends TestCase
     private function mockObjectData($file, $data, $bucket = null)
     {
         $bucket = $bucket ?: $this->bucket;
-        $stream = new \GuzzleHttp\Psr7\BufferStream(100);
+        $stream = new BufferStream(100);
         $stream->write($data);
         $object = $this->prophesize(StorageObject::class);
         $object->downloadAsStream(Argument::any())->willReturn($stream);

--- a/Translate/tests/Unit/V2/Connection/RestTest.php
+++ b/Translate/tests/Unit/V2/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Translate\V2\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.43",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Vision/src/Image.php
+++ b/Vision/src/Image.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Vision;
 
 use Google\Cloud\Storage\StorageObject;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 
 /**
@@ -249,7 +249,7 @@ class Image
             $this->image = $image->gcsUri();
         } elseif (is_resource($image)) {
             $this->type = self::TYPE_BYTES;
-            $this->image = Psr7\stream_for($image);
+            $this->image = Utils::streamFor($image);
         } else {
             throw new InvalidArgumentException(
                 'Given image is not valid. ' .

--- a/Vision/tests/Unit/Connection/RestTest.php
+++ b/Vision/tests/Unit/Connection/RestTest.php
@@ -21,7 +21,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Vision\Connection\Rest;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,13 @@
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
         "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
-        "guzzlehttp/psr7": "^1.2",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*",
         "ramsey/uuid": "^3.0|^4.0",
-        "google/gax": "^1.1",
+        "google/gax": "^1.9",
         "google/common-protos": "^1.3.1",
-        "google/auth": "^1.12",
+        "google/auth": "^1.18",
         "google/crc32": "^0.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR aims to resolve version dependency issues related to older versions(<1.7) for guzzlehttp/psr7 package. See issue #4247 for details.

The use of deprecated methods have been removed and the dependencies have been upgraded.