### PR TITLE
feat: Add support for Monolog 3.x

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7|^2.0",
-        "monolog/monolog": "^1.1|^2.0",
+        "monolog/monolog": "^1.1|^2.0|^3.0",
         "psr/http-message": "1.0.*"
     },
     "require-dev": {

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -18,7 +18,7 @@
         "yoast/phpunit-polyfills": "^1.0",
         "phpspec/prophecy": "^1.10.3",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^3.0||^4.0",
+        "phpdocumentor/reflection": "^3.0||^4.0||^5.3",
         "erusev/parsedown": "^1.6",
         "google/gax": "^1.9",
         "opis/closure": "^3",

--- a/Core/src/Exception/ServiceException.php
+++ b/Core/src/Exception/ServiceException.php
@@ -57,13 +57,13 @@ class ServiceException extends GoogleException
     /**
      * Handle previous exceptions differently here.
      *
-     * @param string $message
+     * @param string|null $message
      * @param int $code
      * @param Exception|null $serviceException
      * @param array $metadata [optional] Exception metadata.
      */
     public function __construct(
-        $message,
+        $message = null,
         $code = 0,
         Exception $serviceException = null,
         array $metadata = []
@@ -74,7 +74,7 @@ class ServiceException extends GoogleException
         $this->errorInfoMetadata = null;
         $this->errorReason = null;
 
-        parent::__construct($message, $code);
+        parent::__construct($message ?: '', $code);
     }
 
     /**

--- a/Core/src/Logger/AppEngineFlexFormatter.php
+++ b/Core/src/Logger/AppEngineFlexFormatter.php
@@ -22,6 +22,7 @@ use Monolog\Formatter\LineFormatter;
  * Monolog 1.x formatter for formatting logs on App Engine flexible environment.
  *
  * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatterV2} instead.
+ * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatterV3} instead.
  */
 class AppEngineFlexFormatter extends LineFormatter
 {

--- a/Core/src/Logger/AppEngineFlexFormatterV3.php
+++ b/Core/src/Logger/AppEngineFlexFormatterV3.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,15 @@
 namespace Google\Cloud\Core\Logger;
 
 use Monolog\Formatter\LineFormatter;
+use Monolog\LogRecord;
 
 /**
- * Monolog 2.x formatter for formatting logs on App Engine flexible environment.
+ * Monolog 3.x formatter for formatting logs on App Engine flexible environment.
  *
  * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatter} instead.
- * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatterV3} instead.
+ * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexFormatterV2} instead.
  */
-class AppEngineFlexFormatterV2 extends LineFormatter
+class AppEngineFlexFormatterV3 extends LineFormatter
 {
     use FormatterTrait;
 
@@ -42,10 +43,10 @@ class AppEngineFlexFormatterV2 extends LineFormatter
      * Get the plain text message with LineFormatter's format method and add
      * metadata including the trace id then return the json string.
      *
-     * @param array $record A record to format
+     * @param LogRecord $record A record to format
      * @return string The formatted record
      */
-    public function format(array $record): string
+    public function format(LogRecord $record): string
     {
         return $this->formatPayload($record, parent::format($record));
     }

--- a/Core/src/Logger/AppEngineFlexHandler.php
+++ b/Core/src/Logger/AppEngineFlexHandler.php
@@ -24,6 +24,7 @@ use Monolog\Logger;
  * Monolog 1.x handler for logging on App Engine flexible environment.
  *
  * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV2} instead.
+ * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV3} instead.
  */
 class AppEngineFlexHandler extends StreamHandler
 {

--- a/Core/src/Logger/AppEngineFlexHandlerFactory.php
+++ b/Core/src/Logger/AppEngineFlexHandlerFactory.php
@@ -39,7 +39,7 @@ class AppEngineFlexHandlerFactory
      *
      * @throws Exception
      *
-     * @return AppEngineFlexHandler|AppEngineFlexHandlerV2
+     * @return AppEngineFlexHandler|AppEngineFlexHandlerV2|AppEngineFlexHandlerV3
      */
     public static function build(
         $level = Logger::INFO,
@@ -55,6 +55,8 @@ class AppEngineFlexHandlerFactory
                 return new AppEngineFlexHandler($level, $bubble, $filePermission, $useLocking, $stream);
             case 2:
                 return new AppEngineFlexHandlerV2($level, $bubble, $filePermission, $useLocking, $stream);
+            case 3:
+                return new AppEngineFlexHandlerV3($level, $bubble, $filePermission, $useLocking, $stream);
             default:
                 throw new Exception('Version not supported');
         }

--- a/Core/src/Logger/AppEngineFlexHandlerV3.php
+++ b/Core/src/Logger/AppEngineFlexHandlerV3.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
 /**
- * Monolog 2.x handler for logging on App Engine flexible environment.
+ * Monolog 3.x handler for logging on App Engine flexible environment.
  *
  * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandler} instead.
- * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV3} instead.
+ * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV2} instead.
  */
-class AppEngineFlexHandlerV2 extends StreamHandler
+class AppEngineFlexHandlerV3 extends StreamHandler
 {
     /**
      * @param int $level [optional] The minimum logging level at which this
@@ -61,6 +61,6 @@ class AppEngineFlexHandlerV2 extends StreamHandler
 
     protected function getDefaultFormatter(): FormatterInterface
     {
-        return new AppEngineFlexFormatterV2();
+        return new AppEngineFlexFormatterV3();
     }
 }

--- a/Core/src/Logger/FormatterTrait.php
+++ b/Core/src/Logger/FormatterTrait.php
@@ -16,14 +16,25 @@
  */
 namespace Google\Cloud\Core\Logger;
 
+use Monolog\LogRecord;
+
 /**
  * Shared trait to enrich and format a record with
  * App Engine Flex specific information.
  */
 trait FormatterTrait
 {
-    protected function formatPayload(array $record, $message)
+    /**
+     * @param array|LogRecord $record
+     * @param string $message
+     * @return string
+     */
+    protected function formatPayload($record, $message)
     {
+        if ($record instanceof LogRecord) {
+            $record = $record->toArray();
+        }
+
         list($usec, $sec) = explode(' ', microtime());
         $usec = (int)(((float)$usec)*1000000000);
         $sec = (int)$sec;

--- a/Core/src/Testing/Reflection/ReflectionHandlerFactory.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerFactory.php
@@ -18,19 +18,26 @@
 namespace Google\Cloud\Core\Testing\Reflection;
 
 use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\Php\EnumCase;
 
 /**
- * Class for determining if phpdocumentor/reflection v3 or v4 is being used.
+ * Class for determining if phpdocumentor/reflection v3, v4 or v5 is being used.
  */
 class ReflectionHandlerFactory
 {
     /**
-     * @return ReflectionHandlerV3|ReflectionHandlerV4
+     * @return ReflectionHandlerV3|ReflectionHandlerV4|ReflectionHandlerV5
      */
     public static function create()
     {
-        return class_exists(LocalFile::class)
-            ? new ReflectionHandlerV4()
-            : new ReflectionHandlerV3();
+        if (class_exists(EnumCase::class)) {
+            return new ReflectionHandlerV5();
+        }
+
+        if (class_exists(LocalFile::class)) {
+            return new ReflectionHandlerV4();
+        }
+
+        return new ReflectionHandlerV3();
     }
 }

--- a/Core/src/Testing/Reflection/ReflectionHandlerV5.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV5.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Testing\Reflection;
+
+use Google\Cloud\Core\Testing\Reflection\DescriptionFactory as CoreDescriptionFactory;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\FqsenResolver;
+use phpDocumentor\Reflection\NodeVisitor\ElementNameResolver;
+use phpDocumentor\Reflection\Php\Factory;
+use phpDocumentor\Reflection\Php\Factory\Noop;
+use phpDocumentor\Reflection\Php\Factory\TraitUse;
+use phpDocumentor\Reflection\Php\NodesFactory;
+use phpDocumentor\Reflection\Php\ProjectFactory;
+use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
+use phpDocumentor\Reflection\TypeResolver;
+use PhpParser\Lexer;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+
+/**
+ * Class for running snippets using phpdocumentor/reflection:v5.
+ */
+class ReflectionHandlerV5
+{
+    private $descriptionFactory;
+    private $docBlockFactory;
+
+    public function __construct()
+    {
+        $this->descriptionFactory = $this->createDescriptionFactory();
+        $this->docBlockFactory = $this->createDocBlockFactory($this->descriptionFactory);
+    }
+
+    /**
+     * @param string $class
+     * @return DocBlock
+     */
+    public function createDocBlock($classOrMethod)
+    {
+        return $this->docBlockFactory->create($classOrMethod);
+    }
+
+    /**
+     * @param DocBlock $docBlock
+     * @return string
+     */
+    public function getDocBlockText(DocBlock $docBlock)
+    {
+        $description = $this->descriptionFactory->create(
+            $docBlock->getSummary() . "\n\n" . $docBlock->getDescription(),
+            $docBlock->getContext()
+        );
+        return $description->render();
+    }
+
+    /**
+     * @param array $files
+     * @return string[]
+     */
+    public function classes(array $files)
+    {
+        $projectFactory = $this->createProjectFactory();
+        $localFiles = [];
+        foreach ($files as $file) {
+            $localFiles[] = new LocalFile($file);
+        }
+        $project = $projectFactory->create('My Project', $localFiles);
+        $classes = [];
+        foreach ($files as $file) {
+            $classesInFile = $project->getFiles()[$file]->getClasses();
+            foreach ($classesInFile as $class) {
+                $classes[] = (string) $class->getFqsen();
+            }
+        }
+        return $classes;
+    }
+
+    /**
+     * @return ProjectFactory
+     */
+    public function createProjectFactory()
+    {
+        $parser = (new ParserFactory())->create(
+            ParserFactory::ONLY_PHP7,
+            new Lexer\Emulative(['phpVersion' => Lexer\Emulative::PHP_8_0])
+        );
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor(new NameResolver());
+        $nodeTraverser->addVisitor(new ElementNameResolver());
+        $nodesFactory = new NodesFactory($parser, $nodeTraverser);
+
+        $docblockFactory = $this->createDocBlockFactory($this->createDescriptionFactory());
+
+        $methodStrategy =  new Factory\Method($docblockFactory);
+
+        $strategies = new ProjectFactoryStrategies(
+            [
+                new Factory\Namespace_(),
+                new Factory\Argument(new PrettyPrinter()),
+                new Factory\Class_($docblockFactory),
+                new Factory\Enum_($docblockFactory),
+                new Factory\EnumCase($docblockFactory, new PrettyPrinter()),
+                new Factory\Define($docblockFactory, new PrettyPrinter()),
+                new Factory\GlobalConstant($docblockFactory, new PrettyPrinter()),
+                new Factory\ClassConstant($docblockFactory, new PrettyPrinter()),
+                new Factory\File($docblockFactory, $nodesFactory),
+                new Factory\Function_($docblockFactory),
+                new Factory\Interface_($docblockFactory),
+                $methodStrategy,
+                new Factory\Property($docblockFactory, new PrettyPrinter()),
+                new Factory\Trait_($docblockFactory),
+                new Factory\IfStatement(),
+                new TraitUse(),
+            ]
+        );
+
+        $strategies->addStrategy(
+            new Factory\ConstructorPromotion($methodStrategy, $docblockFactory, new PrettyPrinter()),
+            1100
+        );
+        $strategies->addStrategy(new Noop(), -PHP_INT_MAX);
+
+        return new ProjectFactory($strategies);
+    }
+
+    /**
+     * @return DescriptionFactory
+     */
+    public function createDescriptionFactory()
+    {
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new CoreDescriptionFactory($tagFactory);
+
+        $tagFactory->addService($descriptionFactory, DescriptionFactory::class);
+        $tagFactory->addService(new TypeResolver($fqsenResolver));
+
+        return $descriptionFactory;
+    }
+
+    /**
+     * @return DocBlockFactory
+     */
+    private function createDocBlockFactory($descriptionFactory)
+    {
+        $tagFactory = $descriptionFactory->getTagFactory();
+        return new DocBlockFactory($descriptionFactory, $tagFactory);
+    }
+}

--- a/Core/tests/Unit/Logger/AppEngineFlexHandlerFactoryTest.php
+++ b/Core/tests/Unit/Logger/AppEngineFlexHandlerFactoryTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\Core\Logger\AppEngineFlexHandlerFactory;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\Core\Logger\AppEngineFlexHandlerV2;
+use Google\Cloud\Core\Logger\AppEngineFlexHandlerV3;
 
 /**
  * @group core
@@ -40,6 +41,13 @@ class AppEngineFlexHandlerFactoryTest extends TestCase
         $this->skipIfNotMonologVersion(2);
 
         $this->assertInstanceOf(AppEngineFlexHandlerV2::class, AppEngineFlexHandlerFactory::build());
+    }
+
+    public function testBuildMonologV3Handler()
+    {
+        $this->skipIfNotMonologVersion(3);
+
+        $this->assertInstanceOf(AppEngineFlexHandlerV3::class, AppEngineFlexHandlerFactory::build());
     }
 
     private function skipIfNotMonologVersion($expected)

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -14,6 +14,7 @@
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0||^4.0||^5.3",
         "erusev/parsedown": "^1.6",
+        "fig/log-test": "^1.0",
         "google/cloud-storage": "^1.3",
         "google/cloud-bigquery": "^1.0",
         "google/cloud-pubsub": "^1.0",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -12,7 +12,7 @@
         "yoast/phpunit-polyfills": "^1.0",
         "phpspec/prophecy": "^1.10.3",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^3.0||^4.0",
+        "phpdocumentor/reflection": "^3.0||^4.0||^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.3",
         "google/cloud-bigquery": "^1.0",
@@ -48,8 +48,5 @@
         "psr-4": {
             "Google\\Cloud\\Logging\\Tests\\": "tests"
         }
-    },
-    "conflict": {
-        "psr/log": ">=3"
     }
 }

--- a/Logging/src/LogMessageProcessor/MonologMessageProcessor.php
+++ b/Logging/src/LogMessageProcessor/MonologMessageProcessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Logging\LogMessageProcessor;
+
+use Google\Cloud\Logging\LogMessageProcessorInterface;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Processor\PsrLogMessageProcessor;
+
+/**
+ * Uses the Monolog 1/2 PsrLogMessageProcessor to process a
+ * record's message according to PSR-3 rules.
+ */
+final class MonologMessageProcessor implements LogMessageProcessorInterface
+{
+    /**
+     * @var NormalizerFormatter
+     */
+    private $formatter;
+
+    /**
+     * @var PsrLogMessageProcessor
+     */
+    private $processor;
+
+    public function __construct()
+    {
+        $this->formatter = new NormalizerFormatter();
+        $this->processor = new PsrLogMessageProcessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processLogMessage($message, $context)
+    {
+        $processor = $this->processor;
+
+        return $processor([
+            'message' => (string) $message,
+            'context' => $this->formatter->format($context)
+        ]);
+    }
+}

--- a/Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
+++ b/Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Logging\LogMessageProcessor;
+
+use Google\Cloud\Logging\LogMessageProcessorInterface;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Processor\PsrLogMessageProcessor;
+
+/**
+ * Uses the Monolog 3 PsrLogMessageProcessor to process a
+ * record's message according to PSR-3 rules.
+ */
+final class MonologV3MessageProcessor implements LogMessageProcessorInterface
+{
+    /**
+     * @var PsrLogMessageProcessor
+     */
+    private $processor;
+
+    public function __construct()
+    {
+        $this->processor = new PsrLogMessageProcessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processLogMessage($message, $context)
+    {
+        // The datetime, channel, and level are required but not relevant here
+        $logRecord = new LogRecord(
+            new \DateTimeImmutable(),
+            'channel',
+            Level::Info,
+            (string) $message,
+            $context
+        );
+
+        $processor = $this->processor;
+        $processed = $processor($logRecord);
+
+        return [
+            'message' => $processed['message'],
+            'context' => $processed['context'],
+        ];
+    }
+}

--- a/Logging/src/LogMessageProcessorFactory.php
+++ b/Logging/src/LogMessageProcessorFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Logging;
+
+use Google\Cloud\Logging\LogMessageProcessor\MonologMessageProcessor;
+use Google\Cloud\Logging\LogMessageProcessor\MonologV3MessageProcessor;
+use Monolog\Logger as MonologLogger;
+use RuntimeException;
+
+/**
+ * Returns a LogMessageProcessor that can be used with the currently install Monolog version
+ */
+class LogMessageProcessorFactory
+{
+    /**
+     * @return LogMessageProcessorInterface
+     */
+    public static function build()
+    {
+        $version = defined('\Monolog\Logger::API') ? MonologLogger::API : 1;
+
+        switch ($version) {
+            case 1:
+            case 2:
+                return new MonologMessageProcessor();
+            case 3:
+                return new MonologV3MessageProcessor();
+            default:
+                throw new RuntimeException('Version not supported');
+        }
+    }
+}

--- a/Logging/src/LogMessageProcessorInterface.php
+++ b/Logging/src/LogMessageProcessorInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Logging;
+
+/**
+ * Interface representing a Log Message Processor used by the {@see PsrLogger}
+ */
+interface LogMessageProcessorInterface
+{
+    /**
+     * @param string|\Stringable $message
+     * @param array $context
+     *
+     * @phpstan-return array{message: string, context: array}
+     * @return array
+     */
+    public function processLogMessage($message, $context);
+}

--- a/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
+++ b/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
@@ -24,6 +24,14 @@ use Psr\Log\Test\LoggerInterfaceTest;
 use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 
+if (!class_exists(LoggerInterfaceTest::class)) {
+    // We have to do this because fig/log-test does not support PHP 7.3 and below,
+    // but is required when using psr/log v2 (PHP 8.0 and above).
+    // This means that we cannot add that dependency to require-dev in the root
+    // composer.json file. As a result, these tests are skipped on PHP 8.0 and above.
+    return;
+}
+
 /**
  * @group logging
  */

--- a/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
+++ b/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
@@ -24,6 +24,7 @@ use Psr\Log\Test\LoggerInterfaceTest;
 use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 
+// phpcs:disable
 if (!class_exists(LoggerInterfaceTest::class)) {
     // We have to do this because fig/log-test does not support PHP 7.3 and below,
     // but is required when using psr/log v2 (PHP 8.0 and above).
@@ -31,6 +32,7 @@ if (!class_exists(LoggerInterfaceTest::class)) {
     // composer.json file. As a result, these tests are skipped on PHP 8.0 and above.
     return;
 }
+// phpcs:enable
 
 /**
  * @group logging

--- a/Logging/tests/Unit/PsrLoggerTest.php
+++ b/Logging/tests/Unit/PsrLoggerTest.php
@@ -17,13 +17,10 @@
 
 namespace Google\Cloud\Logging\Tests\Unit;
 
-use Google\Cloud\Core\Batch\BatchRunner;
-use Google\Cloud\Core\Batch\OpisClosureSerializer;
 use Google\Cloud\Core\Report\EmptyMetadataProvider;
 use Google\Cloud\Logging\Logger;
 use Google\Cloud\Logging\PsrLogger;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
-use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 

--- a/composer.json
+++ b/composer.json
@@ -69,8 +69,7 @@
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
         "rg/avro-php": "^1.8.0||^2.0.1||^3.0.0",
-        "symfony/yaml": "^3.3||^6.0",
-        "fig/log-test": "^1.0"
+        "symfony/yaml": "^3.3||^6.0"
     },
     "conflict": {
         "psr/log": ">=3"

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "swaggest/json-schema": "^0.12.0",
         "rg/avro-php": "^1.8.0||^2.0.1||^3.0.0",
         "symfony/yaml": "^3.3||^6.0",
-        "fig/log-test": "^1.1"
+        "fig/log-test": "^1.0"
     },
     "conflict": {
         "psr/log": ">=3"

--- a/composer.json
+++ b/composer.json
@@ -72,9 +72,6 @@
         "symfony/yaml": "^3.3||^6.0",
         "fig/log-test": "^1.1"
     },
-    "provide": {
-        "psr/log-implementation": "1.0|2.0"
-    },
     "conflict": {
         "psr/log": ">=3"
      },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "rize/uri-template": "~0.3",
         "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/psr7": "^1.7|^2.0",
-        "monolog/monolog": "^1.1|^2.0",
+        "monolog/monolog": "^1.1||^2.0||^3.0",
         "psr/http-message": "1.0.*",
         "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.12",
@@ -60,18 +60,24 @@
         "yoast/phpunit-polyfills": "^1.0",
         "phpspec/prophecy": "^1.10.3",
         "squizlabs/php_codesniffer": "3.*",
-        "phpdocumentor/reflection": "^3.0||^4.0",
+        "phpdocumentor/reflection": "^3.0||^4.0||^5.0",
         "symfony/console": "^3.0",
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
-        "symfony/lock": "3.3.x-dev#1ba6ac9",
         "phpseclib/phpseclib": "^2.0||^3.0",
         "google/cloud-tools": "^0.13.0",
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
         "rg/avro-php": "^1.8.0||^2.0.1||^3.0.0",
-        "symfony/yaml": "^3.3||^6.0"
+        "symfony/yaml": "^3.3||^6.0",
+        "fig/log-test": "^1.1"
     },
+    "provide": {
+        "psr/log-implementation": "1.0|2.0"
+    },
+    "conflict": {
+        "psr/log": ">=3"
+     },
     "replace": {
         "google/access-context-manager": "0.3.1",
         "google/analytics-admin": "0.8.1",


### PR DESCRIPTION
Hey everyone 👋,

this is a follow-up to #2302 and aims to add support for all currently available monolog/monolog versions.

* `AppEngineFlexHandlerV3` and `AppEngineFlexFormatterV3` are the new implementations for Monolog 3.x.
* The `formatPayload` method in the `FormatterTrait` should support arrays and the new `LogRecord` class

#### Prerequisites for this PR to be mergeable

* ~https://github.com/phpDocumentor/Reflection/pull/247  is merged but not released (this PR uses ^5.x-dev for now)~
* ~https://github.com/googleapis/gax-php/pull/389 is not reviewed/merged/released (this PR uses my PR branch from over there for now)~
* ~https://github.com/GoogleCloudPlatform/grpc-gcp-php/pull/45 is not (yet) merged - if it's just because of the CLA, I can create a new PR there~

#### Things to look into

* The ReflectionHandlerV5 class is a 90% copy of the ReflectionHandlerV4 - perhaps this can be deduplicated

#### Notes

* There are deprecation warnings that I was not yet able to tackle yet:
  * `opis/closure`
    > Deprecated: Opis\Closure\SerializableClosure implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /Users/jg/Code/opensource/google-cloud-php/vendor/opis/closure/src/SerializableClosure.php on line 18

:octocat:
