### PR TITLE
chore(Storage): Merging gcs-uploads-retry branch to gcs-retry

### DIFF
--- a/Core/src/Upload/AbstractUploader.php
+++ b/Core/src/Upload/AbstractUploader.php
@@ -103,6 +103,7 @@ abstract class AbstractUploader
         $this->requestOptions = array_intersect_key($options, [
             'restOptions' => null,
             'retries' => null,
+            'restRetryFunction' => null,
             'requestTimeout' => null
         ]);
 

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -284,6 +284,12 @@ class Rest implements ConnectionInterface
     public function insertObject(array $args = [])
     {
         $args = $this->resolveUploadOptions($args);
+        $retryFunc = $this->getRestRetryFunction(
+            'objects',
+            'insert',
+            $args['uploaderOptions']);
+
+        $args['uploaderOptions']['restRetryFunction'] = $retryFunc;
 
         $uploadType = AbstractUploader::UPLOAD_TYPE_RESUMABLE;
         if ($args['streamable']) {


### PR DESCRIPTION
chore(Storage): Merging gcs-uploads-retry branch to gcs-retry

Merging gcs-uploads-retry branch to gcs-retry so that all the changes are at a single place so that for further work, can take out a branch from this updated gcs-retry branch.