### PR TITLE
fix(docs): wrap TOC in component

### DIFF
--- a/.kokoro/docs/publish.sh
+++ b/.kokoro/docs/publish.sh
@@ -9,7 +9,8 @@ elif [ "$#" -ne 0 ]; then
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PROJECT_DIR=${SCRIPT_DIR%/*}/..
+PROJECT_DIR=${SCRIPT_DIR%/*}
+PROJECT_DIR=${PROJECT_DIR%/*}
 
 # Run "composer install" if it hasn't been run yet
 if [ ! -d 'vendor/' ]; then

--- a/.kokoro/docs/publish.sh
+++ b/.kokoro/docs/publish.sh
@@ -9,8 +9,7 @@ elif [ "$#" -ne 0 ]; then
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PROJECT_DIR=${SCRIPT_DIR%/*}
-PROJECT_DIR=${PROJECT_DIR%/*}
+PROJECT_DIR=$(dirname $(dirname $SCRIPT_DIR))
 
 # Run "composer install" if it hasn't been run yet
 if [ ! -d 'vendor/' ]; then

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
         "wikimedia/avro": "^1.9",
-        "symfony/yaml": "^3.3"
+        "symfony/yaml": "^3.3||^6.0"
     },
     "replace": {
         "google/access-context-manager": "0.2.5",

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -88,7 +88,7 @@ class DocFx extends Command
         $output->write(sprintf('Writing output to <fg=white>%s</>... ', $outDir));
 
         // YAML dump configuration
-        $inline = 9; // The level where you switch to inline YAML
+        $inline = 11; // The level where you switch to inline YAML
         $indent = 2; // The amount of spaces to use for indentation of nested nodes
         $flags = Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK;
 

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -113,10 +113,11 @@ class DocFx extends Command
             $tocItems = array_merge($tocItems, $pages->getTocItems());
         }
 
+        $releaseLevel = $this->getReleaseLevel();
         if (file_exists($overviewFile = sprintf('%s/README.md', $componentPath))) {
             $overview = new OverviewPage(
                 file_get_contents($overviewFile),
-                $this->getReleaseLevel() === 'beta'
+                $releaseLevel === 'beta'
             );
             $outFile = sprintf('%s/%s', $outDir, $overview->getFilename());
             file_put_contents($outFile, $overview->getContents());
@@ -125,11 +126,12 @@ class DocFx extends Command
         }
 
         // Write the TOC to a file
-        $componentToc = [
+        $componentToc = array_filter([
             'uid' => $this->getComponentUid(),
             'name' => $this->getDistributionName(),
+            'status' => $releaseLevel === 'beta' ? 'beta' : '',
             'items' => $tocItems,
-        ];
+        ]);
         $tocYaml = Yaml::dump([$componentToc], $inline, $indent, $flags);
         $outFile = sprintf('%s/toc.yml', $outDir);
         file_put_contents($outFile, $tocYaml);

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -132,7 +132,7 @@ class DocFx extends Command
             'name' => $this->getDistributionName(),
             'items' => $tocItems,
         ];
-        $tocYaml = Yaml::dump([$componentToc], $inline, $indent, $flags);
+        $tocYaml = Yaml::dump($componentToc, $inline, $indent, $flags);
         $outFile = sprintf('%s/toc.yml', $outDir);
         file_put_contents($outFile, $tocYaml);
 

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -132,7 +132,7 @@ class DocFx extends Command
             'name' => $this->getDistributionName(),
             'items' => $tocItems,
         ];
-        $tocYaml = Yaml::dump($componentToc, $inline, $indent, $flags);
+        $tocYaml = Yaml::dump([$componentToc], $inline, $indent, $flags);
         $outFile = sprintf('%s/toc.yml', $outDir);
         file_put_contents($outFile, $tocYaml);
 

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 use RuntimeException;
-use Google\Cloud\Dev\DocFx\Node\XrefTrait;
 use Google\Cloud\Dev\DocFx\Page\PageTree;
 use Google\Cloud\Dev\DocFx\Page\OverviewPage;
 
@@ -98,7 +97,6 @@ class DocFx extends Command
         foreach ($namespaces as $namespace) {
             $pages = new PageTree($xml, $namespace, $friendlyApiName);
             $pageList = $pages->getPages();
-            XrefTrait::$protoPackagesToPhpNamespaces = $pages->getProtoPackages();
 
             foreach ($pageList as $page) {
                 $docFxArray = ['items' => $page->getItems()];

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -127,7 +127,12 @@ class DocFx extends Command
         }
 
         // Write the TOC to a file
-        $tocYaml = Yaml::dump($tocItems, $inline, $indent, $flags);
+        $componentToc = [
+            'uid' => $this->getComponentUid(),
+            'name' => $this->getDistributionName(),
+            'items' => $tocItems,
+        ];
+        $tocYaml = Yaml::dump([$componentToc], $inline, $indent, $flags);
         $outFile = sprintf('%s/toc.yml', $outDir);
         file_put_contents($outFile, $tocYaml);
 
@@ -233,6 +238,18 @@ class DocFx extends Command
             throw new RuntimeException('composer.json does not contain "name"');
         }
         return $this->composerJson['name'];
+    }
+
+    /**
+     * Formats distribution name like
+     *   - google-cloud-policy-troubleshooter
+     *   - google-cloud-vision
+     *   - google-grafeas
+     *   - google-analytics-data
+     */
+    private function getComponentUid(): string
+    {
+        return str_replace('/', '-', $this->getDistributionName());
     }
 
     private function getFriendlyApiName(): string

--- a/dev/src/DocFx/Node/ClassNode.php
+++ b/dev/src/DocFx/Node/ClassNode.php
@@ -72,14 +72,18 @@ class ClassNode
 
     public function getStatus(): string
     {
-        if (!$this->xmlNode->docblock) {
-            return '';
+        if ($this->xmlNode->docblock) {
+            foreach ($this->xmlNode->docblock->tag as $tag) {
+                if ((string) $tag['name'] === 'deprecated') {
+                    return 'deprecated';
+                }
+            }
         }
 
-        foreach ($this->xmlNode->docblock->tag as $tag) {
-            if ((string) $tag['name'] === 'deprecated') {
-                return 'deprecated';
-            }
+        // If the namespace contains a segment like "V1alpha1/" or "/V1p1beta1/"
+        $regex = '/\\\V[0-9](p[0-9])?(beta|alpha)[0-9]?(\\\.*)?$/';
+        if (preg_match($regex, $this->getNamespace())) {
+            return 'beta';
         }
 
         return '';

--- a/dev/src/DocFx/Node/ClassNode.php
+++ b/dev/src/DocFx/Node/ClassNode.php
@@ -25,6 +25,7 @@ class ClassNode
     use NameTrait;
 
     private $childNode;
+    private array $protoPackages = [];
 
     public function __construct(
         private SimpleXMLElement $xmlNode
@@ -113,7 +114,7 @@ class ClassNode
     {
         $methods = [];
         foreach ($this->xmlNode->method as $methodNode) {
-            $method = new MethodNode($methodNode);
+            $method = new MethodNode($methodNode, $this->protoPackages);
             if ($method->isPublic() && !$method->isInherited()) {
                 $methods[] = $method;
             }
@@ -133,7 +134,7 @@ class ClassNode
     {
         $constants = [];
         foreach ($this->xmlNode->constant as $constantNode) {
-            $constant = new ConstantNode($constantNode);
+            $constant = new ConstantNode($constantNode, $this->protoPackages);
             if ($constant->isPublic() && !$constant->isInherited()) {
                 $constants[] = $constant;
             }
@@ -170,5 +171,10 @@ class ClassNode
             }
         }
         return null;
+    }
+
+    public function setProtoPackages(array $protoPackages)
+    {
+        $this->protoPackages = $protoPackages;
     }
 }

--- a/dev/src/DocFx/Node/ConstantNode.php
+++ b/dev/src/DocFx/Node/ConstantNode.php
@@ -26,7 +26,8 @@ class ConstantNode
     use VisibilityTrait;
 
     public function __construct(
-        private SimpleXMLElement $xmlNode
+        private SimpleXMLElement $xmlNode,
+        private array $protoPackages = []
     ) {}
 
     public function getName(): string

--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -26,7 +26,8 @@ class MethodNode
     use VisibilityTrait;
 
     public function __construct(
-        private SimpleXMLElement $xmlNode
+        private SimpleXMLElement $xmlNode,
+        private array $protoPackages = []
     ) {}
 
     public function getReturnType(): string

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -19,8 +19,6 @@ namespace Google\Cloud\Dev\DocFx\Node;
 
 trait XrefTrait
 {
-    public static $protoPackagesToPhpNamespaces = [];
-
     /**
      * @param string $type            The parameter type to replace
      */
@@ -106,7 +104,7 @@ trait XrefTrait
 
                 // Check the package name against the proto packages for this component (see Command\DocFx)
                 $namespace =
-                    XrefTrait::$protoPackagesToPhpNamespaces[$package]
+                    $this->protoPackages[$package]
                     ?? str_replace(' ', '\\', ucwords(str_replace('.', ' ', $package)));
 
                 $classParts = explode('.', $class);

--- a/dev/src/DocFx/Page/OverviewPage.php
+++ b/dev/src/DocFx/Page/OverviewPage.php
@@ -55,10 +55,6 @@ class OverviewPage
             'href' => 'index.md'
         ];
 
-        if ($this->isBeta) {
-            $tocItem['status'] = 'beta';
-        }
-
         return $tocItem;
     }
 

--- a/dev/tests/Unit/DocFx/CommandTest.php
+++ b/dev/tests/Unit/DocFx/CommandTest.php
@@ -92,29 +92,17 @@ class CommandTest extends TestCase
     {
         $overview1 = new OverviewPage("# Not beta\n\n", $beta = false);
         $this->assertEquals("# Not beta\n\n", $overview1->getContents());
-        $tocItem1 = $overview1->getTocItem();
-        $this->assertArrayNotHasKey('status', $tocItem1);
 
         $overview2 = new OverviewPage("No header\n\n", $beta = true);
         $this->assertEquals("No header\n\n", $overview2->getContents());
-        $tocItem2 = $overview2->getTocItem();
-        $this->assertArrayHasKey('status', $tocItem2);
-        $this->assertEquals('beta', $tocItem2['status']);
 
         $overview3 = new OverviewPage("# No newline", $beta = true);
         $this->assertEquals('# No newline', $overview3->getContents());
-        $tocItem3 = $overview3->getTocItem();
-        $this->assertArrayHasKey('status', $tocItem3);
-        $this->assertEquals('beta', $tocItem3['status']);
 
         $overview4 = new OverviewPage("# Yes beta\nend.", $beta = true);
         $this->assertStringContainsString('pre-GA', $overview4->getContents());
         $this->assertStringStartsWith("# Yes beta\n", $overview4->getContents());
         $this->assertStringEndsWith("\nend.", $overview4->getContents());
-
-        $tocItem4 = $overview4->getTocItem();
-        $this->assertArrayHasKey('status', $tocItem4);
-        $this->assertEquals('beta', $tocItem4['status']);
     }
 
     public function provideDocFxFiles()

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -189,4 +189,37 @@ class NodeTest extends TestCase
             $xref->replace($description)
         );
     }
+
+    /**
+     * @dataProvider provideClassNodeStatus
+     */
+    public function testClassNodeStatusByVersion(string $version, string $status)
+    {
+        $serviceXml = str_replace(
+            '\Google\Cloud\Vision\V1',
+            '\Google\Cloud\Vision\\' . $version,
+            file_get_contents(__DIR__ . '/../../fixtures/phpdoc/service.xml'));
+        $class = new ClassNode(new SimpleXMLElement($serviceXml));
+
+        $this->assertTrue($class->isServiceClass());
+        $this->assertEquals($status, $class->getStatus());
+    }
+
+    public function provideClassNodeStatusByVersion()
+    {
+        return [
+            ['V1alpha', 'beta'],
+            ['V1beta', 'beta'],
+            ['V1alpha1', 'beta'],
+            ['V1beta1', 'beta'],
+            ['V1p1beta1', 'beta'],
+            ['V1p1alpha1', 'beta'],
+            ['V2p2beta2', 'beta'],
+            ['V1beta1\Foo', 'beta'],
+            ['V1beta\Foo', 'beta'],
+            ['V1', ''],
+            ['V1p1zeta1', ''],
+            ['V1z1beta', ''],
+        ];
+    }
 }

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -172,21 +172,33 @@ class NodeTest extends TestCase
     public function testProtoRefWithXrefUsingPackageName()
     {
         $description = '[ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]';
+        $protoPackages = ['google.bigtable.admin.v2' => 'Google\\Cloud\\Bigtable\\Admin\\V2'];
 
         $xref = new class {
             use XrefTrait;
+            public $protoPackages;
             public function replace(string $description) {
                 return $this->replaceProtoRef($description);
             }
         };
 
-        XrefTrait::$protoPackagesToPhpNamespaces = [
-            'google.bigtable.admin.v2' => 'Google\\Cloud\\Bigtable\\Admin\\V2',
-        ];
+        $xref->protoPackages = $protoPackages;
 
         $this->assertEquals(
             '<xref uid="\Google\Cloud\Bigtable\Admin\V2\BigtableTableAdminClient::listBackups()">ListBackups</xref>',
             $xref->replace($description)
+        );
+
+        $classNode = new ClassNode(new SimpleXMLElement(sprintf(
+            '<class><docblock><description>%s</description></docblock></class>',
+            $description
+        )));
+
+        $classNode->setProtoPackages($protoPackages);
+
+        $this->assertEquals(
+            '<xref uid="\Google\Cloud\Bigtable\Admin\V2\BigtableTableAdminClient::listBackups()">ListBackups</xref>',
+            $classNode->getContent()
         );
     }
 

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -191,7 +191,7 @@ class NodeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideClassNodeStatus
+     * @dataProvider provideClassNodeStatusByVersion
      */
     public function testClassNodeStatusByVersion(string $version, string $status)
     {

--- a/dev/tests/fixtures/docfx/toc.yml
+++ b/dev/tests/fixtures/docfx/toc.yml
@@ -1,380 +1,343 @@
-uid: google-cloud-vision
-name: google/cloud-vision
-items:
-  -
-    name: Overview
-    href: index.md
-  -
-    name: Google\Cloud\Vision\V1
-    uid: 'ns:Google\Cloud\Vision\V1'
-    items:
-      -
-        name: Services
-        uid: 'services:Google\Cloud\Vision\V1'
-        items:
-          -
-            uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-            name: ImageAnnotatorClient
-          -
-            uid: \Google\Cloud\Vision\V1\ProductSearchClient
-            name: ProductSearchClient
-      -
-        name: Messages
-        uid: 'messages:Google\Cloud\Vision\V1'
-        items:
-          -
-            uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
-            name: AddProductToProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
-            name: AnnotateFileRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
-            name: AnnotateFileResponse
-          -
-            uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
-            name: AnnotateImageRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
-            name: AnnotateImageResponse
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
-            name: AsyncAnnotateFileRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
-            name: AsyncAnnotateFileResponse
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
-            name: AsyncBatchAnnotateFilesRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
-            name: AsyncBatchAnnotateFilesResponse
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
-            name: AsyncBatchAnnotateImagesRequest
-          -
-            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
-            name: AsyncBatchAnnotateImagesResponse
-          -
-            uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
-            name: BatchAnnotateFilesRequest
-          -
-            uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
-            name: BatchAnnotateFilesResponse
-          -
-            uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
-            name: BatchAnnotateImagesRequest
-          -
-            uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
-            name: BatchAnnotateImagesResponse
-          -
-            uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
-            name: BatchOperationMetadata
-          -
-            uid: \Google\Cloud\Vision\V1\Block
-            name: Block
-          -
-            uid: \Google\Cloud\Vision\V1\BoundingPoly
-            name: BoundingPoly
-          -
-            uid: \Google\Cloud\Vision\V1\ColorInfo
-            name: ColorInfo
-          -
-            uid: \Google\Cloud\Vision\V1\CreateProductRequest
-            name: CreateProductRequest
-          -
-            uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
-            name: CreateProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
-            name: CreateReferenceImageRequest
-          -
-            uid: \Google\Cloud\Vision\V1\CropHint
-            name: CropHint
-          -
-            uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
-            name: CropHintsAnnotation
-          -
-            uid: \Google\Cloud\Vision\V1\CropHintsParams
-            name: CropHintsParams
-          -
-            uid: \Google\Cloud\Vision\V1\DeleteProductRequest
-            name: DeleteProductRequest
-          -
-            uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
-            name: DeleteProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
-            name: DeleteReferenceImageRequest
-          -
-            uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
-            name: DominantColorsAnnotation
-          -
-            uid: \Google\Cloud\Vision\V1\EntityAnnotation
-            name: EntityAnnotation
-          -
-            uid: \Google\Cloud\Vision\V1\FaceAnnotation
-            name: FaceAnnotation
-          -
-            name: FaceAnnotation
-            uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark
-                name: Landmark
-          -
-            uid: \Google\Cloud\Vision\V1\Feature
-            name: Feature
-          -
-            uid: \Google\Cloud\Vision\V1\GcsDestination
-            name: GcsDestination
-          -
-            uid: \Google\Cloud\Vision\V1\GcsSource
-            name: GcsSource
-          -
-            uid: \Google\Cloud\Vision\V1\GetProductRequest
-            name: GetProductRequest
-          -
-            uid: \Google\Cloud\Vision\V1\GetProductSetRequest
-            name: GetProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
-            name: GetReferenceImageRequest
-          -
-            uid: \Google\Cloud\Vision\V1\Image
-            name: Image
-          -
-            uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
-            name: ImageAnnotationContext
-          -
-            uid: \Google\Cloud\Vision\V1\ImageContext
-            name: ImageContext
-          -
-            uid: \Google\Cloud\Vision\V1\ImageProperties
-            name: ImageProperties
-          -
-            uid: \Google\Cloud\Vision\V1\ImageSource
-            name: ImageSource
-          -
-            uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
-            name: ImportProductSetsGcsSource
-          -
-            uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
-            name: ImportProductSetsInputConfig
-          -
-            uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
-            name: ImportProductSetsRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
-            name: ImportProductSetsResponse
-          -
-            uid: \Google\Cloud\Vision\V1\InputConfig
-            name: InputConfig
-          -
-            uid: \Google\Cloud\Vision\V1\LatLongRect
-            name: LatLongRect
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
-            name: ListProductSetsRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
-            name: ListProductSetsResponse
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
-            name: ListProductsInProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
-            name: ListProductsInProductSetResponse
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductsRequest
-            name: ListProductsRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ListProductsResponse
-            name: ListProductsResponse
-          -
-            uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
-            name: ListReferenceImagesRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
-            name: ListReferenceImagesResponse
-          -
-            uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
-            name: LocalizedObjectAnnotation
-          -
-            uid: \Google\Cloud\Vision\V1\LocationInfo
-            name: LocationInfo
-          -
-            uid: \Google\Cloud\Vision\V1\NormalizedVertex
-            name: NormalizedVertex
-          -
-            uid: \Google\Cloud\Vision\V1\OperationMetadata
-            name: OperationMetadata
-          -
-            uid: \Google\Cloud\Vision\V1\OutputConfig
-            name: OutputConfig
-          -
-            uid: \Google\Cloud\Vision\V1\Page
-            name: Page
-          -
-            uid: \Google\Cloud\Vision\V1\Paragraph
-            name: Paragraph
-          -
-            uid: \Google\Cloud\Vision\V1\Position
-            name: Position
-          -
-            uid: \Google\Cloud\Vision\V1\Product
-            name: Product
-          -
-            uid: \Google\Cloud\Vision\V1\ProductSearchParams
-            name: ProductSearchParams
-          -
-            uid: \Google\Cloud\Vision\V1\ProductSearchResults
-            name: ProductSearchResults
-          -
-            name: ProductSearchResults
-            uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult
-                name: GroupedResult
-              -
-                uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation
-                name: ObjectAnnotation
-              -
-                uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result
-                name: Result
-          -
-            uid: \Google\Cloud\Vision\V1\ProductSet
-            name: ProductSet
-          -
-            uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
-            name: ProductSetPurgeConfig
-          -
-            name: Product
-            uid: 'ns:Google\Cloud\Vision\V1\Product'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\Product\KeyValue
-                name: KeyValue
-          -
-            uid: \Google\Cloud\Vision\V1\Property
-            name: Property
-          -
-            uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
-            name: PurgeProductsRequest
-          -
-            uid: \Google\Cloud\Vision\V1\ReferenceImage
-            name: ReferenceImage
-          -
-            uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
-            name: RemoveProductFromProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
-            name: SafeSearchAnnotation
-          -
-            uid: \Google\Cloud\Vision\V1\Symbol
-            name: Symbol
-          -
-            uid: \Google\Cloud\Vision\V1\TextAnnotation
-            name: TextAnnotation
-          -
-            name: TextAnnotation
-            uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak
-                name: DetectedBreak
-              -
-                uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage
-                name: DetectedLanguage
-              -
-                uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty
-                name: TextProperty
-          -
-            uid: \Google\Cloud\Vision\V1\TextDetectionParams
-            name: TextDetectionParams
-          -
-            uid: \Google\Cloud\Vision\V1\UpdateProductRequest
-            name: UpdateProductRequest
-          -
-            uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
-            name: UpdateProductSetRequest
-          -
-            uid: \Google\Cloud\Vision\V1\Vertex
-            name: Vertex
-          -
-            uid: \Google\Cloud\Vision\V1\WebDetection
-            name: WebDetection
-          -
-            uid: \Google\Cloud\Vision\V1\WebDetectionParams
-            name: WebDetectionParams
-          -
-            name: WebDetection
-            uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity
-                name: WebEntity
-              -
-                uid: \Google\Cloud\Vision\V1\WebDetection\WebImage
-                name: WebImage
-              -
-                uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel
-                name: WebLabel
-              -
-                uid: \Google\Cloud\Vision\V1\WebDetection\WebPage
-                name: WebPage
-          -
-            uid: \Google\Cloud\Vision\V1\Word
-            name: Word
-      -
-        name: Enums
-        uid: 'enums:Google\Cloud\Vision\V1'
-        items:
-          -
-            name: BatchOperationMetadata
-            uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
-                name: State
-          -
-            name: Block
-            uid: 'ns:Google\Cloud\Vision\V1\Block'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\Block\BlockType
-                name: BlockType
-          -
-            name: FaceAnnotation
-            uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
-            items:
-              -
-                name: Landmark
-                uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark'
-                items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }]
-          -
-            name: Feature
-            uid: 'ns:Google\Cloud\Vision\V1\Feature'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\Feature\Type
-                name: Type
-          -
-            uid: \Google\Cloud\Vision\V1\Likelihood
-            name: Likelihood
-          -
-            name: OperationMetadata
-            uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
-            items:
-              -
-                uid: \Google\Cloud\Vision\V1\OperationMetadata\State
-                name: State
-          -
-            name: TextAnnotation
-            uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-            items:
-              -
-                name: DetectedBreak
-                uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak'
-                items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }]
+-
+  uid: google-cloud-vision
+  name: google/cloud-vision
+  items:
+    -
+      name: Overview
+      href: index.md
+    -
+      name: Google\Cloud\Vision\V1
+      uid: 'ns:Google\Cloud\Vision\V1'
+      items:
+        -
+          name: Services
+          uid: 'services:Google\Cloud\Vision\V1'
+          items:
+            -
+              uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
+              name: ImageAnnotatorClient
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchClient
+              name: ProductSearchClient
+        -
+          name: Messages
+          uid: 'messages:Google\Cloud\Vision\V1'
+          items:
+            -
+              uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
+              name: AddProductToProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
+              name: AnnotateFileRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
+              name: AnnotateFileResponse
+            -
+              uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
+              name: AnnotateImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
+              name: AnnotateImageResponse
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
+              name: AsyncAnnotateFileRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
+              name: AsyncAnnotateFileResponse
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
+              name: AsyncBatchAnnotateFilesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
+              name: AsyncBatchAnnotateFilesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
+              name: AsyncBatchAnnotateImagesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
+              name: AsyncBatchAnnotateImagesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
+              name: BatchAnnotateFilesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
+              name: BatchAnnotateFilesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
+              name: BatchAnnotateImagesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
+              name: BatchAnnotateImagesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
+              name: BatchOperationMetadata
+            -
+              uid: \Google\Cloud\Vision\V1\Block
+              name: Block
+            -
+              uid: \Google\Cloud\Vision\V1\BoundingPoly
+              name: BoundingPoly
+            -
+              uid: \Google\Cloud\Vision\V1\ColorInfo
+              name: ColorInfo
+            -
+              uid: \Google\Cloud\Vision\V1\CreateProductRequest
+              name: CreateProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
+              name: CreateProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
+              name: CreateReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CropHint
+              name: CropHint
+            -
+              uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
+              name: CropHintsAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\CropHintsParams
+              name: CropHintsParams
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteProductRequest
+              name: DeleteProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
+              name: DeleteProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
+              name: DeleteReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
+              name: DominantColorsAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\EntityAnnotation
+              name: EntityAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\FaceAnnotation
+              name: FaceAnnotation
+            -
+              name: FaceAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark, name: Landmark }
+            -
+              uid: \Google\Cloud\Vision\V1\Feature
+              name: Feature
+            -
+              uid: \Google\Cloud\Vision\V1\GcsDestination
+              name: GcsDestination
+            -
+              uid: \Google\Cloud\Vision\V1\GcsSource
+              name: GcsSource
+            -
+              uid: \Google\Cloud\Vision\V1\GetProductRequest
+              name: GetProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\GetProductSetRequest
+              name: GetProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
+              name: GetReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\Image
+              name: Image
+            -
+              uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
+              name: ImageAnnotationContext
+            -
+              uid: \Google\Cloud\Vision\V1\ImageContext
+              name: ImageContext
+            -
+              uid: \Google\Cloud\Vision\V1\ImageProperties
+              name: ImageProperties
+            -
+              uid: \Google\Cloud\Vision\V1\ImageSource
+              name: ImageSource
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
+              name: ImportProductSetsGcsSource
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
+              name: ImportProductSetsInputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
+              name: ImportProductSetsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
+              name: ImportProductSetsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\InputConfig
+              name: InputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\LatLongRect
+              name: LatLongRect
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
+              name: ListProductSetsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
+              name: ListProductSetsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
+              name: ListProductsInProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
+              name: ListProductsInProductSetResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsRequest
+              name: ListProductsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsResponse
+              name: ListProductsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
+              name: ListReferenceImagesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
+              name: ListReferenceImagesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
+              name: LocalizedObjectAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\LocationInfo
+              name: LocationInfo
+            -
+              uid: \Google\Cloud\Vision\V1\NormalizedVertex
+              name: NormalizedVertex
+            -
+              uid: \Google\Cloud\Vision\V1\OperationMetadata
+              name: OperationMetadata
+            -
+              uid: \Google\Cloud\Vision\V1\OutputConfig
+              name: OutputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\Page
+              name: Page
+            -
+              uid: \Google\Cloud\Vision\V1\Paragraph
+              name: Paragraph
+            -
+              uid: \Google\Cloud\Vision\V1\Position
+              name: Position
+            -
+              uid: \Google\Cloud\Vision\V1\Product
+              name: Product
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchParams
+              name: ProductSearchParams
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchResults
+              name: ProductSearchResults
+            -
+              name: ProductSearchResults
+              uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult, name: GroupedResult }
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation, name: ObjectAnnotation }
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result, name: Result }
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSet
+              name: ProductSet
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
+              name: ProductSetPurgeConfig
+            -
+              name: Product
+              uid: 'ns:Google\Cloud\Vision\V1\Product'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Product\KeyValue, name: KeyValue }
+            -
+              uid: \Google\Cloud\Vision\V1\Property
+              name: Property
+            -
+              uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
+              name: PurgeProductsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ReferenceImage
+              name: ReferenceImage
+            -
+              uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
+              name: RemoveProductFromProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
+              name: SafeSearchAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\Symbol
+              name: Symbol
+            -
+              uid: \Google\Cloud\Vision\V1\TextAnnotation
+              name: TextAnnotation
+            -
+              name: TextAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak, name: DetectedBreak }
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage, name: DetectedLanguage }
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty, name: TextProperty }
+            -
+              uid: \Google\Cloud\Vision\V1\TextDetectionParams
+              name: TextDetectionParams
+            -
+              uid: \Google\Cloud\Vision\V1\UpdateProductRequest
+              name: UpdateProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
+              name: UpdateProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\Vertex
+              name: Vertex
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetection
+              name: WebDetection
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetectionParams
+              name: WebDetectionParams
+            -
+              name: WebDetection
+              uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity, name: WebEntity }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebImage, name: WebImage }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel, name: WebLabel }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebPage, name: WebPage }
+            -
+              uid: \Google\Cloud\Vision\V1\Word
+              name: Word
+        -
+          name: Enums
+          uid: 'enums:Google\Cloud\Vision\V1'
+          items:
+            -
+              name: BatchOperationMetadata
+              uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State, name: State }
+            -
+              name: Block
+              uid: 'ns:Google\Cloud\Vision\V1\Block'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Block\BlockType, name: BlockType }
+            -
+              name: FaceAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+              items:
+                - { name: Landmark, uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark', items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }] }
+            -
+              name: Feature
+              uid: 'ns:Google\Cloud\Vision\V1\Feature'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Feature\Type, name: Type }
+            -
+              uid: \Google\Cloud\Vision\V1\Likelihood
+              name: Likelihood
+            -
+              name: OperationMetadata
+              uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\OperationMetadata\State, name: State }
+            -
+              name: TextAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+              items:
+                - { name: DetectedBreak, uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak', items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }] }

--- a/dev/tests/fixtures/docfx/toc.yml
+++ b/dev/tests/fixtures/docfx/toc.yml
@@ -1,379 +1,343 @@
 -
-  name: Overview
-  href: index.md
--
-  name: Google\Cloud\Vision\V1
-  uid: 'ns:Google\Cloud\Vision\V1'
+  uid: google-cloud-vision
+  name: google/cloud-vision
   items:
     -
-      name: Services
-      uid: 'services:Google\Cloud\Vision\V1'
-      items:
-        -
-          uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-          name: ImageAnnotatorClient
-        -
-          uid: \Google\Cloud\Vision\V1\ProductSearchClient
-          name: ProductSearchClient
+      name: Overview
+      href: index.md
     -
-      name: Messages
-      uid: 'messages:Google\Cloud\Vision\V1'
+      name: Google\Cloud\Vision\V1
+      uid: 'ns:Google\Cloud\Vision\V1'
       items:
         -
-          uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
-          name: AddProductToProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
-          name: AnnotateFileRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
-          name: AnnotateFileResponse
-        -
-          uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
-          name: AnnotateImageRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
-          name: AnnotateImageResponse
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
-          name: AsyncAnnotateFileRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
-          name: AsyncAnnotateFileResponse
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
-          name: AsyncBatchAnnotateFilesRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
-          name: AsyncBatchAnnotateFilesResponse
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
-          name: AsyncBatchAnnotateImagesRequest
-        -
-          uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
-          name: AsyncBatchAnnotateImagesResponse
-        -
-          uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
-          name: BatchAnnotateFilesRequest
-        -
-          uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
-          name: BatchAnnotateFilesResponse
-        -
-          uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
-          name: BatchAnnotateImagesRequest
-        -
-          uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
-          name: BatchAnnotateImagesResponse
-        -
-          uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
-          name: BatchOperationMetadata
-        -
-          uid: \Google\Cloud\Vision\V1\Block
-          name: Block
-        -
-          uid: \Google\Cloud\Vision\V1\BoundingPoly
-          name: BoundingPoly
-        -
-          uid: \Google\Cloud\Vision\V1\ColorInfo
-          name: ColorInfo
-        -
-          uid: \Google\Cloud\Vision\V1\CreateProductRequest
-          name: CreateProductRequest
-        -
-          uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
-          name: CreateProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
-          name: CreateReferenceImageRequest
-        -
-          uid: \Google\Cloud\Vision\V1\CropHint
-          name: CropHint
-        -
-          uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
-          name: CropHintsAnnotation
-        -
-          uid: \Google\Cloud\Vision\V1\CropHintsParams
-          name: CropHintsParams
-        -
-          uid: \Google\Cloud\Vision\V1\DeleteProductRequest
-          name: DeleteProductRequest
-        -
-          uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
-          name: DeleteProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
-          name: DeleteReferenceImageRequest
-        -
-          uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
-          name: DominantColorsAnnotation
-        -
-          uid: \Google\Cloud\Vision\V1\EntityAnnotation
-          name: EntityAnnotation
-        -
-          uid: \Google\Cloud\Vision\V1\FaceAnnotation
-          name: FaceAnnotation
-        -
-          name: FaceAnnotation
-          uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+          name: Services
+          uid: 'services:Google\Cloud\Vision\V1'
           items:
             -
-              uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark
-              name: Landmark
+              uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
+              name: ImageAnnotatorClient
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchClient
+              name: ProductSearchClient
         -
-          uid: \Google\Cloud\Vision\V1\Feature
-          name: Feature
-        -
-          uid: \Google\Cloud\Vision\V1\GcsDestination
-          name: GcsDestination
-        -
-          uid: \Google\Cloud\Vision\V1\GcsSource
-          name: GcsSource
-        -
-          uid: \Google\Cloud\Vision\V1\GetProductRequest
-          name: GetProductRequest
-        -
-          uid: \Google\Cloud\Vision\V1\GetProductSetRequest
-          name: GetProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
-          name: GetReferenceImageRequest
-        -
-          uid: \Google\Cloud\Vision\V1\Image
-          name: Image
-        -
-          uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
-          name: ImageAnnotationContext
-        -
-          uid: \Google\Cloud\Vision\V1\ImageContext
-          name: ImageContext
-        -
-          uid: \Google\Cloud\Vision\V1\ImageProperties
-          name: ImageProperties
-        -
-          uid: \Google\Cloud\Vision\V1\ImageSource
-          name: ImageSource
-        -
-          uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
-          name: ImportProductSetsGcsSource
-        -
-          uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
-          name: ImportProductSetsInputConfig
-        -
-          uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
-          name: ImportProductSetsRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
-          name: ImportProductSetsResponse
-        -
-          uid: \Google\Cloud\Vision\V1\InputConfig
-          name: InputConfig
-        -
-          uid: \Google\Cloud\Vision\V1\LatLongRect
-          name: LatLongRect
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
-          name: ListProductSetsRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
-          name: ListProductSetsResponse
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
-          name: ListProductsInProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
-          name: ListProductsInProductSetResponse
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductsRequest
-          name: ListProductsRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ListProductsResponse
-          name: ListProductsResponse
-        -
-          uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
-          name: ListReferenceImagesRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
-          name: ListReferenceImagesResponse
-        -
-          uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
-          name: LocalizedObjectAnnotation
-        -
-          uid: \Google\Cloud\Vision\V1\LocationInfo
-          name: LocationInfo
-        -
-          uid: \Google\Cloud\Vision\V1\NormalizedVertex
-          name: NormalizedVertex
-        -
-          uid: \Google\Cloud\Vision\V1\OperationMetadata
-          name: OperationMetadata
-        -
-          uid: \Google\Cloud\Vision\V1\OutputConfig
-          name: OutputConfig
-        -
-          uid: \Google\Cloud\Vision\V1\Page
-          name: Page
-        -
-          uid: \Google\Cloud\Vision\V1\Paragraph
-          name: Paragraph
-        -
-          uid: \Google\Cloud\Vision\V1\Position
-          name: Position
-        -
-          uid: \Google\Cloud\Vision\V1\Product
-          name: Product
-        -
-          uid: \Google\Cloud\Vision\V1\ProductSearchParams
-          name: ProductSearchParams
-        -
-          uid: \Google\Cloud\Vision\V1\ProductSearchResults
-          name: ProductSearchResults
-        -
-          name: ProductSearchResults
-          uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
+          name: Messages
+          uid: 'messages:Google\Cloud\Vision\V1'
           items:
             -
-              uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult
-              name: GroupedResult
+              uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
+              name: AddProductToProductSetRequest
             -
-              uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation
-              name: ObjectAnnotation
+              uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
+              name: AnnotateFileRequest
             -
-              uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result
-              name: Result
-        -
-          uid: \Google\Cloud\Vision\V1\ProductSet
-          name: ProductSet
-        -
-          uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
-          name: ProductSetPurgeConfig
-        -
-          name: Product
-          uid: 'ns:Google\Cloud\Vision\V1\Product'
-          items:
+              uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
+              name: AnnotateFileResponse
             -
-              uid: \Google\Cloud\Vision\V1\Product\KeyValue
-              name: KeyValue
-        -
-          uid: \Google\Cloud\Vision\V1\Property
-          name: Property
-        -
-          uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
-          name: PurgeProductsRequest
-        -
-          uid: \Google\Cloud\Vision\V1\ReferenceImage
-          name: ReferenceImage
-        -
-          uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
-          name: RemoveProductFromProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
-          name: SafeSearchAnnotation
-        -
-          uid: \Google\Cloud\Vision\V1\Symbol
-          name: Symbol
-        -
-          uid: \Google\Cloud\Vision\V1\TextAnnotation
-          name: TextAnnotation
-        -
-          name: TextAnnotation
-          uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-          items:
+              uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
+              name: AnnotateImageRequest
             -
-              uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak
-              name: DetectedBreak
+              uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
+              name: AnnotateImageResponse
             -
-              uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage
-              name: DetectedLanguage
+              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
+              name: AsyncAnnotateFileRequest
             -
-              uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty
-              name: TextProperty
-        -
-          uid: \Google\Cloud\Vision\V1\TextDetectionParams
-          name: TextDetectionParams
-        -
-          uid: \Google\Cloud\Vision\V1\UpdateProductRequest
-          name: UpdateProductRequest
-        -
-          uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
-          name: UpdateProductSetRequest
-        -
-          uid: \Google\Cloud\Vision\V1\Vertex
-          name: Vertex
-        -
-          uid: \Google\Cloud\Vision\V1\WebDetection
-          name: WebDetection
-        -
-          uid: \Google\Cloud\Vision\V1\WebDetectionParams
-          name: WebDetectionParams
-        -
-          name: WebDetection
-          uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
-          items:
+              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
+              name: AsyncAnnotateFileResponse
             -
-              uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity
-              name: WebEntity
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
+              name: AsyncBatchAnnotateFilesRequest
             -
-              uid: \Google\Cloud\Vision\V1\WebDetection\WebImage
-              name: WebImage
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
+              name: AsyncBatchAnnotateFilesResponse
             -
-              uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel
-              name: WebLabel
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
+              name: AsyncBatchAnnotateImagesRequest
             -
-              uid: \Google\Cloud\Vision\V1\WebDetection\WebPage
-              name: WebPage
-        -
-          uid: \Google\Cloud\Vision\V1\Word
-          name: Word
-    -
-      name: Enums
-      uid: 'enums:Google\Cloud\Vision\V1'
-      items:
-        -
-          name: BatchOperationMetadata
-          uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
-          items:
+              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
+              name: AsyncBatchAnnotateImagesResponse
             -
-              uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
-              name: State
-        -
-          name: Block
-          uid: 'ns:Google\Cloud\Vision\V1\Block'
-          items:
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
+              name: BatchAnnotateFilesRequest
             -
-              uid: \Google\Cloud\Vision\V1\Block\BlockType
-              name: BlockType
-        -
-          name: FaceAnnotation
-          uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
-          items:
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
+              name: BatchAnnotateFilesResponse
             -
-              name: Landmark
-              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark'
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
+              name: BatchAnnotateImagesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
+              name: BatchAnnotateImagesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
+              name: BatchOperationMetadata
+            -
+              uid: \Google\Cloud\Vision\V1\Block
+              name: Block
+            -
+              uid: \Google\Cloud\Vision\V1\BoundingPoly
+              name: BoundingPoly
+            -
+              uid: \Google\Cloud\Vision\V1\ColorInfo
+              name: ColorInfo
+            -
+              uid: \Google\Cloud\Vision\V1\CreateProductRequest
+              name: CreateProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
+              name: CreateProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
+              name: CreateReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\CropHint
+              name: CropHint
+            -
+              uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
+              name: CropHintsAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\CropHintsParams
+              name: CropHintsParams
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteProductRequest
+              name: DeleteProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
+              name: DeleteProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
+              name: DeleteReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
+              name: DominantColorsAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\EntityAnnotation
+              name: EntityAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\FaceAnnotation
+              name: FaceAnnotation
+            -
+              name: FaceAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
               items:
-                - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }
-        -
-          name: Feature
-          uid: 'ns:Google\Cloud\Vision\V1\Feature'
-          items:
+                - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark, name: Landmark }
             -
