### PR TITLE
chore: fix owlbot configuration and GcTestListener autoloading

### DIFF
--- a/Core/src/Testing/GcTestListener.php
+++ b/Core/src/Testing/GcTestListener.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+namespace Google\Cloud\Core\Testing;
+
 use PHPUnit\Framework\TestListener;
 use Yoast\PHPUnitPolyfills\TestListeners\TestListenerDefaultImplementation;
 

--- a/Datastream/owlbot.py
+++ b/Datastream/owlbot.py
@@ -30,7 +30,13 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(src=src, dest=dest)
+php.owlbot_main(
+    src=src,
+    dest=dest,
+    copy_excludes=[
+        src / "**/[A-Z]*_*.php"
+    ]
+)
 
 # document and utilize apiEndpoint instead of serviceAddress
 s.replace(

--- a/Datastream/owlbot.py
+++ b/Datastream/owlbot.py
@@ -56,6 +56,15 @@ s.replace(
     r"\$transportConfig, and any \$serviceAddress",
     r"$transportConfig, and any `$apiEndpoint`")
 
+# remove class_alias code
+s.replace(
+    "src/V*/**/*.php",
+    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
+    + "\n"
+    + r"^class_alias\(.*\);$"
+    + "\n",
+    '')
+
 ### [START] protoc backwards compatibility fixes
 
 # roll back to private properties.

--- a/Optimization/owlbot.py
+++ b/Optimization/owlbot.py
@@ -30,7 +30,13 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(src=src, dest=dest)
+php.owlbot_main(
+    src=src,
+    dest=dest,
+    copy_excludes=[
+        src / "**/[A-Z]*_*.php"
+    ]
+)
 
 # document and utilize apiEndpoint instead of serviceAddress
 s.replace(

--- a/Optimization/owlbot.py
+++ b/Optimization/owlbot.py
@@ -56,6 +56,15 @@ s.replace(
     r"\$transportConfig, and any \$serviceAddress",
     r"$transportConfig, and any `$apiEndpoint`")
 
+# remove class_alias code
+s.replace(
+    "src/V*/**/*.php",
+    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
+    + "\n"
+    + r"^class_alias\(.*\);$"
+    + "\n",
+    '')
+
 ### [START] protoc backwards compatibility fixes
 
 # roll back to private properties.

--- a/phpunit-php5.xml.dist
+++ b/phpunit-php5.xml.dist
@@ -24,7 +24,7 @@
     </whitelist>
   </filter>
   <listeners>
-    <listener class="GcTestListener" file="Core/src/Testing/GcTestListener.php"/>
+    <listener class="Google\Cloud\Core\Testing\GcTestListener" file="Core/src/Testing/GcTestListener.php"/>
   </listeners>
   <php>
     <ini name="memory_limit" value="2048M"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,6 @@
     <ini name="memory_limit" value="2048M"/>
   </php>
   <listeners>
-    <listener class="GcTestListener" file="Core/src/Testing/GcTestListener.php"/>
+    <listener class="Google\Cloud\Core\Testing\GcTestListener" file="Core/src/Testing/GcTestListener.php"/>
   </listeners>
 </phpunit>


### PR DESCRIPTION
 - Fix for `Datastream` and `Optimization` to ignore protobuf compatibility files in `owlbot.py`
 - Fix autoloading for `GcTestListener` (this isn't super important but I put it in here anyway)