### PR TITLE
chore: update repo metadata

### DIFF
--- a/AccessApproval/.repo-metadata.json
+++ b/AccessApproval/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-access-approval",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-access-approval/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-access-approval/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AccessContextManager/.repo-metadata.json
+++ b/AccessContextManager/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/access-context-manager",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/access-context-manager/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/access-context-manager/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AnalyticsAdmin/.repo-metadata.json
+++ b/AnalyticsAdmin/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/analytics-admin",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/analytics-admin/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/analytics-admin/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AnalyticsData/.repo-metadata.json
+++ b/AnalyticsData/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/analytics-data",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/analytics-data/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/analytics-data/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ApiGateway/.repo-metadata.json
+++ b/ApiGateway/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-api-gateway",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-api-gateway/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-api-gateway/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ApigeeConnect/.repo-metadata.json
+++ b/ApigeeConnect/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-apigee-connect",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-apigee-connect/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-apigee-connect/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AppEngineAdmin/.repo-metadata.json
+++ b/AppEngineAdmin/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-appengine-admin",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-appengine-admin/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-appengine-admin/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ArtifactRegistry/.repo-metadata.json
+++ b/ArtifactRegistry/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-artifact-registry",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-artifact-registry/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-artifact-registry/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Asset/.repo-metadata.json
+++ b/Asset/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-asset",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-asset/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-asset/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AssuredWorkloads/.repo-metadata.json
+++ b/AssuredWorkloads/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-assured-workloads",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-assured-workloads/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-assured-workloads/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/AutoMl/.repo-metadata.json
+++ b/AutoMl/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-automl",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-automl/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-automl/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BigQuery/.repo-metadata.json
+++ b/BigQuery/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigquery",
     "release_level": "ga",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery/latest",
+    "library_type": "GAPIC_MANUAL"
 }

--- a/BigQueryConnection/.repo-metadata.json
+++ b/BigQueryConnection/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigquery-connection",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-connection/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-connection/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BigQueryDataTransfer/.repo-metadata.json
+++ b/BigQueryDataTransfer/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigquerydatatransfer",
     "release_level": "ga",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquerydatatransfer/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquerydatatransfer/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BigQueryReservation/.repo-metadata.json
+++ b/BigQueryReservation/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigquery-reservation",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-reservation/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-reservation/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BigQueryStorage/.repo-metadata.json
+++ b/BigQueryStorage/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigquery-storage",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-storage/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-bigquery-storage/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Bigtable/.repo-metadata.json
+++ b/Bigtable/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-bigtable",
     "release_level": "ga",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigtable/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-bigtable/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/Billing/.repo-metadata.json
+++ b/Billing/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-billing",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-billing/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-billing/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BillingBudgets/.repo-metadata.json
+++ b/BillingBudgets/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-billing-budgets",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-billing-budgets/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-billing-budgets/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/BinaryAuthorization/.repo-metadata.json
+++ b/BinaryAuthorization/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-binary-authorization",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-binary-authorization/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-binary-authorization/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Build/.repo-metadata.json
+++ b/Build/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-build",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-build/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-build/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Channel/.repo-metadata.json
+++ b/Channel/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+    "distribution_name": "google/cloud-channel",
+    "release_level": "beta",
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-channel/latest",
+    "library_type": "GAPIC_AUTO"
+}

--- a/CommonProtos/.repo-metadata.json
+++ b/CommonProtos/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-common-protos",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-common-protos/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-common-protos/latest",
+    "library_type": "CORE"
 }

--- a/Compute/.repo-metadata.json
+++ b/Compute/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-compute",
     "release_level": "beta",
-    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-compute/latest"
+    "client_documentation": "https://googleapis.github.io/google-cloud-php/#/docs/cloud-compute/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ContactCenterInsights/.repo-metadata.json
+++ b/ContactCenterInsights/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-contact-center-insights",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-contact-center-insights/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-contact-center-insights/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Container/.repo-metadata.json
+++ b/Container/.repo-metadata.json
@@ -2,5 +2,6 @@
     "distribution_name": "google/cloud-container",
     "release_level": "ga",
     "codeowner_team": "@googleapis/cicd",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-container/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-container/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ContainerAnalysis/.repo-metadata.json
