### PR TITLE
fix: insecure credentials wrapper

### DIFF
--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -29,7 +29,7 @@ class InsecureCredentialsWrapper extends CredentialsWrapper
     {
     }
 
-    public function getAuthorizationHeaderCallback($audience = null)
+    public function getAuthorizationHeaderCallback(string $audience = null)
     {
         return null;
     }


### PR DESCRIPTION
The latest version of gax will throw an error because of the lack of typehint