### PR TITLE
fix(Language): fix scores and migrate assertEquals to assertEqualsWithDelta

### DIFF
--- a/Language/tests/System/AnalyzeTest.php
+++ b/Language/tests/System/AnalyzeTest.php
@@ -65,7 +65,7 @@ class AnalyzeTest extends LanguageTestCase
         $info = $result->info();
 
         foreach ($expectedValues as $key => $expected) {
-            $this->assertEquals($expected, $info[$key]);
+            $this->assertEqualsWithDelta($expected, $info[$key], 0.2);
         }
     }
 
@@ -147,17 +147,15 @@ class AnalyzeTest extends LanguageTestCase
                 if ($entity['name'] == $expectedEntity['name']) {
                     $exists = true;
                     $this->assertEquals($entity['type'], $expectedEntity['type']);
-                    $this->assertEquals(
+                    $this->assertEqualsWithDelta(
                         $entity['sentiment']['score'],
                         $expectedEntity['sentiment']['score'],
-                        '',
                         0.2
                     );
 
-                    $this->assertEquals(
+                    $this->assertEqualsWithDelta(
                         $entity['sentiment']['magnitude'],
                         $expectedEntity['sentiment']['magnitude'],
-                        '',
                         0.2
                     );
 
@@ -199,16 +197,16 @@ class AnalyzeTest extends LanguageTestCase
                         'name' => 'San Jose',
                         'type' => 'LOCATION',
                         'sentiment' => [
-                            'magnitude' => 0.3,
-                            'score' => 0.3,
+                            'magnitude' => 0.8,
+                            'score' => 0.8,
                         ],
                     ],
                     [
                         'name' => 'road',
                         'type' => 'LOCATION',
                         'sentiment' => [
-                            'magnitude' => 0.3,
-                            'score' => 0.3,
+                            'magnitude' => 0.8,
+                            'score' => 0.8,
                         ],
                     ],
                 ]


### PR DESCRIPTION
## Changes

1. Language tests overtime have changed scores output for sentiments. 
2. `assertEquals` need to be migrated to `assertEqualsWithDelta` due to deprecation. 
`The optional $delta parameter of assertEquals() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertEqualsWithDelta() instead.`

## Tests

```
google-cloud-php/Language % vendor/bin/phpunit -c phpunit-system.xml.dist                                                (git)-[main]-
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

......RR                                                            8 / 8 (100%)

Time: 6.81 seconds, Memory: 8.00 MB

There were 2 risky tests:

1) Google\Cloud\Language\Tests\System\V1\LanguageServiceSmokeTest::analyzeSentimentTest
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/Language/tests/System/V1/LanguageServiceSmokeTest.php:39

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/Language/vendor/phpunit/phpunit/phpunit:97

2) Google\Cloud\Language\Tests\System\V1beta2\LanguageServiceSmokeTest::analyzeSentimentTest
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/Language/tests/System/V1beta2/LanguageServiceSmokeTest.php:40

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/Language/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 8, Assertions: 27, Risky: 2.
google-cloud-php/Language %   
```

ref: [b/263851138](http://b/263851138)