### PR TITLE
chore: readonly fix in owlbot

### DIFF
--- a/Datastore/owlbot.py
+++ b/Datastore/owlbot.py
@@ -30,9 +30,13 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(src=src, dest=dest)
-
-
+php.owlbot_main(
+    src=src,
+    dest=dest,
+    copy_excludes=[
+        src / "src/V1/TransactionOptions/ReadOnly.php"
+    ]
+)
 
 # document and utilize apiEndpoint instead of serviceAddress
 s.replace(
@@ -67,6 +71,15 @@ for version in ['V1']:
             pathExpr,
             search,
             replace)
+
+# remove ReadOnly class_alias code
+s.replace(
+    "src/V*/**/PBReadOnly.php",
+    r"^// Adding a class alias for backwards compatibility with the \"readonly\" keyword.$"
+    + "\n"
+    + r"^class_alias\(PBReadOnly::class, __NAMESPACE__ . '\\ReadOnly'\);$"
+    + "\n",
+    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -39,6 +39,7 @@ php.owlbot_main(
     copy_excludes=[
         src / '*/src/V1/FirestoreClient.php',
         src / '*/src/Admin/V1/FirestoreAdminClient.php',
+        src / "*/src/V1/TransactionOptions/ReadOnly.php",
     ]
 )
 
@@ -114,6 +115,15 @@ s.replace(
     'tests/**/Admin/V1/*Test.php',
     r'@group admin',
     '@group firestore-admin')
+
+# remove ReadOnly class_alias code
+s.replace(
+    "src/V*/**/PBReadOnly.php",
+    r"^// Adding a class alias for backwards compatibility with the \"readonly\" keyword.$"
+    + "\n"
+    + r"^class_alias\(PBReadOnly::class, __NAMESPACE__ . '\\ReadOnly'\);$"
+    + "\n",
+    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/Spanner/owlbot.py
+++ b/Spanner/owlbot.py
@@ -35,11 +35,10 @@ php.owlbot_main(
     src=src,
     dest=dest,
     copy_excludes=[
-        src / "*/src/V1/SpannerClient.php"
+        src / "*/src/V1/SpannerClient.php",
+        src / "*/src/V1/TransactionOptions/ReadOnly.php",
     ]
 )
-
-
 
 # Spanner Database Admin also lives here
 admin_library = Path(f"../{php.STAGING_DIR}/Spanner/v1/Admin/Database/v1").resolve()
@@ -107,6 +106,15 @@ s.replace(
     'tests/**/Admin/Instance/V1/*Test.php',
     '@group instance',
     '@group spanner-admin-instance')
+
+# remove ReadOnly class_alias code
+s.replace(
+    "src/V*/**/PBReadOnly.php",
+    r"^// Adding a class alias for backwards compatibility with the \"readonly\" keyword.$"
+    + "\n"
+    + r"^class_alias\(PBReadOnly::class, __NAMESPACE__ . '\\ReadOnly'\);$"
+    + "\n",
+    '')
 
 ## START fixing commit() breaking change
 


### PR DESCRIPTION
We made manual changes to `Firestore`, `Datastore`, and `Spanner` in the last release in order to preserve backwards compatibility better in those libraries. This will make sure those changes do not get overwritten in the next owlbot release.