### PR TITLE
chore: require latest version of core

### DIFF
--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.46",
         "google/gax": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This will help ensure https://github.com/googleapis/google-cloud-php/pull/5240 works as intended.