### PR TITLE
chore: fix monitoring owlbot excluse

### DIFF
--- a/Monitoring/owlbot.py
+++ b/Monitoring/owlbot.py
@@ -38,7 +38,7 @@ php.owlbot_main(
         src / "*/src/V3/GroupServiceClient.php",
         src / "*/src/V3/NotificationChannelServiceClient.php",
         src / "*/src/V3/ServiceMonitoringServiceClient.php",
-        src / "*/src/V3/UptimeCheckServiceGapicClient.php",
+        src / "*/src/V3/UptimeCheckServiceClient.php",
     ]
 )
 


### PR DESCRIPTION
The Many APIs PR (#5404) is failing because changes were reverted to `UptimeCheckServiceClient` that were supposed to be excluded, but the wrong class was being excluded.