### PR TITLE
chore(tests): [AutoMl] adding Operations::initOnce()

### DIFF
--- a/AutoMl/tests/System/V1/AutoMlSmokeTest.php
+++ b/AutoMl/tests/System/V1/AutoMlSmokeTest.php
@@ -77,6 +77,10 @@ class AutoMlSmokeTest extends SystemTestCase
             ])
         ]);
 
+        // Note: This line is required. Otherwise test fails citing:
+        // Class google.cloud.automl.v1.OperationMetadata hasn't been added to descriptor pool
+        \GPBMetadata\Google\Cloud\Automl\V1\Operations::initOnce();
+        
         $operationResponse = $automl->createDataset($formattedParent, $dataset);
         $operationResponse->pollUntilComplete();
         $dataset = $operationResponse->getResult();


### PR DESCRIPTION
## Background

1. AutoMl tests are failing with following message:
```
3) Google\Cloud\AutoMl\Tests\System\V1\AutoMlSmokeTest::testAutoMl with data set #1 (Google\Cloud\AutoMl\V1\AutoMlClient Object (...))
Google\Protobuf\Internal\GPBDecodeException: Error occurred during parsing: Class google.cloud.automl.v1.OperationMetadata hasn't been added to descriptor pool

/[tmpfs/src/github/google-cloud-php/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php:1338](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php?l=1338)
/[tmpfs/src/github/google-cloud-php/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php:793](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php?l=793)
/[tmpfs/src/github/google-cloud-php/vendor/google/gax/src/Transport/RestTransport.php:133](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/google/gax/src/Transport/RestTransport.php?l=133)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:204](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=204)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:153](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=153)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/TaskQueue.php:48](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/TaskQueue.php?l=48)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:159](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php?l=159)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:184](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php?l=184)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:248](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=248)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:224](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=224)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:269](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=269)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:226](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=226)
/[tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php:62](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/vendor/guzzlehttp/promises/src/Promise.php?l=62)
/[tmpfs/src/github/google-cloud-php/AutoMl/src/V1/Gapic/AutoMlGapicClient.php:584](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/AutoMl/src/V1/Gapic/AutoMlGapicClient.php?l=584)
/[tmpfs/src/github/google-cloud-php/AutoMl/tests/System/V1/AutoMlSmokeTest.php:80](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/github/google-cloud-php/AutoMl/tests/System/V1/AutoMlSmokeTest.php?l=80)
```

## Change

Adding `\GPBMetadata\Google\Cloud\Automl\V1\Operations::initOnce()` before `createDataset` call leads to no failure.


## Tests

```
google-cloud-php/AutoMl % vendor/bin/phpunit -c phpunit-system.xml.dist                      (git)-[main]-
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 17.71 seconds, Memory: 10.00 MB

OK (4 tests, 4 assertions)
google-cloud-php/AutoMl % 
```

ref: [b/263785306](http://b/263785306)