### PR TITLE
fix(logging): Fix deprecation message in PsrLogger with PHP 8.1

### DIFF
--- a/Logging/src/PsrLogger.php
+++ b/Logging/src/PsrLogger.php
@@ -445,7 +445,7 @@ class PsrLogger implements LoggerInterface, \Serializable
         $this->__unserialize(unserialize($data));
     }
 
-    public function __serialize(): array
+    public function __serialize()
     {
         $debugOutputResource = null;
         if (is_resource($this->debugOutputResource)) {

--- a/Logging/src/PsrLogger.php
+++ b/Logging/src/PsrLogger.php
@@ -431,25 +431,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      */
     public function serialize()
     {
-        $debugOutputResource = null;
-        if (is_resource($this->debugOutputResource)) {
-            $metadata = stream_get_meta_data($this->debugOutputResource);
-            $debugOutputResource = [
-                'uri' => $metadata['uri'],
-                'mode' => $metadata['mode']
-            ];
-        }
-
-        return serialize([
-            $this->messageKey,
-            $this->batchEnabled,
-            $this->metadataProvider,
-            $this->debugOutput,
-            $this->clientConfig,
-            $this->batchMethod,
-            $this->logName,
-            $debugOutputResource
-        ]);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -460,6 +442,34 @@ class PsrLogger implements LoggerInterface, \Serializable
      */
     public function unserialize($data)
     {
+        $this->__unserialize(unserialize($data));
+    }
+
+    public function __serialize(): array
+    {
+        $debugOutputResource = null;
+        if (is_resource($this->debugOutputResource)) {
+            $metadata = stream_get_meta_data($this->debugOutputResource);
+            $debugOutputResource = [
+                'uri' => $metadata['uri'],
+                'mode' => $metadata['mode']
+            ];
+        }
+
+        return [
+            $this->messageKey,
+            $this->batchEnabled,
+            $this->metadataProvider,
+            $this->debugOutput,
+            $this->clientConfig,
+            $this->batchMethod,
+            $this->logName,
+            $debugOutputResource
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
         list(
             $this->messageKey,
             $this->batchEnabled,
@@ -469,7 +479,7 @@ class PsrLogger implements LoggerInterface, \Serializable
             $this->batchMethod,
             $this->logName,
             $debugOutputResource
-        ) = unserialize($data);
+        ) = $data;
 
         if (is_array($debugOutputResource)) {
             $this->debugOutputResource = fopen(

--- a/Logging/src/PsrLogger.php
+++ b/Logging/src/PsrLogger.php
@@ -468,7 +468,7 @@ class PsrLogger implements LoggerInterface, \Serializable
         ];
     }
 
-    public function __unserialize(array $data): void
+    public function __unserialize(array $data)
     {
         list(
             $this->messageKey,

--- a/Logging/tests/Unit/PsrLoggerTest.php
+++ b/Logging/tests/Unit/PsrLoggerTest.php
@@ -277,7 +277,7 @@ class PsrLoggerTest extends TestCase
         );
         $this->assertEquals(
             PHPUnit_Framework_Assert::readAttribute($psrLogger, 'logName'),
-            $this->logName
+            $options['logName']
         );
     }
 


### PR DESCRIPTION
In PHP 8.1, when implementing `Serializable` without implementing the magic `__serialize`/`__unserialize` methods, a deprecation warning will be generated.

This PR adds these methods and moves the logic as to not duplicate any code but still provide BC for >= PHP 7.2. Tests remain unchanged and working.

The `Serializable` interface will be removed in PHP 9.0:
- RFC: https://wiki.php.net/rfc/phase_out_serializable
- Deprecation Warning docs: https://www.php.net/manual/en/class.serializable.php
>As of PHP 8.1.0, a class which implements Serializable without also implementing __serialize() and __unserialize() will generate a deprecation warning.