### PR TITLE
chore(ci): add Roave backwards compatibility check action

### DIFF
--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -10,13 +10,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-      - name: Install roave BC checker
-        run: composer global require roave/backward-compatibility-check
       - name: Check for BC breaks
-        run: |
-          export PATH=$PATH:~/.composer/vendor/bin
-          roave-backward-compatibility-check
+        uses: docker://nyholm/roave-bc-check-ga

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -1,0 +1,14 @@
+on: [pull_request]
+jobs:
+  backwards-compatibility-check:
+    name: Backwards Compatibility Check
+    runs-on: ubuntu-latest
+    # Disable this check by applying the 'breaking change allowed' label to the PR.
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check for BC breaks
+        # More info at https://github.com/Roave/BackwardCompatibilityCheck.
+        uses: docker://nyholm/roave-bc-check-ga

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -1,6 +1,7 @@
 name: Backwards Compatibility Check
 on: [pull_request]
 jobs:
+  # More info at https://github.com/Roave/BackwardCompatibilityCheck.
   backwards-compatibility-check:
     runs-on: ubuntu-latest
     # Disable this check by applying the 'breaking change allowed' label to the PR.
@@ -9,6 +10,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+      - name: Install roave BC checker
+        run: composer global require roave/backward-compatibility-check
       - name: Check for BC breaks
-        # More info at https://github.com/Roave/BackwardCompatibilityCheck.
-        uses: docker://nyholm/roave-bc-check-ga
+        run: |
+          export PATH=$PATH:~/.composer/vendor/bin
+          roave-backward-compatibility-check

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -2,7 +2,6 @@ name: Backwards Compatibility Check
 on: [pull_request]
 jobs:
   backwards-compatibility-check:
-    name: Backwards Compatibility Check
     runs-on: ubuntu-latest
     # Disable this check by applying the 'breaking change allowed' label to the PR.
     if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -1,3 +1,4 @@
+name: Backwards Compatibility Check
 on: [pull_request]
 jobs:
   backwards-compatibility-check:


### PR DESCRIPTION
Adds a workflow that runs [Roave's](https://github.com/Roave/BackwardCompatibilityCheck) `BackwardCompatibilityCheck` on all pull requests. This check can be skipped by adding a `breaking change allowed` label on the PR.