### PR TITLE
Fix null trim

### DIFF
--- a/Firestore/src/PathTrait.php
+++ b/Firestore/src/PathTrait.php
@@ -131,6 +131,9 @@ trait PathTrait
     {
         if (!$this->isRelative($name)) {
             $name = $this->relativeName($name);
+            if ($name === null) {
+                return false;
+            }
         }
 
         $parts = $this->splitName($name);

--- a/Firestore/tests/Unit/PathTraitTest.php
+++ b/Firestore/tests/Unit/PathTraitTest.php
@@ -151,6 +151,7 @@ class PathTraitTest extends TestCase
         return [
             [self::COLLECTION],
             [self::ROOT],
+            [''],
             [sprintf('projects/%s/databases/%s/documents/%s', self::PROJECT, self::DATABASE, self::ROOT)],
             [sprintf('projects/%s/databases/%s/documents/%s', self::PROJECT, self::DATABASE, self::COLLECTION)],
         ];


### PR DESCRIPTION
If `relativeName()` ends up returning `null` then the subsequent call to `splitName()` will pass the same into `trim()` which causes a deprecation warning in PHP 8.1:
```
trim(): Passing null to parameter #1 ($string) of type string is deprecated

firebase/vendor/google/cloud-firestore/src/PathTrait.php:178
firebase/vendor/google/cloud-firestore/src/PathTrait.php:136
firebase/vendor/google/cloud-firestore/src/CollectionReference.php:298
```

This PR interrupts that chain at the most logical point for an early return.