### PR TITLE
[Logging] fix: require the supported psr/log version

### DIFF
--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -5,8 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.39",
-        "google/gax": "^1.1",
-        "psr/log": "^1.0"
+        "google/gax": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",
@@ -18,9 +17,13 @@
         "google/cloud-pubsub": "^1.0",
         "opis/closure": "^3"
     },
+    "provide": {
+        "psr/log-implementation": "1.0|2.0"
+    },
     "suggest": {
         "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
-        "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions."
+        "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.",
+        "psr/log": "For using the PSR logger"
     },
     "extra": {
         "component": {
@@ -40,5 +43,8 @@
         "psr-4": {
             "Google\\Cloud\\Logging\\Tests\\": "tests"
         }
+    },
+    "conflict": {
+        "psr/log": ">=3"
     }
 }

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "google/cloud-core": "^1.39",
         "google/gax": "^1.1",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -5,7 +5,8 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.39",
-        "google/gax": "^1.1"
+        "google/gax": "^1.1",
+        "psr/log": "^1.0",
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
On PHP 8.0, this package can be installed beside a psr library supporting `psr/log:2.0` or `psr/log:3.0`, and the interface is not compatible with our implementation. Therefore we need to define that this package is only compatible with `psr/log:^1.0`.

### Update

Looking into the [provide](https://getcomposer.org/doc/04-schema.md#provide) keyword in the composer JSON schema, this does not seem sufficient to prevent incompatible logging implementations, e.g:

```
"provide": {
    "psr/logging-implementation: "^1.0"
}
```

has no effect on the packages which are allowed

### Update 2

I think we want to use [conflict](https://getcomposer.org/doc/04-schema.md#conflict) in the composer JSON schema, similar to how this is being used in [symfony/console](https://github.com/symfony/console/blob/5.3/composer.json#L46).