+++ b/ContainerAnalysis/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-container-analysis",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-container-analysis/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-container-analysis/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Core/.repo-metadata.json
+++ b/Core/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-core",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-core/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-core/latest",
+    "library_type": "CORE"
 }

--- a/DataCatalog/.repo-metadata.json
+++ b/DataCatalog/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-data-catalog",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-data-catalog/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-data-catalog/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/DataFusion/.repo-metadata.json
+++ b/DataFusion/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-data-fusion",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-data-fusion/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-data-fusion/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/DataLabeling/.repo-metadata.json
+++ b/DataLabeling/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-datalabeling",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datalabeling/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datalabeling/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Dataflow/.repo-metadata.json
+++ b/Dataflow/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dataflow",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataflow/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataflow/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Dataproc/.repo-metadata.json
+++ b/Dataproc/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dataproc",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataproc/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataproc/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/DataprocMetastore/.repo-metadata.json
+++ b/DataprocMetastore/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dataproc-metastore",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataproc-metastore/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dataproc-metastore/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Datastore/.repo-metadata.json
+++ b/Datastore/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-datastore",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datastore/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datastore/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/DatastoreAdmin/.repo-metadata.json
+++ b/DatastoreAdmin/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-datastore-admin",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datastore-admin/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-datastore-admin/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Debugger/.repo-metadata.json
+++ b/Debugger/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-debugger",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-debugger/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-debugger/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/Deploy/.repo-metadata.json
+++ b/Deploy/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-deploy",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-deploy/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-deploy/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Dialogflow/.repo-metadata.json
+++ b/Dialogflow/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dialogflow",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dialogflow/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dialogflow/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Dlp/.repo-metadata.json
+++ b/Dlp/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dlp",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dlp/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dlp/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Dms/.repo-metadata.json
+++ b/Dms/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-dms",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dms/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-dms/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/DocumentAi/.repo-metadata.json
+++ b/DocumentAi/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-document-ai",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-document-ai/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-document-ai/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Domains/.repo-metadata.json
+++ b/Domains/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-domains",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-domains/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-domains/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ErrorReporting/.repo-metadata.json
+++ b/ErrorReporting/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-error-reporting",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-error-reporting/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-error-reporting/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/EssentialContacts/.repo-metadata.json
+++ b/EssentialContacts/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-essential-contacts",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-essential-contacts/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-essential-contacts/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Eventarc/.repo-metadata.json
+++ b/Eventarc/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-eventarc",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-eventarc/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-eventarc/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Filestore/.repo-metadata.json
+++ b/Filestore/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-filestore",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-filestore/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-filestore/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Firestore/.repo-metadata.json
+++ b/Firestore/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-firestore",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-firestore/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-firestore/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/Functions/.repo-metadata.json
+++ b/Functions/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-functions",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-functions/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-functions/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Gaming/.repo-metadata.json
+++ b/Gaming/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-game-servers",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-game-servers/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-game-servers/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/GkeConnectGateway/.repo-metadata.json
+++ b/GkeConnectGateway/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-gke-connect-gateway",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-gke-connect-gateway/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-gke-connect-gateway/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/GkeHub/.repo-metadata.json
+++ b/GkeHub/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-gke-hub",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-gke-hub/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-gke-hub/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Grafeas/.repo-metadata.json
+++ b/Grafeas/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/grafeas",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/grafeas/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/grafeas/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/IamCredentials/.repo-metadata.json
+++ b/IamCredentials/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-iam-credentials",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iam-credentials/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iam-credentials/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Iap/.repo-metadata.json
+++ b/Iap/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-iap",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iap/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iap/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Iot/.repo-metadata.json
+++ b/Iot/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-iot",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iot/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-iot/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Kms/.repo-metadata.json
+++ b/Kms/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-kms",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-kms/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-kms/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Language/.repo-metadata.json
+++ b/Language/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-language",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-language/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-language/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/LifeSciences/.repo-metadata.json
+++ b/LifeSciences/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-life-sciences",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-life-sciences/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-life-sciences/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Logging/.repo-metadata.json
+++ b/Logging/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-logging",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-logging/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-logging/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/ManagedIdentities/.repo-metadata.json
+++ b/ManagedIdentities/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-managed-identities",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-managed-identities/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-managed-identities/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/MediaTranslation/.repo-metadata.json
+++ b/MediaTranslation/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-media-translation",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-media-translation/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-media-translation/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Memcache/.repo-metadata.json
+++ b/Memcache/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-memcache",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-memcache/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-memcache/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Monitoring/.repo-metadata.json
+++ b/Monitoring/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-monitoring",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-monitoring/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-monitoring/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/NetworkConnectivity/.repo-metadata.json
+++ b/NetworkConnectivity/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-network-connectivity",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-connectivity/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-connectivity/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/NetworkManagement/.repo-metadata.json
+++ b/NetworkManagement/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-network-management",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-management/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-management/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/NetworkSecurity/.repo-metadata.json
+++ b/NetworkSecurity/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-network-security",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-security/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-network-security/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Notebooks/.repo-metadata.json
+++ b/Notebooks/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-notebooks",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-notebooks/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-notebooks/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/OrchestrationAirflow/.repo-metadata.json
+++ b/OrchestrationAirflow/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-orchestration-airflow",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-orchestration-airflow/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-orchestration-airflow/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/OrgPolicy/.repo-metadata.json
+++ b/OrgPolicy/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-org-policy",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-org-policy/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-org-policy/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/OsConfig/.repo-metadata.json
+++ b/OsConfig/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-osconfig",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-osconfig/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-osconfig/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/OsLogin/.repo-metadata.json
+++ b/OsLogin/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-oslogin",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-oslogin/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-oslogin/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/PolicyTroubleshooter/.repo-metadata.json
+++ b/PolicyTroubleshooter/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-policy-troubleshooter",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-policy-troubleshooter/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-policy-troubleshooter/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/PrivateCatalog/.repo-metadata.json
+++ b/PrivateCatalog/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-private-catalog",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-private-catalog/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-private-catalog/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Profiler/.repo-metadata.json
+++ b/Profiler/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-profiler",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-profiler/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-profiler/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/PubSub/.repo-metadata.json
+++ b/PubSub/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-pubsub",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-pubsub/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-pubsub/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/RecaptchaEnterprise/.repo-metadata.json
+++ b/RecaptchaEnterprise/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-recaptcha-enterprise",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recaptcha-enterprise/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recaptcha-enterprise/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/RecommendationEngine/.repo-metadata.json
+++ b/RecommendationEngine/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-recommendations-ai",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recommendations-ai/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recommendations-ai/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Recommender/.repo-metadata.json
+++ b/Recommender/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-recommender",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recommender/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-recommender/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Redis/.repo-metadata.json
+++ b/Redis/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-redis",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-redis/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-redis/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ResourceManager/.repo-metadata.json
+++ b/ResourceManager/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-resource-manager",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-resource-manager/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-resource-manager/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ResourceSettings/.repo-metadata.json
+++ b/ResourceSettings/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-resource-settings",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-resource-settings/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-resource-settings/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Retail/.repo-metadata.json
+++ b/Retail/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+    "distribution_name": "google/cloud-retail",
+    "release_level": "beta",
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-retail/latest",
+    "library_type": "GAPIC_AUTO"
+}

