### PR TITLE
fix: missing monitor client imports

### DIFF
--- a/Monitoring/src/V3/GroupServiceClient.php
+++ b/Monitoring/src/V3/GroupServiceClient.php
@@ -25,6 +25,7 @@
 namespace Google\Cloud\Monitoring\V3;
 
 use Google\Cloud\Monitoring\V3\Gapic\GroupServiceGapicClient;
+use Google\ApiCore\PathTemplate;
 
 /** {@inheritdoc} */
 class GroupServiceClient extends GroupServiceGapicClient

--- a/Monitoring/src/V3/NotificationChannelServiceClient.php
+++ b/Monitoring/src/V3/NotificationChannelServiceClient.php
@@ -25,6 +25,7 @@
 namespace Google\Cloud\Monitoring\V3;
 
 use Google\Cloud\Monitoring\V3\Gapic\NotificationChannelServiceGapicClient;
+use Google\ApiCore\PathTemplate;
 
 /** {@inheritdoc} */
 class NotificationChannelServiceClient extends NotificationChannelServiceGapicClient

--- a/Monitoring/src/V3/ServiceMonitoringServiceClient.php
+++ b/Monitoring/src/V3/ServiceMonitoringServiceClient.php
@@ -25,6 +25,7 @@
 namespace Google\Cloud\Monitoring\V3;
 
 use Google\Cloud\Monitoring\V3\Gapic\ServiceMonitoringServiceGapicClient;
+use Google\ApiCore\PathTemplate;
 
 /** {@inheritdoc} */
 class ServiceMonitoringServiceClient extends ServiceMonitoringServiceGapicClient

--- a/Monitoring/src/V3/UptimeCheckServiceClient.php
+++ b/Monitoring/src/V3/UptimeCheckServiceClient.php
@@ -25,6 +25,7 @@
 namespace Google\Cloud\Monitoring\V3;
 
 use Google\Cloud\Monitoring\V3\Gapic\UptimeCheckServiceGapicClient;
+use Google\ApiCore\PathTemplate;
 
 /** {@inheritdoc} */
 class UptimeCheckServiceClient extends UptimeCheckServiceGapicClient

--- a/Monitoring/tests/Unit/V3/CustomMethodsTest.php
+++ b/Monitoring/tests/Unit/V3/CustomMethodsTest.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Monitoring\Tests\Unit\V3;
+
+use Google\Cloud\Monitoring\V3\AlertPolicyServiceClient;
+use Google\Cloud\Monitoring\V3\GroupServiceClient;
+use Google\Cloud\Monitoring\V3\NotificationChannelServiceClient;
+use Google\Cloud\Monitoring\V3\ServiceMonitoringServiceClient;
+use Google\Cloud\Monitoring\V3\UptimeCheckServiceClient;
+use PHPUnit\Framework\TestCase;
+
+class CustomMethodsTest extends TestCase
+{
+    public function testProjectName()
+    {
+        $projectId = 'my-project-id';
+        $projectName = 'projects/' . $projectId;
+        $this->assertEquals($projectName, AlertPolicyServiceClient::projectName($projectId));
+        $this->assertEquals($projectName, GroupServiceClient::projectName($projectId));
+        $this->assertEquals($projectName, NotificationChannelServiceClient::projectName($projectId));
+        $this->assertEquals($projectName, ServiceMonitoringServiceClient::projectName($projectId));
+        $this->assertEquals($projectName, UptimeCheckServiceClient::projectName($projectId));
+    }
+}


### PR DESCRIPTION
Found this error when running tests in the php docs samples:

```
3) Google\Cloud\Samples\Monitoring\monitoringTest::testCreateUptimeCheck
Error: Class 'Google\Cloud\Monitoring\V3\PathTemplate' not found

/tmpfs/src/github/php-docs-samples/monitoring/vendor/google/cloud-monitoring/src/V3/UptimeCheckServiceClient.php:43
/tmpfs/src/github/php-docs-samples/monitoring/src/create_uptime_check.php:56
/tmpfs/src/github/php-docs-samples/testing/sample_helpers.php:58
/tmpfs/src/github/php-docs-samples/monitoring/src/create_uptime_check.php:66
/tmpfs/src/github/php-docs-samples/testing/vendor/google/cloud-tools/src/TestUtils/TestTrait.php:133
/tmpfs/src/github/php-docs-samples/testing/vendor/google/cloud-tools/src/TestUtils/TestTrait.php:144
/tmpfs/src/github/php-docs-samples/testing/vendor/google/cloud-tools/src/TestUtils/TestTrait.php:103
/tmpfs/src/github/php-docs-samples/monitoring/test/monitoringTest.php:62
```