### PR TITLE
chore: documentation fix for bulkwriter

### DIFF
--- a/Firestore/src/BulkWriter.php
+++ b/Firestore/src/BulkWriter.php
@@ -218,7 +218,7 @@ class BulkWriter
      *     upgrading.
      *
      *     For legacy reasons if provided as `string` or `null`, its assumed
-     *     to be transaction id for {@see Google\Cloud\Firestore\WriteBatch}.
+     *     to be transaction id for Google\Cloud\Firestore\WriteBatch.
      *
      *     @type int $maxBatchSize Maximum number of requests per BulkWriter batch.
      *           **Defaults to** `20`.

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -33,7 +33,7 @@ if (false) {
  * $firestore = new FirestoreClient();
  * $batch = $firestore->batch();
  * ```
- * This class is deprecated. Use  {@see Google\Cloud\Firestore\BulkWriter} instead.
+ * This class is deprecated. Use Google\Cloud\Firestore\BulkWriter instead.
  * @deprecated
  */
     class WriteBatch


### PR DESCRIPTION
Fixes documentation for bulkwriter docs:

1. [Link on main](https://googleapis.github.io/google-cloud-php/#/docs/google-cloud/main/firestore/writebatch) vs now:

![writebatch doc](https://user-images.githubusercontent.com/7369612/203516734-974c7e5b-6d30-43b1-af75-50c42472fa8e.png)



2. [Link on main](https://googleapis.github.io/google-cloud-php/#/docs/google-cloud/main/firestore/bulkwriter?method=__construct) vs now:

![bulkwriter doc](https://user-images.githubusercontent.com/7369612/203516787-40accf5e-ce35-4b02-a2e3-f3d3a9890c7e.png)