--- a/Scheduler/.repo-metadata.json
+++ b/Scheduler/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-scheduler",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-scheduler/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-scheduler/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/SecretManager/.repo-metadata.json
+++ b/SecretManager/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-secret-manager",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-secret-manager/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-secret-manager/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/SecurityCenter/.repo-metadata.json
+++ b/SecurityCenter/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-security-center",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-security-center/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-security-center/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/SecurityPrivateCa/.repo-metadata.json
+++ b/SecurityPrivateCa/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+    "distribution_name": "google/cloud-security-private-ca",
+    "release_level": "beta",
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-security-private-ca/latest",
+    "library_type": "GAPIC_AUTO"
+}

--- a/ServiceControl/.repo-metadata.json
+++ b/ServiceControl/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-service-control",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-control/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-control/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ServiceDirectory/.repo-metadata.json
+++ b/ServiceDirectory/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-service-directory",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-directory/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-directory/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ServiceManagement/.repo-metadata.json
+++ b/ServiceManagement/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-service-management",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-management/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-management/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/ServiceUsage/.repo-metadata.json
+++ b/ServiceUsage/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-service-usage",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-usage/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-service-usage/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Shell/.repo-metadata.json
+++ b/Shell/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-shell",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-shell/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-shell/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Spanner/.repo-metadata.json
+++ b/Spanner/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-spanner",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-spanner/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-spanner/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/Speech/.repo-metadata.json
+++ b/Speech/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-speech",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-speech/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-speech/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/SqlAdmin/.repo-metadata.json
+++ b/SqlAdmin/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-sql-admin",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-sql-admin/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-sql-admin/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Storage/.repo-metadata.json
+++ b/Storage/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-storage",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-storage/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-storage/latest",
+    "library_type": "GAPIC_MANUAL"
 }

