### PR TITLE
chore: [BigQuery] fix class references in phpdoc

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -106,7 +106,7 @@ class BigQueryClient
      *     @type string $quotaProject Specifies a user project to bill for
      *           access charges associated with the request.
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      *     @type string $location If provided, determines the default geographic
      *           location used when creating datasets and managing jobs. Please
@@ -114,7 +114,7 @@ class BigQueryClient
      *           and EU regions. Also, if location metadata has already been
      *           fetched over the network it will take precedent over this
      *           setting (by calling
-     *           {@see Google\Cloud\BigQuery\Table::reload()}, for example).
+     *           {@see Table::reload()}, for example).
      * }
      */
     public function __construct(array $config = [])
@@ -146,8 +146,8 @@ class BigQueryClient
 
     /**
      * Returns a job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startQuery()}. A
+     * {@see BigQueryClient::runQuery()} or
+     * {@see BigQueryClient::startQuery()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -217,8 +217,8 @@ class BigQueryClient
 
     /**
      * Returns a job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startQuery()}. A
+     * {@see BigQueryClient::runQuery()} or
+     * {@see BigQueryClient::startQuery()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -228,7 +228,7 @@ class BigQueryClient
      * in this client.
      *
      * As this method is an alias, please see
-     * {@see Google\Cloud\BigQuery\BigQueryClient::query()} for usage examples.
+     * {@see BigQueryClient::query()} for usage examples.
      *
      * @param string $query A BigQuery SQL query.
      * @param array $options [optional] {
@@ -252,7 +252,7 @@ class BigQueryClient
      * Runs a BigQuery SQL query in a synchronous fashion.
      *
      * This method is ideal for queries which return results quickly - otherwise
-     * we highly recommend utilizing {@see Google\Cloud\BigQuery\BigQueryClient::startQuery()}
+     * we highly recommend utilizing {@see BigQueryClient::startQuery()}
      * as it provides better mechanisms for fine grained control over result polling.
      *
      * Unless `$options.maxRetries` is specified, this method will block until
@@ -268,11 +268,11 @@ class BigQueryClient
      * | **PHP Type**                               | **BigQuery Data Type**               |
      * |--------------------------------------------|--------------------------------------|
      * | `\DateTimeInterface`                       | `DATETIME`                           |
-     * | {@see Google\Cloud\BigQuery\Bytes}         | `BYTES`                              |
-     * | {@see Google\Cloud\BigQuery\Date}          | `DATE`                               |
-     * | {@see Google\Cloud\Core\Int64}             | `INT64`                              |
-     * | {@see Google\Cloud\BigQuery\Time}          | `TIME`                               |
-     * | {@see Google\Cloud\BigQuery\Timestamp}     | `TIMESTAMP`                          |
+     * | {@see Bytes}                               | `BYTES`                              |
+     * | {@see Date}                                | `DATE`                               |
+     * | {@see Int64}                               | `INT64`                              |
+     * | {@see Time}                                | `TIME`                               |
+     * | {@see Timestamp}                           | `TIMESTAMP`                          |
      * | Associative Array                          | `STRUCT`                             |
      * | Non-Associative Array                      | `ARRAY`                              |
      * | `float`                                    | `FLOAT64`                            |
@@ -373,7 +373,7 @@ class BigQueryClient
      * Queries constructed using
      * [standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
      * can take advantage of parameterization. For more details and examples
-     * please see {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}.
+     * please see {@see BigQueryClient::runQuery()}.
      *
      * Example:
      * ```
@@ -402,7 +402,7 @@ class BigQueryClient
     /**
      * Lazily instantiates a job. There are no network requests made at this
      * point. To see the operations that can be performed on a job please
-     * see {@see Google\Cloud\BigQuery\Job}.
+     * see {@see Job}.
      *
      * Example:
      * ```
@@ -499,7 +499,7 @@ class BigQueryClient
     /**
      * Lazily instantiates a dataset. There are no network requests made at this
      * point. To see the operations that can be performed on a dataset please
-     * see {@see Google\Cloud\BigQuery\Dataset}.
+     * see {@see Dataset}.
      *
      * If the dataset is owned by a different project than the project used to authenticate the client,
      * provide the project ID as the second argument.
@@ -876,8 +876,8 @@ class BigQueryClient
 
     /**
      * Returns a copy job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -913,8 +913,8 @@ class BigQueryClient
 
     /**
      * Returns an extract job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -950,8 +950,8 @@ class BigQueryClient
 
     /**
      * Returns a load job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *

--- a/BigQuery/src/Connection/Rest.php
+++ b/BigQuery/src/Connection/Rest.php
@@ -30,6 +30,8 @@ use GuzzleHttp\Psr7\Utils;
 /**
  * Implementation of the
  * [Google BigQuery JSON API](https://cloud.google.com/bigquery/docs/reference/v2/).
+ *
+ * @internal
  */
 class Rest implements ConnectionInterface
 {

--- a/BigQuery/src/Dataset.php
+++ b/BigQuery/src/Dataset.php
@@ -179,7 +179,7 @@ class Dataset
     /**
      * Lazily instantiates a table. There are no network requests made at this
      * point. To see the operations that can be performed on a dataset please
-     * see {@see Google\Cloud\BigQuery\Table}.
+     * see {@see Table}.
      *
      * Example:
      * ```
@@ -307,7 +307,7 @@ class Dataset
     /**
      * Lazily instantiates a machine learning model in the dataset. There are no
      * network requests made at this point. To see the operations that can be performed on a
-     * model, please see {@see Google\Cloud\BigQuery\Model}.
+     * model, please see {@see Model}.
      *
      * Example:
      * ```
@@ -340,7 +340,7 @@ class Dataset
      * subset of the resource representation. Fields returned include
      * `modelReference`, `modelType`, `creationTime`, `lastModifiedTime` and
      * `labels`. To obtain a full representation, call
-     * {@see Google\Cloud\BigQuery\Model::reload()}.
+     * {@see Model::reload()}.
      *
      * Example:
      * ```
@@ -390,7 +390,7 @@ class Dataset
      *
      * There are no network requests made at this point. To see the operations
      * that can be performed on a routine, please see
-     * {@see Google\Cloud\BigQuery\Routine}.
+     * {@see Routine}.
      *
      * Example:
      * ```
@@ -420,7 +420,7 @@ class Dataset
      * subset of the resource representation. Fields returned include `etag`,
      * `projectId`, `datasetId`, `routineId`, `routineType`, `creationTime`,
      * `lastModifiedTime` and `language`. To obtain a full representation, call
-     * {@see Google\Cloud\BigQuery\Routine::reload()}.
+     * {@see Routine::reload()}.
      *
      * Example:
      * ```

--- a/BigQuery/src/ExtractJobConfiguration.php
+++ b/BigQuery/src/ExtractJobConfiguration.php
@@ -157,7 +157,7 @@ class ExtractJobConfiguration implements JobConfigurationInterface
      * Sets a reference to the table being exported.
      *
      * Cannot be used in the same job as
-     * {@see Google\Cloud\BigQuery\ExtractJobConfiguration::sourceModel()}.
+     * {@see ExtractJobConfiguration::sourceModel()}.
      *
      * Example:
      * ```
@@ -180,7 +180,7 @@ class ExtractJobConfiguration implements JobConfigurationInterface
      * Sets a reference to the model being exported.
      *
      * Cannot be used in the same job as
-     * {@see Google\Cloud\BigQuery\ExtractJobConfiguration::sourceTable()}.
+     * {@see ExtractJobConfiguration::sourceTable()}.
      *
      * Example:
      * ```

--- a/BigQuery/src/InsertResponse.php
+++ b/BigQuery/src/InsertResponse.php
@@ -21,8 +21,8 @@ namespace Google\Cloud\BigQuery;
  * Represents the result of streaming data into a table.
  *
  * This class should be not instantiated directly, but as a result of calling
- * {@see Google\Cloud\BigQuery\Table::insertRow()} or
- * {@see Google\Cloud\BigQuery\Table::insertRows()}.
+ * {@see Table::insertRow()} or
+ * {@see Table::insertRows()}.
  */
 class InsertResponse
 {

--- a/BigQuery/src/Job.php
+++ b/BigQuery/src/Job.php
@@ -147,9 +147,9 @@ class Job
      * further polling may be necessary in order to access the full query
      * results. Polling for completion can be initiated by iterating on the
      * returned
-     * {@see Google\Cloud\BigQuery\QueryResults}, or by calling either
-     * {@see Google\Cloud\BigQuery\QueryResults::rows()} or
-     * {@see Google\Cloud\BigQuery\QueryResults::waitUntilComplete()}.
+     * {@see QueryResults}, or by calling either
+     * {@see QueryResults::rows()} or
+     * {@see QueryResults::waitUntilComplete()}.
      *
      * Example:
      * ```
@@ -238,7 +238,7 @@ class Job
 
     /**
      * Checks the job's completeness. Useful in combination with
-     * {@see Google\Cloud\BigQuery\Job::reload()} to poll for job status.
+     * {@see Job::reload()} to poll for job status.
      *
      * Example:
      * ```

--- a/BigQuery/src/JobConfigurationTrait.php
+++ b/BigQuery/src/JobConfigurationTrait.php
@@ -120,7 +120,7 @@ trait JobConfigurationTrait
      *        **Defaults to** a location specified in the client configuration,
      *        if provided, or through location metadata fetched by a network
      *        request
-     *        (by calling {@see Google\Cloud\BigQuery\Table::reload()}, for example).
+     *        (by calling {@see Table::reload()}, for example).
      * @return JobConfigurationInterface
      */
     public function location($location)

--- a/BigQuery/src/Model.php
+++ b/BigQuery/src/Model.php
@@ -82,7 +82,7 @@ class Model
      *
      * Please note that Model instances created by list calls may not contain a
      * full representation of the model resource. To obtain a full resource on a
-     * Model instance, call {@see Google\Cloud\BigQuery\Model::reload()}.
+     * Model instance, call {@see Model::reload()}.
      *
      * Example:
      * ```
@@ -242,8 +242,8 @@ class Model
 
     /**
      * Returns an extract job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -256,7 +256,7 @@ class Model
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $destination The destination object. May be
-     *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to
+     *        a {@see StorageObject} or a URI pointing to
      *        a Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
      * @param array $options [optional] Please see the

--- a/BigQuery/src/QueryJobConfiguration.php
+++ b/BigQuery/src/QueryJobConfiguration.php
@@ -64,7 +64,7 @@ class QueryJobConfiguration implements JobConfigurationInterface
      * Sets whether or not the query can produce arbitrarily large result
      * tables at a slight cost in performance. Only applies to queries
      * performed with legacy SQL dialect and requires a
-     * {@see Google\Cloud\BigQuery\QueryJobConfiguration::destinationTable()} to
+     * {@see QueryJobConfiguration::destinationTable()} to
      * be set.
      *
      * Example:
@@ -193,7 +193,7 @@ class QueryJobConfiguration implements JobConfigurationInterface
     /**
      * Sets whether or not to flatten all nested and repeated fields in the
      * query results. Only applies to queries performed with legacy SQL dialect.
-     * {@see Google\Cloud\BigQuery\QueryJobConfiguration::allowLargeResults()}
+     * {@see QueryJobConfiguration::allowLargeResults()}
      * must be true if this is set to false.
      *
      * Example:
@@ -257,7 +257,7 @@ class QueryJobConfiguration implements JobConfigurationInterface
      * queries.
      *
      * For examples of usage please see
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}.
+     * {@see BigQueryClient::runQuery()}.
      *
      * @param array $parameters Parameters to use on the query. When providing
      *        a non-associative array positional parameters (`?`) will be used.

--- a/BigQuery/src/QueryResults.php
+++ b/BigQuery/src/QueryResults.php
@@ -28,8 +28,8 @@ use Google\Cloud\Core\Iterator\PageIterator;
  * [Query Response API Documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#response-body)
  *
  * This class should be not instantiated directly, but as a result of
- * calling {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
- * {@see Google\Cloud\BigQuery\Job::queryResults()}.
+ * calling {@see BigQueryClient::runQuery()} or
+ * {@see Job::queryResults()}.
  */
 class QueryResults implements \IteratorAggregate
 {
@@ -107,20 +107,20 @@ class QueryResults implements \IteratorAggregate
      * Refer to the table below for a guide on how BigQuery types are mapped as
      * they come back from the API.
      *
-     * | **PHP Type**                               | **BigQuery Data Type**               |
-     * |--------------------------------------------|--------------------------------------|
-     * | `\DateTimeInterface`                       | `DATETIME`                           |
-     * | {@see Google\Cloud\BigQuery\Bytes}         | `BYTES`                              |
-     * | {@see Google\Cloud\BigQuery\Date}          | `DATE`                               |
-     * | {@see Google\Cloud\Core\Int64}             | `INTEGER`                            |
-     * | {@see Google\Cloud\BigQuery\Time}          | `TIME`                               |
-     * | {@see Google\Cloud\BigQuery\Timestamp}     | `TIMESTAMP`                          |
-     * | Associative Array                          | `RECORD`                             |
-     * | Non-Associative Array                      | `RECORD` (Repeated)                  |
-     * | `float`                                    | `FLOAT`                              |
-     * | `int`                                      | `INTEGER`                            |
-     * | `string`                                   | `STRING`                             |
-     * | `bool`                                     | `BOOLEAN`                            |
+     * | **PHP Type**                    | **BigQuery Data Type**               |
+     * |---------------------------------|--------------------------------------|
+     * | `\DateTimeInterface`            | `DATETIME`                           |
+     * | {@see Bytes}                    | `BYTES`                              |
+     * | {@see Date}                     | `DATE`                               |
+     * | {@see \Google\Cloud\Core\Int64} | `INTEGER`                            |
+     * | {@see Time}                     | `TIME`                               |
+     * | {@see Timestamp}                | `TIMESTAMP`                          |
+     * | Associative Array               | `RECORD`                             |
+     * | Non-Associative Array           | `RECORD` (Repeated)                  |
+     * | `float`                         | `FLOAT`                              |
+     * | `int`                           | `INTEGER`                            |
+     * | `string`                        | `STRING`                             |
+     * | `bool`                          | `BOOLEAN`                            |
      *
      * Example:
      * ```
@@ -134,8 +134,8 @@ class QueryResults implements \IteratorAggregate
      * @param array $options [optional] {
      *     Configuration options. Please note, these options will inherit the
      *     values set by either
-     *     {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
-     *     {@see Google\Cloud\BigQuery\Job::queryResults()}.
+     *     {@see BigQueryClient::runQuery()} or
+     *     {@see Job::queryResults()}.
      *
      *     @type int $maxResults Maximum number of results to read per page.
      *     @type int $startIndex Zero-based index of the starting row.
@@ -206,8 +206,8 @@ class QueryResults implements \IteratorAggregate
      * @param array $options [optional] {
      *     Configuration options. Please note, these options will inherit the
      *     values set by either
-     *     {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
-     *     {@see Google\Cloud\BigQuery\Job::queryResults()}.
+     *     {@see BigQueryClient::runQuery()} or
+     *     {@see Job::queryResults()}.
      *
      *     @type int $maxResults Maximum number of results to read per page.
      *     @type int $startIndex Zero-based index of the starting row.
@@ -304,7 +304,7 @@ class QueryResults implements \IteratorAggregate
 
     /**
      * Checks the job's completeness. Useful in combination with
-     * {@see Google\Cloud\BigQuery\QueryResults::reload()} to poll for query
+     * {@see QueryResults::reload()} to poll for query
      * status.
      *
      * Example:
@@ -328,10 +328,10 @@ class QueryResults implements \IteratorAggregate
     }
 
     /**
-     * Returns a reference to the {@see Google\Cloud\BigQuery\Job} instance used
+     * Returns a reference to the {@see Job} instance used
      * to fetch the query results. This is especially useful when attempting to
      * access job statistics after calling
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}.
+     * {@see BigQueryClient::runQuery()}.
      *
      * Example:
      * ```

--- a/BigQuery/src/Routine.php
+++ b/BigQuery/src/Routine.php
@@ -97,7 +97,7 @@ class Routine
      *
      * If the value is not already cached, a service call will be made. To force
      * a refresh of the cached value, use
-     * {@see Google\Cloud\BigQuery\Routine::reload()}.
+     * {@see Routine::reload()}.
      *
      * Example:
      * ```
@@ -118,7 +118,7 @@ class Routine
      *
      * This method will always trigger a service request. To make use of a
      * cached representation of the resource, see
-     * {@see Google\Cloud\BigQuery\Routine::info()}.
+     * {@see Routine::info()}.
      *
      * Example:
      * ```

--- a/BigQuery/src/Table.php
+++ b/BigQuery/src/Table.php
@@ -274,7 +274,7 @@ class Table
      *
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
-     * @deprecated Use {@see Google\Cloud\BigQuery\BigQueryClient::runJob()}.
+     * @deprecated Use {@see BigQueryClient::runJob()}.
      * @param JobConfigurationInterface $config The job configuration.
      * @param array $options [optional] {
      *     Configuration options.
@@ -304,7 +304,7 @@ class Table
      *
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
-     * @deprecated Use {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}.
+     * @deprecated Use {@see BigQueryClient::startJob()}.
      * @param JobConfigurationInterface $config The job configuration.
      * @param array $options [optional] Configuration options.
      * @return Job
@@ -331,8 +331,8 @@ class Table
 
     /**
      * Returns a copy job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -376,8 +376,8 @@ class Table
 
     /**
      * Returns an extract job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -390,7 +390,7 @@ class Table
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $destination The destination object. May be
-     *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to
+     *        a {@see StorageObject} or a URI pointing to
      *        a Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
      * @param array $options [optional] {
@@ -424,8 +424,8 @@ class Table
 
     /**
      * Returns a load job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -469,8 +469,8 @@ class Table
 
     /**
      * Returns a load job configuration to be passed to either
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runJob()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::startJob()}. A
+     * {@see BigQueryClient::runJob()} or
+     * {@see BigQueryClient::startJob()}. A
      * configuration can be built using fluent setters or by providing a full
      * set of options at once.
      *
@@ -483,7 +483,7 @@ class Table
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert Jobs insert API Documentation.
      *
      * @param string|StorageObject $object The object to load data from. May be
-     *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to a
+     *        a {@see StorageObject} or a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
      * @param array $options [optional] {
@@ -544,7 +544,7 @@ class Table
      * @param array $row Key/value set of data matching the table's schema.
      * @param array $options [optional] {
      *     Please see
-     *     {@see Google\Cloud\BigQuery\Table::insertRows()} for the
+     *     {@see Table::insertRows()} for the
      *     other available configuration options.
      *
      *     @type string $insertId Used to

--- a/BigQuery/src/ValueMapper.php
+++ b/BigQuery/src/ValueMapper.php
@@ -52,14 +52,14 @@ class ValueMapper
 
     /**
      * @var bool $returnInt64AsObject If true, 64 bit integers will be returned
-     *      as a {@see Google\Cloud\Core\Int64} object for 32 bit platform
+     *      as a {@see Int64} object for 32 bit platform
      *      compatibility.
      */
     private $returnInt64AsObject;
 
     /**
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        returned as a {@see Int64} object for 32 bit
      *        platform compatibility.
      */
     public function __construct($returnInt64AsObject)
@@ -334,7 +334,7 @@ class ValueMapper
 
     /**
      * Converts a timestamp in string format received from BigQuery to a
-     * {@see Google\Cloud\BigQuery\Timestamp}.
+     * {@see Timestamp}.
      *
      * @param string $value The timestamp.
      * @return Timestamp


### PR DESCRIPTION
Using `phpdoc`, I was able to confirm that these changes will fix the previous references

I also marked `Connection\Rest` as `@internal`. This will allow the docs to leave it out of our reference documentation