### PR TITLE
chore: migrate away from set-output

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
         steps:
         - id: getTag
           name: Get Tag
-          run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+          run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
         - name: Checkout
           uses: actions/checkout@v3
           with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             command: composer update
         - id: getTag
           name: Get Tag
-          run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+          run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
         - name: Run Subtree Split and Release
           env:
             tagName: ${{ steps.getTag.outputs.tag }}


### PR DESCRIPTION
ref [github doc](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples), Github is migrating away from `set-output` and it causes warnings in our test logs.

With this change, we are migrating to `GITHUB_OUTPUT` for writing workflow logs.

Example of such logs:

<img width="930" alt="Screenshot 2022-10-25 at 11 34 07" src="https://user-images.githubusercontent.com/7369612/197694957-53999cb5-56fe-4149-a4a6-1666b1728dcb.png">
