### PR TITLE
fix: remove deprecated aliases in double-nested protos

### DIFF
--- a/AnalyticsData/owlbot.py
+++ b/AnalyticsData/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Compute/owlbot.py
+++ b/Compute/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ContactCenterInsights/owlbot.py
+++ b/ContactCenterInsights/owlbot.py
@@ -41,7 +41,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ContainerAnalysis/owlbot.py
+++ b/ContainerAnalysis/owlbot.py
@@ -41,7 +41,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Deploy/owlbot.py
+++ b/Deploy/owlbot.py
@@ -41,7 +41,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/DocumentAi/owlbot.py
+++ b/DocumentAi/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Domains/owlbot.py
+++ b/Domains/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Functions/owlbot.py
+++ b/Functions/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Gaming/owlbot.py
+++ b/Gaming/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Grafeas/owlbot.py
+++ b/Grafeas/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/IamCredentials/owlbot.py
+++ b/IamCredentials/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/NetworkSecurity/owlbot.py
+++ b/NetworkSecurity/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/OsConfig/owlbot.py
+++ b/OsConfig/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/RecommendationEngine/owlbot.py
+++ b/RecommendationEngine/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ResourceManager/owlbot.py
+++ b/ResourceManager/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ResourceSettings/owlbot.py
+++ b/ResourceSettings/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Retail/owlbot.py
+++ b/Retail/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/SecurityPrivateCa/owlbot.py
+++ b/SecurityPrivateCa/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ServiceControl/owlbot.py
+++ b/ServiceControl/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ServiceDirectory/owlbot.py
+++ b/ServiceDirectory/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ServiceManagement/owlbot.py
+++ b/ServiceManagement/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/ServiceUsage/owlbot.py
+++ b/ServiceUsage/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Shell/owlbot.py
+++ b/Shell/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/SqlAdmin/owlbot.py
+++ b/SqlAdmin/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/StorageTransfer/owlbot.py
+++ b/StorageTransfer/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Talent/owlbot.py
+++ b/Talent/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Tpu/owlbot.py
+++ b/Tpu/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/VideoTranscoder/owlbot.py
+++ b/VideoTranscoder/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/VpcAccess/owlbot.py
+++ b/VpcAccess/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/WebSecurityScanner/owlbot.py
+++ b/WebSecurityScanner/owlbot.py
@@ -40,7 +40,7 @@ php.owlbot_main(
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"

--- a/Workflows/owlbot.py
+++ b/Workflows/owlbot.py
@@ -79,7 +79,7 @@ s.move(executions_library / 'proto/src/GPBMetadata/Google/Cloud/Workflows',
 
 # remove class_alias code
 s.replace(
-    "src/V*/*/*.php",
+    "src/V*/**/*.php",
     r"^// Adding a class alias for backwards compatibility with the previous class name.$"
     + "\n"
     + r"^class_alias\(.*\);$"


### PR DESCRIPTION
Matching only one directory deep is missing a lot of classes which need their aliases removed.

For example, see [`NetworkSecurity/src/V1beta1/AuthorizationPolicy/Rule/Destination.php`](https://github.com/googleapis/google-cloud-php/blob/master/NetworkSecurity/src/V1beta1/AuthorizationPolicy/Rule/Destination.php#L212)

The following Services will need to be generated:
  - AnalyticsData
  - ContactCenterInsights
  - Deploy
  - DocumentAi
  - Domains
  - Gaming
 - Grafeas
 - NetworkSecurity (https://github.com/googleapis/google-cloud-php/pull/4914)
 - OsConfig
 - Retail
 - SecurityPrivateCa
 - ServiceControl
 - Shell
 - SqlAdmin
 - Talent
 - VideoTranscoder
 - WebSecurityScanner
 - Workflows