### PR TITLE
chore(Spanner): Removed JSONB array system tests

### DIFF
--- a/Spanner/tests/System/PgWriteTest.php
+++ b/Spanner/tests/System/PgWriteTest.php
@@ -65,7 +65,6 @@ class PgWriteTest extends SpannerPgTestCase
                 arraytimestampfield timestamptz[],
                 arraydatefield date[],
                 arraypgnumericfield numeric[],
-                arraypgjsonbfield jsonb[],
                 PRIMARY KEY (id)
             )',
             'CREATE TABLE ' . self::COMMIT_TIMESTAMP_TABLE_NAME . ' (
@@ -253,9 +252,6 @@ class PgWriteTest extends SpannerPgTestCase
             [$this->randId(), 'arraydatefield', null],
             [$this->randId(), 'arraypgnumericfield', []],
             [$this->randId(), 'arraypgnumericfield', null],
-            [$this->randId(), 'arraypgjsonbfield', null],
-            [$this->randId(), 'arraypgjsonbfield', []],
-            [$this->randId(), 'arraypgjsonbfield', null],
         ];
     }
 
@@ -301,7 +297,6 @@ class PgWriteTest extends SpannerPgTestCase
             [$this->randId(), 'arraytimestampfield', [new Timestamp(new \DateTime),null,new Timestamp(new \DateTime)]],
             [$this->randId(), 'arraydatefield', [new Date(new \DateTime),null,new Date(new \DateTime)]],
             [$this->randId(), 'arraypgnumericfield', [new PgNumeric("0.12345"),null,new PgNumeric("12345")]],
-            [$this->randId(), 'arraypgjsonbfield', [new PgJsonb('{"a":1.1,"b":"hello"}'),null,new PgJsonb(["a" => 1])]],
         ];
     }
 


### PR DESCRIPTION
Removing the tests as JSONB array isn't supported yet.