### PR TITLE
feat(Spanner): Support FGAC

### DIFF
--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -120,6 +120,11 @@ class BatchClient
     private $databaseName;
 
     /**
+     * @var string
+     */
+    private $databaseRole;
+
+    /**
      * @var array
      */
     private $allowedPartitionTypes = [

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -139,7 +139,7 @@ class BatchClient
      * @param array $options  [optional] {
      *     Configuration options.
      *
-     *     @type string $databaseRole The session owner database role.
+     *     @type string $databaseRole The user created database role which creates the session.
      * }
      */
     public function __construct(Operation $operation, $databaseName, array $options = [])
@@ -189,7 +189,7 @@ class BatchClient
 
         $transactionOptions = $this->configureSnapshotOptions($transactionOptions);
 
-        if ($this->databaseRole != null) {
+        if ($this->databaseRole !== null) {
             $sessionOptions['creator_role'] = $this->databaseRole;
         }
 

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -778,7 +778,8 @@ class Grpc implements ConnectionInterface
 
         $session = $this->pluck('session', $args, false);
         if ($session) {
-            $args['session'] = $this->serializer->decodeMessage(new Session, $session);
+            $args['session'] = $this->serializer->decodeMessage(new Session,
+                array_filter($session, fn ($value) => !is_null($value)));
         }
 
         return $this->send([$this->spannerClient, 'createSession'], [

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -778,8 +778,15 @@ class Grpc implements ConnectionInterface
 
         $session = $this->pluck('session', $args, false);
         if ($session) {
-            $args['session'] = $this->serializer->decodeMessage(new Session,
-                array_filter($session, fn ($value) => !is_null($value)));
+            $args['session'] = $this->serializer->decodeMessage(
+                new Session,
+                array_filter(
+                    $session,
+                    function ($value) {
+                        return !is_null($value);
+                    }
+                )
+            );
         }
 
         return $this->send([$this->spannerClient, 'createSession'], [

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -170,6 +170,11 @@ class Database
     private $isRunningTransaction = false;
 
     /**
+     * @var string
+     */
+    private $databaseRole;
+
+    /**
      * Create an object representing a Database.
      *
      * @param ConnectionInterface $connection The connection to the
@@ -185,6 +190,7 @@ class Database
      * @param bool $returnInt64AsObject [optional If true, 64 bit integers will
      *        be returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility. **Defaults to** false.
+     * @param string $databaseRole The session owner database role.
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -195,7 +201,8 @@ class Database
         $name,
         SessionPoolInterface $sessionPool = null,
         $returnInt64AsObject = false,
-        array $info = []
+        array $info = [],
+        $databaseRole = null
     ) {
         $this->connection = $connection;
         $this->instance = $instance;
@@ -210,6 +217,7 @@ class Database
         }
 
         $this->setLroProperties($lroConnection, $lroCallables, $this->name);
+        $this->databaseRole = $databaseRole;
     }
 
     /**
@@ -2023,6 +2031,10 @@ class Database
             return $this->session = $this->sessionPool->acquire($context);
         }
 
+        if ($this->databaseRole != null) {
+            $options['creator_role'] = $this->databaseRole;
+        }
+
         return $this->session = $this->operation->createSession($this->name, $options);
     }
 
@@ -2092,4 +2104,5 @@ class Database
 
         return sprintf('CREATE DATABASE `%s`', $databaseId);
     }
+
 }

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -2104,5 +2104,4 @@ class Database
 
         return sprintf('CREATE DATABASE `%s`', $databaseId);
     }
-
 }

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -190,7 +190,7 @@ class Database
      * @param bool $returnInt64AsObject [optional If true, 64 bit integers will
      *        be returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility. **Defaults to** false.
-     * @param string $databaseRole The session owner database role.
+     * @param string $databaseRole The user created database role which creates the session.
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -2031,7 +2031,7 @@ class Database
             return $this->session = $this->sessionPool->acquire($context);
         }
 
-        if ($this->databaseRole != null) {
+        if ($this->databaseRole !== null) {
             $options['creator_role'] = $this->databaseRole;
         }
 

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -482,9 +482,9 @@ class Instance
      * $database = $instance->database('my-database');
      * ```
      *
-     * ```
      * Database role configured on the database object
      * will be applied to the session created by this object.
+     * ```
      * $database = $instance->database('my-database', ['databaseRole' => 'Reader']);
      * ```
      *

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -482,12 +482,19 @@ class Instance
      * $database = $instance->database('my-database');
      * ```
      *
+     * ```
+     * Database role configured on the database object
+     * will be applied to the session created by this object.
+     * $database = $instance->database('my-database', ['databaseRole' => 'Reader']);
+     * ```
+     *
      * @param string $name The database name
      * @param array $options [optional] {
      *     Configuration options.
      *
      *     @type SessionPoolInterface $sessionPool A pool used to manage
      *           sessions.
+     *     @type string $databaseRole The session owner database role.
      * }
      * @return Database
      */
@@ -502,7 +509,8 @@ class Instance
             $name,
             isset($options['sessionPool']) ? $options['sessionPool'] : null,
             $this->returnInt64AsObject,
-            isset($options['database']) ? $options['database'] : []
+            isset($options['database']) ? $options['database'] : [],
+            isset($options['databaseRole']) ? $options['databaseRole'] : null
         );
     }
 

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -494,7 +494,7 @@ class Instance
      *
      *     @type SessionPoolInterface $sessionPool A pool used to manage
      *           sessions.
-     *     @type string $databaseRole The session owner database role.
+     *     @type string $databaseRole The user created database role which creates the session.
      * }
      * @return Database
      */

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -553,6 +553,7 @@ class Operation
      *           labels can be associated with a given session. See
      *           https://goo.gl/xmQnxf for more information on and examples of
      *           labels.
+     *     @type string $creator_role The session owner database role.
      * }
      * @return Session
      */
@@ -561,7 +562,8 @@ class Operation
         $res = $this->connection->createSession([
             'database' => $databaseName,
             'session' => [
-                'labels' => $this->pluck('labels', $options, false) ?: []
+                'labels' => $this->pluck('labels', $options, false) ?: [],
+                'creator_role' => $this->pluck('creator_role', $options, false) ?: null
             ]
         ] + $options);
 

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -553,7 +553,7 @@ class Operation
      *           labels can be associated with a given session. See
      *           https://goo.gl/xmQnxf for more information on and examples of
      *           labels.
-     *     @type string $creator_role The session owner database role.
+     *     @type string $creator_role The user created database role which creates the session.
      * }
      * @return Session
      */

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -105,8 +105,8 @@ use Psr\Cache\CacheItemPoolInterface;
  * ]);
  * ```
  *
- * ```
  * Database role configured on the pool will be applied to each session created by the pool.
