### PR TITLE
fix(Logging): outputVersionFormat is deprecated

### DIFF
--- a/Logging/tests/System/ManageSinksTest.php
+++ b/Logging/tests/System/ManageSinksTest.php
@@ -71,7 +71,6 @@ class ManageSinksTest extends LoggingTestCase
 
         $this->assertTrue($client->sink($name)->exists());
         $this->assertEquals($destination, $sink->info()['destination']);
-        $this->assertEquals($options['outputVersionFormat'], $sink->info()['outputVersionFormat']);
         $this->assertEquals($options['filter'], $sink->info()['filter']);
     }
 
@@ -134,7 +133,6 @@ class ManageSinksTest extends LoggingTestCase
         $destination = sprintf('pubsub.googleapis.com/%s', self::$topic->info()['name']);
         $sink = $client->createSink($name, $destination, $options);
         self::$deletionQueue->add($sink);
-
-        $this->assertEquals($options['outputVersionFormat'], $sink->reload()['outputVersionFormat']);
+        $this->assertEquals($options['filter'], $sink->reload()['filter']);
     }
 }


### PR DESCRIPTION
## Context
Currently, Logging system tests assert on `outputVersionFormat`. But per our docs [ref link](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.sinks#get), this field is deprecated.

<img width="522" alt="Screenshot 2022-12-27 at 18 01 13" src="https://user-images.githubusercontent.com/7369612/209667155-bee96a88-01b0-4af6-a1b6-3e038e32cfbc.png">


## Fix

Removing asserts on `outputVersionFormat` and relying on asserts over`filter` property.

## Tests

```
google-cloud-php/Logging % vendor/bin/phpunit -c phpunit-system.xml.dist --filter="ManageSinksTest"
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

............                                                      12 / 12 (100%)

Time: 51.76 seconds, Memory: 12.00 MB

OK (12 tests, 32 assertions)
google-cloud-php/Logging % 
```

ref: [b/263776172](http://b/263776172)