### PR TITLE
build: release-please for component-less release should not use `packageName`

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,5 +1,4 @@
 releaseType: php-yoshi
-packageName: Google Cloud PHP
 bumpMinorPreMajor: true
 handleGHRelease: true
 primaryBranch: main


### PR DESCRIPTION
This was a bugfix in release-please - if there is a `packageName` configured for the app, it expects that the release tag will have the `packageName` as part of the tag.