-              uid: \Google\Cloud\Vision\V1\Feature\Type
-              name: Type
-        -
-          uid: \Google\Cloud\Vision\V1\Likelihood
-          name: Likelihood
-        -
-          name: OperationMetadata
-          uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
-          items:
+              uid: \Google\Cloud\Vision\V1\Feature
+              name: Feature
             -
-              uid: \Google\Cloud\Vision\V1\OperationMetadata\State
-              name: State
-        -
-          name: TextAnnotation
-          uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-          items:
+              uid: \Google\Cloud\Vision\V1\GcsDestination
+              name: GcsDestination
             -
-              name: DetectedBreak
-              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak'
+              uid: \Google\Cloud\Vision\V1\GcsSource
+              name: GcsSource
+            -
+              uid: \Google\Cloud\Vision\V1\GetProductRequest
+              name: GetProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\GetProductSetRequest
+              name: GetProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
+              name: GetReferenceImageRequest
+            -
+              uid: \Google\Cloud\Vision\V1\Image
+              name: Image
+            -
+              uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
+              name: ImageAnnotationContext
+            -
+              uid: \Google\Cloud\Vision\V1\ImageContext
+              name: ImageContext
+            -
+              uid: \Google\Cloud\Vision\V1\ImageProperties
+              name: ImageProperties
+            -
+              uid: \Google\Cloud\Vision\V1\ImageSource
+              name: ImageSource
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
+              name: ImportProductSetsGcsSource
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
+              name: ImportProductSetsInputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
+              name: ImportProductSetsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
+              name: ImportProductSetsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\InputConfig
+              name: InputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\LatLongRect
+              name: LatLongRect
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
+              name: ListProductSetsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
+              name: ListProductSetsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
+              name: ListProductsInProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
+              name: ListProductsInProductSetResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsRequest
+              name: ListProductsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListProductsResponse
+              name: ListProductsResponse
+            -
+              uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
+              name: ListReferenceImagesRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
+              name: ListReferenceImagesResponse
+            -
+              uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
+              name: LocalizedObjectAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\LocationInfo
+              name: LocationInfo
+            -
+              uid: \Google\Cloud\Vision\V1\NormalizedVertex
+              name: NormalizedVertex
+            -
+              uid: \Google\Cloud\Vision\V1\OperationMetadata
+              name: OperationMetadata
+            -
+              uid: \Google\Cloud\Vision\V1\OutputConfig
+              name: OutputConfig
+            -
+              uid: \Google\Cloud\Vision\V1\Page
+              name: Page
+            -
+              uid: \Google\Cloud\Vision\V1\Paragraph
+              name: Paragraph
+            -
+              uid: \Google\Cloud\Vision\V1\Position
+              name: Position
+            -
+              uid: \Google\Cloud\Vision\V1\Product
+              name: Product
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchParams
+              name: ProductSearchParams
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSearchResults
+              name: ProductSearchResults
+            -
+              name: ProductSearchResults
+              uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
               items:
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult, name: GroupedResult }
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation, name: ObjectAnnotation }
+                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result, name: Result }
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSet
+              name: ProductSet
+            -
+              uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
+              name: ProductSetPurgeConfig
+            -
+              name: Product
+              uid: 'ns:Google\Cloud\Vision\V1\Product'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Product\KeyValue, name: KeyValue }
+            -
+              uid: \Google\Cloud\Vision\V1\Property
+              name: Property
+            -
+              uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
+              name: PurgeProductsRequest
+            -
+              uid: \Google\Cloud\Vision\V1\ReferenceImage
+              name: ReferenceImage
+            -
+              uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
+              name: RemoveProductFromProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
+              name: SafeSearchAnnotation
+            -
+              uid: \Google\Cloud\Vision\V1\Symbol
+              name: Symbol
+            -
+              uid: \Google\Cloud\Vision\V1\TextAnnotation
+              name: TextAnnotation
+            -
+              name: TextAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak, name: DetectedBreak }
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage, name: DetectedLanguage }
+                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty, name: TextProperty }
+            -
+              uid: \Google\Cloud\Vision\V1\TextDetectionParams
+              name: TextDetectionParams
+            -
+              uid: \Google\Cloud\Vision\V1\UpdateProductRequest
+              name: UpdateProductRequest
+            -
+              uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
+              name: UpdateProductSetRequest
+            -
+              uid: \Google\Cloud\Vision\V1\Vertex
+              name: Vertex
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetection
+              name: WebDetection
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetectionParams
+              name: WebDetectionParams
+            -
+              name: WebDetection
+              uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity, name: WebEntity }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebImage, name: WebImage }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel, name: WebLabel }
+                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebPage, name: WebPage }
+            -
+              uid: \Google\Cloud\Vision\V1\Word
+              name: Word
+        -
+          name: Enums
+          uid: 'enums:Google\Cloud\Vision\V1'
+          items:
+            -
+              name: BatchOperationMetadata
+              uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State, name: State }
+            -
+              name: Block
+              uid: 'ns:Google\Cloud\Vision\V1\Block'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Block\BlockType, name: BlockType }
+            -
+              name: FaceAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+              items:
+                - { name: Landmark, uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark', items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }] }
+            -
+              name: Feature
+              uid: 'ns:Google\Cloud\Vision\V1\Feature'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\Feature\Type, name: Type }
+            -
+              uid: \Google\Cloud\Vision\V1\Likelihood
+              name: Likelihood
+            -
+              name: OperationMetadata
+              uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
+              items:
+                - { uid: \Google\Cloud\Vision\V1\OperationMetadata\State, name: State }
+            -
+              name: TextAnnotation
+              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+              items:
+                - { name: DetectedBreak, uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak', items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }] }

--- a/dev/tests/fixtures/docfx/toc.yml
+++ b/dev/tests/fixtures/docfx/toc.yml
@@ -120,7 +120,9 @@
               name: FaceAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
               items:
-                - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark, name: Landmark }
+                -
+                  uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark
+                  name: Landmark
             -
               uid: \Google\Cloud\Vision\V1\Feature
               name: Feature