+ * ```
  * use Google\Cloud\Spanner\Session\CacheSessionPool;
  * use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  *

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -104,6 +104,17 @@ use Psr\Cache\CacheItemPoolInterface;
  *     ]
  * ]);
  * ```
+ *
+ * ```
+ * Database role configured on the pool will be applied to each session created by the pool.
+ * use Google\Cloud\Spanner\Session\CacheSessionPool;
+ * use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+ *
+ * $cache = new FilesystemAdapter();
+ * $sessionPool = new CacheSessionPool($cache, [
+ *     'databaseRole' => 'Reader'
+ * ]);
+ * ```
  */
 class CacheSessionPool implements SessionPoolInterface
 {
@@ -191,6 +202,8 @@ class CacheSessionPool implements SessionPoolInterface
      *           labels can be associated with a given session. See
      *           https://goo.gl/xmQnxf for more information on and examples of
      *           labels.
+     *     @type string $databaseRole The session owner database role.
+     * }
      * }
      * @throws \InvalidArgumentException
      */
@@ -660,7 +673,8 @@ class CacheSessionPool implements SessionPoolInterface
                 $res = $this->database->connection()->batchCreateSessions([
                     'database' => $this->database->name(),
                     'sessionTemplate' => [
-                        'labels' => isset($this->config['labels']) ? $this->config['labels'] : []
+                        'labels' => isset($this->config['labels']) ? $this->config['labels'] : [],
+                        'creator_role' => isset($this->config['databaseRole']) ? $this->config['databaseRole'] : null
                     ],
                     'sessionCount' => $count - $created
                 ]);

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -202,7 +202,7 @@ class CacheSessionPool implements SessionPoolInterface
      *           labels can be associated with a given session. See
      *           https://goo.gl/xmQnxf for more information on and examples of
      *           labels.
