### PR TITLE
chore: remove build from gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-build/
 composer.phar
 composer.lock
 composer-local.*


### PR DESCRIPTION
the `build/` entry in `.gitignore` conflicts with the `Build` component on case-insensitive filesystems like MacOSX