@@ -233,9 +235,15 @@
               name: ProductSearchResults
               uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
               items:
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult, name: GroupedResult }
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation, name: ObjectAnnotation }
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result, name: Result }
+                -
+                  uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult
+                  name: GroupedResult
+                -
+                  uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation
+                  name: ObjectAnnotation
+                -
+                  uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result
+                  name: Result
             -
               uid: \Google\Cloud\Vision\V1\ProductSet
               name: ProductSet
@@ -246,7 +254,9 @@
               name: Product
               uid: 'ns:Google\Cloud\Vision\V1\Product'
               items:
-                - { uid: \Google\Cloud\Vision\V1\Product\KeyValue, name: KeyValue }
+                -
+                  uid: \Google\Cloud\Vision\V1\Product\KeyValue
+                  name: KeyValue
             -
               uid: \Google\Cloud\Vision\V1\Property
               name: Property
@@ -272,9 +282,15 @@
               name: TextAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
               items:
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak, name: DetectedBreak }
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage, name: DetectedLanguage }
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty, name: TextProperty }
+                -
+                  uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak
+                  name: DetectedBreak
+                -
+                  uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage
+                  name: DetectedLanguage
+                -
+                  uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty
+                  name: TextProperty
             -
               uid: \Google\Cloud\Vision\V1\TextDetectionParams
               name: TextDetectionParams
