### PR TITLE
fix: throw an exception when the credentials fetcher cannot fetch a token

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -86,10 +86,8 @@ class ExponentialBackoff
                 }
 
                 if ($retryAttempt >= $this->retries) {
-                    exit('here');
                     break;
                 }
-                exit('here2');
 
                 $delayFunction($calcDelayFunction($retryAttempt));
                 $retryAttempt++;

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -86,8 +86,10 @@ class ExponentialBackoff
                 }
 
                 if ($retryAttempt >= $this->retries) {
+                    exit('here');
                     break;
                 }
+                exit('here2');
 
                 $delayFunction($calcDelayFunction($retryAttempt));
                 $retryAttempt++;

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -319,8 +319,14 @@ class RequestWrapper
 
         try {
             return $backoff->execute(
-                [$credentialsFetcher, 'fetchAuthToken'],
-                [$this->authHttpHandler]
+                function () use ($credentialsFetcher) {
+                    if ($token = $credentialsFetcher->fetchAuthToken($this->authHttpHandler)) {
+                        return $token;
+                    }
+                    // As we do not know the reason the credentials fetcher could not fetch the
+                    // token, we should not retry.
+                    throw new \RuntimeException('Unable to fetch token');
+                }
             );
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -555,6 +555,29 @@ class RequestWrapperTest extends TestCase
             new Request('GET', 'http://www.example.com')
         );
     }
+
+    public function testEmptyTokenThrowsException()
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('Unable to fetch token');
+
+        $credentialsFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+
+        // Set the response to an empty array (no token)
+        $credentialsFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([]);
+
+        // We have to mock this message because RequestWrapper wraps the credentials using the
+        // FetchAuthTokenCache class
+        $credentialsFetcher->getCacheKey()
+            ->willReturn(null);
+
+        $requestWrapper = new RequestWrapper([
+            'credentialsFetcher' => $credentialsFetcher->reveal(),
+        ]);
+
+        $requestWrapper->send(new Request('GET', 'http://www.example.com'));
+    }
 }
 
 //@codingStandardsIgnoreStart


### PR DESCRIPTION
Related to https://github.com/googleapis/google-auth-library-php/pull/422

When an empty token `[]` is returned from the `FetchAuthTokenInterface`, the `RequestWrapper` attempts to put this in the `Authorization Bearer` header and send it in anyway. It would be better to either skip adding the header (rather than send in an empty bearer token), or throw the exception early, so that we know where the problem is.