### PR TITLE
fix: add back projectName methods for monitoring clients

### DIFF
--- a/Monitoring/owlbot.py
+++ b/Monitoring/owlbot.py
@@ -34,7 +34,11 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/V3/AlertPolicyServiceClient.php"
+        src / "*/src/V3/AlertPolicyServiceClient.php",
+        src / "*/src/V3/GroupServiceClient.php",
+        src / "*/src/V3/NotificationChannelServiceClient.php",
+        src / "*/src/V3/ServiceMonitoringServiceClient.php",
+        src / "*/src/V3/UptimeCheckServiceGapicClient.php",
     ]
 )
 

--- a/Monitoring/src/V3/GroupServiceClient.php
+++ b/Monitoring/src/V3/GroupServiceClient.php
@@ -29,6 +29,19 @@ use Google\Cloud\Monitoring\V3\Gapic\GroupServiceGapicClient;
 /** {@inheritdoc} */
 class GroupServiceClient extends GroupServiceGapicClient
 {
-    // This class is intentionally empty, and is intended to hold manual additions to
-    // the generated {@see GroupServiceGapicClient} class.
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a project resource.
+     *
+     * @param string $project
+     *
+     * @return string The formatted project resource.
+     * @deprecated
+     */
+    public static function projectName($project)
+    {
+        return (new PathTemplate('projects/{project}'))->render([
+            'project' => $project,
+        ]);
+    }
 }

--- a/Monitoring/src/V3/NotificationChannelServiceClient.php
+++ b/Monitoring/src/V3/NotificationChannelServiceClient.php
@@ -29,6 +29,19 @@ use Google\Cloud\Monitoring\V3\Gapic\NotificationChannelServiceGapicClient;
 /** {@inheritdoc} */
 class NotificationChannelServiceClient extends NotificationChannelServiceGapicClient
 {
-    // This class is intentionally empty, and is intended to hold manual additions to
-    // the generated {@see NotificationChannelServiceGapicClient} class.
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a project resource.
+     *
+     * @param string $project
+     *
+     * @return string The formatted project resource.
+     * @deprecated
+     */
+    public static function projectName($project)
+    {
+        return (new PathTemplate('projects/{project}'))->render([
+            'project' => $project,
+        ]);
+    }
 }

--- a/Monitoring/src/V3/ServiceMonitoringServiceClient.php
+++ b/Monitoring/src/V3/ServiceMonitoringServiceClient.php
@@ -29,6 +29,19 @@ use Google\Cloud\Monitoring\V3\Gapic\ServiceMonitoringServiceGapicClient;
 /** {@inheritdoc} */
 class ServiceMonitoringServiceClient extends ServiceMonitoringServiceGapicClient
 {
-    // This class is intentionally empty, and is intended to hold manual additions to
-    // the generated {@see ServiceMonitoringServiceGapicClient} class.
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a project resource.
+     *
+     * @param string $project
+     *
+     * @return string The formatted project resource.
+     * @deprecated
+     */
+    public static function projectName($project)
+    {
+        return (new PathTemplate('projects/{project}'))->render([
+            'project' => $project,
+        ]);
+    }
 }

--- a/Monitoring/src/V3/UptimeCheckServiceClient.php
+++ b/Monitoring/src/V3/UptimeCheckServiceClient.php
@@ -29,6 +29,19 @@ use Google\Cloud\Monitoring\V3\Gapic\UptimeCheckServiceGapicClient;
 /** {@inheritdoc} */
 class UptimeCheckServiceClient extends UptimeCheckServiceGapicClient
 {
-    // This class is intentionally empty, and is intended to hold manual additions to
-    // the generated {@see UptimeCheckServiceGapicClient} class.
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a project resource.
+     *
+     * @param string $project
+     *
+     * @return string The formatted project resource.
+     * @deprecated
+     */
+    public static function projectName($project)
+    {
+        return (new PathTemplate('projects/{project}'))->render([
+            'project' => $project,
+        ]);
+    }
 }


### PR DESCRIPTION
We accidentally merged an update which broke backwards compatibility with some of the Monitoring Clients by removing the `projectName` static method. This adds them back.

See https://github.com/googleapis/google-cloud-php/pull/4917