### PR TITLE
chore: use new samples in cloud RAD

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,0 +1,2 @@
+ignoreFiles:
+  - dev/tests/fixtures/**

--- a/.kokoro/docs/publish.sh
+++ b/.kokoro/docs/publish.sh
@@ -4,7 +4,7 @@
 if [ "$#" -eq 1 ]; then
     STAGING_BUCKET=$1
 elif [ "$#" -ne 0 ]; then
-    echo "usage: build-docs.sh [STAGING_BUCKET]"
+    echo "usage: publish.sh [STAGING_BUCKET]"
     exit 1;
 fi
 

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -42,6 +42,7 @@ class DocFx extends Command
             ->addOption('out', '', InputOption::VALUE_REQUIRED, 'Path where to store the generated output.', 'out')
             ->addOption('metadata-version', '', InputOption::VALUE_REQUIRED, 'version to write to docs.metadata using docuploader')
             ->addOption('staging-bucket', '', InputOption::VALUE_REQUIRED, 'Upload to the specified staging bucket using docuploader.')
+            ->addOption('component-path', '', InputOption::VALUE_OPTIONAL, 'Specify the path of the desired component.')
         ;
     }
 
@@ -52,7 +53,8 @@ class DocFx extends Command
         }
 
         $component = $input->getOption('component') ?: basename(getcwd());
-        $componentPath = $this->checkComponent($component);
+        $componentPath = $input->getOption('component-path') ?: $this->getComponentPath($component);
+        $this->validateComponentFiles($componentPath, $component);
         $output->writeln(sprintf('Generating documentation for <options=bold;fg=white>%s</>', $component));
         $xml = $input->getOption('xml');
         $outDir = $input->getOption('out');
@@ -93,7 +95,12 @@ class DocFx extends Command
         $tocItems = [];
         $packageDescription = $this->getPackageDescription();
         foreach ($this->getNamespaces() as $namespace) {
-            $pageTree = new PageTree($xml, $namespace, $packageDescription);
+            $pageTree = new PageTree(
+                $xml,
+                $namespace,
+                $packageDescription,
+                $componentPath
+            );
 
             foreach ($pageTree->getPages() as $page) {
                 $docFxArray = ['items' => $page->getItems()];
@@ -171,7 +178,7 @@ class DocFx extends Command
         }
     }
 
-    private function checkComponent(string $component): string
+    private function getComponentPath(string $component): string
     {
         $rootDir = __DIR__ . '/../../../../';
 
@@ -193,6 +200,11 @@ class DocFx extends Command
             throw new RuntimeException(sprintf('component "%s" not found', $component));
         }
 
+        return $componentPath;
+    }
+
+    private function validateComponentFiles(string $componentPath, string $component)
+    {
         $composerPath = $componentPath . '/composer.json';
         if (!file_exists($composerPath)) {
             throw new RuntimeException(sprintf('composer.json not found for component "%s"', $component));
@@ -208,8 +220,6 @@ class DocFx extends Command
         if (!$this->repoMetadataJson = json_decode(file_get_contents($repoMetadataPath), true)) {
             throw new RuntimeException(sprintf('Invalid .repo-metadata.json for component "%s"', $component));
         }
-
-        return $componentPath;
     }
 
     private function getReleaseLevel(): string

--- a/dev/src/DocFx/Command/DocFx.php
+++ b/dev/src/DocFx/Command/DocFx.php
@@ -42,7 +42,12 @@ class DocFx extends Command
             ->addOption('out', '', InputOption::VALUE_REQUIRED, 'Path where to store the generated output.', 'out')
             ->addOption('metadata-version', '', InputOption::VALUE_REQUIRED, 'version to write to docs.metadata using docuploader')
             ->addOption('staging-bucket', '', InputOption::VALUE_REQUIRED, 'Upload to the specified staging bucket using docuploader.')
-            ->addOption('component-path', '', InputOption::VALUE_OPTIONAL, 'Specify the path of the desired component.')
+            ->addOption(
+                'component-path',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'Specify the path of the desired component. Please note, this option is only intended for testing purposes.
+            ')
         ;
     }
 

--- a/dev/src/DocFx/Node/DocblockTrait.php
+++ b/dev/src/DocFx/Node/DocblockTrait.php
@@ -27,7 +27,6 @@ trait DocblockTrait
         if (empty($this->xmlNode->docblock)) {
             return '';
         }
-        $docblockNode = $this->xmlNode->docblock;
 
         $content = $this->getDescription();
         if ($longDescription = $this->getLongDescription()) {

--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -113,10 +113,10 @@ class Page
      * method docblocks to link out to the generated samples and remove the
      * inline ones.
      *
-     * @param string $content
+     * @param string $methodDocContent
      * @param string $methodName
      */
