### PR TITLE
chore: remove label action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,12 +3,10 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
   test:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'gh:run-tests' }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
@@ -23,10 +21,6 @@ jobs:
     name: PHP ${{ matrix.php }} Unit Test (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     steps:
-    - if: ${{ github.event.action == 'labeled' }}
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: gh:run-tests
     - uses: actions/checkout@v3
     - name: Setup PHP
       uses: shivammathur/setup-php@verbose
@@ -48,7 +42,6 @@ jobs:
         vendor/bin/phpunit -c ${{ matrix.phpunit-filename }}-snippets.xml.dist --verbose
 
   style:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'gh:run-tests' }}
     runs-on: ubuntu-latest
     name: PHP Style Check
     steps:
@@ -67,7 +60,6 @@ jobs:
       run: dev/sh/style
 
   docs:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'gh:run-tests' }}
     runs-on: ubuntu-latest
     name: Generate Documentation (Dry Run)
     steps:


### PR DESCRIPTION
The addition of #5355 has caused an issue on OwlBot PRs, as every time an OwlBot PR is updated, the bot adds a `owlbot:run` label. This in turn kicks off an action run which gets skipped. The problem is that, the skipped action is then seen as the most recent one, and so the previous test run is no longer visible in the PR, and the PR is no longer mergeable unless `gh:run-tests` is added. This means every test suite would need to be run an _extra_ time.

I looked for a way to fix it and keep the label, but I believe the _intended_ way is to either:
1. Update a PR by merging in the `main` branch if there are changes we would like it to have (as was the case with the older owlbot PRs when we switched to GH actions). This is doable on the command line (as I did in the screenshot below).
    - One potentially better solution here is by requiring all PRs to be up-to-date with `main`, we can have a button to update the PR right here in the Pull Request UI. This is something we have enabled on our other repositories, and I'll discuss with @dwsupplee and see if he likes this solution.

3. Use the GH actions UI to [re-run actions](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs) when we don't need to update the PR.

<img width="991" alt="Screen Shot 2022-07-29 at 10 57 58 AM" src="https://user-images.githubusercontent.com/103941/181817815-ac9ed719-5d78-4f23-ae9a-917994940d5f.png">

