### PR TITLE
chore: Add a style-fix composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -573,6 +573,7 @@
     "scripts": {
         "google-cloud": "dev/google-cloud",
         "style": "dev/sh/style",
+        "style-fix": "dev/sh/style-fix",
         "tests": "dev/sh/tests"
     },
     "bin": [

--- a/dev/sh/style-fix
+++ b/dev/sh/style-fix
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+$(dirname $0)/../../vendor/bin/phpcbf --standard=$(dirname $0)/../../phpcs-ruleset.xml


### PR DESCRIPTION
This script is identical to our `composer style` script and should help contributors fix some lint errors automatically.