### PR TITLE
chore: fix workflow owlbot selector for deprecated proto aliases

### DIFF
--- a/Workflows/owlbot.py
+++ b/Workflows/owlbot.py
@@ -79,7 +79,7 @@ s.move(executions_library / 'proto/src/GPBMetadata/Google/Cloud/Workflows',
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"


### PR DESCRIPTION
See #4872 - only one alias is removed, where three classes are removed in #4993. This is because the subdirectory `Executions` was not being selected by the existing selector