### PR TITLE
fix(Vision): relax strict asserts on SafeSearch likelihood param

### DIFF
--- a/Vision/tests/System/AnnotationsTest.php
+++ b/Vision/tests/System/AnnotationsTest.php
@@ -64,11 +64,11 @@ class AnnotationsTest extends VisionTestCase
 
         // Safe Search
         $this->assertInstanceOf(SafeSearch::class, $res->safeSearch());
-        $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->adult());
-        $this->assertEquals('UNLIKELY', $res->safeSearch()->spoof());
-        $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->medical());
-        $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->violence());
-        $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->racy());
+        $this->assertStringContainsString('UNLIKELY', $res->safeSearch()->adult());
+        $this->assertStringContainsString('UNLIKELY', $res->safeSearch()->spoof());
+        $this->assertStringContainsString('UNLIKELY', $res->safeSearch()->medical());
+        $this->assertStringContainsString('UNLIKELY', $res->safeSearch()->violence());
+        $this->assertStringContainsString('UNLIKELY', $res->safeSearch()->racy());
         $this->assertFalse($res->safeSearch()->isAdult());
         $this->assertFalse($res->safeSearch()->isSpoof());
         $this->assertFalse($res->safeSearch()->isMedical());


### PR DESCRIPTION
## Context

Vision tests currently assert on the SafeSearch's likelihood param. These params can have following values:

```
// STRENGTH_HIGH 
'VERY_LIKELY'

// STRENGTH_MEDIUM
'LIKELY'

// STRENGTH_LOW
'POSSIBLE'
'UNLIKELY'
'VERY_UNLIKELY'
```

But due to constant improvements in the underlying models, responses seems to have deviated within the strength range and hence System tests are failing.

As a fix, we are migrating away from asserting on the exact likelihood param to a more sustainable, assert on strength.

## Tests

```
google-cloud-php/Vision % vendor/bin/phpunit -c phpunit-system.xml.dist
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

.....R                                                              6 / 6 (100%)

Time: 4.89 seconds, Memory: 8.00 MB

There was 1 risky test:

1) Google\Cloud\Vision\Tests\System\V1\ImageAnnotatorSmokeTest::batchAnnotateImagesTest
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/Vision/tests/System/V1/ImageAnnotatorSmokeTest.php:42

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/Vision/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 6, Assertions: 46, Risky: 1.
google-cloud-php/Vision % 
```

ref: [b/263772129](http://b/263772129)