### PR TITLE
[Firestore] add getQuery to return the current query as array

### DIFF
--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -667,6 +667,17 @@ class Query
     }
 
     /**
+     * Returns the current query.
+     *
+     * @return array
+     * @access public
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
      * Builds a Firestore query position.
      *
      * @param string $key The query key.


### PR DESCRIPTION
This is needed in order to log the query somewhere, or for debugging purposes, etc.