### PR TITLE
fix: make partial veneer client excludes explicit

### DIFF
--- a/Bigtable/owlbot.py
+++ b/Bigtable/owlbot.py
@@ -38,7 +38,7 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/*Client.php"
+        src / "*/src/V2/BigtableClient.php"
     ]
 )
 

--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -34,13 +34,7 @@ preserve_copyright_year = php._merge
 _tracked_paths.add(src)
 
 # Exclude the partial veneer
-php.owlbot_main(
-    src=src,
-    dest=dest,
-    copy_excludes=[
-        src / "*/src/*/*Client.php"
-    ]
-)
+php.owlbot_main(src=src, dest=dest)
 
 # Firestore Admin also lives here
 admin_library = Path(f"../{php.STAGING_DIR}/Firestore/v1/Admin").resolve()

--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -33,7 +33,6 @@ preserve_copyright_year = php._merge
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-# Exclude the partial veneer
 php.owlbot_main(src=src, dest=dest)
 
 # Firestore Admin also lives here

--- a/Redis/owlbot.py
+++ b/Redis/owlbot.py
@@ -34,7 +34,8 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/*Client.php"
+        src / "*/src/V1/CloudRedisClient.php",
+        src / "*/src/V1beta1/CloudRedisClient.php"
     ]
 )
 

--- a/Speech/owlbot.py
+++ b/Speech/owlbot.py
@@ -35,7 +35,7 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/*Client.php"
+        src / "*/src/V1/SpeechClient.php"
     ]
 )
 

--- a/Translate/owlbot.py
+++ b/Translate/owlbot.py
@@ -34,7 +34,7 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/*Client.php"
+        src / "*/src/V2/TranslateClient.php"
     ]
 )
 


### PR DESCRIPTION
Partial veneer excludes were being greedy, also excluding `GrpcClient.php` classes, which are autogenerated and shouldn't be excluded, and in many cases excluding veneer classes which do not contain customizations.

This was causing the error in https://github.com/googleapis/google-cloud-php/pull/4887

We should be explicit whenever a veneer is customized. This will prevent unexpected behavior.