### PR TITLE
chore(docs): add links to protobuf reference docs

### DIFF
--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -20,13 +20,14 @@ namespace Google\Cloud\Dev\DocFx\Node;
 trait XrefTrait
 {
     /**
-     * @param string $type            The parameter type to replace
+     * @param string $type The parameter type to replace
      */
     private function normalizeTypedVariables(string $type): string
     {
         $types = explode('|', $type);
 
         // Remove redundant "RepeatedField" type for protobuf parameters
+        // e.g. "@return array<Google\Cloud\SomeMessage>|\Google\Protobuf\Internal\RepeatedField[]"
         if (count($types) == 2 && '\Google\Protobuf\Internal\RepeatedField' === $types[1]) {
             array_pop($types);
         }
@@ -149,8 +150,8 @@ trait XrefTrait
                 $extLinkRoot = 'https://googleapis.github.io/google-auth-library-php/main/';
                 break;
             case 0 === strpos($uid, '\Google\Protobuf\\'):
-                // @TODO: link to reference docs for Protobuf
-                return $name;
+                $extLinkRoot = 'https://protobuf.dev/reference/php/api-docs/';
+                break;
             case 0 === strpos($uid, '\Google\Api\\'):
             case 0 === strpos($uid, '\Google\Cloud\Iam\V1\\'):
             case 0 === strpos($uid, '\Google\Cloud\Location\\'):

--- a/dev/tests/fixtures/docfx/V1.AnnotateFileRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.AnnotateFileRequest.yml
@@ -125,7 +125,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateFileRequest::setFeatures()'
     name: setFeatures
@@ -225,7 +225,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateFileRequest::setPages()'
     name: setPages

--- a/dev/tests/fixtures/docfx/V1.AnnotateFileResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.AnnotateFileResponse.yml
@@ -127,7 +127,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateFileResponse::setResponses()'
     name: setResponses

--- a/dev/tests/fixtures/docfx/V1.AnnotateImageRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.AnnotateImageRequest.yml
@@ -120,7 +120,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageRequest::setFeatures()'
     name: setFeatures

--- a/dev/tests/fixtures/docfx/V1.AnnotateImageResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.AnnotateImageResponse.yml
@@ -144,7 +144,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setFaceAnnotations()'
     name: setFaceAnnotations
@@ -181,7 +181,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setLandmarkAnnotations()'
     name: setLandmarkAnnotations
@@ -218,7 +218,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setLogoAnnotations()'
     name: setLogoAnnotations
@@ -255,7 +255,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setLabelAnnotations()'
     name: setLabelAnnotations
@@ -294,7 +294,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setLocalizedObjectAnnotations()'
     name: setLocalizedObjectAnnotations
@@ -333,7 +333,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AnnotateImageResponse::setTextAnnotations()'
     name: setTextAnnotations

--- a/dev/tests/fixtures/docfx/V1.AsyncAnnotateFileRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.AsyncAnnotateFileRequest.yml
@@ -127,7 +127,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AsyncAnnotateFileRequest::setFeatures()'
     name: setFeatures

--- a/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateFilesRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateFilesRequest.yml
@@ -57,7 +57,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest::setRequests()'
     name: setRequests

--- a/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateFilesResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateFilesResponse.yml
@@ -51,7 +51,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesResponse::setResponses()'
     name: setResponses

--- a/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateImagesRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.AsyncBatchAnnotateImagesRequest.yml
@@ -64,7 +64,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest::setRequests()'
     name: setRequests

--- a/dev/tests/fixtures/docfx/V1.BatchAnnotateFilesRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.BatchAnnotateFilesRequest.yml
@@ -57,7 +57,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BatchAnnotateFilesRequest::setRequests()'
     name: setRequests

--- a/dev/tests/fixtures/docfx/V1.BatchAnnotateFilesResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.BatchAnnotateFilesResponse.yml
@@ -51,7 +51,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BatchAnnotateFilesResponse::setResponses()'
     name: setResponses

--- a/dev/tests/fixtures/docfx/V1.BatchAnnotateImagesRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.BatchAnnotateImagesRequest.yml
@@ -56,7 +56,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BatchAnnotateImagesRequest::setRequests()'
     name: setRequests

--- a/dev/tests/fixtures/docfx/V1.BatchAnnotateImagesResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.BatchAnnotateImagesResponse.yml
@@ -50,7 +50,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse::setResponses()'
     name: setResponses

--- a/dev/tests/fixtures/docfx/V1.BatchOperationMetadata.yml
+++ b/dev/tests/fixtures/docfx/V1.BatchOperationMetadata.yml
@@ -48,11 +48,11 @@ items:
           description: 'The current state of the batch operation.'
         -
           id: '↳ submit_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'The time when the batch request was submitted to the server.'
         -
           id: '↳ end_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'The time when the batch request is finished and <xref uid="\Google\Longrunning\Operation::getDone()">google.longrunning.Operation.done</xref> is set to true.'
   -
     uid: '\Google\Cloud\Vision\V1\BatchOperationMetadata::getState()'
@@ -106,7 +106,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\BatchOperationMetadata::hasSubmitTime()'
     name: hasSubmitTime
@@ -139,7 +139,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -
@@ -160,7 +160,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\BatchOperationMetadata::hasEndTime()'
     name: hasEndTime
@@ -194,7 +194,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -

--- a/dev/tests/fixtures/docfx/V1.Block.yml
+++ b/dev/tests/fixtures/docfx/V1.Block.yml
@@ -214,7 +214,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Block::setParagraphs()'
     name: setParagraphs

--- a/dev/tests/fixtures/docfx/V1.BoundingPoly.yml
+++ b/dev/tests/fixtures/docfx/V1.BoundingPoly.yml
@@ -56,7 +56,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BoundingPoly::setVertices()'
     name: setVertices
@@ -93,7 +93,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\BoundingPoly::setNormalizedVertices()'
     name: setNormalizedVertices

--- a/dev/tests/fixtures/docfx/V1.CropHintsAnnotation.yml
+++ b/dev/tests/fixtures/docfx/V1.CropHintsAnnotation.yml
@@ -50,7 +50,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\CropHintsAnnotation::setCropHints()'
     name: setCropHints

--- a/dev/tests/fixtures/docfx/V1.CropHintsParams.yml
+++ b/dev/tests/fixtures/docfx/V1.CropHintsParams.yml
@@ -55,7 +55,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\CropHintsParams::setAspectRatios()'
     name: setAspectRatios

--- a/dev/tests/fixtures/docfx/V1.DominantColorsAnnotation.yml
+++ b/dev/tests/fixtures/docfx/V1.DominantColorsAnnotation.yml
@@ -50,7 +50,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\DominantColorsAnnotation::setColors()'
     name: setColors

--- a/dev/tests/fixtures/docfx/V1.EntityAnnotation.yml
+++ b/dev/tests/fixtures/docfx/V1.EntityAnnotation.yml
@@ -406,7 +406,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\EntityAnnotation::setLocations()'
     name: setLocations
@@ -449,7 +449,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\EntityAnnotation::setProperties()'
     name: setProperties

--- a/dev/tests/fixtures/docfx/V1.FaceAnnotation.yml
+++ b/dev/tests/fixtures/docfx/V1.FaceAnnotation.yml
@@ -268,7 +268,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\FaceAnnotation::setLandmarks()'
     name: setLandmarks

--- a/dev/tests/fixtures/docfx/V1.ImageContext.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageContext.yml
@@ -150,7 +150,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ImageContext::setLanguageHints()'
     name: setLanguageHints

--- a/dev/tests/fixtures/docfx/V1.ImportProductSetsResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.ImportProductSetsResponse.yml
@@ -60,7 +60,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ImportProductSetsResponse::setReferenceImages()'
     name: setReferenceImages
@@ -102,7 +102,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ImportProductSetsResponse::setStatuses()'
     name: setStatuses

--- a/dev/tests/fixtures/docfx/V1.ListProductSetsResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.ListProductSetsResponse.yml
@@ -56,7 +56,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ListProductSetsResponse::setProductSets()'
     name: setProductSets

--- a/dev/tests/fixtures/docfx/V1.ListProductsInProductSetResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.ListProductsInProductSetResponse.yml
@@ -56,7 +56,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ListProductsInProductSetResponse::setProducts()'
     name: setProducts

--- a/dev/tests/fixtures/docfx/V1.ListProductsResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.ListProductsResponse.yml
@@ -56,7 +56,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ListProductsResponse::setProducts()'
     name: setProducts

--- a/dev/tests/fixtures/docfx/V1.ListReferenceImagesResponse.yml
+++ b/dev/tests/fixtures/docfx/V1.ListReferenceImagesResponse.yml
@@ -62,7 +62,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ListReferenceImagesResponse::setReferenceImages()'
     name: setReferenceImages

--- a/dev/tests/fixtures/docfx/V1.OperationMetadata.yml
+++ b/dev/tests/fixtures/docfx/V1.OperationMetadata.yml
@@ -45,11 +45,11 @@ items:
           description: 'Current state of the batch operation.'
         -
           id: '↳ create_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'The time when the batch request was received.'
         -
           id: '↳ update_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'The time when the operation result was last updated.'
   -
     uid: '\Google\Cloud\Vision\V1\OperationMetadata::getState()'
@@ -103,7 +103,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\OperationMetadata::hasCreateTime()'
     name: hasCreateTime
@@ -136,7 +136,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -
@@ -156,7 +156,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\OperationMetadata::hasUpdateTime()'
     name: hasUpdateTime
@@ -189,7 +189,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -

--- a/dev/tests/fixtures/docfx/V1.Page.yml
+++ b/dev/tests/fixtures/docfx/V1.Page.yml
@@ -207,7 +207,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Page::setBlocks()'
     name: setBlocks

--- a/dev/tests/fixtures/docfx/V1.Paragraph.yml
+++ b/dev/tests/fixtures/docfx/V1.Paragraph.yml
@@ -208,7 +208,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Paragraph::setWords()'
     name: setWords

--- a/dev/tests/fixtures/docfx/V1.Product.yml
+++ b/dev/tests/fixtures/docfx/V1.Product.yml
@@ -250,7 +250,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Product::setProductLabels()'
     name: setProductLabels

--- a/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchClient.yml
@@ -1863,7 +1863,7 @@ items:
         -
           id: '↳ updateMask'
           var_type: FieldMask
-          description: 'The FieldMask that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask paths include `product_labels`, `display_name`, and `description`.'
+          description: 'The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask paths include `product_labels`, `display_name`, and `description`.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -1936,7 +1936,7 @@ items:
         -
           id: '↳ updateMask'
           var_type: FieldMask
-          description: 'The FieldMask that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask path is `display_name`.'
+          description: 'The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask path is `display_name`.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array

--- a/dev/tests/fixtures/docfx/V1.ProductSearchParams.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchParams.yml
@@ -176,7 +176,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchParams::setProductCategories()'
     name: setProductCategories

--- a/dev/tests/fixtures/docfx/V1.ProductSearchResults.GroupedResult.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchResults.GroupedResult.yml
@@ -118,7 +118,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult::setResults()'
     name: setResults
@@ -155,7 +155,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchResults\GroupedResult::setObjectAnnotations()'
     name: setObjectAnnotations

--- a/dev/tests/fixtures/docfx/V1.ProductSearchResults.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSearchResults.yml
@@ -39,7 +39,7 @@ items:
           description: 'Optional. Data for populating the Message object.'
         -
           id: '↳ index_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'Timestamp of the index which provided these results. Products added to the product set and products removed from the product set after this time are not reflected in the current results.'
         -
           id: '↳ results'
@@ -66,7 +66,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchResults::hasIndexTime()'
     name: hasIndexTime
@@ -101,7 +101,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -
@@ -121,7 +121,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchResults::setResults()'
     name: setResults
@@ -161,7 +161,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchResults::setProductGroupedResults()'
     name: setProductGroupedResults

--- a/dev/tests/fixtures/docfx/V1.ProductSet.yml
+++ b/dev/tests/fixtures/docfx/V1.ProductSet.yml
@@ -53,7 +53,7 @@ items:
           description: 'The user-provided name for this ProductSet. Must not be empty. Must be at most 4096 characters long.'
         -
           id: '↳ index_time'
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: 'Output only. The time at which this ProductSet was last indexed. Query results will reflect all updates before this time. If this ProductSet has never been indexed, this timestamp is the default value "1970-01-01T00:00:00Z". This field is ignored when creating a ProductSet.'
         -
           id: '↳ index_error'
@@ -163,7 +163,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Timestamp|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSet::hasIndexTime()'
     name: hasIndexTime
@@ -201,7 +201,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\Timestamp
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp">Google\Protobuf\Timestamp</a>'
           description: ''
       returns:
         -

--- a/dev/tests/fixtures/docfx/V1.ReferenceImage.yml
+++ b/dev/tests/fixtures/docfx/V1.ReferenceImage.yml
@@ -156,7 +156,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ReferenceImage::setBoundingPolys()'
     name: setBoundingPolys

--- a/dev/tests/fixtures/docfx/V1.TextAnnotation.TextProperty.yml
+++ b/dev/tests/fixtures/docfx/V1.TextAnnotation.TextProperty.yml
@@ -58,7 +58,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\TextAnnotation\TextProperty::setDetectedLanguages()'
     name: setDetectedLanguages

--- a/dev/tests/fixtures/docfx/V1.TextAnnotation.yml
+++ b/dev/tests/fixtures/docfx/V1.TextAnnotation.yml
@@ -63,7 +63,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\TextAnnotation::setPages()'
     name: setPages

--- a/dev/tests/fixtures/docfx/V1.TextDetectionParams.yml
+++ b/dev/tests/fixtures/docfx/V1.TextDetectionParams.yml
@@ -98,7 +98,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\TextDetectionParams::setAdvancedOcrOptions()'
     name: setAdvancedOcrOptions

--- a/dev/tests/fixtures/docfx/V1.UpdateProductRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.UpdateProductRequest.yml
@@ -43,8 +43,8 @@ items:
           description: 'Required. The Product resource which replaces the one on the server. product.name is immutable.'
         -
           id: '↳ update_mask'
-          var_type: Google\Protobuf\FieldMask
-          description: 'The FieldMask that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask paths include `product_labels`, `display_name`, and `description`.'
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>'
+          description: 'The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask paths include `product_labels`, `display_name`, and `description`.'
   -
     uid: '\Google\Cloud\Vision\V1\UpdateProductRequest::getProduct()'
     name: getProduct
@@ -107,7 +107,7 @@ items:
     name: getUpdateMask
     id: getUpdateMask
     summary: |
-      The FieldMask that specifies which fields
+      The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields
       to update.
       
       If update_mask isn't specified, all mutable fields are to be updated.
@@ -122,7 +122,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\FieldMask|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\UpdateProductRequest::hasUpdateMask()'
     name: hasUpdateMask
@@ -144,7 +144,7 @@ items:
     name: setUpdateMask
     id: setUpdateMask
     summary: |
-      The FieldMask that specifies which fields
+      The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields
       to update.
       
       If update_mask isn't specified, all mutable fields are to be updated.
@@ -160,7 +160,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\FieldMask
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>'
           description: ''
       returns:
         -

--- a/dev/tests/fixtures/docfx/V1.UpdateProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/V1.UpdateProductSetRequest.yml
@@ -43,8 +43,8 @@ items:
           description: 'Required. The ProductSet resource which replaces the one on the server.'
         -
           id: '↳ update_mask'
-          var_type: Google\Protobuf\FieldMask
-          description: 'The FieldMask that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask path is `display_name`.'
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>'
+          description: 'The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to update. If update_mask isn''t specified, all mutable fields are to be updated. Valid mask path is `display_name`.'
   -
     uid: '\Google\Cloud\Vision\V1\UpdateProductSetRequest::getProductSet()'
     name: getProductSet
@@ -103,7 +103,7 @@ items:
     name: getUpdateMask
     id: getUpdateMask
     summary: |
-      The FieldMask that specifies which fields to
+      The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to
       update.
       
       If update_mask isn't specified, all mutable fields are to be updated.
@@ -117,7 +117,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\FieldMask|null
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>|null'
   -
     uid: '\Google\Cloud\Vision\V1\UpdateProductSetRequest::hasUpdateMask()'
     name: hasUpdateMask
@@ -139,7 +139,7 @@ items:
     name: setUpdateMask
     id: setUpdateMask
     summary: |
-      The FieldMask that specifies which fields to
+      The <a href="https://protobuf.dev/reference/php/api-docs/FieldMask">FieldMask</a> that specifies which fields to
       update.
       
       If update_mask isn't specified, all mutable fields are to be updated.
@@ -154,7 +154,7 @@ items:
       parameters:
         -
           id: var
-          var_type: Google\Protobuf\FieldMask
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/FieldMask">Google\Protobuf\FieldMask</a>'
           description: ''
       returns:
         -

--- a/dev/tests/fixtures/docfx/V1.WebDetection.WebPage.yml
+++ b/dev/tests/fixtures/docfx/V1.WebDetection.WebPage.yml
@@ -187,7 +187,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection\WebPage::setFullMatchingImages()'
     name: setFullMatchingImages
@@ -230,7 +230,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection\WebPage::setPartialMatchingImages()'
     name: setPartialMatchingImages

--- a/dev/tests/fixtures/docfx/V1.WebDetection.yml
+++ b/dev/tests/fixtures/docfx/V1.WebDetection.yml
@@ -80,7 +80,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setWebEntities()'
     name: setWebEntities
@@ -119,7 +119,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setFullMatchingImages()'
     name: setFullMatchingImages
@@ -161,7 +161,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setPartialMatchingImages()'
     name: setPartialMatchingImages
@@ -201,7 +201,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setPagesWithMatchingImages()'
     name: setPagesWithMatchingImages
@@ -238,7 +238,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setVisuallySimilarImages()'
     name: setVisuallySimilarImages
@@ -277,7 +277,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\WebDetection::setBestGuessLabels()'
     name: setBestGuessLabels

--- a/dev/tests/fixtures/docfx/V1.Word.yml
+++ b/dev/tests/fixtures/docfx/V1.Word.yml
@@ -210,7 +210,7 @@ items:
     syntax:
       returns:
         -
-          var_type: Google\Protobuf\Internal\RepeatedField
+          var_type: '<a href="https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Internal/RepeatedField">Google\Protobuf\Internal\RepeatedField</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Word::setSymbols()'
     name: setSymbols


### PR DESCRIPTION
Links to new Protobuf reference docs for PHP in Cloud RAD: https://protobuf.dev/reference/php/api-docs/