### PR TITLE
fix: Improve PHP 8.1 compatibility by disabling deprecation notices

### DIFF
--- a/BigQuery/src/QueryResults.php
+++ b/BigQuery/src/QueryResults.php
@@ -352,6 +352,7 @@ class QueryResults implements \IteratorAggregate
      *         query completion has been exceeded.
      * @throws GoogleException Thrown in the case of a malformed response.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->rows();

--- a/Bigtable/src/ChunkFormatter.php
+++ b/Bigtable/src/ChunkFormatter.php
@@ -490,6 +490,7 @@ class ChunkFormatter implements \IteratorAggregate
      * @return \Generator
      * @throws BigtableDataOperationException Thrown in the case of a malformed response.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->readAll();

--- a/Bigtable/src/ResumableStream.php
+++ b/Bigtable/src/ResumableStream.php
@@ -112,6 +112,7 @@ class ResumableStream implements \IteratorAggregate
      * @return \Generator
      * @throws ApiException Thrown in the case of a malformed response.
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->readAll();

--- a/Core/src/Iterator/ItemIteratorTrait.php
+++ b/Core/src/Iterator/ItemIteratorTrait.php
@@ -74,6 +74,7 @@ trait ItemIteratorTrait
      *
      * @return null
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->pageIndex = 0;
@@ -86,6 +87,7 @@ trait ItemIteratorTrait
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $page = $this->pageIterator->current();
@@ -100,6 +102,7 @@ trait ItemIteratorTrait
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -110,6 +113,7 @@ trait ItemIteratorTrait
      *
      * @return null
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->pageIndex++;
@@ -126,6 +130,7 @@ trait ItemIteratorTrait
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         $page = $this->pageIterator->current();

