### PR TITLE
fix(Translate): test failures addressed

### DIFF
--- a/Translate/src/V2/TranslateClient.php
+++ b/Translate/src/V2/TranslateClient.php
@@ -336,11 +336,14 @@ class TranslateClient
         foreach ($response['data']['detections'] as $key => $detection) {
             $detection = $detection[0];
 
-            $detections[] = array_filter([
-                'languageCode' => $detection['language'],
-                'input' => $strings[$key],
-                'confidence' => isset($detection['confidence']) ? $detection['confidence'] : null
-            ]);
+            $detections[] = array_filter(
+                [
+                    'languageCode' => $detection['language'],
+                    'input' => $strings[$key],
+                    'confidence' => isset($detection['confidence']) ? $detection['confidence'] : null
+                ],
+                fn ($value) => !is_null($value)
+            );
         }
 
         return $detections;

--- a/Translate/src/V2/TranslateClient.php
+++ b/Translate/src/V2/TranslateClient.php
@@ -343,7 +343,7 @@ class TranslateClient
                     'confidence' => isset($detection['confidence']) ? $detection['confidence'] : null
                 ],
                 function ($value) {
-                  return !is_null($value);
+                    return !is_null($value);
                 }
             );
         }

--- a/Translate/src/V2/TranslateClient.php
+++ b/Translate/src/V2/TranslateClient.php
@@ -342,7 +342,9 @@ class TranslateClient
                     'input' => $strings[$key],
                     'confidence' => isset($detection['confidence']) ? $detection['confidence'] : null
                 ],
-                fn ($value) => !is_null($value)
+                function ($value) {
+                  return !is_null($value);
+                }
             );
         }
 

--- a/Translate/tests/System/V2/TranslateTest.php
+++ b/Translate/tests/System/V2/TranslateTest.php
@@ -32,7 +32,7 @@ class TranslateTest extends TranslateTestCase
 
     const INPUT_LANGUAGE = 'es';
     const INPUT_STRING = '¿hola, como estas?';
-    const OUTPUT_STRING = 'Hello how are you doing?';
+    const OUTPUT_STRING = 'Hello how are you?';
 
     public function testTranslate()
     {
@@ -64,7 +64,7 @@ class TranslateTest extends TranslateTestCase
         $this->assertEquals(self::INPUT_LANGUAGE, $res['source']);
         $this->assertEquals(self::INPUT_STRING, $res['input']);
         $this->assertEquals(self::OUTPUT_STRING, $res['text']);
-        $this->assertEquals('base', $res['model']);
+        $this->assertEquals('nmt', $res['model']);
     }
 
     public function testTranslateInvalidModel()
@@ -103,7 +103,7 @@ class TranslateTest extends TranslateTestCase
     {
         $client = self::$client;
 
-        $res = $client->translateBatch([self::INPUT_STRING], ['model' => 'nmt']);
+        $res = $client->translateBatch([self::INPUT_STRING], ['model' => 'base']);
         $this->assertEquals(self::INPUT_LANGUAGE, $res[0]['source']);
         $this->assertEquals(self::INPUT_STRING, $res[0]['input']);
         $this->assertEquals(self::OUTPUT_STRING, $res[0]['text']);
@@ -118,7 +118,7 @@ class TranslateTest extends TranslateTestCase
         $this->assertEquals(self::INPUT_LANGUAGE, $res[0]['source']);
         $this->assertEquals(self::INPUT_STRING, $res[0]['input']);
         $this->assertEquals(self::OUTPUT_STRING, $res[0]['text']);
-        $this->assertEquals('base', $res[0]['model']);
+        $this->assertEquals('nmt', $res[0]['model']);
     }
 
     public function testTranslateBatchInvalidModel()
@@ -164,7 +164,7 @@ class TranslateTest extends TranslateTestCase
 
         $res = $client->detectLanguage('');
         $this->assertEquals('und', $res['languageCode']);
-        $this->assertEquals(1, $res['confidence']);
+        $this->assertEquals(0, $res['confidence']);
     }
 
     public function testDetectLanguageBatch()
@@ -189,7 +189,7 @@ class TranslateTest extends TranslateTestCase
 
         $res = $client->detectLanguageBatch(['']);
         $this->assertEquals('und', $res[0]['languageCode']);
-        $this->assertEquals(1, $res[0]['confidence']);
+        $this->assertEquals(0, $res[0]['confidence']);
     }
 
     public function testDetectLanguages()
@@ -198,8 +198,8 @@ class TranslateTest extends TranslateTestCase
 
         $res = $client->languages();
         $this->assertIsArray($res);
-        $this->assertStringContainsString('en', $res);
-        $this->assertStringContainsString('es', $res);
+        $this->assertContains('en', $res);
+        $this->assertContains('es', $res);
     }
 
     public function testLocalizedLanguages()
@@ -208,7 +208,7 @@ class TranslateTest extends TranslateTestCase
 
         $res = $client->localizedLanguages();
         $this->assertIsArray($res);
-        $this->assertStringContainsString(['code' => 'es', 'name' => 'Spanish'], $res);
-        $this->assertStringContainsString(['code' => 'en', 'name' => 'English'], $res);
+        $this->assertContains(['code' => 'es', 'name' => 'Spanish'], $res);
+        $this->assertContains(['code' => 'en', 'name' => 'English'], $res);
     }
 }

--- a/Translate/tests/System/V3/TranslationServiceSmokeTest.php
+++ b/Translate/tests/System/V3/TranslationServiceSmokeTest.php
@@ -48,7 +48,7 @@ class TranslationServiceSmokeTest extends SystemTestCase
         );
 
         $this->assertEquals(
-            'uno',
+            'una',
             $res->getTranslations()[0]->getTranslatedText()
         );
     }


### PR DESCRIPTION
## Addressing following test failure fixes for Translate:

1. `confidence` value was earlier digested inside `TranslateClient` due to `array_filter`. Now a custom comparator is used in `array_filter` to ensure it surfaces up.
2. Fixed wrong translation in `Translate/tests/System/V2/TranslateTest.php`
3. Now, `base` model is outdated and its redirected to `nmt`, so migrated tests to reflect that.
<img width="904" alt="Screenshot 2022-12-23 at 03 41 40" src="https://user-images.githubusercontent.com/7369612/209236125-59303147-fc10-45f9-a4e6-970e179f56b1.png">

4. For empty strings, confidence is zero, but it was expected 1 which means 100% confident of the translation.
5. Migrating `assertStringContainsString` to `assertContains`  in case of array comparison.

## Tests passing on local:
<img width="825" alt="Screenshot 2022-12-23 at 03 49 05" src="https://user-images.githubusercontent.com/7369612/209236076-79b11481-3741-41ec-9b82-6402eceab762.png">


## Fixes
[b/263478992](http://b/263478992)
