### PR TITLE
fix: step ordering for component release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,17 @@ jobs:
           with:
             persist-credentials: false
             fetch-depth: 0
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: '7.4'
+            ini-values: memory_limit=2048M
         - name: Install Dependencies
           uses: nick-invision/retry@v1
           with:
             timeout_minutes: 10
             max_attempts: 3
             command: composer update
-        - name: Setup PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: '7.4'
-            ini-values: memory_limit=2048M
         - id: getTag
           name: Get Tag
           run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/Core/unit-bootstrap.php
+++ b/Core/unit-bootstrap.php
@@ -8,3 +8,5 @@ date_default_timezone_set('UTC');
 \SebastianBergmann\Comparator\Factory::getInstance()->register(new MessageAwareArrayComparator());
 \SebastianBergmann\Comparator\Factory::getInstance()->register(new ProtobufMessageComparator());
 \SebastianBergmann\Comparator\Factory::getInstance()->register(new ProtobufGPBEmptyComparator());
+
+PHPUnit_Framework_Error_Deprecated::$enabled = false;


### PR DESCRIPTION
Without this, the component `split` command fails because the appropriate version of PHP (7.4) has not been set up