### PR TITLE
fix: [Spanner] exclude partial veneer SpannerClient from owlbot

### DIFF
--- a/Spanner/owlbot.py
+++ b/Spanner/owlbot.py
@@ -31,7 +31,13 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(src=src, dest=dest)
+php.owlbot_main(
+    src=src,
+    dest=dest,
+    copy_excludes=[
+        src / "*/src/V1/SpannerClient.php"
+    ]
+)
 
 
 


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/pull/4888

Without this, tests are failing in spanner with the following error (because the `getTransport` method is being overwritten)


```
Prophecy\Exception\Doubler\MethodNotFoundException: Method `Double\Google\Cloud\Spanner\V1\SpannerClient\P73::getTransport()` not found.
```
