### PR TITLE
chore: update CI status in README to php74

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 PHP Version  | Status
 ------------ | ------
-PHP 7.2 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/php/badges/google-cloud-php/php72.svg)](https://storage.googleapis.com/cloud-devrel-public/php/badges/google-cloud-php/php72.html)
+PHP 7.4 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/php/badges/google-cloud-php/php74.svg)](https://storage.googleapis.com/cloud-devrel-public/php/badges/google-cloud-php/php74.html)
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud/v/stable)](https://packagist.org/packages/google/cloud) [![Packagist](https://img.shields.io/packagist/dm/google/cloud.svg)](https://packagist.org/packages/google/cloud)
 


### PR DESCRIPTION
Partly addresses: https://github.com/googleapis/google-cloud-php/issues/5535

## Changes
* CI builds stats should be upgraded to php7.4
* PHP 7.2 tests haven't been running since April

## Next
1. Get build status to green