@@ -297,10 +313,18 @@
               name: WebDetection
               uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
               items:
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity, name: WebEntity }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebImage, name: WebImage }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel, name: WebLabel }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebPage, name: WebPage }
+                -
+                  uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity
+                  name: WebEntity
+                -
+                  uid: \Google\Cloud\Vision\V1\WebDetection\WebImage
+                  name: WebImage
+                -
+                  uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel
+                  name: WebLabel
+                -
+                  uid: \Google\Cloud\Vision\V1\WebDetection\WebPage
+                  name: WebPage
             -
               uid: \Google\Cloud\Vision\V1\Word
               name: Word
@@ -312,22 +336,32 @@
               name: BatchOperationMetadata
               uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
               items:
-                - { uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State, name: State }
+                -
+                  uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
+                  name: State
             -
               name: Block
               uid: 'ns:Google\Cloud\Vision\V1\Block'
               items:
-                - { uid: \Google\Cloud\Vision\V1\Block\BlockType, name: BlockType }
+                -
+                  uid: \Google\Cloud\Vision\V1\Block\BlockType
+                  name: BlockType
             -
               name: FaceAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
               items:
-                - { name: Landmark, uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark', items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }] }
+                -
+                  name: Landmark
+                  uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark'
+                  items:
+                    - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }
             -
               name: Feature
               uid: 'ns:Google\Cloud\Vision\V1\Feature'
               items:
