### PR TITLE
fix(PubSub): PHP8.1 deprecation warning on preg_match()

### DIFF
--- a/PubSub/src/ResourceNameTrait.php
+++ b/PubSub/src/ResourceNameTrait.php
@@ -123,6 +123,6 @@ trait ResourceNameTrait
                 $type
             ));
         }
-        return (preg_match($this->regexes[$type], $name) === 1);
+        return (preg_match($this->regexes[$type], $name ?? '') === 1);
     }
 }

--- a/PubSub/src/ResourceNameTrait.php
+++ b/PubSub/src/ResourceNameTrait.php
@@ -123,6 +123,7 @@ trait ResourceNameTrait
                 $type
             ));
         }
-        return (preg_match($this->regexes[$type], $name ?? '') === 1);
+        $name = empty($name) ? '' : $name;
+        return (preg_match($this->regexes[$type], $name) === 1);
     }
 }


### PR DESCRIPTION
Fixes #4869 by null-coalescing the second param of `preg_match()` to an empty string.

Alternative solutions:
- ensuring the param is non-nullable (which may be better overall given the type signature here, though it comes with a higher surface area of changes required)
- update it to accept a nullable `$name`, and `if $name === null return false;` (which makes sense - if only a `$type` is provided, it's not a fully-qualified _resource_ name)

edit:
* CLA signed