### PR TITLE
 feat: [Spanner] make ValueMapper customizable

### DIFF
--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -191,6 +191,8 @@ class Database
      *        be returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility. **Defaults to** false.
      * @param string $databaseRole The user created database role which creates the session.
+     * @param ValueMapperInterface|null $valueMapper A mapper which maps values
+     *        between PHP and Spanner.
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -202,14 +204,15 @@ class Database
         SessionPoolInterface $sessionPool = null,
         $returnInt64AsObject = false,
         array $info = [],
-        $databaseRole = null
+        $databaseRole = null,
+        $valueMapper = null
     ) {
         $this->connection = $connection;
         $this->instance = $instance;
         $this->projectId = $projectId;
         $this->name = $this->fullyQualifiedDatabaseName($name);
         $this->sessionPool = $sessionPool;
-        $this->operation = new Operation($connection, $returnInt64AsObject);
+        $this->operation = new Operation($connection, $returnInt64AsObject, $valueMapper);
         $this->info = $info;
 
         if ($this->sessionPool) {
@@ -2090,7 +2093,7 @@ class Database
 
     /**
      * Returns the 'CREATE DATABASE' statement as per the given database dialect
-     * 
+     *
      * @param string $dialect The dialect of the database to be created
      * @return string The specific 'CREATE DATABASE' statement
      */

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -495,6 +495,8 @@ class Instance
      *     @type SessionPoolInterface $sessionPool A pool used to manage
      *           sessions.
      *     @type string $databaseRole The user created database role which creates the session.
+     *     @type ValueMapperInterface|null $valueMapper A mapper which maps values
+     *     between PHP and Spanner.
      * }
      * @return Database
      */
@@ -510,7 +512,8 @@ class Instance
             isset($options['sessionPool']) ? $options['sessionPool'] : null,
             $this->returnInt64AsObject,
             isset($options['database']) ? $options['database'] : [],
-            isset($options['databaseRole']) ? $options['databaseRole'] : null
+            isset($options['databaseRole']) ? $options['databaseRole'] : null,
+            isset($options['valueMapper']) ? $options['valueMapper'] : null
         );
     }
 

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -65,11 +65,20 @@ class Operation
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
      *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility.
+     * @param ValueMapperInterface|null $valueMapper A mapper which maps values
+     *        between PHP and Spanner.
      */
-    public function __construct(ConnectionInterface $connection, $returnInt64AsObject)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        $returnInt64AsObject,
+        $valueMapper = null
+    ) {
+        if ($valueMapper === null) {
+            $valueMapper = new ValueMapper($returnInt64AsObject);
+        }
+
         $this->connection = $connection;
-        $this->mapper = new ValueMapper($returnInt64AsObject);
+        $this->mapper = $valueMapper;
     }
 
     /**

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -26,7 +26,7 @@ use Google\Cloud\Spanner\V1\TypeAnnotationCode;
 /**
  * Manage value mappings between Google Cloud PHP and Cloud Spanner
  */
-class ValueMapper
+class ValueMapper implements ValueMapperInterface
 {
     use ArrayTrait;
     use TimeTrait;

--- a/Spanner/src/ValueMapperInterface.php
+++ b/Spanner/src/ValueMapperInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Spanner;
+
+use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\Int64;
+use Google\Cloud\Core\TimeTrait;
+use Google\Cloud\Spanner\V1\TypeAnnotationCode;
+use Google\Cloud\Spanner\V1\TypeCode;
+
+/**
+ * Manage value mappings between Google Cloud PHP and Cloud Spanner
+ */
+interface ValueMapperInterface
+{
+    /**
+     * @param array $parameters The key/value parameters.
+     * @param array $types The types of values.
+     * @return array An associative array containing params and paramTypes.
+     */
+    public function formatParamsForExecuteSql(array $parameters, array $types = []);
+
+    /**
+     * @param array $values The list of values
+     * @param bool $allowMixedArrayType If true, array values may be of mixed type.
+     *        **Defaults to** `false`.
+     * @return array The encoded values
+     */
+    public function encodeValuesAsSimpleType(array $values, $allowMixedArrayType = false);
+
+    /**
+     * @param array $columns The list of columns.
+     * @param array $row The row data.
+     * @param string $format The format in which to return the rows.
+     * @return array The decoded row data.
+     * @throws \InvalidArgumentException
+     */
+    public function decodeValues(array $columns, array $row, $format);
+}


### PR DESCRIPTION
This PR makes Spanner's ValueMapper customizable.

I made this PR because I'd like to modify ValueMapper so that `decodeValues` return raw values instead of column types like TIMESTAMP being converted into `DateTimeImmutable` automatically. 
Right now, there is no good way to achieve this. 

I want this feature because in [Laravel](https://laravel.com/) (the web framework I use and [wrote a spanner driver for](https://github.com/colopl/laravel-spanner)), data is expected to be passed to the model as raw values and should be converted to useful types only when it is actually used, which is more efficient since not all rows retrieved from the database are actually used during the request's lifecycle.

This feature does not introduce any breaking changes.

Please let me know what you all think.

Thank you.