### PR TITLE
fix(Spanner): transportConfig overrides are now passed on to GAPIC constructor

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -218,6 +218,12 @@ class Grpc implements ConnectionInterface
                 : null
         );
 
+        // make sure that transportConfig overrides are passed on
+        // to GAPIC constructors
+        if (isset($config['transportConfig'])) {
+            $grpcConfig['transportConfig'] = $config['transportConfig'];
+        }
+
         $config += [
             'emulatorHost' => null,
             'queryOptions' => []


### PR DESCRIPTION
`transportConfig` overrides are now passed to `SpannerGapicClient` constructor, fixes #5223