### PR TITLE
chore: tests should use correct keys

### DIFF
--- a/BigQuery/tests/System/ManageTablesTest.php
+++ b/BigQuery/tests/System/ManageTablesTest.php
@@ -154,7 +154,7 @@ class ManageTablesTest extends BigQueryTestCase
 
     public function testCreatesExternalTable()
     {
-        $externalKeyFilePath = getenv('GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH');
+        $externalKeyFilePath = getenv('GOOGLE_CLOUD_PHP_FIRESTORE_TESTS_KEY_PATH');
         $authenticatedKeyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
         $externalKey = json_decode(file_get_contents($externalKeyFilePath), true);
         $authenticatedKey = json_decode(file_get_contents($authenticatedKeyFilePath), true);

--- a/Storage/tests/System/RequesterPaysTest.php
+++ b/Storage/tests/System/RequesterPaysTest.php
@@ -53,7 +53,7 @@ class RequesterPaysTest extends StorageTestCase
     {
         parent::set_up_before_class();
 
-        $requesterKeyFilePath = getenv('GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH');
+        $requesterKeyFilePath = getenv('GOOGLE_CLOUD_PHP_FIRESTORE_TESTS_KEY_PATH');
         $ownerKeyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
         self::$requesterKeyFile = json_decode(file_get_contents($requesterKeyFilePath), true);
         self::$requesterEmail = self::$requesterKeyFile['client_email'];


### PR DESCRIPTION
Currently system tests are failing due to use of wrong keys which no longer exist. 

# Change

Move from `GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH ` keys to `GOOGLE_CLOUD_PHP_FIRESTORE_TESTS_KEY_PATH`

# Tests

```
google-cloud-php/BigQuery % 
google-cloud-php/BigQuery % vendor/bin/phpunit -c phpunit-system.xml.dist --filter="testCreatesExternalTable"
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 12.09 seconds, Memory: 12.00 MB

OK (1 test, 1 assertion)
google-cloud-php/BigQuery % ../Storage
google-cloud-php/Storage % vendor/bin/phpunit -c phpunit-system.xml.dist --filter="RequesterPaysTest"        
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

................................................................. 65 / 71 ( 91%)
..RR..                                                            71 / 71 (100%)

Time: 1.21 minutes, Memory: 14.00 MB

There were 2 risky tests:

1) Google\Cloud\Storage\Tests\System\RequesterPaysTest::testUploadMethodsWithUserProject with data set "resumable-upload" (Closure Object (...))
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/Storage/tests/System/RequesterPaysTest.php:375

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/Storage/vendor/phpunit/phpunit/phpunit:97

2) Google\Cloud\Storage\Tests\System\RequesterPaysTest::testUploadMethodsWithUserProject with data set "streamable-upload" (Closure Object (...))
This test did not perform any assertions

/Users/vishwarajanand/github/google-cloud-php/Storage/tests/System/RequesterPaysTest.php:375

phpvfscomposer:///Users/vishwarajanand/github/google-cloud-php/Storage/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 71, Assertions: 71, Risky: 2.
google-cloud-php/Storage % 
```

ref: [b/264159447](http://b/264159447)
ref: [b/263473669](http://b/263473669#comment5)