### PR TITLE
fix(storage): seeking object before file creation

### DIFF
--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -611,10 +611,11 @@ class StorageObject
      */
     public function downloadToFile($path, array $options = [])
     {
+        $source = $this->downloadAsStream($options);
         $destination = Utils::streamFor(fopen($path, 'w'));
 
         Utils::copyToStream(
-            $this->downloadAsStream($options),
+            $source,
             $destination
         );
 

--- a/Storage/tests/System/ManageObjectsTest.php
+++ b/Storage/tests/System/ManageObjectsTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\System;
 
+use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -181,6 +182,25 @@ class ManageObjectsTest extends StorageTestCase
         $stream = self::$object->downloadToFile('php://temp');
 
         $this->assertEquals($contents, (string) $stream);
+    }
+
+    public function testDownloadsToFileShouldNotCreateFileWhenObjectNotFound()
+    {
+        $objectName = uniqid(self::TESTING_PREFIX);
+        $testObject = self::$bucket->object($objectName);
+        $exceptionString = 'No such object';
+        $downloadFilePath = __DIR__ . '/' . $objectName;
+
+        $throws = false;
+        try {
+            $testObject->downloadToFile($downloadFilePath);
+        } catch (NotFoundException $e) {
+            $this->assertStringContainsString($exceptionString, $e->getMessage());
+            $throws = true;
+        }
+
+        $this->assertTrue($throws);
+        $this->assertFileDoesNotExist($downloadFilePath);
     }
 
     public function testDownloadsPublicFileWithUnauthenticatedClient()

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -466,6 +466,26 @@ class StorageObjectTest extends TestCase
         $this->assertEquals($string, $contents);
     }
 
+    public function testDownloadsToFileShouldNotCreateFileWhenObjectNotFound()
+    {
+        $exceptionString = 'object does not exist';
+        $this->connection->downloadObject(Argument::any())
+            ->willThrow(new NotFoundException($exceptionString));
+        $object = 'non_existent_object.txt';
+        $downloadFilePath = __DIR__ . '/storage_test_downloads_to_file.txt';
+        $object = new StorageObject($this->connection->reveal(), $object, self::BUCKET);
+        $throws = false;
+        try {
+            $object->downloadToFile($downloadFilePath);
+        } catch (NotFoundException $e) {
+            $this->assertStringContainsString($e->getMessage(), $exceptionString);
+            $throws = true;
+        }
+
+        $this->assertTrue($throws);
+        $this->assertFileDoesNotExist($downloadFilePath);
+    }
+
     public function testDownloadAsStreamWithoutExtraOptions()
     {
         $bucket = 'bucket';


### PR DESCRIPTION
Addresses : https://github.com/googleapis/google-cloud-php/issues/3347

## Change:
Moving object seek before file creation while downloading a storage object.

## Test:

Directly edited the `/vendor` folder in `php-docs-samples` and validated that:

1. File is created while object is present
`php src/download_public_file.php $GOOGLE_STORAGE_BUCKET sample.txt ./temp.txt` 

2. No file is created when object is not present (previously an empty file was being created)
`php src/download_public_file.php $GOOGLE_STORAGE_BUCKET no_sample.txt ./temp.txt`

3. Added a System test which evaluates against the network: (log is below, since system tests are not running on PR)

```
google-cloud-php/Storage % XDEBUG_MODE=debug vendor/bin/phpunit -c phpunit-system.xml.dist --filter="testDownloadsToFileShouldNotCreateFileWhenObjectNotFound"
Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port) :-(
PHPUnit 8.5.30 #StandWithUkraine

.                                                                   1 / 1 (100%)

Time: 3.23 seconds, Memory: 12.00 MB

OK (1 test, 3 assertions)
google-cloud-php/Storage %                                                                                  (git)-[storage_fix_3347]-
google-cloud-php/Storage %
```

**Note:** 
In test case 2, with or without this change, an exception is thrown.