### PR TITLE
fix: added memory limit to phpunit

### DIFF
--- a/.kokoro/continuous/run-tests.sh
+++ b/.kokoro/continuous/run-tests.sh
@@ -47,8 +47,8 @@ vendor/bin/phpunit -c phpunit-snippets.xml.dist --verbose --log-junit \
                    ${SNIPPETS_LOG_FILENAME}
 
 echo "Running System Test Suite"
-vendor/bin/phpunit -c phpunit${PHPUNIT_SUFFIX}-system.xml.dist --verbose --log-junit \
-                   ${SYSTEM_LOG_FILENAME}
+vendor/bin/phpunit -d memory_limit=512M -c phpunit${PHPUNIT_SUFFIX}-system.xml.dist \
+                   --verbose --log-junit ${SYSTEM_LOG_FILENAME}
 
 echo "Running package integration Test"
 


### PR DESCRIPTION
In order to fix the build flag of this repo (https://github.com/googleapis/google-cloud-php/issues/5535), I tried updating the memory limit in test php images, https://github.com/googleapis/testing-infra-docker/pull/250 but the build fails.

So, as a fix, I am adding memory limit in the `phpunit` command.