### PR TITLE
feat: fix emulator config for datastore, firestore, and pubsub

### DIFF
--- a/Datastore/src/Connection/Grpc.php
+++ b/Datastore/src/Connection/Grpc.php
@@ -101,7 +101,10 @@ class Grpc implements ConnectionInterface
         }
 
         if ((bool) $config['emulatorHost']) {
-            $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
+            $grpcConfig = array_merge(
+                $grpcConfig,
+                $this->emulatorGapicConfig($config['emulatorHost'])
+            );
         }
 
         $this->datastoreClient = isset($config['gapicDatastoreClient'])

--- a/Datastore/src/Connection/Grpc.php
+++ b/Datastore/src/Connection/Grpc.php
@@ -101,10 +101,7 @@ class Grpc implements ConnectionInterface
         }
 
         if ((bool) $config['emulatorHost']) {
-            $grpcConfig = array_merge(
-                $grpcConfig,
-                $this->emulatorGapicConfig($config['emulatorHost'])
-            );
+            $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
         }
 
         $this->datastoreClient = isset($config['gapicDatastoreClient'])

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -101,7 +101,10 @@ class Grpc implements ConnectionInterface
         $config += ['emulatorHost' => null];
         if ((bool) $config['emulatorHost']) {
             $this->isUsingEmulator = true;
-            $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
+            $grpcConfig = array_merge(
+                $grpcConfig,
+                $this->emulatorGapicConfig($config['emulatorHost'])
+            );
         }
         //@codeCoverageIgnoreEnd
 

--- a/PubSub/src/Connection/Grpc.php
+++ b/PubSub/src/Connection/Grpc.php
@@ -115,7 +115,10 @@ class Grpc implements ConnectionInterface
         }
 
         if ((bool) $config['emulatorHost']) {
-            $grpcConfig += $this->emulatorGapicConfig($config['emulatorHost']);
+            $grpcConfig = array_merge(
+                $grpcConfig,
+                $this->emulatorGapicConfig($config['emulatorHost'])
+            );
         }
         //@codeCoverageIgnoreEnd
 


### PR DESCRIPTION
Adds `InsecureCredentialsWrapper` for emulators across applicable packages

https://github.com/googleapis/google-cloud-php/pull/5224