### PR TITLE
feat(storage): adding tests for autoclass

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -941,6 +941,10 @@ class Bucket
      *           more information, refer to the
      *           [Storage Classes](https://cloud.google.com/storage/docs/storage-classes)
      *           documentation. **Defaults to** `"STANDARD"`.
+     *     @type array $autoclass The bucket's autoclass configuration.
+     *           Buckets can have either StorageClass OLM rules or Autoclass,
+     *           but not both. When Autoclass is enabled on a bucket, adding
+     *           StorageClass OLM rules will result in failure.
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
      *     @type array $billing The bucket's billing configuration.

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -284,6 +284,10 @@ class StorageClient
      *           more information, refer to the
      *           [Storage Classes](https://cloud.google.com/storage/docs/storage-classes)
      *           documentation. **Defaults to** `"STANDARD"`.
+     *     @type array $autoclass The bucket's autoclass configuration.
+     *           Buckets can have either StorageClass OLM rules or Autoclass,
+     *           but not both. When Autoclass is enabled on a bucket, adding
+     *           StorageClass OLM rules will result in failure.
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
      *     @type array $billing The bucket's billing configuration.

--- a/Storage/tests/System/ManageBucketsTest.php
+++ b/Storage/tests/System/ManageBucketsTest.php
@@ -163,6 +163,29 @@ class ManageBucketsTest extends StorageTestCase
         $this->assertEquals($lifecycle->toArray(), $bucket->info()['lifecycle']);
     }
 
+    public function testUpdateBucketWithAutoclassConfig()
+    {
+        $autoclassConfig = [
+            'autoclass' => [
+                'enabled' => true,
+            ],
+        ];
+
+        $bucket = self::createBucket(
+            self::$client,
+            uniqid(self::TESTING_PREFIX),
+            $autoclassConfig
+        );
+        $this->assertArrayHasKey('autoclass', $bucket->info());
+        $this->assertTrue($bucket->info()['autoclass']['enabled']);
+
+        // test disabling autoclass
+        $autoclassConfig['autoclass']['enabled'] = false;
+        $bucket->update($autoclassConfig);
+        $this->assertArrayHasKey('autoclass', $bucket->info());
+        $this->assertFalse($bucket->info()['autoclass']['enabled']);
+    }
+
     public function lifecycleRules()
     {
         return [

--- a/Storage/tests/Unit/BucketTest.php
+++ b/Storage/tests/Unit/BucketTest.php
@@ -348,6 +348,27 @@ class BucketTest extends TestCase
         $this->assertTrue($bucket->info()['versioning']['enabled']);
     }
 
+    public function testUpdateAutoclassConfig()
+    {
+        $autoclassConfig = [
+            'autoclass' => [
+                'enabled' => true,
+            ],
+        ];
+        $this->connection->patchBucket(Argument::any())->willReturn(
+            ['name' => 'bucket'] +
+            $autoclassConfig +
+            ['autoclass' => ['toggleTime' => '2022-09-18T01:01:01.045123456Z']]
+        );
+        $bucket = $this->getBucket([
+            'name' => 'bucket',
+        ] + $autoclassConfig);
+
+        $bucket->update($autoclassConfig);
+
+        $this->assertTrue($bucket->info()['autoclass']['enabled']);
+    }
+
     public function testUpdatesDataWithLifecycleBuilder()
     {
         $lifecycleArr = ['test' => 'test'];


### PR DESCRIPTION
Addresses https://github.com/googleapis/google-cloud-php/issues/5479
(couldn't test in local, since feature not enabled in my gcp proj)

Design doc: [go/php-storage-autoclass](http://goto.google.com/php-storage-autoclass)
ref: Test plan - [go/sat-client-library-request](https://goto.google.com/sat-client-library-request)

**Note:** Another PR with same changes were reverted before: https://github.com/googleapis/google-cloud-php/pull/5487