### PR TITLE
docs: fix cloud rad links, add php typehint to fenced codeblocks

### DIFF
--- a/dev/src/DocFx/Node/DocblockTrait.php
+++ b/dev/src/DocFx/Node/DocblockTrait.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Dev\DocFx\Node;
 trait DocblockTrait
 {
     use XrefTrait;
+    use FencedCodeBlockTrait;
 
     public function getContent(): string
     {
@@ -39,6 +40,7 @@ trait DocblockTrait
         $content = $this->replaceSeeTag($content);
         $content = $this->replaceProtoRef($content);
         $content = $this->stripSnippetTag($content);
+        $content = $this->addPhpLanguageHintToFencedCodeBlock($content);
 
         return $content;
     }

--- a/dev/src/DocFx/Node/FencedCodeBlockTrait.php
+++ b/dev/src/DocFx/Node/FencedCodeBlockTrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocFx\Node;
+
+trait FencedCodeBlockTrait
+{
+    /**
+     * Adds "php" to an open fenced codeblock which does not have a language
+     * (e.x. ``` => ```php)
+     */
+    private function addPhpLanguageHintToFencedCodeBlock(string $description): string
+    {
+        return preg_replace_callback(
+            '/^(\s+)?```\n((.|\n)*)\n^(\s+)?```$/m',
+            function ($matches) {
+                list($codeblock, $leadingWhitespace, $contents, $_, $trailingWhitespace) = $matches + [4 => ''];
+                return sprintf("%s```php\n%s\n%s```",
+                    $leadingWhitespace,
+                    $contents,
+                    $trailingWhitespace
+                );
+            },
+            $description
+        );
+    }
+}

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -83,7 +83,7 @@ trait XrefTrait
     private function replaceProtoRef(string $description): string
     {
         return preg_replace_callback(
-            '/\[([^ ]*?)\]\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
+            '/\[([^\]]*?)\]\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
             function ($matches) {
                 list($link, $name, $package, $class) = $matches;
                 $property = $method = $constant = null;

--- a/dev/src/DocFx/Page/PageTree.php
+++ b/dev/src/DocFx/Page/PageTree.php
@@ -112,10 +112,7 @@ class PageTree
         }
 
         // Combine Client classes with internal Gapic\Client
-        $pages = $this->combineGapicClients($gapicClients,$pages);
-
-        // We don't need the array keys anymore
-        $pages = array_values($pages);
+        $pages = $this->combineGapicClients($gapicClients, $pages);
 
         /**
          * Set a map of protobuf package names to PHP namespaces for Xrefs.
@@ -152,6 +149,9 @@ class PageTree
                 $pages[$clientFullName]->getClassNode()->setChildNode($gapicClient);
             }
         }
+
+        // We don't need the array keys anymore
+        $pages = array_values($pages);
 
         return $pages;
     }

--- a/dev/src/DocFx/Page/PageTree.php
+++ b/dev/src/DocFx/Page/PageTree.php
@@ -77,7 +77,7 @@ class PageTree
 
             $fullName = $classNode->getFullname();
             // Manually skip GAPIC clients
-            if ('GapicClient' === substr($classNode->getClassName(), -11)) {
+            if ('GapicClient' === substr($classNode->getFullName(), -11)) {
                 $gapicClients[] = $classNode;
                 continue;
             }
@@ -143,14 +143,13 @@ class PageTree
         // Combine Client with internal Gapic\Client
         foreach ($gapicClients as $gapicClient) {
             // Find  Classname
-            $parts = explode('\\', $className);
+            $parts = explode('\\', $gapicClient->getFullName());
             $clientClassName = substr(array_pop($parts), 0, -11) . 'Client';
             array_pop($parts); // remove "Gapic" namespace
             $parts[] = $clientClassName;
             $clientFullName = implode('\\', $parts);
             if (isset($pages[$clientFullName])) {
-                $page->getClassNode()->setChildNode($gapicClient);
-                unset($pages[$clientFullName]);
+                $pages[$clientFullName]->getClassNode()->setChildNode($gapicClient);
             }
         }
 

--- a/dev/src/DocFx/Page/PageTree.php
+++ b/dev/src/DocFx/Page/PageTree.php
@@ -77,7 +77,7 @@ class PageTree
 
             $fullName = $classNode->getFullname();
             // Manually skip GAPIC clients
-            if ('GapicClient' === substr($classNode->getFullName(), -11)) {
+            if ('GapicClient' === substr($fullName, -11)) {
                 $gapicClients[] = $classNode;
                 continue;
             }

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -13,7 +13,7 @@ items:
       This class provides the ability to make remote calls to the backing service through method
       calls that map to API methods. Sample code to get started:
       
-      ```
+      ```php
       $imageAnnotatorClient = new ImageAnnotatorClient();
       try {
           $requests = [];
@@ -84,7 +84,7 @@ items:
       Creates an Image object that can be used as part of an image annotation request.
       
       Example:
-      ```
+      ```php
       
       $imageResource = fopen('path/to/image.jpg', 'r');
       $image = $imageAnnotatorClient->createImageObject($imageResource);
@@ -125,7 +125,7 @@ items:
       Run image detection and annotation for an image.
       
       Example:
-      ```
+      ```php
       use Google\Cloud\Vision\V1\Feature;
       use Google\Cloud\Vision\V1\Feature\Type;
       
@@ -170,7 +170,7 @@ items:
       Run face detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->faceDetection($imageContent);
       ```
@@ -207,7 +207,7 @@ items:
       Run landmark detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->landmarkDetection($imageContent);
       ```
@@ -244,7 +244,7 @@ items:
       Run logo detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->logoDetection($imageContent);
       ```
@@ -281,7 +281,7 @@ items:
       Run label detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->labelDetection($imageContent);
       ```
@@ -318,7 +318,7 @@ items:
       Run text detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->textDetection($imageContent);
       ```
@@ -355,7 +355,7 @@ items:
       Run document text detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->documentTextDetection($imageContent);
       ```
@@ -392,7 +392,7 @@ items:
       Run safe search detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->safeSearchDetection($imageContent);
       ```
@@ -429,7 +429,7 @@ items:
       Run image properties detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->imagePropertiesDetection($imageContent);
       ```
@@ -466,7 +466,7 @@ items:
       Run crop hints detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->cropHintsDetection($imageContent);
       ```
@@ -503,7 +503,7 @@ items:
       Run web detection for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->webDetection($imageContent);
       ```
@@ -540,7 +540,7 @@ items:
       Run object localization for an image.
       
       Example:
-      ```
+      ```php
       $imageContent = file_get_contents('path/to/image.jpg');
       $response = $imageAnnotatorClient->objectLocalization($imageContent);
       ```
@@ -577,7 +577,7 @@ items:
       Run product search for an image.
       
       Example:
-      ```
+      ```php
       use Google\Cloud\Vision\V1\ProductSearchClient;
       use Google\Cloud\Vision\V1\ProductSearchParams;
       
@@ -723,7 +723,7 @@ items:
       `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
       
       Sample code:
-      ```
+      ```php
       $imageAnnotatorClient = new ImageAnnotatorClient();
       try {
           $requests = [];
@@ -798,7 +798,7 @@ items:
       GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
       
       Sample code:
-      ```
+      ```php
       $imageAnnotatorClient = new ImageAnnotatorClient();
       try {
           $requests = [];
@@ -877,7 +877,7 @@ items:
       extracted.
       
       Sample code:
-      ```
+      ```php
       $imageAnnotatorClient = new ImageAnnotatorClient();
       try {
           $requests = [];
@@ -919,7 +919,7 @@ items:
       Run image detection and annotation for a batch of images.
       
       Sample code:
-      ```
+      ```php
       $imageAnnotatorClient = new ImageAnnotatorClient();
       try {
           $requests = [];

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -24,7 +24,7 @@ items:
       This class provides the ability to make remote calls to the backing service through method
       calls that map to API methods. Sample code to get started:
       
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -332,7 +332,7 @@ items:
       * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -379,7 +379,7 @@ items:
       * Returns INVALID_ARGUMENT if product_category is missing or invalid.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -431,7 +431,7 @@ items:
       4096 characters.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -496,7 +496,7 @@ items:
       * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
@@ -547,7 +547,7 @@ items:
       until all related caches are refreshed.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
@@ -585,7 +585,7 @@ items:
       The actual image files are not deleted from Google Cloud Storage.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -626,7 +626,7 @@ items:
       The actual image files are not deleted from Google Cloud Storage.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->referenceImageName('[PROJECT]', '[LOCATION]', '[PRODUCT]', '[REFERENCE_IMAGE]');
@@ -665,7 +665,7 @@ items:
       * Returns NOT_FOUND if the Product does not exist.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
@@ -707,7 +707,7 @@ items:
       * Returns NOT_FOUND if the ProductSet does not exist.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -749,7 +749,7 @@ items:
       * Returns NOT_FOUND if the specified image does not exist.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->referenceImageName('[PROJECT]', '[LOCATION]', '[PRODUCT]', '[REFERENCE_IMAGE]');
@@ -797,7 +797,7 @@ items:
       <xref uid="\Google\Cloud\Vision\V1\ImportProductSetsGcsSource::getCsvFileUri()">ImportProductSetsGcsSource.csv_file_uri</xref>.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -870,7 +870,7 @@ items:
       than 1.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -932,7 +932,7 @@ items:
       * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -996,7 +996,7 @@ items:
       * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -1060,7 +1060,7 @@ items:
       than 1.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
@@ -1141,7 +1141,7 @@ items:
       `Operation.metadata` contains `BatchOperationMetadata`. (progress)
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
@@ -1214,7 +1214,7 @@ items:
       Removes a Product from the specified ProductSet.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
@@ -1269,7 +1269,7 @@ items:
       * Returns INVALID_ARGUMENT if product_category is present in update_mask.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $product = new Product();
@@ -1319,7 +1319,7 @@ items:
       missing from the request or longer than 4096 characters.
       
       Sample code:
-      ```
+      ```php
       $productSearchClient = new ProductSearchClient();
       try {
           $productSet = new ProductSet();

--- a/dev/tests/fixtures/docfx/toc.yml
+++ b/dev/tests/fixtures/docfx/toc.yml
@@ -114,15 +114,15 @@
               uid: \Google\Cloud\Vision\V1\EntityAnnotation
               name: EntityAnnotation
             -
-              uid: \Google\Cloud\Vision\V1\FaceAnnotation
-              name: FaceAnnotation
-            -
               name: FaceAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\FaceAnnotation'
               items:
                 -
                   uid: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark
                   name: Landmark
+            -
+              uid: \Google\Cloud\Vision\V1\FaceAnnotation
+              name: FaceAnnotation
             -
               uid: \Google\Cloud\Vision\V1\Feature
               name: Feature
@@ -223,14 +223,18 @@
               uid: \Google\Cloud\Vision\V1\Position
               name: Position
             -
+              name: Product
+              uid: 'ns:Google\Cloud\Vision\V1\Product'
+              items:
+                -
+                  uid: \Google\Cloud\Vision\V1\Product\KeyValue
+                  name: KeyValue
+            -
               uid: \Google\Cloud\Vision\V1\Product
               name: Product
             -
               uid: \Google\Cloud\Vision\V1\ProductSearchParams
               name: ProductSearchParams
-            -
-              uid: \Google\Cloud\Vision\V1\ProductSearchResults
-              name: ProductSearchResults
             -
               name: ProductSearchResults
               uid: 'ns:Google\Cloud\Vision\V1\ProductSearchResults'
@@ -245,18 +249,14 @@
                   uid: \Google\Cloud\Vision\V1\ProductSearchResults\Result
                   name: Result
             -
+              uid: \Google\Cloud\Vision\V1\ProductSearchResults
+              name: ProductSearchResults
+            -
               uid: \Google\Cloud\Vision\V1\ProductSet
               name: ProductSet
             -
               uid: \Google\Cloud\Vision\V1\ProductSetPurgeConfig
               name: ProductSetPurgeConfig
-            -
-              name: Product
-              uid: 'ns:Google\Cloud\Vision\V1\Product'
-              items:
-                -
-                  uid: \Google\Cloud\Vision\V1\Product\KeyValue
-                  name: KeyValue
             -
               uid: \Google\Cloud\Vision\V1\Property
               name: Property
@@ -276,9 +276,6 @@
               uid: \Google\Cloud\Vision\V1\Symbol
               name: Symbol
             -
-              uid: \Google\Cloud\Vision\V1\TextAnnotation
-              name: TextAnnotation
-            -
               name: TextAnnotation
               uid: 'ns:Google\Cloud\Vision\V1\TextAnnotation'
               items:
@@ -292,6 +289,9 @@
                   uid: \Google\Cloud\Vision\V1\TextAnnotation\TextProperty
                   name: TextProperty
             -
+              uid: \Google\Cloud\Vision\V1\TextAnnotation
+              name: TextAnnotation
+            -
               uid: \Google\Cloud\Vision\V1\TextDetectionParams
               name: TextDetectionParams
             -
@@ -303,12 +303,6 @@
             -
               uid: \Google\Cloud\Vision\V1\Vertex
               name: Vertex
-            -
-              uid: \Google\Cloud\Vision\V1\WebDetection
-              name: WebDetection
-            -
-              uid: \Google\Cloud\Vision\V1\WebDetectionParams
-              name: WebDetectionParams
             -
               name: WebDetection
               uid: 'ns:Google\Cloud\Vision\V1\WebDetection'
@@ -325,6 +319,12 @@
                 -
                   uid: \Google\Cloud\Vision\V1\WebDetection\WebPage
                   name: WebPage
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetection
+              name: WebDetection
+            -
+              uid: \Google\Cloud\Vision\V1\WebDetectionParams
+              name: WebDetectionParams
             -
               uid: \Google\Cloud\Vision\V1\Word
               name: Word


### PR DESCRIPTION
- Fixes broken links for links that contained spaces (e.g. `[this link here][google.cloud.somepackage.SomeMessage]`)
- Fixes other broken links by refactoring how `$protoPackages` are determined
- Automatically adds `php` to the end of fenced code blocks if no language is specified (do we have any instances where this would be a different language?)