-     *     @type string $databaseRole The session owner database role.
+     *     @type string $databaseRole The user created database role which creates the session.
      * }
      * }
      * @throws \InvalidArgumentException

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -107,12 +107,18 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * Database role configured on the pool will be applied to each session created by the pool.
  * ```
+ * use Google\Cloud\Spanner\SpannerClient;
  * use Google\Cloud\Spanner\Session\CacheSessionPool;
  * use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  *
+ * $spanner = new SpannerClient();
  * $cache = new FilesystemAdapter();
  * $sessionPool = new CacheSessionPool($cache, [
  *     'databaseRole' => 'Reader'
+ * ]);
+ *
+ * $database = $spanner->connect('my-instance', 'my-database', [
+ *     'sessionPool' => $sessionPool
  * ]);
  * ```
  */

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -252,9 +252,9 @@ class SpannerClient
      * $batch = $spanner->batch('instance-id', 'database-id');
      * ```
      *
-     * ```
      * Database role configured in the optional $options array
      * will be applied to the session created by this object.
+     * ```
      * $batch = $spanner->batch('instance-id', 'database-id', ['databaseRole' => 'Reader']);
      * ```
      *
@@ -578,11 +578,11 @@ class SpannerClient
      * $database = $spanner->connect('instance-id', 'database-id');
      * ```
      *
-     * ```
      * Database role configured on the $options parameter
      * will be applied to the session created by this object.
      * Note: When the databseRole and sessionPool both are present in the options,
      * we prioritize the sessionPool.
+     * ```
      * $database = $spanner->connect('instance-id', 'database-id', ['databaseRole' => 'Reader']);
      * ```
      *

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -252,11 +252,22 @@ class SpannerClient
      * $batch = $spanner->batch('instance-id', 'database-id');
      * ```
      *
+     * ```
+     * Database role configured in the optional $options array
+     * will be applied to the session created by this object.
+     * $batch = $spanner->batch('instance-id', 'database-id', ['databaseRole' => 'Reader']);
+     * ```
+     *
      * @param string $instanceId The instance to connect to.
      * @param string $databaseId The database to connect to.
+     * @param array $options  [optional] {
+     *     Configuration options.
+     *
+     *     @type string $databaseRole The session owner database role.
+     * }
      * @return BatchClient
      */
-    public function batch($instanceId, $databaseId)
+    public function batch($instanceId, $databaseId, array $options = [])
     {
         $operation = new Operation(
             $this->connection,
@@ -269,7 +280,8 @@ class SpannerClient
                 $this->projectId,
                 $instanceId,
                 $databaseId
-            )
+            ),
+            $options
         );
     }
 
@@ -564,6 +576,14 @@ class SpannerClient
      * Example:
      * ```
      * $database = $spanner->connect('instance-id', 'database-id');