--- a/StorageTransfer/.repo-metadata.json
+++ b/StorageTransfer/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-storage-transfer",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-storage-transfer/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-storage-transfer/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Talent/.repo-metadata.json
+++ b/Talent/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-talent",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-talent/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-talent/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Tasks/.repo-metadata.json
+++ b/Tasks/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-tasks",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-tasks/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-tasks/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/TextToSpeech/.repo-metadata.json
+++ b/TextToSpeech/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-text-to-speech",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-text-to-speech/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-text-to-speech/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Tpu/.repo-metadata.json
+++ b/Tpu/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-tpu",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-tpu/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-tpu/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Trace/.repo-metadata.json
+++ b/Trace/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-trace",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-trace/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-trace/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/Translate/.repo-metadata.json
+++ b/Translate/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-translate",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-translate/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-translate/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/VideoIntelligence/.repo-metadata.json
+++ b/VideoIntelligence/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-videointelligence",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-videointelligence/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-videointelligence/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/VideoTranscoder/.repo-metadata.json
+++ b/VideoTranscoder/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-video-transcoder",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-video-transcoder/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-video-transcoder/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Vision/.repo-metadata.json
+++ b/Vision/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-vision",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-vision/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-vision/latest",
+    "library_type": "GAPIC_COMBO"
 }

--- a/VpcAccess/.repo-metadata.json
+++ b/VpcAccess/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-vpc-access",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-vpc-access/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-vpc-access/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/WebRisk/.repo-metadata.json
+++ b/WebRisk/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-web-risk",
     "release_level": "ga",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-web-risk/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-web-risk/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/WebSecurityScanner/.repo-metadata.json
+++ b/WebSecurityScanner/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-web-security-scanner",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-web-security-scanner/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-web-security-scanner/latest",
+    "library_type": "GAPIC_AUTO"
 }

--- a/Workflows/.repo-metadata.json
+++ b/Workflows/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "distribution_name": "google/cloud-workflows",
     "release_level": "beta",
-    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-workflows/latest"
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-workflows/latest",
+    "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
Add `library_type` for all packages with `.repo-metadata.json`. This data was gathered using the following script:

```sh
# List all packages with a handwritten component
find . -name *Client.php -depth 3 | grep -v tests | sed 's/\/src\/.*//' | cut -c 3- | sort | uniq > handwritten.txt

# List all packages with Gapic components
find . -name Gapic -type d | cut -c 3- | sed 's/\/src\/.*//' | sort | uniq > generated.txt

# List "Manual" packages
diff handwritten.txt generated.txt | grep '^<' | cut -c 3- > manual.txt

# List "Combo" packages
diff handwritten.txt manual.txt | grep '^<' | cut -c 3- > combo.txt
```

1. The following have `library_type` of `CORE`:
    * `Core`
    * `CommonProtos`
2. The following have `library_type` of `GAPIC_MANUAL`:
    * `BigQuery`
    * `Storage`
3. The following have `library_type` of `GAPIC_COMBO`:
    * `Bigtable`
    * `Datastore`
    * `Debugger`
    * `Firestore`
    * `Language`
    * `Logging`
    * `PubSub`
    * `Spanner`
    * `Speech`
    * `Trace`
    * `Translate`
    * `Vision`
5. All the other `.repo-metadata.json` files have `GAPIC_AUTO`
5. The following were missing `.repo-metadata.json` files (I presume was by accident), which have now been added:
    * `Channel`
    * `Retail`
    * `SecurityPrivateCa`


