### PR TITLE
chore(VideoIntelligence): fixing test resource link

### DIFF
--- a/VideoIntelligence/tests/System/V1/VideoIntelligenceServiceClientTest.php
+++ b/VideoIntelligence/tests/System/V1/VideoIntelligenceServiceClientTest.php
@@ -72,7 +72,7 @@ class VideoIntelligenceServiceClientTest extends TestCase
      */
     public function testAnnotateVideo(VideoIntelligenceServiceClient $client)
     {
-        $inputUri = "gs://cloudmleap/video/next/animals.mp4";
+        $inputUri = "gs://cloud-samples-data/video/cat.mp4";
         $features = [
             Feature::LABEL_DETECTION,
             Feature::SHOT_CHANGE_DETECTION,
@@ -90,6 +90,5 @@ class VideoIntelligenceServiceClientTest extends TestCase
 
         $results = $operationResponse->getResult();
         $this->assertInstanceOf(AnnotateVideoResponse::class, $results);
-
     }
 }


### PR DESCRIPTION
Currently `VideoIntelligence/tests/System/V1/VideoIntelligenceServiceClientTest.php` fails because it has no permissions to the test resource (a video). With this change, the test resource link is changed.

# Changes
1. Changing test resource link.
2. Style fix.

# Tests

```
google-cloud-php/VideoIntelligence % vendor/bin/phpunit -c phpunit-system.xml.dist           
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

..R                                                                 3 / 3 (100%)

Time: 45.24 seconds, Memory: 8.00 MB

There was 1 risky test:

1) Google\Cloud\VideoIntelligence\Tests\System\V1\VideoIntelligenceServiceSmokeTest::annotateVideoTest
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/VideoIntelligence/tests/System/V1/VideoIntelligenceServiceSmokeTest.php:38

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/VideoIntelligence/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 3, Assertions: 6, Risky: 1.
google-cloud-php/VideoIntelligence %
```

ref: [b/263854178](http://b/263854178)