-    private function handleSample(string $content, string $methodName): array
+    private function handleSample(string $methodDocContent, string $methodName): array
     {
         $sample = null;
         $path = sprintf(
@@ -125,10 +125,10 @@ class Page
             substr($this->filePath, 0, -4),
             $this->toSnakeCase($methodName)
         );
-        $contents = @file_get_contents($path);
-        if ($contents) {
+        $sampleContents = @file_get_contents($path);
+        if ($sampleContents) {
             // Finds the relevant code between the region tags in the generated sample.
-            if (preg_match('/\/\/ \[START\N*\n(.*?)\/\/ \[END/s', $contents, $match) === 1) {
+            if (preg_match('/\/\/ \[START\N*\n(.*?)\/\/ \[END/s', $sampleContents, $match) === 1) {
                 // Generated samples include the method description, which is redundant on the doc
                 // site. This removes the description.
                 $sample = preg_replace(
@@ -138,14 +138,14 @@ class Page
                 );
                 $sample = '```php' . PHP_EOL . $sample . '```';
                 // Removes the existing inline snippet.
-                $content = preg_replace(
+                $methodDocContent = preg_replace(
                     '/Sample code:\n```php.*```/s',
                     '',
-                    $content
+                    $methodDocContent
                 );
             }
         }
-        return [$content, $sample];
+        return [$methodDocContent, $sample];
     }
 
     private function getMethodItems(): array

--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -136,7 +136,7 @@ class Page
                     '$1 * $3',
                     $match[1]
                 );
-                $sample = 'Sample code:' . PHP_EOL . '```php' . PHP_EOL . $sample . '```';
+                $sample = '```php' . PHP_EOL . $sample . '```';
                 // Removes the existing inline snippet.
                 $content = preg_replace(
                     '/Sample code:\n```php.*```/s',

--- a/dev/src/DocFx/Page/PageTree.php
+++ b/dev/src/DocFx/Page/PageTree.php
@@ -27,12 +27,12 @@ use SimpleXMLElement;
 class PageTree
 {
     private array $pages;
-    private string $filePath;
 
     public function __construct(
         private string $xmlPath,
         private string $namespace,
-        private string $packageDescription
+        private string $packageDescription,
+        private string $componentPath
     ) {}
 
     public function getPages(): array
@@ -105,7 +105,12 @@ class PageTree
                 continue;
             }
 
-            $pageMap[$fullName] = new Page($classNode, $file['path'], $this->packageDescription);
+            $pageMap[$fullName] = new Page(
+                $classNode,
+                $file['path'],
+                $this->packageDescription,
+                $this->componentPath
+            );
         }
 
         /**

--- a/dev/tests/Unit/DocFx/CommandTest.php
+++ b/dev/tests/Unit/DocFx/CommandTest.php
@@ -17,11 +17,8 @@
 
 namespace Google\Cloud\Dev\Tests\Unit\DocFx;
 
-use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Dev\ComponentManager;
 use Google\Cloud\Dev\DocFx\Page\OverviewPage;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * @group dev
@@ -37,7 +34,6 @@ class CommandTest extends TestCase
         $generatedFiles = array_diff(scandir(self::$tmpDir), ['..', '.']);
 
         $this->assertEquals([], array_diff($fixturesFiles, $generatedFiles));
-
     }
 
     /**
@@ -108,12 +104,14 @@ class CommandTest extends TestCase
     public function provideDocFxFiles()
     {
         $structureXml = __DIR__ . '/../../fixtures/phpdoc/structure.xml';
+        $componentDir = __DIR__ . '/../../fixtures/component/Vision';
         $tmpDir = sys_get_temp_dir() . '/' . rand();
         $cmd = sprintf(
-            '%s/google-cloud docfx --component Vision --xml %s --out=%s --metadata-version=1.0.0',
+            '%s/google-cloud docfx --component Vision --xml %s --out=%s --metadata-version=1.0.0 --component-path=%s',
             __DIR__ . '/../../../',
             $structureXml,
-            $tmpDir
+            $tmpDir,
+            $componentDir
         );
         passthru($cmd);
 

--- a/dev/tests/Unit/DocFx/PageTest.php
+++ b/dev/tests/Unit/DocFx/PageTest.php
@@ -42,7 +42,8 @@ class PageTest extends TestCase
             file_get_contents(__DIR__ . '/../../fixtures/phpdoc/service.xml')
         );
         $classNode = new ClassNode(new SimpleXMLElement($serviceXml));
-        $page = new Page($classNode, '', $packageDescription);
+        $componentPath = __DIR__ . '/../../fixtures/component/Vision';
+        $page = new Page($classNode, '', $packageDescription, $componentPath);
 
         $this->assertEquals($expected, $page->getItems()[0]['friendlyApiName']);
     }
@@ -64,7 +65,8 @@ class PageTest extends TestCase
     public function testLoadPagesProtoPackages()
     {
         $structureXml = __DIR__ . '/../../fixtures/phpdoc/structure.xml';
-        $pageTree = new PageTree($structureXml, 'Google\Cloud\Vision', '');
+        $componentPath = __DIR__ . '/../../fixtures/component/Vision';
+        $pageTree = new PageTree($structureXml, 'Google\Cloud\Vision', '', $componentPath);
 
         $pages = $pageTree->getPages();
         $this->assertTrue(count($pages) > 0);

--- a/dev/tests/fixtures/component/Vision/.repo-metadata.json
+++ b/dev/tests/fixtures/component/Vision/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+    "distribution_name": "google/cloud-vision",
+    "release_level": "ga",
+    "client_documentation": "http://googleapis.github.io/google-cloud-php/#/docs/cloud-vision/latest",
+    "library_type": "GAPIC_COMBO"
+}

--- a/dev/tests/fixtures/component/Vision/README.md
+++ b/dev/tests/fixtures/component/Vision/README.md
@@ -1,0 +1,70 @@
+# Google Cloud Vision for PHP
+
+> Idiomatic PHP client for [Cloud Vision](https://cloud.google.com/vision/).
+
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-vision/v/stable)](https://packagist.org/packages/google/cloud-vision) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-vision.svg)](https://packagist.org/packages/google/cloud-vision)
+
+* [API documentation](http://googleapis.github.io/google-cloud-php/#/docs/cloud-vision/latest)
+
+**NOTE:** This repository is part of [Google Cloud PHP](https://github.com/googleapis/google-cloud-php). Any
+support requests, bug reports, or development contributions should be directed to
+that project.
+
+Allows developers to easily integrate vision detection features within applications, including image labeling, face and
+landmark detection, optical character recognition (OCR), and tagging of explicit content.
+
+### Installation
+
+To begin, install the preferred dependency manager for PHP, [Composer](https://getcomposer.org/).
+
+Now to install just this component:
+
+```sh
+$ composer require google/cloud-vision
+```
+
+Or to install the entire suite of components at once:
+
+```sh
+$ composer require google/cloud
+```
+
+### Authentication
+
+Please see our [Authentication guide](https://github.com/googleapis/google-cloud-php/blob/main/AUTHENTICATION.md) for more information
+on authenticating your client. Once authenticated, you'll be ready to start making requests.
+
+### Sample
+
+```php
+require 'vendor/autoload.php';
+
+use Google\Cloud\Vision\V1\Feature\Type;
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+use Google\Cloud\Vision\V1\Likelihood;
+
+$client = new ImageAnnotatorClient();
+
+// Annotate an image, detecting faces.
+$annotation = $client->annotateImage(
+    fopen('/data/photos/family_photo.jpg', 'r'),
+    [Type::FACE_DETECTION]
+);
+
+// Determine if the detected faces have headwear.
+foreach ($annotation->getFaceAnnotations() as $faceAnnotation) {
+	$likelihood = Likelihood::name($faceAnnotation->getHeadwearLikelihood());
+    echo "Likelihood of headwear: $likelihood" . PHP_EOL;
+}
+```
+
+### Version
+
+This component is considered GA (generally available). As such, it will not introduce backwards-incompatible changes in
+any minor or patch releases. We will address issues and requests with the highest priority.
+
+### Next Steps
+
+1. Understand the [official documentation](https://cloud.google.com/vision/docs/).
+2. Take a look at [in-depth usage samples](https://github.com/GoogleCloudPlatform/php-docs-samples/tree/master/vision/).
+

--- a/dev/tests/fixtures/component/Vision/composer.json
+++ b/dev/tests/fixtures/component/Vision/composer.json
@@ -1,0 +1,43 @@
+{
+    "name": "google/cloud-vision",
+    "description": "Cloud Vision Client for PHP",
+    "license": "Apache-2.0",
+    "minimum-stability": "stable",
+    "require": {
+        "google/cloud-core": "^1.43",
+        "google/gax": "^1.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8|^5.0|^8.0",
+        "yoast/phpunit-polyfills": "^1.0",
+        "phpspec/prophecy": "^1.10.3",
+        "squizlabs/php_codesniffer": "2.*",
+        "phpdocumentor/reflection": "^3.0||^4.0",
+        "erusev/parsedown": "^1.6",
+        "google/cloud-storage": "^1.12"
+    },
+    "suggest": {
+        "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
+        "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.",
+        "google/cloud-storage": "Annotate images stored in Google Cloud Storage"
+    },
+    "extra": {
+        "component": {
+            "id": "cloud-vision",
+            "target": "googleapis/google-cloud-php-vision.git",
+            "path": "Vision",
+            "entry": "src/VisionClient.php"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Google\\Cloud\\Vision\\": "src",
+            "GPBMetadata\\Google\\Cloud\\Vision\\": "metadata"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Google\\Cloud\\Vision\\Tests\\": "tests"
+        }
+    }
+}

--- a/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_files.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_files.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\OperationResponse;
+use Google\Cloud\Vision\V1\AsyncAnnotateFileRequest;
+use Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse;
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+use Google\Rpc\Status;
+
+/**
+ * Run asynchronous image detection and annotation for a list of generic
+ * files, such as PDF files, which may contain multiple pages and multiple
+ * images per page. Progress and results can be retrieved through the
+ * `google.longrunning.Operations` interface.
+ * `Operation.metadata` contains `OperationMetadata` (metadata).
+ * `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function async_batch_annotate_files_sample(): void
+{
+    // Create a client.
+    $imageAnnotatorClient = new ImageAnnotatorClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $requests = [new AsyncAnnotateFileRequest()];
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var OperationResponse $response */
+        $response = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
+        $response->pollUntilComplete();
+
+        if ($response->operationSucceeded()) {
+            /** @var AsyncBatchAnnotateFilesResponse $result */
+            $result = $response->getResult();
+            printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+        } else {
+            /** @var Status $error */
+            $error = $response->getError();
+            printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_images.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_images.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\OperationResponse;
+use Google\Cloud\Vision\V1\AnnotateImageRequest;
+use Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse;
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+use Google\Cloud\Vision\V1\OutputConfig;
+use Google\Rpc\Status;
+
+/**
+ * Run asynchronous image detection and annotation for a list of images.
+ *
+ * Progress and results can be retrieved through the
+ * `google.longrunning.Operations` interface.
+ * `Operation.metadata` contains `OperationMetadata` (metadata).
+ * `Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
+ *
+ * This service will write image annotation outputs to json files in customer
+ * GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function async_batch_annotate_images_sample(): void
+{
+    // Create a client.
+    $imageAnnotatorClient = new ImageAnnotatorClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $requests = [new AnnotateImageRequest()];
+    $outputConfig = new OutputConfig();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var OperationResponse $response */
+        $response = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
+        $response->pollUntilComplete();
+
+        if ($response->operationSucceeded()) {
+            /** @var AsyncBatchAnnotateImagesResponse $result */
+            $result = $response->getResult();
+            printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+        } else {
+            /** @var Status $error */
+            $error = $response->getError();
+            printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_files.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_files.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ImageAnnotator_BatchAnnotateFiles_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\AnnotateFileRequest;
+use Google\Cloud\Vision\V1\BatchAnnotateFilesResponse;
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+
+/**
+ * Service that performs image detection and annotation for a batch of files.
+ * Now only "application/pdf", "image/tiff" and "image/gif" are supported.
+ *
+ * This service will extract at most 5 (customers can specify which 5 in
+ * AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
+ * file provided and perform detection and annotation for each image
+ * extracted.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function batch_annotate_files_sample(): void
+{
+    // Create a client.
+    $imageAnnotatorClient = new ImageAnnotatorClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $requests = [new AnnotateFileRequest()];
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var BatchAnnotateFilesResponse $response */
+        $response = $imageAnnotatorClient->batchAnnotateFiles($requests);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ImageAnnotator_BatchAnnotateFiles_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_images.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_images.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ImageAnnotator_BatchAnnotateImages_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\AnnotateImageRequest;
+use Google\Cloud\Vision\V1\BatchAnnotateImagesResponse;
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+
+/**
+ * Run image detection and annotation for a batch of images.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function batch_annotate_images_sample(): void
+{
+    // Create a client.
+    $imageAnnotatorClient = new ImageAnnotatorClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $requests = [new AnnotateImageRequest()];
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var BatchAnnotateImagesResponse $response */
+        $response = $imageAnnotatorClient->batchAnnotateImages($requests);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ImageAnnotator_BatchAnnotateImages_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/add_product_to_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/add_product_to_product_set.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_AddProductToProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Adds a Product to the specified ProductSet. If the Product is already
+ * present, no change is made.
+ *
+ * One Product can be added to at most 100 ProductSets.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+ *
+ * @param string $formattedName    The resource name for the ProductSet to modify.
+ *
+ *                                 Format is:
+ *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+ *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+ * @param string $formattedProduct The resource name for the Product to be added to this ProductSet.
+ *
+ *                                 Format is:
+ *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+ *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+ */
+function add_product_to_product_set_sample(string $formattedName, string $formattedProduct): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        $productSearchClient->addProductToProductSet($formattedName, $formattedProduct);
+        printf('Call completed successfully.' . PHP_EOL);
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+    $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+
+    add_product_to_product_set_sample($formattedName, $formattedProduct);
+}
+// [END vision_v1_generated_ProductSearch_AddProductToProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_product.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_product.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_CreateProduct_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\Product;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Creates and returns a new product resource.
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+ * characters.
+ * * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+ * * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+ *
+ * @param string $formattedParent The project in which the Product should be created.
+ *
+ *                                Format is
+ *                                `projects/PROJECT_ID/locations/LOC_ID`. Please see
+ *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function create_product_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $product = new Product();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var Product $response */
+        $response = $productSearchClient->createProduct($formattedParent, $product);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    create_product_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_CreateProduct_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_product_set.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_CreateProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ProductSet;
+
+/**
+ * Creates and returns a new ProductSet resource.
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+ * 4096 characters.
+ *
+ * @param string $formattedParent The project in which the ProductSet should be created.
+ *
+ *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+ *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function create_product_set_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $productSet = new ProductSet();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var ProductSet $response */
+        $response = $productSearchClient->createProductSet($formattedParent, $productSet);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    create_product_set_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_CreateProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_reference_image.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/create_reference_image.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_CreateReferenceImage_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ReferenceImage;
+
+/**
+ * Creates and returns a new ReferenceImage resource.
+ *
+ * The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+ * the system will try to detect regions of interest in the image that are
+ * compatible with the product_category on the parent product. If it is
+ * specified, detection is ALWAYS skipped. The system converts polygons into
+ * non-rotated rectangles.
+ *
+ * Note that the pipeline will resize the image if the image resolution is too
+ * large to process (above 50MP).
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+ * characters.
+ * * Returns INVALID_ARGUMENT if the product does not exist.
+ * * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+ * compatible with the parent product's product_category is detected.
+ * * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+ *
+ * @param string $formattedParent   Resource name of the product in which to create the reference image.
+ *
+ *                                  Format is
+ *                                  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+ *                                  {@see ProductSearchClient::productName()} for help formatting this field.
+ * @param string $referenceImageUri The Google Cloud Storage URI of the reference image.
+ *
+ *                                  The URI must start with `gs://`.
+ */
+function create_reference_image_sample(string $formattedParent, string $referenceImageUri): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $referenceImage = (new ReferenceImage())
+        ->setUri($referenceImageUri);
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var ReferenceImage $response */
+        $response = $productSearchClient->createReferenceImage($formattedParent, $referenceImage);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+    $referenceImageUri = '[URI]';
+
+    create_reference_image_sample($formattedParent, $referenceImageUri);
+}
+// [END vision_v1_generated_ProductSearch_CreateReferenceImage_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_product.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_product.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_DeleteProduct_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Permanently deletes a product and its reference images.
+ *
+ * Metadata of the product and all its images will be deleted right away, but
+ * search queries against ProductSets containing the product may still work
+ * until all related caches are refreshed.
+ *
+ * @param string $formattedName Resource name of product to delete.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+ *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+ */
+function delete_product_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        $productSearchClient->deleteProduct($formattedName);
+        printf('Call completed successfully.' . PHP_EOL);
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+
+    delete_product_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_DeleteProduct_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_product_set.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_DeleteProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Permanently deletes a ProductSet. Products and ReferenceImages in the
+ * ProductSet are not deleted.
+ *
+ * The actual image files are not deleted from Google Cloud Storage.
+ *
+ * @param string $formattedName Resource name of the ProductSet to delete.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+ *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+ */
+function delete_product_set_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        $productSearchClient->deleteProductSet($formattedName);
+        printf('Call completed successfully.' . PHP_EOL);
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+
+    delete_product_set_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_DeleteProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_reference_image.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/delete_reference_image.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_DeleteReferenceImage_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Permanently deletes a reference image.
+ *
+ * The image metadata will be deleted right away, but search queries
+ * against ProductSets containing the image may still work until all related
+ * caches are refreshed.
+ *
+ * The actual image files are not deleted from Google Cloud Storage.
+ *
+ * @param string $formattedName The resource name of the reference image to delete.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
+ *                              Please see {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+ */
+function delete_reference_image_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        $productSearchClient->deleteReferenceImage($formattedName);
+        printf('Call completed successfully.' . PHP_EOL);
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::referenceImageName(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[PRODUCT]',
+        '[REFERENCE_IMAGE]'
+    );
+
+    delete_reference_image_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_DeleteReferenceImage_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_product.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_product.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_GetProduct_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\Product;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Gets information associated with a Product.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the Product does not exist.
+ *
+ * @param string $formattedName Resource name of the Product to get.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+ *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+ */
+function get_product_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var Product $response */
+        $response = $productSearchClient->getProduct($formattedName);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+
+    get_product_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_GetProduct_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_product_set.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_GetProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ProductSet;
+
+/**
+ * Gets information associated with a ProductSet.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the ProductSet does not exist.
+ *
+ * @param string $formattedName Resource name of the ProductSet to get.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+ *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+ */
+function get_product_set_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var ProductSet $response */
+        $response = $productSearchClient->getProductSet($formattedName);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+
+    get_product_set_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_GetProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_reference_image.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/get_reference_image.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_GetReferenceImage_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ReferenceImage;
+
+/**
+ * Gets information associated with a ReferenceImage.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the specified image does not exist.
+ *
+ * @param string $formattedName The resource name of the ReferenceImage to get.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`. Please see
+ *                              {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+ */
+function get_reference_image_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var ReferenceImage $response */
+        $response = $productSearchClient->getReferenceImage($formattedName);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::referenceImageName(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[PRODUCT]',
+        '[REFERENCE_IMAGE]'
+    );
+
+    get_reference_image_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_GetReferenceImage_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/import_product_sets.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/import_product_sets.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_ImportProductSets_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\OperationResponse;
+use Google\Cloud\Vision\V1\ImportProductSetsInputConfig;
+use Google\Cloud\Vision\V1\ImportProductSetsResponse;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Rpc\Status;
+
+/**
+ * Asynchronous API that imports a list of reference images to specified
+ * product sets based on a list of image information.
+ *
+ * The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+ * progress and results of the request.
+ * `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+ * `Operation.response` contains `ImportProductSetsResponse`. (results)
+ *
+ * The input source of this method is a csv file on Google Cloud Storage.
+ * For the format of the csv file please see
+ * [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+ *
+ * @param string $formattedParent The project in which the ProductSets should be imported.
+ *
+ *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+ *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function import_product_sets_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $inputConfig = new ImportProductSetsInputConfig();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var OperationResponse $response */
+        $response = $productSearchClient->importProductSets($formattedParent, $inputConfig);
+        $response->pollUntilComplete();
+
+        if ($response->operationSucceeded()) {
+            /** @var ImportProductSetsResponse $result */
+            $result = $response->getResult();
+            printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+        } else {
+            /** @var Status $error */
+            $error = $response->getError();
+            printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    import_product_sets_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_ImportProductSets_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_product_sets.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_product_sets.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_ListProductSets_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\PagedListResponse;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ProductSet;
+
+/**
+ * Lists ProductSets in an unspecified order.
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+ * than 1.
+ *
+ * @param string $formattedParent The project from which ProductSets should be listed.
+ *
+ *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+ *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function list_product_sets_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var PagedListResponse $response */
+        $response = $productSearchClient->listProductSets($formattedParent);
+
+        /** @var ProductSet $element */
+        foreach ($response as $element) {
+            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    list_product_sets_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_ListProductSets_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_products.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_products.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_ListProducts_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\PagedListResponse;
+use Google\Cloud\Vision\V1\Product;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Lists products in an unspecified order.
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+ *
+ * @param string $formattedParent The project OR ProductSet from which Products should be listed.
+ *
+ *                                Format:
+ *                                `projects/PROJECT_ID/locations/LOC_ID`
+ *                                Please see {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function list_products_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var PagedListResponse $response */
+        $response = $productSearchClient->listProducts($formattedParent);
+
+        /** @var Product $element */
+        foreach ($response as $element) {
+            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    list_products_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_ListProducts_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_products_in_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_products_in_product_set.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_ListProductsInProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\PagedListResponse;
+use Google\Cloud\Vision\V1\Product;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Lists the Products in a ProductSet, in an unspecified order. If the
+ * ProductSet does not exist, the products field of the response will be
+ * empty.
+ *
+ * Possible errors:
+ *
+ * * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+ *
+ * @param string $formattedName The ProductSet resource for which to retrieve Products.
+ *
+ *                              Format is:
+ *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+ *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+ */
+function list_products_in_product_set_sample(string $formattedName): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var PagedListResponse $response */
+        $response = $productSearchClient->listProductsInProductSet($formattedName);
+
+        /** @var Product $element */
+        foreach ($response as $element) {
+            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+
+    list_products_in_product_set_sample($formattedName);
+}
+// [END vision_v1_generated_ProductSearch_ListProductsInProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_reference_images.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/list_reference_images.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_ListReferenceImages_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\PagedListResponse;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ReferenceImage;
+
+/**
+ * Lists reference images.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the parent product does not exist.
+ * * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+ * than 1.
+ *
+ * @param string $formattedParent Resource name of the product containing the reference images.
+ *
+ *                                Format is
+ *                                `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+ *                                {@see ProductSearchClient::productName()} for help formatting this field.
+ */
+function list_reference_images_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var PagedListResponse $response */
+        $response = $productSearchClient->listReferenceImages($formattedParent);
+
+        /** @var ReferenceImage $element */
+        foreach ($response as $element) {
+            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+
+    list_reference_images_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_ListReferenceImages_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/purge_products.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/purge_products.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_PurgeProducts_sync]
+use Google\ApiCore\ApiException;
+use Google\ApiCore\OperationResponse;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Rpc\Status;
+
+/**
+ * Asynchronous API to delete all Products in a ProductSet or all Products
+ * that are in no ProductSet.
+ *
+ * If a Product is a member of the specified ProductSet in addition to other
+ * ProductSets, the Product will still be deleted.
+ *
+ * It is recommended to not delete the specified ProductSet until after this
+ * operation has completed. It is also recommended to not add any of the
+ * Products involved in the batch delete to a new ProductSet while this
+ * operation is running because those Products may still end up deleted.
+ *
+ * It's not possible to undo the PurgeProducts operation. Therefore, it is
+ * recommended to keep the csv files used in ImportProductSets (if that was
+ * how you originally built the Product Set) before starting PurgeProducts, in
+ * case you need to re-import the data after deletion.
+ *
+ * If the plan is to purge all of the Products from a ProductSet and then
+ * re-use the empty ProductSet to re-import new Products into the empty
+ * ProductSet, you must wait until the PurgeProducts operation has finished
+ * for that ProductSet.
+ *
+ * The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+ * progress and results of the request.
+ * `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+ *
+ * @param string $formattedParent The project and location in which the Products should be deleted.
+ *
+ *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+ *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+ */
+function purge_products_sample(string $formattedParent): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var OperationResponse $response */
+        $response = $productSearchClient->purgeProducts($formattedParent);
+        $response->pollUntilComplete();
+
+        if ($response->operationSucceeded()) {
+            printf('Operation completed successfully.' . PHP_EOL);
+        } else {
+            /** @var Status $error */
+            $error = $response->getError();
+            printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+        }
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+
+    purge_products_sample($formattedParent);
+}
+// [END vision_v1_generated_ProductSearch_PurgeProducts_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/remove_product_from_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/remove_product_from_product_set.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_RemoveProductFromProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Removes a Product from the specified ProductSet.
+ *
+ * @param string $formattedName    The resource name for the ProductSet to modify.
+ *
+ *                                 Format is:
+ *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+ *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+ * @param string $formattedProduct The resource name for the Product to be removed from this ProductSet.
+ *
+ *                                 Format is:
+ *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+ *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+ */
+function remove_product_from_product_set_sample(
+    string $formattedName,
+    string $formattedProduct
+): void {
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Call the API and handle any network failures.
+    try {
+        $productSearchClient->removeProductFromProductSet($formattedName, $formattedProduct);
+        printf('Call completed successfully.' . PHP_EOL);
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+    $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+
+    remove_product_from_product_set_sample($formattedName, $formattedProduct);
+}
+// [END vision_v1_generated_ProductSearch_RemoveProductFromProductSet_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/update_product.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/update_product.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_UpdateProduct_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\Product;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+
+/**
+ * Makes changes to a Product resource.
+ * Only the `display_name`, `description`, and `labels` fields can be updated
+ * right now.
+ *
+ * If labels are updated, the change will not be reflected in queries until
+ * the next index time.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the Product does not exist.
+ * * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+ * missing from the request or longer than 4096 characters.
+ * * Returns INVALID_ARGUMENT if description is present in update_mask but is
+ * longer than 4096 characters.
+ * * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function update_product_sample(): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $product = new Product();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var Product $response */
+        $response = $productSearchClient->updateProduct($product);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ProductSearch_UpdateProduct_sync]

--- a/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/update_product_set.php
+++ b/dev/tests/fixtures/component/Vision/samples/V1/ProductSearchClient/update_product_set.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START vision_v1_generated_ProductSearch_UpdateProductSet_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Vision\V1\ProductSearchClient;
+use Google\Cloud\Vision\V1\ProductSet;
+
+/**
+ * Makes changes to a ProductSet resource.
+ * Only display_name can be updated currently.
+ *
+ * Possible errors:
+ *
+ * * Returns NOT_FOUND if the ProductSet does not exist.
+ * * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+ * missing from the request or longer than 4096 characters.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function update_product_set_sample(): void
+{
+    // Create a client.
+    $productSearchClient = new ProductSearchClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $productSet = new ProductSet();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var ProductSet $response */
+        $response = $productSearchClient->updateProductSet($productSet);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END vision_v1_generated_ProductSearch_UpdateProductSet_sync]

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -724,37 +724,46 @@ items:
       
       Sample code:
       ```php
-      $imageAnnotatorClient = new ImageAnnotatorClient();
-      try {
-          $requests = [];
-          $operationResponse = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
-          $operationResponse->pollUntilComplete();
-          if ($operationResponse->operationSucceeded()) {
-              $result = $operationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $operationResponse->getError();
-              // handleError($error)
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\OperationResponse;
+      use Google\Cloud\Vision\V1\AsyncAnnotateFileRequest;
+      use Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse;
+      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+      use Google\Rpc\Status;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function async_batch_annotate_files_sample(): void
+      {
+          // Create a client.
+          $imageAnnotatorClient = new ImageAnnotatorClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
+          $requests = [new AsyncAnnotateFileRequest()];
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var OperationResponse $response */
+              $response = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
+              $response->pollUntilComplete();
+      
+              if ($response->operationSucceeded()) {
+                  /** @var AsyncBatchAnnotateFilesResponse $result */
+                  $result = $response->getResult();
+                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+              } else {
+                  /** @var Status $error */
+                  $error = $response->getError();
+                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+              }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // start the operation, keep the operation name, and resume later
-          $operationResponse = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
-          $operationName = $operationResponse->getName();
-          // ... do other work
-          $newOperationResponse = $imageAnnotatorClient->resumeOperation($operationName, 'asyncBatchAnnotateFiles');
-          while (!$newOperationResponse->isDone()) {
-              // ... do other work
-              $newOperationResponse->reload();
-          }
-          if ($newOperationResponse->operationSucceeded()) {
-              $result = $newOperationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $newOperationResponse->getError();
-              // handleError($error)
-          }
-      } finally {
-          $imageAnnotatorClient->close();
       }
       ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
@@ -799,38 +808,48 @@ items:
       
       Sample code:
       ```php
-      $imageAnnotatorClient = new ImageAnnotatorClient();
-      try {
-          $requests = [];
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\OperationResponse;
+      use Google\Cloud\Vision\V1\AnnotateImageRequest;
+      use Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse;
+      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+      use Google\Cloud\Vision\V1\OutputConfig;
+      use Google\Rpc\Status;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function async_batch_annotate_images_sample(): void
+      {
+          // Create a client.
+          $imageAnnotatorClient = new ImageAnnotatorClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
+          $requests = [new AnnotateImageRequest()];
           $outputConfig = new OutputConfig();
-          $operationResponse = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
-          $operationResponse->pollUntilComplete();
-          if ($operationResponse->operationSucceeded()) {
-              $result = $operationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $operationResponse->getError();
-              // handleError($error)
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var OperationResponse $response */
+              $response = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
+              $response->pollUntilComplete();
+      
+              if ($response->operationSucceeded()) {
+                  /** @var AsyncBatchAnnotateImagesResponse $result */
+                  $result = $response->getResult();
+                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+              } else {
+                  /** @var Status $error */
+                  $error = $response->getError();
+                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+              }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // start the operation, keep the operation name, and resume later
-          $operationResponse = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
-          $operationName = $operationResponse->getName();
-          // ... do other work
-          $newOperationResponse = $imageAnnotatorClient->resumeOperation($operationName, 'asyncBatchAnnotateImages');
-          while (!$newOperationResponse->isDone()) {
-              // ... do other work
-              $newOperationResponse->reload();
-          }
-          if ($newOperationResponse->operationSucceeded()) {
-              $result = $newOperationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $newOperationResponse->getError();
-              // handleError($error)
-          }
-      } finally {
-          $imageAnnotatorClient->close();
       }
       ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
@@ -878,12 +897,34 @@ items:
       
       Sample code:
       ```php
-      $imageAnnotatorClient = new ImageAnnotatorClient();
-      try {
-          $requests = [];
-          $response = $imageAnnotatorClient->batchAnnotateFiles($requests);
-      } finally {
-          $imageAnnotatorClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\AnnotateFileRequest;
+      use Google\Cloud\Vision\V1\BatchAnnotateFilesResponse;
+      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function batch_annotate_files_sample(): void
+      {
+          // Create a client.
+          $imageAnnotatorClient = new ImageAnnotatorClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
+          $requests = [new AnnotateFileRequest()];
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var BatchAnnotateFilesResponse $response */
+              $response = $imageAnnotatorClient->batchAnnotateFiles($requests);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
       }
       ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
@@ -920,12 +961,34 @@ items:
       
       Sample code:
       ```php
-      $imageAnnotatorClient = new ImageAnnotatorClient();
-      try {
-          $requests = [];
-          $response = $imageAnnotatorClient->batchAnnotateImages($requests);
-      } finally {
-          $imageAnnotatorClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\AnnotateImageRequest;
+      use Google\Cloud\Vision\V1\BatchAnnotateImagesResponse;
+      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function batch_annotate_images_sample(): void
+      {
+          // Create a client.
+          $imageAnnotatorClient = new ImageAnnotatorClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
+          $requests = [new AnnotateImageRequest()];
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var BatchAnnotateImagesResponse $response */
+              $response = $imageAnnotatorClient->batchAnnotateImages($requests);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
       }
       ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -722,54 +722,57 @@ items:
       `Operation.metadata` contains `OperationMetadata` (metadata).
       `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\OperationResponse;
-      use Google\Cloud\Vision\V1\AsyncAnnotateFileRequest;
-      use Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse;
-      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
-      use Google\Rpc\Status;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function async_batch_annotate_files_sample(): void
-      {
-          // Create a client.
-          $imageAnnotatorClient = new ImageAnnotatorClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $requests = [new AsyncAnnotateFileRequest()];
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var OperationResponse $response */
-              $response = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
-              $response->pollUntilComplete();
-      
-              if ($response->operationSucceeded()) {
-                  /** @var AsyncBatchAnnotateFilesResponse $result */
-                  $result = $response->getResult();
-                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
-              } else {
-                  /** @var Status $error */
-                  $error = $response->getError();
-                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\OperationResponse;
+        use Google\Cloud\Vision\V1\AsyncAnnotateFileRequest;
+        use Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse;
+        use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+        use Google\Rpc\Status;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function async_batch_annotate_files_sample(): void
+        {
+            // Create a client.
+            $imageAnnotatorClient = new ImageAnnotatorClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $requests = [new AsyncAnnotateFileRequest()];
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var OperationResponse $response */
+                $response = $imageAnnotatorClient->asyncBatchAnnotateFiles($requests);
+                $response->pollUntilComplete();
+        
+                if ($response->operationSucceeded()) {
+                    /** @var AsyncBatchAnnotateFilesResponse $result */
+                    $result = $response->getResult();
+                    printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+                } else {
+                    /** @var Status $error */
+                    $error = $response->getError();
+                    printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -
@@ -806,56 +809,59 @@ items:
       This service will write image annotation outputs to json files in customer
       GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\OperationResponse;
-      use Google\Cloud\Vision\V1\AnnotateImageRequest;
-      use Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse;
-      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
-      use Google\Cloud\Vision\V1\OutputConfig;
-      use Google\Rpc\Status;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function async_batch_annotate_images_sample(): void
-      {
-          // Create a client.
-          $imageAnnotatorClient = new ImageAnnotatorClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $requests = [new AnnotateImageRequest()];
-          $outputConfig = new OutputConfig();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var OperationResponse $response */
-              $response = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
-              $response->pollUntilComplete();
-      
-              if ($response->operationSucceeded()) {
-                  /** @var AsyncBatchAnnotateImagesResponse $result */
-                  $result = $response->getResult();
-                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
-              } else {
-                  /** @var Status $error */
-                  $error = $response->getError();
-                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\OperationResponse;
+        use Google\Cloud\Vision\V1\AnnotateImageRequest;
+        use Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesResponse;
+        use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+        use Google\Cloud\Vision\V1\OutputConfig;
+        use Google\Rpc\Status;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function async_batch_annotate_images_sample(): void
+        {
+            // Create a client.
+            $imageAnnotatorClient = new ImageAnnotatorClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $requests = [new AnnotateImageRequest()];
+            $outputConfig = new OutputConfig();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var OperationResponse $response */
+                $response = $imageAnnotatorClient->asyncBatchAnnotateImages($requests, $outputConfig);
+                $response->pollUntilComplete();
+        
+                if ($response->operationSucceeded()) {
+                    /** @var AsyncBatchAnnotateImagesResponse $result */
+                    $result = $response->getResult();
+                    printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+                } else {
+                    /** @var Status $error */
+                    $error = $response->getError();
+                    printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -
@@ -895,42 +901,45 @@ items:
       file provided and perform detection and annotation for each image
       extracted.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\AnnotateFileRequest;
-      use Google\Cloud\Vision\V1\BatchAnnotateFilesResponse;
-      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function batch_annotate_files_sample(): void
-      {
-          // Create a client.
-          $imageAnnotatorClient = new ImageAnnotatorClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $requests = [new AnnotateFileRequest()];
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var BatchAnnotateFilesResponse $response */
-              $response = $imageAnnotatorClient->batchAnnotateFiles($requests);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\AnnotateFileRequest;
+        use Google\Cloud\Vision\V1\BatchAnnotateFilesResponse;
+        use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function batch_annotate_files_sample(): void
+        {
+            // Create a client.
+            $imageAnnotatorClient = new ImageAnnotatorClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $requests = [new AnnotateFileRequest()];
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var BatchAnnotateFilesResponse $response */
+                $response = $imageAnnotatorClient->batchAnnotateFiles($requests);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -
@@ -959,42 +968,45 @@ items:
     summary: |
       Run image detection and annotation for a batch of images.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\AnnotateImageRequest;
-      use Google\Cloud\Vision\V1\BatchAnnotateImagesResponse;
-      use Google\Cloud\Vision\V1\ImageAnnotatorClient;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function batch_annotate_images_sample(): void
-      {
-          // Create a client.
-          $imageAnnotatorClient = new ImageAnnotatorClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $requests = [new AnnotateImageRequest()];
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var BatchAnnotateImagesResponse $response */
-              $response = $imageAnnotatorClient->batchAnnotateImages($requests);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\AnnotateImageRequest;
+        use Google\Cloud\Vision\V1\BatchAnnotateImagesResponse;
+        use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function batch_annotate_images_sample(): void
+        {
+            // Create a client.
+            $imageAnnotatorClient = new ImageAnnotatorClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $requests = [new AnnotateImageRequest()];
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var BatchAnnotateImagesResponse $response */
+                $response = $imageAnnotatorClient->batchAnnotateImages($requests);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -729,7 +729,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\OperationResponse;
@@ -816,7 +815,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\OperationResponse;
@@ -908,7 +906,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\AnnotateFileRequest;
@@ -975,7 +972,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\AnnotateImageRequest;

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -338,7 +338,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -423,7 +422,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\Product;
@@ -512,7 +510,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -613,7 +610,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -706,7 +702,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -777,7 +772,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -851,7 +845,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -928,7 +921,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\Product;
@@ -1005,7 +997,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -1082,7 +1073,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -1170,7 +1160,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\OperationResponse;
@@ -1267,7 +1256,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\PagedListResponse;
@@ -1356,7 +1344,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\PagedListResponse;
@@ -1448,7 +1435,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\PagedListResponse;
@@ -1540,7 +1526,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\PagedListResponse;
@@ -1649,7 +1634,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\ApiCore\OperationResponse;
@@ -1742,7 +1726,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;
@@ -1837,7 +1820,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\Product;
@@ -1911,7 +1893,6 @@ items:
       - php
     example:
       - |
-        Sample code:
         ```php
         use Google\ApiCore\ApiException;
         use Google\Cloud\Vision\V1\ProductSearchClient;

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -333,13 +333,48 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $formattedProduct = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $productSearchClient->addProductToProductSet($formattedName, $formattedProduct);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName    The resource name for the ProductSet to modify.
+       *
+       *                                 Format is:
+       *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+       *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+       * @param string $formattedProduct The resource name for the Product to be added to this ProductSet.
+       *
+       *                                 Format is:
+       *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+       *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+       */
+      function add_product_to_product_set_sample(string $formattedName, string $formattedProduct): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              $productSearchClient->addProductToProductSet($formattedName, $formattedProduct);
+              printf('Call completed successfully.' . PHP_EOL);
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+          $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+      
+          add_product_to_product_set_sample($formattedName, $formattedProduct);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -380,13 +415,47 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\Product;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedParent The project in which the Product should be created.
+       *
+       *                                Format is
+       *                                `projects/PROJECT_ID/locations/LOC_ID`. Please see
+       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function create_product_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
           $product = new Product();
-          $response = $productSearchClient->createProduct($formattedParent, $product);
-      } finally {
-          $productSearchClient->close();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var Product $response */
+              $response = $productSearchClient->createProduct($formattedParent, $product);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          create_product_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -432,13 +501,46 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ProductSet;
+      
+      /**
+       * @param string $formattedParent The project in which the ProductSet should be created.
+       *
+       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function create_product_set_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
           $productSet = new ProductSet();
-          $response = $productSearchClient->createProductSet($formattedParent, $productSet);
-      } finally {
-          $productSearchClient->close();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var ProductSet $response */
+              $response = $productSearchClient->createProductSet($formattedParent, $productSet);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          create_product_set_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -497,13 +599,52 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $referenceImage = new ReferenceImage();
-          $response = $productSearchClient->createReferenceImage($formattedParent, $referenceImage);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ReferenceImage;
+      
+      /**
+       * @param string $formattedParent   Resource name of the product in which to create the reference image.
+       *
+       *                                  Format is
+       *                                  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+       *                                  {@see ProductSearchClient::productName()} for help formatting this field.
+       * @param string $referenceImageUri The Google Cloud Storage URI of the reference image.
+       *
+       *                                  The URI must start with `gs://`.
+       */
+      function create_reference_image_sample(string $formattedParent, string $referenceImageUri): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
+          $referenceImage = (new ReferenceImage())
+              ->setUri($referenceImageUri);
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var ReferenceImage $response */
+              $response = $productSearchClient->createReferenceImage($formattedParent, $referenceImage);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+          $referenceImageUri = '[URI]';
+      
+          create_reference_image_sample($formattedParent, $referenceImageUri);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -548,12 +689,42 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $productSearchClient->deleteProduct($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName Resource name of product to delete.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+       *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+       */
+      function delete_product_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              $productSearchClient->deleteProduct($formattedName);
+              printf('Call completed successfully.' . PHP_EOL);
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+      
+          delete_product_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -586,12 +757,42 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $productSearchClient->deleteProductSet($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName Resource name of the ProductSet to delete.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+       */
+      function delete_product_set_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              $productSearchClient->deleteProductSet($formattedName);
+              printf('Call completed successfully.' . PHP_EOL);
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+      
+          delete_product_set_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -627,12 +828,47 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->referenceImageName('[PROJECT]', '[LOCATION]', '[PRODUCT]', '[REFERENCE_IMAGE]');
-          $productSearchClient->deleteReferenceImage($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName The resource name of the reference image to delete.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
+       *                              Please see {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+       */
+      function delete_reference_image_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              $productSearchClient->deleteReferenceImage($formattedName);
+              printf('Call completed successfully.' . PHP_EOL);
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::referenceImageName(
+              '[PROJECT]',
+              '[LOCATION]',
+              '[PRODUCT]',
+              '[REFERENCE_IMAGE]'
+          );
+      
+          delete_reference_image_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -666,12 +902,44 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $response = $productSearchClient->getProduct($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\Product;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName Resource name of the Product to get.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+       *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+       */
+      function get_product_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var Product $response */
+              $response = $productSearchClient->getProduct($formattedName);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+      
+          get_product_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -708,12 +976,44 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $response = $productSearchClient->getProductSet($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ProductSet;
+      
+      /**
+       * @param string $formattedName Resource name of the ProductSet to get.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+       */
+      function get_product_set_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var ProductSet $response */
+              $response = $productSearchClient->getProductSet($formattedName);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+      
+          get_product_set_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -750,12 +1050,49 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->referenceImageName('[PROJECT]', '[LOCATION]', '[PRODUCT]', '[REFERENCE_IMAGE]');
-          $response = $productSearchClient->getReferenceImage($formattedName);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ReferenceImage;
+      
+      /**
+       * @param string $formattedName The resource name of the ReferenceImage to get.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`. Please see
+       *                              {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+       */
+      function get_reference_image_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var ReferenceImage $response */
+              $response = $productSearchClient->getReferenceImage($formattedName);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::referenceImageName(
+              '[PROJECT]',
+              '[LOCATION]',
+              '[PRODUCT]',
+              '[REFERENCE_IMAGE]'
+          );
+      
+          get_reference_image_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -798,38 +1135,59 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\OperationResponse;
+      use Google\Cloud\Vision\V1\ImportProductSetsInputConfig;
+      use Google\Cloud\Vision\V1\ImportProductSetsResponse;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Rpc\Status;
+      
+      /**
+       * @param string $formattedParent The project in which the ProductSets should be imported.
+       *
+       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function import_product_sets_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
           $inputConfig = new ImportProductSetsInputConfig();
-          $operationResponse = $productSearchClient->importProductSets($formattedParent, $inputConfig);
-          $operationResponse->pollUntilComplete();
-          if ($operationResponse->operationSucceeded()) {
-              $result = $operationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $operationResponse->getError();
-              // handleError($error)
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var OperationResponse $response */
+              $response = $productSearchClient->importProductSets($formattedParent, $inputConfig);
+              $response->pollUntilComplete();
+      
+              if ($response->operationSucceeded()) {
+                  /** @var ImportProductSetsResponse $result */
+                  $result = $response->getResult();
+                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+              } else {
+                  /** @var Status $error */
+                  $error = $response->getError();
+                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+              }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // start the operation, keep the operation name, and resume later
-          $operationResponse = $productSearchClient->importProductSets($formattedParent, $inputConfig);
-          $operationName = $operationResponse->getName();
-          // ... do other work
-          $newOperationResponse = $productSearchClient->resumeOperation($operationName, 'importProductSets');
-          while (!$newOperationResponse->isDone()) {
-              // ... do other work
-              $newOperationResponse->reload();
-          }
-          if ($newOperationResponse->operationSucceeded()) {
-              $result = $newOperationResponse->getResult();
-          // doSomethingWith($result)
-          } else {
-              $error = $newOperationResponse->getError();
-              // handleError($error)
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          import_product_sets_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -871,24 +1229,48 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
-          // Iterate over pages of elements
-          $pagedResponse = $productSearchClient->listProductSets($formattedParent);
-          foreach ($pagedResponse->iteratePages() as $page) {
-              foreach ($page as $element) {
-                  // doSomethingWith($element);
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\PagedListResponse;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ProductSet;
+      
+      /**
+       * @param string $formattedParent The project from which ProductSets should be listed.
+       *
+       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function list_product_sets_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var PagedListResponse $response */
+              $response = $productSearchClient->listProductSets($formattedParent);
+      
+              /** @var ProductSet $element */
+              foreach ($response as $element) {
+                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
               }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // Iterate through all elements
-          $pagedResponse = $productSearchClient->listProductSets($formattedParent);
-          foreach ($pagedResponse->iterateAllElements() as $element) {
-              // doSomethingWith($element);
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          list_product_sets_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -933,24 +1315,49 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
-          // Iterate over pages of elements
-          $pagedResponse = $productSearchClient->listProducts($formattedParent);
-          foreach ($pagedResponse->iteratePages() as $page) {
-              foreach ($page as $element) {
-                  // doSomethingWith($element);
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\PagedListResponse;
+      use Google\Cloud\Vision\V1\Product;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedParent The project OR ProductSet from which Products should be listed.
+       *
+       *                                Format:
+       *                                `projects/PROJECT_ID/locations/LOC_ID`
+       *                                Please see {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function list_products_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var PagedListResponse $response */
+              $response = $productSearchClient->listProducts($formattedParent);
+      
+              /** @var Product $element */
+              foreach ($response as $element) {
+                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
               }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // Iterate through all elements
-          $pagedResponse = $productSearchClient->listProducts($formattedParent);
-          foreach ($pagedResponse->iterateAllElements() as $element) {
-              // doSomethingWith($element);
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          list_products_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -997,24 +1404,49 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          // Iterate over pages of elements
-          $pagedResponse = $productSearchClient->listProductsInProductSet($formattedName);
-          foreach ($pagedResponse->iteratePages() as $page) {
-              foreach ($page as $element) {
-                  // doSomethingWith($element);
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\PagedListResponse;
+      use Google\Cloud\Vision\V1\Product;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName The ProductSet resource for which to retrieve Products.
+       *
+       *                              Format is:
+       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+       */
+      function list_products_in_product_set_sample(string $formattedName): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var PagedListResponse $response */
+              $response = $productSearchClient->listProductsInProductSet($formattedName);
+      
+              /** @var Product $element */
+              foreach ($response as $element) {
+                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
               }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // Iterate through all elements
-          $pagedResponse = $productSearchClient->listProductsInProductSet($formattedName);
-          foreach ($pagedResponse->iterateAllElements() as $element) {
-              // doSomethingWith($element);
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+      
+          list_products_in_product_set_sample($formattedName);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -1061,24 +1493,49 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          // Iterate over pages of elements
-          $pagedResponse = $productSearchClient->listReferenceImages($formattedParent);
-          foreach ($pagedResponse->iteratePages() as $page) {
-              foreach ($page as $element) {
-                  // doSomethingWith($element);
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\PagedListResponse;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ReferenceImage;
+      
+      /**
+       * @param string $formattedParent Resource name of the product containing the reference images.
+       *
+       *                                Format is
+       *                                `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+       *                                {@see ProductSearchClient::productName()} for help formatting this field.
+       */
+      function list_reference_images_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var PagedListResponse $response */
+              $response = $productSearchClient->listReferenceImages($formattedParent);
+      
+              /** @var ReferenceImage $element */
+              foreach ($response as $element) {
+                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
               }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // Iterate through all elements
-          $pagedResponse = $productSearchClient->listReferenceImages($formattedParent);
-          foreach ($pagedResponse->iterateAllElements() as $element) {
-              // doSomethingWith($element);
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+      
+          list_reference_images_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -1142,35 +1599,52 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedParent = $productSearchClient->locationName('[PROJECT]', '[LOCATION]');
-          $operationResponse = $productSearchClient->purgeProducts($formattedParent);
-          $operationResponse->pollUntilComplete();
-          if ($operationResponse->operationSucceeded()) {
-              // operation succeeded and returns no value
-          } else {
-              $error = $operationResponse->getError();
-              // handleError($error)
+      use Google\ApiCore\ApiException;
+      use Google\ApiCore\OperationResponse;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Rpc\Status;
+      
+      /**
+       * @param string $formattedParent The project and location in which the Products should be deleted.
+       *
+       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+       */
+      function purge_products_sample(string $formattedParent): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var OperationResponse $response */
+              $response = $productSearchClient->purgeProducts($formattedParent);
+              $response->pollUntilComplete();
+      
+              if ($response->operationSucceeded()) {
+                  printf('Operation completed successfully.' . PHP_EOL);
+              } else {
+                  /** @var Status $error */
+                  $error = $response->getError();
+                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+              }
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
           }
-          // Alternatively:
-          // start the operation, keep the operation name, and resume later
-          $operationResponse = $productSearchClient->purgeProducts($formattedParent);
-          $operationName = $operationResponse->getName();
-          // ... do other work
-          $newOperationResponse = $productSearchClient->resumeOperation($operationName, 'purgeProducts');
-          while (!$newOperationResponse->isDone()) {
-              // ... do other work
-              $newOperationResponse->reload();
-          }
-          if ($newOperationResponse->operationSucceeded()) {
-              // operation succeeded and returns no value
-          } else {
-              $error = $newOperationResponse->getError();
-              // handleError($error)
-          }
-      } finally {
-          $productSearchClient->close();
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+      
+          purge_products_sample($formattedParent);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -1215,13 +1689,50 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
-          $formattedName = $productSearchClient->productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $formattedProduct = $productSearchClient->productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $productSearchClient->removeProductFromProductSet($formattedName, $formattedProduct);
-      } finally {
-          $productSearchClient->close();
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * @param string $formattedName    The resource name for the ProductSet to modify.
+       *
+       *                                 Format is:
+       *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+       *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+       * @param string $formattedProduct The resource name for the Product to be removed from this ProductSet.
+       *
+       *                                 Format is:
+       *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+       *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+       */
+      function remove_product_from_product_set_sample(
+          string $formattedName,
+          string $formattedProduct
+      ): void {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Call the API and handle any network failures.
+          try {
+              $productSearchClient->removeProductFromProductSet($formattedName, $formattedProduct);
+              printf('Call completed successfully.' . PHP_EOL);
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
+      }
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function callSample(): void
+      {
+          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+          $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+      
+          remove_product_from_product_set_sample($formattedName, $formattedProduct);
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -1270,12 +1781,33 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\Product;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function update_product_sample(): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
           $product = new Product();
-          $response = $productSearchClient->updateProduct($product);
-      } finally {
-          $productSearchClient->close();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var Product $response */
+              $response = $productSearchClient->updateProduct($product);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
@@ -1320,12 +1852,33 @@ items:
       
       Sample code:
       ```php
-      $productSearchClient = new ProductSearchClient();
-      try {
+      use Google\ApiCore\ApiException;
+      use Google\Cloud\Vision\V1\ProductSearchClient;
+      use Google\Cloud\Vision\V1\ProductSet;
+      
+      /**
+       * This sample has been automatically generated and should be regarded as a code
+       * template only. It will require modifications to work:
+       *  - It may require correct/in-range values for request initialization.
+       *  - It may require specifying regional endpoints when creating the service client,
+       *    please see the apiEndpoint client configuration option for more details.
+       */
+      function update_product_set_sample(): void
+      {
+          // Create a client.
+          $productSearchClient = new ProductSearchClient();
+      
+          // Prepare any non-scalar elements to be passed along with the request.
           $productSet = new ProductSet();
-          $response = $productSearchClient->updateProductSet($productSet);
-      } finally {
-          $productSearchClient->close();
+      
+          // Call the API and handle any network failures.
+          try {
+              /** @var ProductSet $response */
+              $response = $productSearchClient->updateProductSet($productSet);
+              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+          } catch (ApiException $ex) {
+              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+          }
       }
       ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -331,56 +331,59 @@ items:
       
       * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName    The resource name for the ProductSet to modify.
-       *
-       *                                 Format is:
-       *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-       *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
-       * @param string $formattedProduct The resource name for the Product to be added to this ProductSet.
-       *
-       *                                 Format is:
-       *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-       *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
-       */
-      function add_product_to_product_set_sample(string $formattedName, string $formattedProduct): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              $productSearchClient->addProductToProductSet($formattedName, $formattedProduct);
-              printf('Call completed successfully.' . PHP_EOL);
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-      
-          add_product_to_product_set_sample($formattedName, $formattedProduct);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName    The resource name for the ProductSet to modify.
+         *
+         *                                 Format is:
+         *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+         *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+         * @param string $formattedProduct The resource name for the Product to be added to this ProductSet.
+         *
+         *                                 Format is:
+         *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+         *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+         */
+        function add_product_to_product_set_sample(string $formattedName, string $formattedProduct): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                $productSearchClient->addProductToProductSet($formattedName, $formattedProduct);
+                printf('Call completed successfully.' . PHP_EOL);
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+            $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+        
+            add_product_to_product_set_sample($formattedName, $formattedProduct);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -413,55 +416,58 @@ items:
       * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
       * Returns INVALID_ARGUMENT if product_category is missing or invalid.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\Product;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedParent The project in which the Product should be created.
-       *
-       *                                Format is
-       *                                `projects/PROJECT_ID/locations/LOC_ID`. Please see
-       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function create_product_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $product = new Product();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var Product $response */
-              $response = $productSearchClient->createProduct($formattedParent, $product);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          create_product_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\Product;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedParent The project in which the Product should be created.
+         *
+         *                                Format is
+         *                                `projects/PROJECT_ID/locations/LOC_ID`. Please see
+         *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function create_product_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $product = new Product();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var Product $response */
+                $response = $productSearchClient->createProduct($formattedParent, $product);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            create_product_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -499,54 +505,57 @@ items:
       * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
       4096 characters.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ProductSet;
       
-      /**
-       * @param string $formattedParent The project in which the ProductSet should be created.
-       *
-       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
-       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function create_product_set_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $productSet = new ProductSet();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var ProductSet $response */
-              $response = $productSearchClient->createProductSet($formattedParent, $productSet);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          create_product_set_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ProductSet;
+        
+        /**
+         * @param string $formattedParent The project in which the ProductSet should be created.
+         *
+         *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+         *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function create_product_set_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $productSet = new ProductSet();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var ProductSet $response */
+                $response = $productSearchClient->createProductSet($formattedParent, $productSet);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            create_product_set_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -597,60 +606,63 @@ items:
       compatible with the parent product's product_category is detected.
       * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ReferenceImage;
       
-      /**
-       * @param string $formattedParent   Resource name of the product in which to create the reference image.
-       *
-       *                                  Format is
-       *                                  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
-       *                                  {@see ProductSearchClient::productName()} for help formatting this field.
-       * @param string $referenceImageUri The Google Cloud Storage URI of the reference image.
-       *
-       *                                  The URI must start with `gs://`.
-       */
-      function create_reference_image_sample(string $formattedParent, string $referenceImageUri): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $referenceImage = (new ReferenceImage())
-              ->setUri($referenceImageUri);
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var ReferenceImage $response */
-              $response = $productSearchClient->createReferenceImage($formattedParent, $referenceImage);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-          $referenceImageUri = '[URI]';
-      
-          create_reference_image_sample($formattedParent, $referenceImageUri);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ReferenceImage;
+        
+        /**
+         * @param string $formattedParent   Resource name of the product in which to create the reference image.
+         *
+         *                                  Format is
+         *                                  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+         *                                  {@see ProductSearchClient::productName()} for help formatting this field.
+         * @param string $referenceImageUri The Google Cloud Storage URI of the reference image.
+         *
+         *                                  The URI must start with `gs://`.
+         */
+        function create_reference_image_sample(string $formattedParent, string $referenceImageUri): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $referenceImage = (new ReferenceImage())
+                ->setUri($referenceImageUri);
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var ReferenceImage $response */
+                $response = $productSearchClient->createReferenceImage($formattedParent, $referenceImage);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+            $referenceImageUri = '[URI]';
+        
+            create_reference_image_sample($formattedParent, $referenceImageUri);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -687,50 +699,53 @@ items:
       search queries against ProductSets containing the product may still work
       until all related caches are refreshed.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName Resource name of product to delete.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-       *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
-       */
-      function delete_product_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              $productSearchClient->deleteProduct($formattedName);
-              printf('Call completed successfully.' . PHP_EOL);
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-      
-          delete_product_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName Resource name of product to delete.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+         *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+         */
+        function delete_product_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                $productSearchClient->deleteProduct($formattedName);
+                printf('Call completed successfully.' . PHP_EOL);
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+        
+            delete_product_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -755,50 +770,53 @@ items:
       
       The actual image files are not deleted from Google Cloud Storage.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName Resource name of the ProductSet to delete.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
-       */
-      function delete_product_set_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              $productSearchClient->deleteProductSet($formattedName);
-              printf('Call completed successfully.' . PHP_EOL);
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-      
-          delete_product_set_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName Resource name of the ProductSet to delete.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+         *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+         */
+        function delete_product_set_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                $productSearchClient->deleteProductSet($formattedName);
+                printf('Call completed successfully.' . PHP_EOL);
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+        
+            delete_product_set_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -826,55 +844,58 @@ items:
       
       The actual image files are not deleted from Google Cloud Storage.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName The resource name of the reference image to delete.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-       *                              Please see {@see ProductSearchClient::referenceImageName()} for help formatting this field.
-       */
-      function delete_reference_image_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              $productSearchClient->deleteReferenceImage($formattedName);
-              printf('Call completed successfully.' . PHP_EOL);
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::referenceImageName(
-              '[PROJECT]',
-              '[LOCATION]',
-              '[PRODUCT]',
-              '[REFERENCE_IMAGE]'
-          );
-      
-          delete_reference_image_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName The resource name of the reference image to delete.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
+         *                              Please see {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+         */
+        function delete_reference_image_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                $productSearchClient->deleteReferenceImage($formattedName);
+                printf('Call completed successfully.' . PHP_EOL);
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::referenceImageName(
+                '[PROJECT]',
+                '[LOCATION]',
+                '[PRODUCT]',
+                '[REFERENCE_IMAGE]'
+            );
+        
+            delete_reference_image_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -900,52 +921,55 @@ items:
       
       * Returns NOT_FOUND if the Product does not exist.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\Product;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName Resource name of the Product to get.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-       *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
-       */
-      function get_product_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var Product $response */
-              $response = $productSearchClient->getProduct($formattedName);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-      
-          get_product_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\Product;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName Resource name of the Product to get.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+         *                              Please see {@see ProductSearchClient::productName()} for help formatting this field.
+         */
+        function get_product_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var Product $response */
+                $response = $productSearchClient->getProduct($formattedName);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+        
+            get_product_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -974,52 +998,55 @@ items:
       
       * Returns NOT_FOUND if the ProductSet does not exist.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ProductSet;
       
-      /**
-       * @param string $formattedName Resource name of the ProductSet to get.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
-       */
-      function get_product_set_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var ProductSet $response */
-              $response = $productSearchClient->getProductSet($formattedName);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-      
-          get_product_set_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ProductSet;
+        
+        /**
+         * @param string $formattedName Resource name of the ProductSet to get.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+         *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+         */
+        function get_product_set_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var ProductSet $response */
+                $response = $productSearchClient->getProductSet($formattedName);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+        
+            get_product_set_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1048,57 +1075,60 @@ items:
       
       * Returns NOT_FOUND if the specified image does not exist.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ReferenceImage;
       
-      /**
-       * @param string $formattedName The resource name of the ReferenceImage to get.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`. Please see
-       *                              {@see ProductSearchClient::referenceImageName()} for help formatting this field.
-       */
-      function get_reference_image_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var ReferenceImage $response */
-              $response = $productSearchClient->getReferenceImage($formattedName);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::referenceImageName(
-              '[PROJECT]',
-              '[LOCATION]',
-              '[PRODUCT]',
-              '[REFERENCE_IMAGE]'
-          );
-      
-          get_reference_image_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ReferenceImage;
+        
+        /**
+         * @param string $formattedName The resource name of the ReferenceImage to get.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`. Please see
+         *                              {@see ProductSearchClient::referenceImageName()} for help formatting this field.
+         */
+        function get_reference_image_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var ReferenceImage $response */
+                $response = $productSearchClient->getReferenceImage($formattedName);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::referenceImageName(
+                '[PROJECT]',
+                '[LOCATION]',
+                '[PRODUCT]',
+                '[REFERENCE_IMAGE]'
+            );
+        
+            get_reference_image_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1133,67 +1163,70 @@ items:
       For the format of the csv file please see
       <xref uid="\Google\Cloud\Vision\V1\ImportProductSetsGcsSource::getCsvFileUri()">ImportProductSetsGcsSource.csv_file_uri</xref>.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\OperationResponse;
-      use Google\Cloud\Vision\V1\ImportProductSetsInputConfig;
-      use Google\Cloud\Vision\V1\ImportProductSetsResponse;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Rpc\Status;
       
-      /**
-       * @param string $formattedParent The project in which the ProductSets should be imported.
-       *
-       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
-       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function import_product_sets_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $inputConfig = new ImportProductSetsInputConfig();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var OperationResponse $response */
-              $response = $productSearchClient->importProductSets($formattedParent, $inputConfig);
-              $response->pollUntilComplete();
-      
-              if ($response->operationSucceeded()) {
-                  /** @var ImportProductSetsResponse $result */
-                  $result = $response->getResult();
-                  printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
-              } else {
-                  /** @var Status $error */
-                  $error = $response->getError();
-                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          import_product_sets_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\OperationResponse;
+        use Google\Cloud\Vision\V1\ImportProductSetsInputConfig;
+        use Google\Cloud\Vision\V1\ImportProductSetsResponse;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Rpc\Status;
+        
+        /**
+         * @param string $formattedParent The project in which the ProductSets should be imported.
+         *
+         *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+         *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function import_product_sets_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $inputConfig = new ImportProductSetsInputConfig();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var OperationResponse $response */
+                $response = $productSearchClient->importProductSets($formattedParent, $inputConfig);
+                $response->pollUntilComplete();
+        
+                if ($response->operationSucceeded()) {
+                    /** @var ImportProductSetsResponse $result */
+                    $result = $response->getResult();
+                    printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
+                } else {
+                    /** @var Status $error */
+                    $error = $response->getError();
+                    printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            import_product_sets_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1227,56 +1260,59 @@ items:
       * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
       than 1.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\PagedListResponse;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ProductSet;
       
-      /**
-       * @param string $formattedParent The project from which ProductSets should be listed.
-       *
-       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
-       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function list_product_sets_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var PagedListResponse $response */
-              $response = $productSearchClient->listProductSets($formattedParent);
-      
-              /** @var ProductSet $element */
-              foreach ($response as $element) {
-                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          list_product_sets_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\PagedListResponse;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ProductSet;
+        
+        /**
+         * @param string $formattedParent The project from which ProductSets should be listed.
+         *
+         *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+         *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function list_product_sets_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var PagedListResponse $response */
+                $response = $productSearchClient->listProductSets($formattedParent);
+        
+                /** @var ProductSet $element */
+                foreach ($response as $element) {
+                    printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            list_product_sets_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1313,57 +1349,60 @@ items:
       
       * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\PagedListResponse;
-      use Google\Cloud\Vision\V1\Product;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedParent The project OR ProductSet from which Products should be listed.
-       *
-       *                                Format:
-       *                                `projects/PROJECT_ID/locations/LOC_ID`
-       *                                Please see {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function list_products_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var PagedListResponse $response */
-              $response = $productSearchClient->listProducts($formattedParent);
-      
-              /** @var Product $element */
-              foreach ($response as $element) {
-                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          list_products_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\PagedListResponse;
+        use Google\Cloud\Vision\V1\Product;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedParent The project OR ProductSet from which Products should be listed.
+         *
+         *                                Format:
+         *                                `projects/PROJECT_ID/locations/LOC_ID`
+         *                                Please see {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function list_products_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var PagedListResponse $response */
+                $response = $productSearchClient->listProducts($formattedParent);
+        
+                /** @var Product $element */
+                foreach ($response as $element) {
+                    printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            list_products_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1402,57 +1441,60 @@ items:
       
       * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\PagedListResponse;
-      use Google\Cloud\Vision\V1\Product;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName The ProductSet resource for which to retrieve Products.
-       *
-       *                              Format is:
-       *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-       *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
-       */
-      function list_products_in_product_set_sample(string $formattedName): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var PagedListResponse $response */
-              $response = $productSearchClient->listProductsInProductSet($formattedName);
-      
-              /** @var Product $element */
-              foreach ($response as $element) {
-                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-      
-          list_products_in_product_set_sample($formattedName);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\PagedListResponse;
+        use Google\Cloud\Vision\V1\Product;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName The ProductSet resource for which to retrieve Products.
+         *
+         *                              Format is:
+         *                              `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+         *                              Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+         */
+        function list_products_in_product_set_sample(string $formattedName): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var PagedListResponse $response */
+                $response = $productSearchClient->listProductsInProductSet($formattedName);
+        
+                /** @var Product $element */
+                foreach ($response as $element) {
+                    printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+        
+            list_products_in_product_set_sample($formattedName);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1491,57 +1533,60 @@ items:
       * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
       than 1.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\PagedListResponse;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ReferenceImage;
       
-      /**
-       * @param string $formattedParent Resource name of the product containing the reference images.
-       *
-       *                                Format is
-       *                                `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
-       *                                {@see ProductSearchClient::productName()} for help formatting this field.
-       */
-      function list_reference_images_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var PagedListResponse $response */
-              $response = $productSearchClient->listReferenceImages($formattedParent);
-      
-              /** @var ReferenceImage $element */
-              foreach ($response as $element) {
-                  printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-      
-          list_reference_images_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\PagedListResponse;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ReferenceImage;
+        
+        /**
+         * @param string $formattedParent Resource name of the product containing the reference images.
+         *
+         *                                Format is
+         *                                `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`. Please see
+         *                                {@see ProductSearchClient::productName()} for help formatting this field.
+         */
+        function list_reference_images_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var PagedListResponse $response */
+                $response = $productSearchClient->listReferenceImages($formattedParent);
+        
+                /** @var ReferenceImage $element */
+                foreach ($response as $element) {
+                    printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+        
+            list_reference_images_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1597,60 +1642,63 @@ items:
       progress and results of the request.
       `Operation.metadata` contains `BatchOperationMetadata`. (progress)
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\ApiCore\OperationResponse;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Rpc\Status;
       
-      /**
-       * @param string $formattedParent The project and location in which the Products should be deleted.
-       *
-       *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
-       *                                {@see ProductSearchClient::locationName()} for help formatting this field.
-       */
-      function purge_products_sample(string $formattedParent): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var OperationResponse $response */
-              $response = $productSearchClient->purgeProducts($formattedParent);
-              $response->pollUntilComplete();
-      
-              if ($response->operationSucceeded()) {
-                  printf('Operation completed successfully.' . PHP_EOL);
-              } else {
-                  /** @var Status $error */
-                  $error = $response->getError();
-                  printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
-              }
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
-      
-          purge_products_sample($formattedParent);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\ApiCore\OperationResponse;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Rpc\Status;
+        
+        /**
+         * @param string $formattedParent The project and location in which the Products should be deleted.
+         *
+         *                                Format is `projects/PROJECT_ID/locations/LOC_ID`. Please see
+         *                                {@see ProductSearchClient::locationName()} for help formatting this field.
+         */
+        function purge_products_sample(string $formattedParent): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var OperationResponse $response */
+                $response = $productSearchClient->purgeProducts($formattedParent);
+                $response->pollUntilComplete();
+        
+                if ($response->operationSucceeded()) {
+                    printf('Operation completed successfully.' . PHP_EOL);
+                } else {
+                    /** @var Status $error */
+                    $error = $response->getError();
+                    printf('Operation failed with error data: %s' . PHP_EOL, $error->serializeToJsonString());
+                }
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedParent = ProductSearchClient::locationName('[PROJECT]', '[LOCATION]');
+        
+            purge_products_sample($formattedParent);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1687,58 +1735,61 @@ items:
     summary: |
       Removes a Product from the specified ProductSet.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * @param string $formattedName    The resource name for the ProductSet to modify.
-       *
-       *                                 Format is:
-       *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-       *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
-       * @param string $formattedProduct The resource name for the Product to be removed from this ProductSet.
-       *
-       *                                 Format is:
-       *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-       *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
-       */
-      function remove_product_from_product_set_sample(
-          string $formattedName,
-          string $formattedProduct
-      ): void {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Call the API and handle any network failures.
-          try {
-              $productSearchClient->removeProductFromProductSet($formattedName, $formattedProduct);
-              printf('Call completed successfully.' . PHP_EOL);
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function callSample(): void
-      {
-          $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
-          $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
-      
-          remove_product_from_product_set_sample($formattedName, $formattedProduct);
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * @param string $formattedName    The resource name for the ProductSet to modify.
+         *
+         *                                 Format is:
+         *                                 `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+         *                                 Please see {@see ProductSearchClient::productSetName()} for help formatting this field.
+         * @param string $formattedProduct The resource name for the Product to be removed from this ProductSet.
+         *
+         *                                 Format is:
+         *                                 `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+         *                                 Please see {@see ProductSearchClient::productName()} for help formatting this field.
+         */
+        function remove_product_from_product_set_sample(
+            string $formattedName,
+            string $formattedProduct
+        ): void {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Call the API and handle any network failures.
+            try {
+                $productSearchClient->removeProductFromProductSet($formattedName, $formattedProduct);
+                printf('Call completed successfully.' . PHP_EOL);
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function callSample(): void
+        {
+            $formattedName = ProductSearchClient::productSetName('[PROJECT]', '[LOCATION]', '[PRODUCT_SET]');
+            $formattedProduct = ProductSearchClient::productName('[PROJECT]', '[LOCATION]', '[PRODUCT]');
+        
+            remove_product_from_product_set_sample($formattedName, $formattedProduct);
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1779,41 +1830,44 @@ items:
       longer than 4096 characters.
       * Returns INVALID_ARGUMENT if product_category is present in update_mask.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\Product;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function update_product_sample(): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $product = new Product();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var Product $response */
-              $response = $productSearchClient->updateProduct($product);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\Product;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function update_product_sample(): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $product = new Product();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var Product $response */
+                $response = $productSearchClient->updateProduct($product);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -
@@ -1850,41 +1904,44 @@ items:
       * Returns INVALID_ARGUMENT if display_name is present in update_mask but
       missing from the request or longer than 4096 characters.
       
-      Sample code:
-      ```php
-      use Google\ApiCore\ApiException;
-      use Google\Cloud\Vision\V1\ProductSearchClient;
-      use Google\Cloud\Vision\V1\ProductSet;
       
-      /**
-       * This sample has been automatically generated and should be regarded as a code
-       * template only. It will require modifications to work:
-       *  - It may require correct/in-range values for request initialization.
-       *  - It may require specifying regional endpoints when creating the service client,
-       *    please see the apiEndpoint client configuration option for more details.
-       */
-      function update_product_set_sample(): void
-      {
-          // Create a client.
-          $productSearchClient = new ProductSearchClient();
-      
-          // Prepare any non-scalar elements to be passed along with the request.
-          $productSet = new ProductSet();
-      
-          // Call the API and handle any network failures.
-          try {
-              /** @var ProductSet $response */
-              $response = $productSearchClient->updateProductSet($productSet);
-              printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
-          } catch (ApiException $ex) {
-              printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
-          }
-      }
-      ```
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
     langs:
       - php
+    example:
+      - |
+        Sample code:
+        ```php
+        use Google\ApiCore\ApiException;
+        use Google\Cloud\Vision\V1\ProductSearchClient;
+        use Google\Cloud\Vision\V1\ProductSet;
+        
+        /**
+         * This sample has been automatically generated and should be regarded as a code
+         * template only. It will require modifications to work:
+         *  - It may require correct/in-range values for request initialization.
+         *  - It may require specifying regional endpoints when creating the service client,
+         *    please see the apiEndpoint client configuration option for more details.
+         */
+        function update_product_set_sample(): void
+        {
+            // Create a client.
+            $productSearchClient = new ProductSearchClient();
+        
+            // Prepare any non-scalar elements to be passed along with the request.
+            $productSet = new ProductSet();
+        
+            // Call the API and handle any network failures.
+            try {
+                /** @var ProductSet $response */
+                $response = $productSearchClient->updateProductSet($productSet);
+                printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+            } catch (ApiException $ex) {
+                printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+            }
+        }
+        ```
     syntax:
       parameters:
         -


### PR DESCRIPTION
This updates Cloud RAD to utilize our newly generated samples (found in `ComponentID/samples`) where they are available.