### PR TITLE
chore: fix typos in beyondcorp

### DIFF
--- a/BeyondCorpAppConnections/README.md
+++ b/BeyondCorpAppConnections/README.md
@@ -1,4 +1,4 @@
-# Google Cloud BeyondCorp AppConnections for PHP for PHP
+# Google Cloud BeyondCorp AppConnections for PHP
 
 > Idiomatic PHP client for [Google Cloud BeyondCorp AppConnections for PHP](https://cloud.google.com/beyondcorp-enterprise).
 

--- a/BeyondCorpAppConnections/composer.json
+++ b/BeyondCorpAppConnections/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-beyondcorp-appconnections",
-    "description": "Google Cloud BeyondCorp AppConnections for PHP Client for PHP",
+    "description": "Google Cloud BeyondCorp AppConnections for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "autoload": {

--- a/BeyondCorpAppConnectors/README.md
+++ b/BeyondCorpAppConnectors/README.md
@@ -1,4 +1,4 @@
-# Google Cloud BeyondCorp AppConnectors for PHP for PHP
+# Google Cloud BeyondCorp AppConnectors for PHP
 
 > Idiomatic PHP client for [Google Cloud BeyondCorp AppConnectors for PHP](https://cloud.google.com/beyondcorp-enterprise).
 

--- a/BeyondCorpAppConnectors/composer.json
+++ b/BeyondCorpAppConnectors/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-beyondcorp-appconnectors",
-    "description": "Google Cloud BeyondCorp AppConnectors for PHP Client for PHP",
+    "description": "Google Cloud BeyondCorp AppConnectors for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "autoload": {

--- a/BeyondCorpAppGateways/README.md
+++ b/BeyondCorpAppGateways/README.md
@@ -1,4 +1,4 @@
-# Google Cloud BeyondCorp AppGateways for PHP for PHP
+# Google Cloud BeyondCorp AppGateways for PHP
 
 > Idiomatic PHP client for [Google Cloud BeyondCorp AppGateways for PHP](https://cloud.google.com/beyondcorp-enterprise).
 

--- a/BeyondCorpAppGateways/composer.json
+++ b/BeyondCorpAppGateways/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-beyondcorp-appgateways",
-    "description": "Google Cloud BeyondCorp AppGateways for PHP Client for PHP",
+    "description": "Google Cloud BeyondCorp AppGateways for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "autoload": {

--- a/BeyondCorpClientConnectorServices/README.md
+++ b/BeyondCorpClientConnectorServices/README.md
@@ -1,4 +1,4 @@
-# Google Cloud BeyondCorp Client Connector Services for PHP for PHP
+# Google Cloud BeyondCorp Client Connector Services for PHP
 
 > Idiomatic PHP client for [Google Cloud BeyondCorp Client Connector Services for PHP](https://cloud.google.com/beyondcorp-enterprise).
 

--- a/BeyondCorpClientConnectorServices/composer.json
+++ b/BeyondCorpClientConnectorServices/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-beyondcorp-clientconnectorservices",
-    "description": "Google Cloud BeyondCorp Client Connector Services for PHP Client for PHP",
+    "description": "Google Cloud BeyondCorp Client Connector Services for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "autoload": {

--- a/BeyondCorpClientGateways/README.md
+++ b/BeyondCorpClientGateways/README.md
@@ -1,4 +1,4 @@
-# Google Cloud BeyondCorp Client Gateways for PHP for PHP
+# Google Cloud BeyondCorp Client Gateways for PHP
 
 > Idiomatic PHP client for [Google Cloud BeyondCorp Client Gateways for PHP](https://cloud.google.com/beyondcorp-enterprise).
 

--- a/BeyondCorpClientGateways/composer.json
+++ b/BeyondCorpClientGateways/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-beyondcorp-clientgateways",
-    "description": "Google Cloud BeyondCorp Client Gateways for PHP Client for PHP",
+    "description": "Google Cloud BeyondCorp Client Gateways for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "autoload": {

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "google/cloud-firestore",
-    "description": "Cloud Firestore client for PHP",
+    "description": "Cloud Firestore Client for PHP",
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {


### PR DESCRIPTION
 - Removes redundancy in BeyondCorp naming
 - Makes description in `Firestore/composer.json` consistent
