### PR TITLE
chore(docs): escape HTML entities

### DIFF
--- a/dev/src/DocFx/Node/DocblockTrait.php
+++ b/dev/src/DocFx/Node/DocblockTrait.php
@@ -37,6 +37,7 @@ trait DocblockTrait
             $content .= $longDescription;
         }
 
+        $content = html_entity_decode($content);
         $content = $this->replaceSeeTag($content);
         $content = $this->replaceProtoRef($content);
         $content = $this->stripSnippetTag($content);

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -10,16 +10,16 @@ items:
       search. It uses the following resource model:
       
       - The API has a collection of <xref uid="\Google\Cloud\Vision\V1\ProductSet">ProductSet</xref> resources, named
-      `projects/&#42;/locations/&#42;/productSets/*`, which acts as a way to put different
+      `projects/*/locations/*/productSets/*`, which acts as a way to put different
       products into groups to limit identification.
       
       In parallel,
       
       - The API has a collection of <xref uid="\Google\Cloud\Vision\V1\Product">Product</xref> resources, named
-      `projects/&#42;/locations/&#42;/products/*`
+      `projects/*/locations/*/products/*`
       
       - Each <xref uid="\Google\Cloud\Vision\V1\Product">Product</xref> has a collection of <xref uid="\Google\Cloud\Vision\V1\ReferenceImage">ReferenceImage</xref> resources, named
-      `projects/&#42;/locations/&#42;/products/&#42;/referenceImages/*`
+      `projects/*/locations/*/products/*/referenceImages/*`
       
       This class provides the ability to make remote calls to the backing service through method
       calls that map to API methods. Sample code to get started:


### PR DESCRIPTION
(potentially) temporary fix for https://github.com/googleapis/gapic-generator-php/issues/546

See https://github.com/protocolbuffers/protobuf/pull/11208 

Fixes difficult-to-read HTML escaping in [our public documentation](https://cloud.google.com/php/docs/reference/cloud-vision/latest/V1.ProductSearchClient) from
```
projects/&#42;&#47;{table_location=instances/&#42;}/tables/&#42;
```
to
```
projects/*/{table_location=instances/*}/tables/*
```