### PR TITLE
build: switch release tagging to release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,3 +1,4 @@
 releaseType: php-yoshi
 packageName: Google Cloud PHP
 bumpMinorPreMajor: true
+handleGHRelease: true


### PR DESCRIPTION
Let release-please handle the GitHub tagging