### PR TITLE
chore: Raise minimum versions of Guzzle

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
         "google/auth": "^1.18",
-        "guzzlehttp/guzzle": "^5.3|^6.5.6|^7.4.3",
+        "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "guzzlehttp/guzzle": "^5.3|^6.5.6|^7.4.3",
+        "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0",
         "psr/http-message": "1.0.*",


### PR DESCRIPTION
Hey there 👋 

This change addresses the [CVE-2022-31042](https://github.com/advisories/GHSA-f2wf-25xc-69c9) security issue with Guzzle.

:octocat: