### PR TITLE
fix: grpc issue (UNAUTHENTICATED errors against Cloud Spanner emulator in v1.45.0)

### DIFF
--- a/Core/src/EmulatorTrait.php
+++ b/Core/src/EmulatorTrait.php
@@ -44,7 +44,8 @@ trait EmulatorTrait
                         'credentials' => \Grpc\ChannelCredentials::createInsecure()
                     ]
                 ]
-            ]
+            ],
+            'credentials' => new InsecureCredentialsWrapper(),
         ];
     }
     /**

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -25,7 +25,9 @@ use Google\ApiCore\CredentialsWrapper;
  */
 class InsecureCredentialsWrapper extends CredentialsWrapper
 {
-    function __construct() {}
+    public function __construct()
+    {
+    }
 
     public function getAuthorizationHeaderCallback($audience = null)
     {

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+use Google\ApiCore\CredentialsWrapper;
+
+/**
+ * For connect to emulator.
+ */
+class InsecureCredentialsWrapper extends CredentialsWrapper
+{
+    function __construct() {}
+
+    public function getAuthorizationHeaderCallback($audience = null)
+    {
+        return null;
+    }
+}

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -227,7 +227,7 @@ class Grpc implements ConnectionInterface
                 $grpcConfig,
                 $this->emulatorGapicConfig($config['emulatorHost'])
             );
-        } else if (isset($config['apiEndpoint'])) {
+        } elseif (isset($config['apiEndpoint'])) {
             $grpcConfig['apiEndpoint'] = $config['apiEndpoint'];
         }
         $this->credentialsWrapper = $grpcConfig['credentials'];

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -223,13 +223,14 @@ class Grpc implements ConnectionInterface
             'queryOptions' => []
         ];
         if ((bool) $config['emulatorHost']) {
-            $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
-        } else {
-            $this->credentialsWrapper = $grpcConfig['credentials'];
-            if (isset($config['apiEndpoint'])) {
-                $grpcConfig['apiEndpoint'] = $config['apiEndpoint'];
-            }
+            $grpcConfig = array_merge(
+                $grpcConfig,
+                $this->emulatorGapicConfig($config['emulatorHost'])
+            );
+        } else if (isset($config['apiEndpoint'])) {
+            $grpcConfig['apiEndpoint'] = $config['apiEndpoint'];
         }
+        $this->credentialsWrapper = $grpcConfig['credentials'];
 
         $this->defaultQueryOptions = $config['queryOptions'];
 


### PR DESCRIPTION
fix of https://github.com/grpc/grpc/issues/29233, which is caused by https://github.com/grpc/grpc/pull/25586 which removed insecure channel.

Regardless whether Spanner connects to emulator or production server, gax-php always create a CredentialsWrapper (https://github.com/googleapis/gax-php/blob/v1.12.0/src/GapicClientTrait.php#L434) and add it to callstack (https://github.com/googleapis/gax-php/blob/v1.12.0/src/GapicClientTrait.php#L610).
When creating gRPC calls, GrpcTransport calls CredentialsWrapper (https://github.com/googleapis/gax-php/blob/v1.12.0/src/Transport/GrpcTransport.php#L258-L259) to setup a callback for auth token, which requires secure level to be equal or higher than GRPC_PRIVACY_AND_INTEGRITY which doesn’t work on an insecure channel.