+     * ```
+     *
+     * ```
+     * Database role configured on the $options parameter
+     * will be applied to the session created by this object.
+     * Note: When the databseRole and sessionPool both are present in the options,
+     * we prioritize the sessionPool.
+     * $database = $spanner->connect('instance-id', 'database-id', ['databaseRole' => 'Reader']);
      * ```
      *
      * @param Instance|string $instance The instance object or instance name.

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -263,7 +263,7 @@ class SpannerClient
      * @param array $options  [optional] {
      *     Configuration options.
      *
-     *     @type string $databaseRole The session owner database role.
+     *     @type string $databaseRole The user created database role which creates the session.
      * }
      * @return BatchClient
      */

--- a/Spanner/tests/Snippet/InstanceTest.php
+++ b/Spanner/tests/Snippet/InstanceTest.php
@@ -399,4 +399,14 @@ class InstanceTest extends SnippetTestCase
         $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertContainsOnlyInstancesOf(LongRunningOperation::class, $res->returnVal());
     }
+
+    public function testDatabaseWithDatabaseRole()
+    {
+        $snippet = $this->snippetFromMethod(Instance::class, 'database', 1);
+        $snippet->addLocal('instance', $this->instance);
+
+        $res = $snippet->invoke('database');
+        $this->assertInstanceOf(Database::class, $res->returnVal());
+        $this->assertEquals(self::DATABASE, DatabaseAdminClient::parseName($res->returnVal()->name())['database']);
+    }
 }

--- a/Spanner/tests/Snippet/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Snippet/Session/CacheSessionPoolTest.php
@@ -51,4 +51,17 @@ class CacheSessionPoolTest extends SnippetTestCase
         $snippet->addLocal('cache', new MemoryCacheItemPool);
         $res = $snippet->invoke();
     }
+
+    public function testClassWithDatabaseRole()
+    {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+
+        $snippet = $this->snippetFromClass(CacheSessionPool::class, 2);
+        $snippet->replace('$cache =', '//$cache =');
+        $snippet->addLocal('cache', new MemoryCacheItemPool);
+        $res = $snippet->invoke('database');
+        $this->assertInstanceOf(Database::class, $res->returnVal());
+    }
 }

--- a/Spanner/tests/Snippet/SpannerClientTest.php
+++ b/Spanner/tests/Snippet/SpannerClientTest.php
@@ -281,4 +281,21 @@ class SpannerClientTest extends SnippetTestCase
         $this->assertInstanceOf(SpannerClient::class, $res->returnVal());
         $this->assertEquals('localhost:9010', getenv('SPANNER_EMULATOR_HOST'));
     }
+
+    public function testConnectWithDatabaseRole()
+    {
+        $snippet = $this->snippetFromMethod(SpannerClient::class, 'connect', 1);
+        $snippet->addLocal('spanner', $this->client);
+
+        $res = $snippet->invoke('database');
+        $this->assertInstanceOf(Database::class, $res->returnVal());
+    }
+
+    public function testBatchWithDatabaseRole()
+    {
+        $snippet = $this->snippetFromMethod(SpannerClient::class, 'batch', 1);
+        $snippet->addLocal('spanner', $this->client);
+        $res = $snippet->invoke('batch');
+        $this->assertInstanceOf(BatchClient::class, $res->returnVal());
+    }
 }

--- a/Spanner/tests/System/BatchTest.php
+++ b/Spanner/tests/System/BatchTest.php
@@ -19,10 +19,10 @@ namespace Google\Cloud\Spanner\Tests\System;
 
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
+use Google\Cloud\Spanner\Admin\Database\V1\DatabaseDialect;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Core\Exception\ServiceException;
-use Google\Cloud\Spanner\Admin\Database\V1\DatabaseDialect;
 
 /**
  * @group spanner
@@ -127,7 +127,8 @@ class BatchTest extends SpannerTestCase
     {
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
-        
+
+        $error = null;
         $query = 'SELECT
                 id,
                 decade
@@ -152,10 +153,12 @@ class BatchTest extends SpannerTestCase
         try {
             $partitions = $snapshot->partitionQuery($query, ['parameters' => $parameters]);
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
 
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+        
         $snapshot->close();
     }
 

--- a/Spanner/tests/System/OperationsTest.php
+++ b/Spanner/tests/System/OperationsTest.php
@@ -203,6 +203,7 @@ class OperationsTest extends SpannerTestCase
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
         
+        $error = null;
         $db = self::$databaseWithReaderDatabaseRole;
 
         try {
@@ -212,9 +213,11 @@ class OperationsTest extends SpannerTestCase
                 'birthday' => new Date(new \DateTime('2000-01-01'))
             ]);
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
+
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
     }
 
     public function testInsertWithRestrictiveDatabaseRole()
@@ -222,6 +225,7 @@ class OperationsTest extends SpannerTestCase
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
         
+        $error = null;
         $db = self::$databaseWithReaderDatabaseRole;
 
         try {
@@ -231,9 +235,11 @@ class OperationsTest extends SpannerTestCase
                 'birthday' => new Date(new \DateTime('2000-01-01'))
             ]);
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
+
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
     }
 
     public function testReadWithDatabaseRole()
@@ -258,6 +264,7 @@ class OperationsTest extends SpannerTestCase
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
         
+        $error = null;
         $db = self::$databaseWithRestrictiveDatabaseRole;
 
         $keySet = self::$client->keySet([
@@ -269,9 +276,11 @@ class OperationsTest extends SpannerTestCase
             $res = $db->read(self::TEST_TABLE_NAME, $keySet, $columns);
             $row = $res->rows()->current();
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
+
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
     }
 
     private function getRow()

--- a/Spanner/tests/System/OperationsTest.php
+++ b/Spanner/tests/System/OperationsTest.php
@@ -200,6 +200,9 @@ class OperationsTest extends SpannerTestCase
 
     public function testInsertWithDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+        
         $db = self::$databaseWithReaderDatabaseRole;
 
         try {
@@ -216,6 +219,9 @@ class OperationsTest extends SpannerTestCase
 
     public function testInsertWithRestrictiveDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+        
         $db = self::$databaseWithReaderDatabaseRole;
 
         try {
@@ -232,6 +238,9 @@ class OperationsTest extends SpannerTestCase
 
     public function testReadWithDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+        
         $db = self::$databaseWithReaderDatabaseRole;
 
         $keySet = self::$client->keySet([
@@ -246,6 +255,9 @@ class OperationsTest extends SpannerTestCase
 
     public function testReadWithRestrictiveDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+        
         $db = self::$databaseWithRestrictiveDatabaseRole;
 
         $keySet = self::$client->keySet([

--- a/Spanner/tests/System/SpannerTestCase.php
+++ b/Spanner/tests/System/SpannerTestCase.php
@@ -82,38 +82,40 @@ class SpannerTestCase extends SystemTestCase
             ON ' . self::TEST_TABLE_NAME . ' (name)'
         )->pollUntilComplete();
 
-        $db->updateDdl(
-            'CREATE ROLE ' . self::DATABASE_ROLE
-        )->pollUntilComplete();
-        $db->updateDdl(
-            'CREATE ROLE ' . self::RESTRICTIVE_DATABASE_ROLE
-        )->pollUntilComplete();
-
-        $db->updateDdl(
-            'GRANT SELECT ON TABLE ' . self::TEST_TABLE_NAME . ' TO ROLE ' . self::DATABASE_ROLE
-        )->pollUntilComplete();
-        $db->updateDdl(
-            'GRANT SELECT(id, name), INSERT(id, name), UPDATE(id, name) ON TABLE '
-            . self::TEST_TABLE_NAME . ' TO ROLE ' . self::RESTRICTIVE_DATABASE_ROLE
-        )->pollUntilComplete();
-
         self::$database = $db;
         self::$database2 = self::getDatabaseInstance(self::$dbName);
 
-        self::$databaseWithReaderDatabaseRole = self::getDatabaseFromInstance(
-            self::$dbName,
-            ['databaseRole' => self::DATABASE_ROLE]
-        );
+        if ($db->info()['databaseDialect'] == DatabaseDialect::GOOGLE_STANDARD_SQL) {
+            $db->updateDdl(
+                'CREATE ROLE ' . self::DATABASE_ROLE
+            )->pollUntilComplete();
+            $db->updateDdl(
+                'CREATE ROLE ' . self::RESTRICTIVE_DATABASE_ROLE
+            )->pollUntilComplete();
 
-        self::$databaseWithRestrictiveDatabaseRole = self::getDatabaseInstance(
-            self::$dbName,
-            ['databaseRole' => self::RESTRICTIVE_DATABASE_ROLE]
-        );
+            $db->updateDdl(
+                'GRANT SELECT ON TABLE ' . self::TEST_TABLE_NAME . ' TO ROLE ' . self::DATABASE_ROLE
+            )->pollUntilComplete();
+            $db->updateDdl(
+                'GRANT SELECT(id, name), INSERT(id, name), UPDATE(id, name) ON TABLE '
+                . self::TEST_TABLE_NAME . ' TO ROLE ' . self::RESTRICTIVE_DATABASE_ROLE
+            )->pollUntilComplete();
 
-        self::$databaseWithSessionPoolRestrictiveDatabaseRole = self::getDatabaseWithSessionPool(
-            self::$dbName,
-            ['minSessions' => 1, 'maxSession' => 2, 'databaseRole' => self::RESTRICTIVE_DATABASE_ROLE]
-        );
+            self::$databaseWithReaderDatabaseRole = self::getDatabaseFromInstance(
+                self::$dbName,
+                ['databaseRole' => self::DATABASE_ROLE]
+            );
+
+            self::$databaseWithRestrictiveDatabaseRole = self::getDatabaseInstance(
+                self::$dbName,
+                ['databaseRole' => self::RESTRICTIVE_DATABASE_ROLE]
+            );
+
+            self::$databaseWithSessionPoolRestrictiveDatabaseRole = self::getDatabaseWithSessionPool(
+                self::$dbName,
+                ['minSessions' => 1, 'maxSession' => 2, 'databaseRole' => self::RESTRICTIVE_DATABASE_ROLE]
+            );
+        }
 
         self::$hasSetUp = true;
     }

--- a/Spanner/tests/System/SpannerTestCase.php
+++ b/Spanner/tests/System/SpannerTestCase.php
@@ -102,6 +102,7 @@ class SpannerTestCase extends SystemTestCase
             )->pollUntilComplete();
 
             self::$databaseWithReaderDatabaseRole = self::getDatabaseFromInstance(
+                self::INSTANCE_NAME,
                 self::$dbName,
                 ['databaseRole' => self::DATABASE_ROLE]
             );
@@ -154,23 +155,17 @@ class SpannerTestCase extends SystemTestCase
 
     public static function getDatabaseInstance($dbName, $options = [])
     {
-        $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-
         return self::$client->connect(self::INSTANCE_NAME, $dbName, $options);
     }
 
-    public static function getDatabaseFromInstance($dbName, $options = [])
+    public static function getDatabaseFromInstance($instance, $dbName, $options = [])
     {
-        $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-
-        $instance = self::$client->instance(self::INSTANCE_NAME);
+        $instance = self::$client->instance($instance);
         return $instance->database($dbName, $options);
     }
 
     public static function getDatabaseWithSessionPool($dbName, $options = [])
     {
-        $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-
         $sessionCache = new MemoryCacheItemPool;
         $sessionPool = new CacheSessionPool(
             $sessionCache,

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -19,8 +19,8 @@ namespace Google\Cloud\Spanner\Tests\System;
 
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\KeySet;
-use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Spanner\Timestamp;
 
 /**
  * @group spanner
@@ -31,9 +31,8 @@ class TransactionTest extends SpannerTestCase
     const TABLE_NAME = 'Transactions';
 
     private static $row = [];
-
+    
     private static $tableName;
-
     private static $id1;
 
     public static function set_up_before_class()
@@ -221,11 +220,12 @@ class TransactionTest extends SpannerTestCase
         $this->assertInstanceOf(Timestamp::class, $snapshot->readTimestamp());
     }
 
-    public function testRunTransactionWithDatabaseRole()
+    public function testRunTransactionWithRestrictiveDatabaseRole()
     {
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
         
+        $error = null;
         $db = self::$databaseWithRestrictiveDatabaseRole;
 
         $row = $this->getRow();
@@ -251,9 +251,11 @@ class TransactionTest extends SpannerTestCase
                 $t->commit();
             });
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
+
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
     }
 
     public function testRunTransactionWithSessionPoolDatabaseRole()
@@ -261,6 +263,7 @@ class TransactionTest extends SpannerTestCase
         // Emulator does not support FGAC
         $this->skipEmulatorTests();
 
+        $error = null;
         $db = self::$databaseWithSessionPoolRestrictiveDatabaseRole;
 
         $row = $this->getRow();
@@ -286,9 +289,11 @@ class TransactionTest extends SpannerTestCase
                 $t->commit();
             });
         } catch (ServiceException $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+            $error = $e;
         }
+
+        $this->assertInstanceOf(ServiceException::class, $error);
+        $this->assertEquals($error->getServiceException()->getStatus(), 'PERMISSION_DENIED');
     }
 
     private function readArgs()

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Spanner\Tests\System;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Timestamp;
+use Google\Cloud\Core\Exception\ServiceException;
 
 /**
  * @group spanner
@@ -33,14 +34,17 @@ class TransactionTest extends SpannerTestCase
 
     private static $tableName;
 
+    private static $id1;
+
     public static function set_up_before_class()
     {
         parent::set_up_before_class();
 
         self::$tableName = uniqid(self::TABLE_NAME);
+        self::$id1 = rand(1000, 9999);
 
         self::$row = [
-            'id' => rand(1000, 9999),
+            'id' => self::$id1,
             'name' => uniqid(self::TESTING_PREFIX),
             'birthday' => new Date(new \DateTime('2000-01-01'))
         ];
@@ -217,6 +221,70 @@ class TransactionTest extends SpannerTestCase
         $this->assertInstanceOf(Timestamp::class, $snapshot->readTimestamp());
     }
 
+    public function testRunTransactionWithDatabaseRole()
+    {
+        $db = self::$databaseWithRestrictiveDatabaseRole;
+
+        $row = $this->getRow();
+        $row['name'] = 'Doug';
+
+        $db->runTransaction(function ($t) use ($row) {
+            $t->update('Users', $row);
+
+            $t->commit();
+        });
+        $row = $this->getRow();
+        $this->assertEquals('Doug', $row['name']);
+
+        try {
+            $db->runTransaction(function ($t) {
+                $id = rand(1, 346464);
+                $t->insert(self::TEST_TABLE_NAME, [
+                    'id' => $id,
+                    'name' => uniqid(self::TESTING_PREFIX),
+                    'birthday' => new Date(new \DateTime)
+                ]);
+
+                $t->commit();
+            });
+        } catch (ServiceException $e) {
+            $this->assertInstanceOf(ServiceException::class, $e);
+            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+        }
+    }
+
+    public function testRunTransactionWithSessionPoolDatabaseRole()
+    {
+        $db = self::$databaseWithSessionPoolRestrictiveDatabaseRole;
+
+        $row = $this->getRow();
+        $row['name'] = 'Doug';
+
+        $db->runTransaction(function ($t) use ($row) {
+            $t->update('Users', $row);
+
+            $t->commit();
+        });
+        $row = $this->getRow();
+        $this->assertEquals('Doug', $row['name']);
+
+        try {
+            $db->runTransaction(function ($t) {
+                $id = rand(1, 346464);
+                $t->insert(self::TEST_TABLE_NAME, [
+                    'id' => $id,
+                    'name' => uniqid(self::TESTING_PREFIX),
+                    'birthday' => new Date(new \DateTime)
+                ]);
+
+                $t->commit();
+            });
+        } catch (ServiceException $e) {
+            $this->assertInstanceOf(ServiceException::class, $e);
+            $this->assertEquals($e->getServiceException()->getStatus(), 'PERMISSION_DENIED');
+        }
+    }
+
     private function readArgs()
     {
         return [
@@ -225,5 +293,17 @@ class TransactionTest extends SpannerTestCase
             ]),
             array_keys(self::$row)
         ];
+    }
+
+    private function getRow()
+    {
+        $db = self::$database;
+        $res = $db->execute('SELECT id, name FROM ' . self::TEST_TABLE_NAME . ' WHERE id=@id', [
+            'parameters' => [
+                'id' => self::$id1
+            ]
+        ]);
+
+        return $res->rows()->current();
     }
 }

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -223,6 +223,9 @@ class TransactionTest extends SpannerTestCase
 
     public function testRunTransactionWithDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+        
         $db = self::$databaseWithRestrictiveDatabaseRole;
 
         $row = $this->getRow();
@@ -255,6 +258,9 @@ class TransactionTest extends SpannerTestCase
 
     public function testRunTransactionWithSessionPoolDatabaseRole()
     {
+        // Emulator does not support FGAC
+        $this->skipEmulatorTests();
+
         $db = self::$databaseWithSessionPoolRestrictiveDatabaseRole;
 
         $row = $this->getRow();

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -31,7 +31,7 @@ class TransactionTest extends SpannerTestCase
     const TABLE_NAME = 'Transactions';
 
     private static $row = [];
-    
+
     private static $tableName;
     private static $id1;
 

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -77,6 +77,7 @@ class DatabaseTest extends TestCase
     private $lroCallables;
     private $database;
     private $session;
+    private $databaseWithDatabaseRole;
 
 
     public function set_up()
@@ -129,6 +130,20 @@ class DatabaseTest extends TestCase
         ];
 
         $this->database = TestHelpers::stub(Database::class, $args, $props);
+
+        $args = [
+            $this->connection->reveal(),
+            $this->instance,
+            $this->lro->reveal(),
+            $this->lroCallables,
+            self::PROJECT,
+            self::DATABASE,
+            null,
+            false,
+            [],
+            'Reader'
+        ];
+        $this->databaseWithDatabaseRole = TestHelpers::stub(Database::class, $args, $props);
     }
 
     public function testName()
@@ -1385,5 +1400,20 @@ class DatabaseTest extends TestCase
         return function () {
             return;
         };
+    }
+
+    public function testDBDatabaseRole()
+    {
+        $this->connection->createSession(Argument::withEntry(
+            'session',
+            ['labels' => [], 'creator_role' => 'Reader']
+        ))
+        ->shouldBeCalled()
+        ->willReturn([
+                'name' => $this->session->name()
+            ]);
+
+        $sql = 'SELECT * FROM Table';
+        $this->databaseWithDatabaseRole->execute($sql);
     }
 }

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -122,7 +122,10 @@ class DatabaseTest extends TestCase
             $this->lroCallables,
             self::PROJECT,
             self::DATABASE,
-            $this->sessionPool->reveal()
+            $this->sessionPool->reveal(),
+            false,
+            [],
+            'Reader'
         ];
 
         $props = [
@@ -130,19 +133,7 @@ class DatabaseTest extends TestCase
         ];
 
         $this->database = TestHelpers::stub(Database::class, $args, $props);
-
-        $args = [
-            $this->connection->reveal(),
-            $this->instance,
-            $this->lro->reveal(),
-            $this->lroCallables,
-            self::PROJECT,
-            self::DATABASE,
-            null,
-            false,
-            [],
-            'Reader'
-        ];
+        $args[6] = null;
         $this->databaseWithDatabaseRole = TestHelpers::stub(Database::class, $args, $props);
     }
 

--- a/Spanner/tests/Unit/InstanceTest.php
+++ b/Spanner/tests/Unit/InstanceTest.php
@@ -30,7 +30,6 @@ use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Tests\StubCreationTrait;
 use Google\Cloud\Spanner\Backup;
-use PHPUnit\Framework\Assert;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -43,7 +43,6 @@ use Google\Cloud\Spanner\Timestamp;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
-use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 
 /**
  * @group spanner

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -43,6 +43,7 @@ use Google\Cloud\Spanner\Timestamp;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Prophecy\Argument;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 
 /**
  * @group spanner
@@ -60,6 +61,7 @@ class SpannerClientTest extends TestCase
 
     private $client;
     private $connection;
+    private $instance;
 
     public function set_up()
     {
@@ -69,6 +71,10 @@ class SpannerClientTest extends TestCase
         $this->client = TestHelpers::stub(SpannerClient::class, [
             ['projectId' => self::PROJECT]
         ]);
+        $this->client = TestHelpers::stub(SpannerClient::class, [
+            ['projectId' => self::PROJECT]
+        ]);
+        $this->instance = $this->prophesize(Instance::class);
     }
 
     public function testBatch()
@@ -435,5 +441,11 @@ class SpannerClientTest extends TestCase
     {
         $t = $this->client->commitTimestamp();
         $this->assertInstanceOf(CommitTimestamp::class, $t);
+    }
+
+    public function testSpannerClientDatabaseRole()
+    {
+        $this->instance->database(Argument::any(), ['databaseRole' => 'Reader'])->shouldBeCalled();
+        $this->client->connect($this->instance->reveal(), self::DATABASE, ['databaseRole' => 'Reader']);
     }
 }

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -60,7 +60,6 @@ class SpannerClientTest extends TestCase
 
     private $client;
     private $connection;
-    private $instance;
 
     public function set_up()
     {
@@ -70,10 +69,6 @@ class SpannerClientTest extends TestCase
         $this->client = TestHelpers::stub(SpannerClient::class, [
             ['projectId' => self::PROJECT]
         ]);
-        $this->client = TestHelpers::stub(SpannerClient::class, [
-            ['projectId' => self::PROJECT]
-        ]);
-        $this->instance = $this->prophesize(Instance::class);
     }
 
     public function testBatch()
@@ -444,7 +439,8 @@ class SpannerClientTest extends TestCase
 
     public function testSpannerClientDatabaseRole()
     {
-        $this->instance->database(Argument::any(), ['databaseRole' => 'Reader'])->shouldBeCalled();
-        $this->client->connect($this->instance->reveal(), self::DATABASE, ['databaseRole' => 'Reader']);
+        $instance = $this->prophesize(Instance::class);
+        $instance->database(Argument::any(), ['databaseRole' => 'Reader'])->shouldBeCalled();
+        $this->client->connect($instance->reveal(), self::DATABASE, ['databaseRole' => 'Reader']);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -69,11 +69,7 @@
         "google/cloud-tools": "^0.13.0",
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
-<<<<<<< HEAD
         "rg/avro-php": "^1.8.0||^2.0.1||^3.0.0",
-=======
-        "rg/avro-php": "^1.8.0",
->>>>>>> 454622f3943 (temp commit just to resolve pr issues)
         "symfony/yaml": "^3.3||^6.0"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,11 @@
         "google/cloud-tools": "^0.13.0",
         "opis/closure": "^3.0",
         "swaggest/json-schema": "^0.12.0",
+<<<<<<< HEAD
         "rg/avro-php": "^1.8.0||^2.0.1||^3.0.0",
+=======
+        "rg/avro-php": "^1.8.0",
+>>>>>>> 454622f3943 (temp commit just to resolve pr issues)
         "symfony/yaml": "^3.3||^6.0"
     },
     "replace": {


### PR DESCRIPTION
This PR add the FGAC support for PHP Spanner library.

The FGAC integration tests are skipped in the emulator since it has not yet implemented the FGAC support.

Other languages also skips the same. Ref: https://github.com/googleapis/google-cloud-ruby/pull/19067/files#diff-3bf69404604fe1c87333533412f6e24d5867aab51a726e98843ebd63cd39b3a5R28