### PR TITLE
chore: fix longrunning docs TOC

### DIFF
--- a/docs/contents/longrunning.json
+++ b/docs/contents/longrunning.json
@@ -8,7 +8,7 @@
         },
 	{
             "title": "OperationsClient",
-            "type": "longrunning\/apicore\/longrunning\/operationsclient"
+            "type": "longrunning\/apicore"
         }
     ],
     "pattern": "longrunning\/\\w{1,}"


### PR DESCRIPTION
In the docs for php-longrunning, the [TOC is broken](https://googleapis.github.io/google-cloud-php/#/docs/longrunning/v0.1.0/longrunning/readme) - clicking `OperationsClient` results in a 404 because it's configured to go to `longrunning/apicore/longrunning/operationsclient` in `docs/content/longrunning.json`. The link _should_ be `longrunning/apicore` instead: https://googleapis.github.io/google-cloud-php/#/docs/longrunning/v0.1.0/longrunning/apicore

This PR updates `docs/content/longrunning.json` to be `longrunning/apicore`. I don't quite understand why the other URL isn't working, but I believe it has something to do with LongRunning not having a version number.