### PR TITLE
fix(core): Fixed return type for service exception

### DIFF
--- a/Core/src/Exception/ServiceException.php
+++ b/Core/src/Exception/ServiceException.php
@@ -30,7 +30,7 @@ class ServiceException extends GoogleException
     const ERRORINFO_TYPE_REST = 'type.googleapis.com/google.rpc.ErrorInfo';
 
     /**
-     * @var Exception
+     * @var Exception|null
      */
     private $serviceException;
 
@@ -90,7 +90,7 @@ class ServiceException extends GoogleException
     /**
      * Return the service exception object.
      *
-     * @return Exception
+     * @return Exception|null
      */
     public function getServiceException()
     {


### PR DESCRIPTION
The constructor accepts a nullable exception for this property. The phpdoc however states that it's always an exception. This can lead to static analysis issues.