### PR TITLE
chore(tests): [Core] fixing BatchRunnerTests

### DIFF
--- a/Core/phpunit-system.xml.dist
+++ b/Core/phpunit-system.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit bootstrap="./system-bootstrap.php" colors="true">
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>

--- a/Core/tests/System/Batch/BatchRunnerTest.php
+++ b/Core/tests/System/Batch/BatchRunnerTest.php
@@ -136,12 +136,13 @@ class BatchRunnerTest extends TestCase
         // It should be still in the buffer.
         $this->assertEmpty($this->getResult());
         $this->runner->submitItem('batch-daemon-system-test', 'orange');
+        // This item should be picked by the call period.
+        sleep(1);
         $this->assertResultContains('APPLE');
         $this->assertResultContains('ORANGE');
 
-        // This item should be picked by the call period.
-        sleep(1);
         $this->runner->submitItem('batch-daemon-system-test', 'peach');
+        sleep(1);
         $this->assertResultContains('PEACH');
 
         // Failure simulation
@@ -149,9 +150,10 @@ class BatchRunnerTest extends TestCase
 
         $this->runner->submitItem('batch-daemon-system-test', 'banana');
         $this->runner->submitItem('batch-daemon-system-test', 'lemon');
+        sleep(1);
         $result = $this->getResult();
-        $this->assertNotContains('BANANA', $result);
-        $this->assertNotContains('LEMON', $result);
+        $this->assertStringNotContainsString('BANANA', $result);
+        $this->assertStringNotContainsString('LEMON', $result);
 
         // Retry simulation
         unlink(self::$commandFile);
@@ -165,6 +167,7 @@ class BatchRunnerTest extends TestCase
             $retry = new Retry();
             $retry->retryAll();
         }
+        sleep(1);
         $this->assertResultContains('BANANA');
         $this->assertResultContains('LEMON');
     }


### PR DESCRIPTION
## Changes
1. bootstrap file path is wrong in `Core/phpunit-system.xml.dist`. @reviewers pls check whether this will cause failures in other tests.
2. `Core/tests/System/Batch/BatchRunnerTest.php` is generating warnings and failures due to frequent mutations (added sleep) and migrated `assertNotContains` to `assertStringNotContainsString` due to deprecation in latest PhpUnit.

## Tests

```
google-cloud-php/Core % vendor/bin/phpunit -c phpunit-system.xml.dist              (git)-[fix_core_tests]-
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

Starting a child.
Running the job with 2 items
Running the job with 1 items
Running the job with 2 items
.                                                                   1 / 1 (100%)Shutting down, waiting for the children
BatchDaemon exiting


Time: 5.49 seconds, Memory: 6.00 MB

OK (1 test, 8 assertions)
google-cloud-php/Core %                                                            (git)-[fix_core_tests]-
```


ref: [b/263856842](http://b/263856842)