### PR TITLE
chore: [Vision] fix owlbot copy_excludes

### DIFF
--- a/Vision/owlbot.py
+++ b/Vision/owlbot.py
@@ -29,12 +29,11 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-# Exclude gapic_metadata.json and partial veneer files.
+# Exclude partial veneer files.
 php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/gapic_metadata.json",
         src / "*/src/*/*.php"
     ]
 )

--- a/Vision/owlbot.py
+++ b/Vision/owlbot.py
@@ -34,7 +34,8 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/*/*.php"
+        src / "*/src/V1/ProductSearchClient.php",
+        src / "*/src/V1/ImageAnnotatorClient.php",
     ]
 )
 


### PR DESCRIPTION
For some reason the Vision API was excluding `gapic_metadata.json`. I believe this is an error.

Also, we want to be explicit about which files (in this case, Client classes) we exclude