### PR TITLE
chore(docs): configure automerge for python non-major dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
                 "symfony/console"
             ],
             "allowedVersions": "< 4.0"
+        },
+        {
+            "matchDatasources": ["pypi"],
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "python non-major dependencies",
+            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
Currently, we only use python in Cloud RAD for calling `docsuploader`, which uploads the zip files to GCS. This is a very small part of the process, and yet, we get [constant requests](https://github.com/googleapis/google-cloud-php/blob/main/.kokoro/docs/docker/requirements.txt) from renovate to keep these deps up-to-date. 

This PR configures minor/patch updates to python dependencies to be bundled in a single PR and automerged. This should help cut down on the noise from minor updates made to transitive dependencies in `.kokoro/docs/docker/requirements.txt`