-                - { uid: \Google\Cloud\Vision\V1\Feature\Type, name: Type }
+                -
+                  uid: \Google\Cloud\Vision\V1\Feature\Type
+                  name: Type
             -
               uid: \Google\Cloud\Vision\V1\Likelihood
               name: Likelihood
@@ -335,9 +369,15 @@
               name: OperationMetadata
               uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
               items:
-                - { uid: \Google\Cloud\Vision\V1\OperationMetadata\State, name: State }
+                -
+                  uid: \Google\Cloud\Vision\V1\OperationMetadata\State
+                  name: State
             -
               name: TextAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
               items:
-                - { name: DetectedBreak, uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak', items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }] }
+                -
+                  name: DetectedBreak
+                  uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak'
+                  items:
+                    - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }

--- a/dev/tests/fixtures/docfx/toc.yml
+++ b/dev/tests/fixtures/docfx/toc.yml
@@ -1,343 +1,380 @@
--
-  uid: google-cloud-vision
-  name: google/cloud-vision
-  items:
-    -
-      name: Overview
-      href: index.md
-    -
-      name: Google\Cloud\Vision\V1
-      uid: 'ns:Google\Cloud\Vision\V1'
-      items:
-        -
-          name: Services
-          uid: 'services:Google\Cloud\Vision\V1'
-          items:
-            -
-              uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-              name: ImageAnnotatorClient
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSearchClient
-              name: ProductSearchClient
-        -
-          name: Messages
-          uid: 'messages:Google\Cloud\Vision\V1'
-          items:
-            -
-              uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
-              name: AddProductToProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
-              name: AnnotateFileRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
-              name: AnnotateFileResponse
-            -
-              uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
-              name: AnnotateImageRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
-              name: AnnotateImageResponse
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
-              name: AsyncAnnotateFileRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
-              name: AsyncAnnotateFileResponse
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
-              name: AsyncBatchAnnotateFilesRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
-              name: AsyncBatchAnnotateFilesResponse
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
-              name: AsyncBatchAnnotateImagesRequest
-            -
-              uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
-              name: AsyncBatchAnnotateImagesResponse
-            -
-              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
-              name: BatchAnnotateFilesRequest
-            -
-              uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
-              name: BatchAnnotateFilesResponse
-            -
-              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
-              name: BatchAnnotateImagesRequest
-            -
-              uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
-              name: BatchAnnotateImagesResponse
-            -
-              uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
-              name: BatchOperationMetadata
-            -
-              uid: \Google\Cloud\Vision\V1\Block
-              name: Block
-            -
-              uid: \Google\Cloud\Vision\V1\BoundingPoly
-              name: BoundingPoly
-            -
-              uid: \Google\Cloud\Vision\V1\ColorInfo
-              name: ColorInfo
-            -
-              uid: \Google\Cloud\Vision\V1\CreateProductRequest
-              name: CreateProductRequest
-            -
-              uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
-              name: CreateProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
-              name: CreateReferenceImageRequest
-            -
-              uid: \Google\Cloud\Vision\V1\CropHint
-              name: CropHint
-            -
-              uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
-              name: CropHintsAnnotation
-            -
-              uid: \Google\Cloud\Vision\V1\CropHintsParams
-              name: CropHintsParams
-            -
-              uid: \Google\Cloud\Vision\V1\DeleteProductRequest
-              name: DeleteProductRequest
-            -
-              uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
-              name: DeleteProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
-              name: DeleteReferenceImageRequest
-            -
-              uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
-              name: DominantColorsAnnotation
-            -
-              uid: \Google\Cloud\Vision\V1\EntityAnnotation
-              name: EntityAnnotation
-            -
-              uid: \Google\Cloud\Vision\V1\FaceAnnotation
-              name: FaceAnnotation
-            -
-              name: FaceAnnotation
-              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark, name: Landmark }
-            -
-              uid: \Google\Cloud\Vision\V1\Feature
-              name: Feature
-            -
-              uid: \Google\Cloud\Vision\V1\GcsDestination
-              name: GcsDestination
-            -
-              uid: \Google\Cloud\Vision\V1\GcsSource
-              name: GcsSource
-            -
-              uid: \Google\Cloud\Vision\V1\GetProductRequest
-              name: GetProductRequest
-            -
-              uid: \Google\Cloud\Vision\V1\GetProductSetRequest
-              name: GetProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
-              name: GetReferenceImageRequest
-            -
-              uid: \Google\Cloud\Vision\V1\Image
-              name: Image
-            -
-              uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
-              name: ImageAnnotationContext
-            -
-              uid: \Google\Cloud\Vision\V1\ImageContext
-              name: ImageContext
-            -
-              uid: \Google\Cloud\Vision\V1\ImageProperties
-              name: ImageProperties
-            -
-              uid: \Google\Cloud\Vision\V1\ImageSource
-              name: ImageSource
-            -
-              uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
-              name: ImportProductSetsGcsSource
-            -
-              uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
-              name: ImportProductSetsInputConfig
-            -
-              uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
-              name: ImportProductSetsRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
-              name: ImportProductSetsResponse
-            -
-              uid: \Google\Cloud\Vision\V1\InputConfig
-              name: InputConfig
-            -
-              uid: \Google\Cloud\Vision\V1\LatLongRect
-              name: LatLongRect
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
-              name: ListProductSetsRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
-              name: ListProductSetsResponse
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
-              name: ListProductsInProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
-              name: ListProductsInProductSetResponse
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductsRequest
-              name: ListProductsRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ListProductsResponse
-              name: ListProductsResponse
-            -
-              uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
-              name: ListReferenceImagesRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
-              name: ListReferenceImagesResponse
-            -
-              uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
-              name: LocalizedObjectAnnotation
-            -
-              uid: \Google\Cloud\Vision\V1\LocationInfo
-              name: LocationInfo
-            -
-              uid: \Google\Cloud\Vision\V1\NormalizedVertex
-              name: NormalizedVertex
-            -
-              uid: \Google\Cloud\Vision\V1\OperationMetadata
-              name: OperationMetadata
-            -
-              uid: \Google\Cloud\Vision\V1\OutputConfig
-              name: OutputConfig
-            -
-              uid: \Google\Cloud\Vision\V1\Page
-              name: Page
-            -
-              uid: \Google\Cloud\Vision\V1\Paragraph
-              name: Paragraph
-            -
-              uid: \Google\Cloud\Vision\V1\Position
-              name: Position
-            -
-              uid: \Google\Cloud\Vision\V1\Product
-              name: Product
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSearchParams
-              name: ProductSearchParams
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSearchResults
-              name: ProductSearchResults
-            -
-              name: ProductSearchResults
-              uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult, name: GroupedResult }
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation, name: ObjectAnnotation }
-                - { uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result, name: Result }
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSet
-              name: ProductSet
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
-              name: ProductSetPurgeConfig
-            -
-              name: Product
-              uid: 'ns:Google\Cloud\Vision\V1\Product'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\Product\KeyValue, name: KeyValue }
-            -
-              uid: \Google\Cloud\Vision\V1\Property
-              name: Property
-            -
-              uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
-              name: PurgeProductsRequest
-            -
-              uid: \Google\Cloud\Vision\V1\ReferenceImage
-              name: ReferenceImage
-            -
-              uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
-              name: RemoveProductFromProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
-              name: SafeSearchAnnotation
-            -
-              uid: \Google\Cloud\Vision\V1\Symbol
-              name: Symbol
-            -
-              uid: \Google\Cloud\Vision\V1\TextAnnotation
-              name: TextAnnotation
-            -
-              name: TextAnnotation
-              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak, name: DetectedBreak }
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage, name: DetectedLanguage }
-                - { uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty, name: TextProperty }
-            -
-              uid: \Google\Cloud\Vision\V1\TextDetectionParams
-              name: TextDetectionParams
-            -
-              uid: \Google\Cloud\Vision\V1\UpdateProductRequest
-              name: UpdateProductRequest
-            -
-              uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
-              name: UpdateProductSetRequest
-            -
-              uid: \Google\Cloud\Vision\V1\Vertex
-              name: Vertex
-            -
-              uid: \Google\Cloud\Vision\V1\WebDetection
-              name: WebDetection
-            -
-              uid: \Google\Cloud\Vision\V1\WebDetectionParams
-              name: WebDetectionParams
-            -
-              name: WebDetection
-              uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity, name: WebEntity }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebImage, name: WebImage }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel, name: WebLabel }
-                - { uid: \Google\Cloud\Vision\V1\WebDetection\WebPage, name: WebPage }
-            -
-              uid: \Google\Cloud\Vision\V1\Word
-              name: Word
-        -
-          name: Enums
-          uid: 'enums:Google\Cloud\Vision\V1'
-          items:
-            -
-              name: BatchOperationMetadata
-              uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State, name: State }
-            -
-              name: Block
-              uid: 'ns:Google\Cloud\Vision\V1\Block'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\Block\BlockType, name: BlockType }
-            -
-              name: FaceAnnotation
-              uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
-              items:
-                - { name: Landmark, uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark', items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }] }
-            -
-              name: Feature
-              uid: 'ns:Google\Cloud\Vision\V1\Feature'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\Feature\Type, name: Type }
-            -
-              uid: \Google\Cloud\Vision\V1\Likelihood
-              name: Likelihood
-            -
-              name: OperationMetadata
-              uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
-              items:
-                - { uid: \Google\Cloud\Vision\V1\OperationMetadata\State, name: State }
-            -
-              name: TextAnnotation
-              uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
-              items:
-                - { name: DetectedBreak, uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak', items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }] }
+uid: google-cloud-vision
+name: google/cloud-vision
+items:
+  -
+    name: Overview
+    href: index.md
+  -
+    name: Google\Cloud\Vision\V1
+    uid: 'ns:Google\Cloud\Vision\V1'
+    items:
+      -
+        name: Services
+        uid: 'services:Google\Cloud\Vision\V1'
+        items:
+          -
+            uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
+            name: ImageAnnotatorClient
+          -
+            uid: \Google\Cloud\Vision\V1\ProductSearchClient
+            name: ProductSearchClient
+      -
+        name: Messages
+        uid: 'messages:Google\Cloud\Vision\V1'
+        items:
+          -
+            uid: \Google\Cloud\Vision\V1\AddProductToProductSetRequest
+            name: AddProductToProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AnnotateFileRequest
+            name: AnnotateFileRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AnnotateFileResponse
+            name: AnnotateFileResponse
+          -
+            uid: \Google\Cloud\Vision\V1\AnnotateImageRequest
+            name: AnnotateImageRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AnnotateImageResponse
+            name: AnnotateImageResponse
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileRequest
+            name: AsyncAnnotateFileRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncAnnotateFileResponse
+            name: AsyncAnnotateFileResponse
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest
+            name: AsyncBatchAnnotateFilesRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse
+            name: AsyncBatchAnnotateFilesResponse
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest
+            name: AsyncBatchAnnotateImagesRequest
+          -
+            uid: \Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse
+            name: AsyncBatchAnnotateImagesResponse
+          -
+            uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesRequest
+            name: BatchAnnotateFilesRequest
+          -
+            uid: \Google\Cloud\Vision\V1\BatchAnnotateFilesResponse
+            name: BatchAnnotateFilesResponse
+          -
+            uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesRequest
+            name: BatchAnnotateImagesRequest
+          -
+            uid: \Google\Cloud\Vision\V1\BatchAnnotateImagesResponse
+            name: BatchAnnotateImagesResponse
+          -
+            uid: \Google\Cloud\Vision\V1\BatchOperationMetadata
+            name: BatchOperationMetadata
+          -
+            uid: \Google\Cloud\Vision\V1\Block
+            name: Block
+          -
+            uid: \Google\Cloud\Vision\V1\BoundingPoly
+            name: BoundingPoly
+          -
+            uid: \Google\Cloud\Vision\V1\ColorInfo
+            name: ColorInfo
+          -
+            uid: \Google\Cloud\Vision\V1\CreateProductRequest
+            name: CreateProductRequest
+          -
+            uid: \Google\Cloud\Vision\V1\CreateProductSetRequest
+            name: CreateProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\CreateReferenceImageRequest
+            name: CreateReferenceImageRequest
+          -
+            uid: \Google\Cloud\Vision\V1\CropHint
+            name: CropHint
+          -
+            uid: \Google\Cloud\Vision\V1\CropHintsAnnotation
+            name: CropHintsAnnotation
+          -
+            uid: \Google\Cloud\Vision\V1\CropHintsParams
+            name: CropHintsParams
+          -
+            uid: \Google\Cloud\Vision\V1\DeleteProductRequest
+            name: DeleteProductRequest
+          -
+            uid: \Google\Cloud\Vision\V1\DeleteProductSetRequest
+            name: DeleteProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\DeleteReferenceImageRequest
+            name: DeleteReferenceImageRequest
+          -
+            uid: \Google\Cloud\Vision\V1\DominantColorsAnnotation
+            name: DominantColorsAnnotation
+          -
+            uid: \Google\Cloud\Vision\V1\EntityAnnotation
+            name: EntityAnnotation
+          -
+            uid: \Google\Cloud\Vision\V1\FaceAnnotation
+            name: FaceAnnotation
+          -
+            name: FaceAnnotation
+            uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark
+                name: Landmark
+          -
+            uid: \Google\Cloud\Vision\V1\Feature
+            name: Feature
+          -
+            uid: \Google\Cloud\Vision\V1\GcsDestination
+            name: GcsDestination
+          -
+            uid: \Google\Cloud\Vision\V1\GcsSource
+            name: GcsSource
+          -
+            uid: \Google\Cloud\Vision\V1\GetProductRequest
+            name: GetProductRequest
+          -
+            uid: \Google\Cloud\Vision\V1\GetProductSetRequest
+            name: GetProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\GetReferenceImageRequest
+            name: GetReferenceImageRequest
+          -
+            uid: \Google\Cloud\Vision\V1\Image
+            name: Image
+          -
+            uid: \Google\Cloud\Vision\V1\ImageAnnotationContext
+            name: ImageAnnotationContext
+          -
+            uid: \Google\Cloud\Vision\V1\ImageContext
+            name: ImageContext
+          -
+            uid: \Google\Cloud\Vision\V1\ImageProperties
+            name: ImageProperties
+          -
+            uid: \Google\Cloud\Vision\V1\ImageSource
+            name: ImageSource
+          -
+            uid: \Google\Cloud\Vision\V1\ImportProductSetsGcsSource
+            name: ImportProductSetsGcsSource
+          -
+            uid: \Google\Cloud\Vision\V1\ImportProductSetsInputConfig
+            name: ImportProductSetsInputConfig
+          -
+            uid: \Google\Cloud\Vision\V1\ImportProductSetsRequest
+            name: ImportProductSetsRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ImportProductSetsResponse
+            name: ImportProductSetsResponse
+          -
+            uid: \Google\Cloud\Vision\V1\InputConfig
+            name: InputConfig
+          -
+            uid: \Google\Cloud\Vision\V1\LatLongRect
+            name: LatLongRect
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductSetsRequest
+            name: ListProductSetsRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductSetsResponse
+            name: ListProductSetsResponse
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductsInProductSetRequest
+            name: ListProductsInProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductsInProductSetResponse
+            name: ListProductsInProductSetResponse
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductsRequest
+            name: ListProductsRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ListProductsResponse
+            name: ListProductsResponse
+          -
+            uid: \Google\Cloud\Vision\V1\ListReferenceImagesRequest
+            name: ListReferenceImagesRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ListReferenceImagesResponse
+            name: ListReferenceImagesResponse
+          -
+            uid: \Google\Cloud\Vision\V1\LocalizedObjectAnnotation
+            name: LocalizedObjectAnnotation
+          -
+            uid: \Google\Cloud\Vision\V1\LocationInfo
+            name: LocationInfo
+          -
+            uid: \Google\Cloud\Vision\V1\NormalizedVertex
+            name: NormalizedVertex
+          -
+            uid: \Google\Cloud\Vision\V1\OperationMetadata
+            name: OperationMetadata
+          -
+            uid: \Google\Cloud\Vision\V1\OutputConfig
+            name: OutputConfig
+          -
+            uid: \Google\Cloud\Vision\V1\Page
+            name: Page
+          -
+            uid: \Google\Cloud\Vision\V1\Paragraph
+            name: Paragraph
+          -
+            uid: \Google\Cloud\Vision\V1\Position
+            name: Position
+          -
+            uid: \Google\Cloud\Vision\V1\Product
+            name: Product
+          -
+            uid: \Google\Cloud\Vision\V1\ProductSearchParams
+            name: ProductSearchParams
+          -
+            uid: \Google\Cloud\Vision\V1\ProductSearchResults
+            name: ProductSearchResults
+          -
+            name: ProductSearchResults
+            uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult
+                name: GroupedResult
+              -
+                uid: \Google\Cloud\Vision\V1\ProductSearchResults\ObjectAnnotation
+                name: ObjectAnnotation
+              -
+                uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result
+                name: Result
+          -
+            uid: \Google\Cloud\Vision\V1\ProductSet
+            name: ProductSet
+          -
+            uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
+            name: ProductSetPurgeConfig
+          -
+            name: Product
+            uid: 'ns:Google\Cloud\Vision\V1\Product'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\Product\KeyValue
+                name: KeyValue
+          -
+            uid: \Google\Cloud\Vision\V1\Property
+            name: Property
+          -
+            uid: \Google\Cloud\Vision\V1\PurgeProductsRequest
+            name: PurgeProductsRequest
+          -
+            uid: \Google\Cloud\Vision\V1\ReferenceImage
+            name: ReferenceImage
+          -
+            uid: \Google\Cloud\Vision\V1\RemoveProductFromProductSetRequest
+            name: RemoveProductFromProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\SafeSearchAnnotation
+            name: SafeSearchAnnotation
+          -
+            uid: \Google\Cloud\Vision\V1\Symbol
+            name: Symbol
+          -
+            uid: \Google\Cloud\Vision\V1\TextAnnotation
+            name: TextAnnotation
+          -
+            name: TextAnnotation
+            uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak
+                name: DetectedBreak
+              -
+                uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedLanguage
+                name: DetectedLanguage
+              -
+                uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty
+                name: TextProperty
+          -
+            uid: \Google\Cloud\Vision\V1\TextDetectionParams
+            name: TextDetectionParams
+          -
+            uid: \Google\Cloud\Vision\V1\UpdateProductRequest
+            name: UpdateProductRequest
+          -
+            uid: \Google\Cloud\Vision\V1\UpdateProductSetRequest
+            name: UpdateProductSetRequest
+          -
+            uid: \Google\Cloud\Vision\V1\Vertex
+            name: Vertex
+          -
+            uid: \Google\Cloud\Vision\V1\WebDetection
+            name: WebDetection
+          -
+            uid: \Google\Cloud\Vision\V1\WebDetectionParams
+            name: WebDetectionParams
+          -
+            name: WebDetection
+            uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\WebDetection\WebEntity
+                name: WebEntity
+              -
+                uid: \Google\Cloud\Vision\V1\WebDetection\WebImage
+                name: WebImage
+              -
+                uid: \Google\Cloud\Vision\V1\WebDetection\WebLabel
+                name: WebLabel
+              -
+                uid: \Google\Cloud\Vision\V1\WebDetection\WebPage
+                name: WebPage
+          -
+            uid: \Google\Cloud\Vision\V1\Word
+            name: Word
+      -
+        name: Enums
+        uid: 'enums:Google\Cloud\Vision\V1'
+        items:
+          -
+            name: BatchOperationMetadata
+            uid: 'ns:Google\Cloud\Vision\V1\BatchOperationMetadata'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
+                name: State
+          -
+            name: Block
+            uid: 'ns:Google\Cloud\Vision\V1\Block'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\Block\BlockType
+                name: BlockType
+          -
+            name: FaceAnnotation
+            uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
+            items:
+              -
+                name: Landmark
+                uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation\Landmark'
+                items: [{ uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type, name: Type }]
+          -
+            name: Feature
+            uid: 'ns:Google\Cloud\Vision\V1\Feature'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\Feature\Type
+                name: Type
+          -
+            uid: \Google\Cloud\Vision\V1\Likelihood
+            name: Likelihood
+          -
+            name: OperationMetadata
+            uid: 'ns:Google\Cloud\Vision\V1\OperationMetadata'
+            items:
+              -
+                uid: \Google\Cloud\Vision\V1\OperationMetadata\State
+                name: State
+          -
+            name: TextAnnotation
+            uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
+            items:
+              -
+                name: DetectedBreak
+                uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak'
+                items: [{ uid: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType, name: BreakType }]


### PR DESCRIPTION
Fixes a small issue we found when staging - the TOC items needs to be wrapped in a "component" TOC item with the `name` and `uid`.

Also adds "beta" tag to any class in a versioned namespace containing `beta` or `alpha`

Also refactors out `XrefTrait::$protoPackages`, as this is deprecated in PHP 8.1