### PR TITLE
chore(docs): bigtable typehint for exactMatch

### DIFF
--- a/Bigtable/src/Filter/Builder/FamilyFilter.php
+++ b/Bigtable/src/Filter/Builder/FamilyFilter.php
@@ -68,7 +68,7 @@ class FamilyFilter
      * $familyFilter = $builder->exactMatch('cf1');
      * ```
      *
-     * @param string $value An exact value to match.
+     * @param array|string $value An exact value to match.
      * @return SimpleFilter
      * @throws \InvalidArgumentException When the provided value is not an array
      *         or string.

--- a/Bigtable/src/Filter/Builder/KeyFilter.php
+++ b/Bigtable/src/Filter/Builder/KeyFilter.php
@@ -71,7 +71,7 @@ class KeyFilter
      * $keyFilter = $builder->exactMatch('r1');
      * ```
      *
-     * @param string $value An exact value.
+     * @param array|string $value An exact value.
      * @return SimpleFilter
      * @throws \InvalidArgumentException When the provided value is not an array
      *         or string.

--- a/Bigtable/src/Filter/Builder/QualifierFilter.php
+++ b/Bigtable/src/Filter/Builder/QualifierFilter.php
@@ -70,7 +70,7 @@ class QualifierFilter
      * $qualifierFilter = $builder->exactMatch('cq1');
      * ```
      *
-     * @param string $value An exact value.
+     * @param array|string $value An exact value.
      * @return SimpleFilter
      * @throws \InvalidArgumentException When the provided value is not an array
      *         or string.

--- a/Bigtable/src/Filter/Builder/ValueFilter.php
+++ b/Bigtable/src/Filter/Builder/ValueFilter.php
@@ -68,7 +68,7 @@ class ValueFilter
      * $valueFilter = $builder->exactMatch('value1');
      * ```
      *
-     * @param string $value An exact value to match.
+     * @param array|string $value An exact value to match.
      * @return SimpleFilter
      * @throws \InvalidArgumentException When the provided value is not an array
      *         or string.


### PR DESCRIPTION
BigTable typehints for `exactMatch` functions are passed to [`RegexTrait::escapeLiteralValue`](https://github.com/googleapis/google-cloud-php/blob/5b5a70131e1751e63bea8b23073c57d1c9528d20/Bigtable/src/Filter/Builder/RegexTrait.php#L50), which accepts `array|string`. This is seen in [our samples as well](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/bigtable/src/filter_composing_condition.php#L50) (the result of `unpack` is an array).

This was caught by static analysis. I believe these methods should be widened to also accept arrays.