### PR TITLE
fix(Core): Add a default argument to ArrayTrait::isAssoc

### DIFF
--- a/BigQuery/src/ValueMapper.php
+++ b/BigQuery/src/ValueMapper.php
@@ -194,7 +194,7 @@ class ValueMapper
 
                 break;
             case 'array':
-                list($pType, $pValue) = $this->isAssoc($value)
+                list($pType, $pValue) = $this->isAssoc($value, false)
                     ? $this->assocArrayToParameter($value)
                     : $this->arrayToParameter($value);
 

--- a/Core/src/ArrayTrait.php
+++ b/Core/src/ArrayTrait.php
@@ -70,12 +70,20 @@ trait ArrayTrait
 
     /**
      * Determine whether given array is associative.
+     * If $arr is empty, then $onEmpty will be returned
+     * $onEmpty defaults to true to maintain compatibility
+     * with the current usage.
      *
      * @param array $arr
+     * @param bool $onEmpty
      * @return bool
      */
-    private function isAssoc(array $arr)
+    private function isAssoc(array $arr, $onEmpty = true)
     {
+        if (empty($arr)) {
+            return $onEmpty;
+        }
+
         return array_keys($arr) !== range(0, count($arr) - 1);
     }
 

--- a/Core/tests/Unit/ArrayTraitTest.php
+++ b/Core/tests/Unit/ArrayTraitTest.php
@@ -82,18 +82,42 @@ class ArrayTraitTest extends TestCase
 
     public function testIsAssocTrue()
     {
-        $actual = $this->impl->call('isAssoc', [[
+        $inputArr = [
             'test' => 1,
             'test' => 2
-        ]]);
+        ];
 
+        $actual = $this->impl->call('isAssoc', [$inputArr]);
+        $this->assertTrue($actual);
+
+        // test second argument is irrelevant when array isn't empty
+        $actual = $this->impl->call('isAssoc', [$inputArr, false]);
         $this->assertTrue($actual);
     }
 
     public function testIsAssocFalse()
     {
-        $actual = $this->impl->call('isAssoc', [[1, 2, 3]]);
+        $inputArr = [1, 2, 3];
+        $actual = $this->impl->call('isAssoc', [$inputArr]);
+        $this->assertFalse($actual);
 
+        // test second argument is irrelevant when array isn't empty
+        $actual = $this->impl->call('isAssoc', [$inputArr, true]);
+        $this->assertFalse($actual);
+    }
+
+    public function testIsAssocEmptyArray()
+    {
+        // default (with absent $onEmpty)
+        $actual = $this->impl->call('isAssoc', [[]]);
+        $this->assertTrue($actual);
+
+        // pass $onEmpty = true
+        $actual = $this->impl->call('isAssoc', [[], true]);
+        $this->assertTrue($actual);
+
+        // pass $onEmpty = false
+        $actual = $this->impl->call('isAssoc', [[], false]);
         $this->assertFalse($actual);
     }
 


### PR DESCRIPTION
The new argument `$onEmpty` is returned when the input array is empty.

`ValueMapper` in `BigQuery` should receive a `false` on passing an empty array to `isAssoc`.

Should fix #3937's error message.