### PR TITLE
chore: add name attr in phpunit config testsuite

### DIFF
--- a/AccessApproval/phpunit.xml.dist
+++ b/AccessApproval/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-php/issues/5382

Checkout [latest test logs](https://pipelines.actions.githubusercontent.com/serviceHosts/0f3ab822-4928-4da8-b790-ff9c74861046/_apis/pipelines/1/runs/7060/signedlogcontent/23?urlExpires=2022-11-08T09%3A06%3A31.6074542Z&urlSigningMethod=HMACV1&urlSignature=Fi0N7sMRutepI6fzw9ENpWz50ZXaBveZArW%2FAjQ%2BuoQ%3D) have this unnecessary warning:

```
Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 4:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```