--- a/Core/src/Iterator/PageIteratorTrait.php
+++ b/Core/src/Iterator/PageIteratorTrait.php
@@ -146,6 +146,7 @@ trait PageIteratorTrait
      *
      * @return null
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->itemCount = 0;
@@ -169,6 +170,7 @@ trait PageIteratorTrait
      *
      * @return array|null
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->page === null) {
@@ -189,6 +191,7 @@ trait PageIteratorTrait
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -199,6 +202,7 @@ trait PageIteratorTrait
      *
      * @return null
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->position++;
@@ -212,6 +216,7 @@ trait PageIteratorTrait
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if (!$this->page && $this->position) {

--- a/Core/src/Testing/FileListFilterIterator.php
+++ b/Core/src/Testing/FileListFilterIterator.php
@@ -62,6 +62,7 @@ class FileListFilterIterator extends \FilterIterator
      * @experimental
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         /** @var \SplFileInfo */

--- a/Core/src/Testing/Snippet/Coverage/ExcludeFilter.php
+++ b/Core/src/Testing/Snippet/Coverage/ExcludeFilter.php
@@ -44,6 +44,7 @@ class ExcludeFilter extends FilterIterator
     /**
      * @return bool Determines whether to accept or exclude a path
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         // Accept the current item if we can recurse into it

--- a/Core/src/Testing/Snippet/Parser/Snippet.php
+++ b/Core/src/Testing/Snippet/Parser/Snippet.php
@@ -291,6 +291,7 @@ class Snippet implements \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->config;

--- a/Datastore/src/DatastoreSessionHandler.php
+++ b/Datastore/src/DatastoreSessionHandler.php
@@ -189,6 +189,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
      *        used here. It will use this value as the Datastore kind.
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         $this->kind = $sessionName;
@@ -206,6 +207,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Just return true for this implementation.
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -214,6 +216,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Read the session data from Cloud Datastore.
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         try {
@@ -243,6 +246,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
      * @param string $data The session data to write to the {@see \Google\Cloud\Datastore\Entity}.
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         try {
@@ -274,6 +278,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Delete the session data from Cloud Datastore.
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         try {
@@ -297,6 +302,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Delete the old session data from Cloud Datastore.
      */
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         if ($this->gcLimit === 0) {

--- a/Datastore/src/Entity.php
+++ b/Datastore/src/Entity.php
@@ -113,6 +113,7 @@ class Entity implements ArrayAccess, EntityInterface
      * @return void
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $val)
     {
         $this->entity[$key] = $val;
@@ -123,6 +124,7 @@ class Entity implements ArrayAccess, EntityInterface
      * @return bool
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->entity[$key]);
@@ -133,6 +135,7 @@ class Entity implements ArrayAccess, EntityInterface
      * @return void
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->entity[$key]);
@@ -143,6 +146,7 @@ class Entity implements ArrayAccess, EntityInterface
      * @return mixed
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return isset($this->entity[$key])

--- a/Datastore/src/EntityPageIterator.php
+++ b/Datastore/src/EntityPageIterator.php
@@ -51,6 +51,7 @@ class EntityPageIterator implements \Iterator
      *
      * @return array|null
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (!$this->page) {

--- a/Datastore/src/Key.php
+++ b/Datastore/src/Key.php
@@ -421,6 +421,7 @@ class Key implements JsonSerializable
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->keyObject();

--- a/Datastore/src/Query/GqlQuery.php
+++ b/Datastore/src/Query/GqlQuery.php
@@ -214,6 +214,7 @@ class GqlQuery implements QueryInterface
      * @access private
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->queryObject();

--- a/Datastore/src/Query/Query.php
+++ b/Datastore/src/Query/Query.php
@@ -476,6 +476,7 @@ class Query implements QueryInterface
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->queryObject();

--- a/Datastore/tests/Unit/SampleEntity.php
+++ b/Datastore/tests/Unit/SampleEntity.php
@@ -33,21 +33,25 @@ class SampleEntity implements EntityInterface, \arrayaccess
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $val)
     {
         $this->entity[$key] = $val;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->entity[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->entity[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return isset($this->entity[$key])

--- a/Debugger/src/MatchingFileIterator.php
+++ b/Debugger/src/MatchingFileIterator.php
@@ -62,6 +62,7 @@ class MatchingFileIterator extends \FilterIterator
      * @access private
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         $candidate = $this->getInnerIterator()->current();

--- a/Firestore/src/DocumentSnapshot.php
+++ b/Firestore/src/DocumentSnapshot.php
@@ -310,6 +310,7 @@ class DocumentSnapshot implements \ArrayAccess
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \BadMethodCallException('DocumentSnapshots are read-only.');
@@ -318,6 +319,7 @@ class DocumentSnapshot implements \ArrayAccess
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->data);
@@ -326,6 +328,7 @@ class DocumentSnapshot implements \ArrayAccess
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \BadMethodCallException('DocumentSnapshots are read-only.');
@@ -334,6 +337,7 @@ class DocumentSnapshot implements \ArrayAccess
     /**
      * @access private
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {

--- a/Firestore/src/FirestoreSessionHandler.php
+++ b/Firestore/src/FirestoreSessionHandler.php
@@ -211,6 +211,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      *        used in the Firestore collection ID.
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         $this->savePath = $savePath;
@@ -241,6 +242,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
     /**
      * Close the transaction and commit any changes.
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         if (is_null($this->transaction)) {
@@ -264,6 +266,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      * @param string $id Identifier used for the session.
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         $this->id = $id;
@@ -298,6 +301,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      * @param string $data The session data to write to the Firestore document.
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         $docRef = $this->getDocumentReference(
@@ -320,6 +324,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      * @param string $id Identifier used for the session
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         $docRef = $this->getDocumentReference(
@@ -340,6 +345,7 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      *        in seconds.
      * @return int|bool
      */
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         if (0 === $this->options['gcLimit']) {

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -112,6 +112,7 @@ class QuerySnapshot implements \IteratorAggregate
      * @access private
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->rows);

--- a/Spanner/src/Result.php
+++ b/Spanner/src/Result.php
@@ -374,6 +374,7 @@ class Result implements \IteratorAggregate
      * @access private
      * @return \Generator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->rows();

--- a/Storage/src/Lifecycle.php
+++ b/Storage/src/Lifecycle.php
@@ -304,6 +304,7 @@ class Lifecycle implements \ArrayAccess, \IteratorAggregate
      * @access private
      * @return \Generator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         if (!isset($this->lifecycle['rule'])) {
@@ -329,6 +330,7 @@ class Lifecycle implements \ArrayAccess, \IteratorAggregate
      * @param string $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->lifecycle['rule'][$offset] = $value;
@@ -339,6 +341,7 @@ class Lifecycle implements \ArrayAccess, \IteratorAggregate
      * @param string $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->lifecycle['rule'][$offset]);
@@ -348,6 +351,7 @@ class Lifecycle implements \ArrayAccess, \IteratorAggregate
      * @access private
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->lifecycle['rule'][$offset]);
@@ -358,6 +362,7 @@ class Lifecycle implements \ArrayAccess, \IteratorAggregate
      * @param string $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->lifecycle['rule'][$offset])

--- a/Storage/src/ObjectPageIterator.php
+++ b/Storage/src/ObjectPageIterator.php
@@ -48,6 +48,7 @@ class ObjectPageIterator implements \Iterator
      *
      * @return array|null
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (!$this->page) {

--- a/Trace/src/Attributes.php
+++ b/Trace/src/Attributes.php
@@ -51,6 +51,7 @@ class Attributes implements \ArrayAccess
      * @param string $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->attributes[$offset] = $value;
@@ -62,6 +63,7 @@ class Attributes implements \ArrayAccess
      * @access private
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->attributes[$offset]);
@@ -73,6 +75,7 @@ class Attributes implements \ArrayAccess
      * @access private
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
@@ -84,6 +87,7 @@ class Attributes implements \ArrayAccess
      * @access private
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->attributes[$offset])


### PR DESCRIPTION
Closes #4554 

I honestly have no idea how to reliably test this, but what I did was open the project in PHPStorm, set the language level to PHP 8.1, and run the **Class Hierarchy Checks** inspection.

See https://php.watch/versions/8.1/internal-method-return-types#ReturnTypeWillChange

:octocat:

PS: This will probably not survive PHP 8.2 😅 