### PR TITLE
add `void` return type to `PsrLogger` methods

### DIFF
--- a/Logging/src/PsrLogger.php
+++ b/Logging/src/PsrLogger.php
@@ -165,7 +165,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->log(Logger::EMERGENCY, $message, $context);
     }
@@ -183,7 +183,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->log(Logger::ALERT, $message, $context);
     }
@@ -201,7 +201,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->log(Logger::CRITICAL, $message, $context);
     }
@@ -219,7 +219,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->log(Logger::ERROR, $message, $context);
     }
@@ -237,7 +237,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->log(Logger::WARNING, $message, $context);
     }
@@ -255,7 +255,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->log(Logger::NOTICE, $message, $context);
     }
@@ -273,7 +273,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->log(Logger::INFO, $message, $context);
     }
@@ -291,7 +291,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->log(Logger::DEBUG, $message, $context);
     }
@@ -368,7 +368,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * @return void
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->validateLogLevel($level);
         $options = [];


### PR DESCRIPTION
`PsrLogger` should match return types from `LoggerInterface` v3.0.0

- emergency:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L30

- alert:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L43

- critical:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L55

- error:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L66

- warning:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L79

- notice:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L89

- info:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L101

- debug:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L111

- log:
https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L124

---

We've seen the following error in Google App Engine Standard runtime PHP 8.1:
>```
> PHP message: PHP Fatal error:  Declaration of 
> Google\Cloud\Logging\PsrLogger::emergency($message, array $context = []) 
> must be compatible with 
> Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void 
> in /workspace/vendor/google/cloud/Logging/src/PsrLogger.php on line 168
>```

This error was worked around using `"psr/log": "2.0.0"` as a dependency instead of `v3.0.0`.

`LoggerInterface` [v2.0.0](https://github.com/php-fig/log/blob/2.0.0/src/LoggerInterface.php) did not have explicit return types, but [v3.0.0](https://github.com/php-fig/log/blob/3.0.0/src/LoggerInterface.php) does explicitly declares `void` return types.
