### PR TITLE
chore(Storage): fix UrlStatTest::testIsExecutable

### DIFF
--- a/Storage/tests/System/StreamWrapper/UrlStatTest.php
+++ b/Storage/tests/System/StreamWrapper/UrlStatTest.php
@@ -89,7 +89,7 @@ class UrlStatTest extends StreamWrapperTestCase
     {
         // php returns false for is_executable if the file is a directory
         // https://github.com/php/php-src/blob/master/ext/standard/filestat.c#L907
-        $this->assertFalse(is_executable(self::$dirUrl));
+        $this->assertTrue(is_executable(self::$dirUrl));
         $this->assertFalse(is_executable(self::$fileUrl));
     }
 

--- a/Storage/tests/System/StreamWrapper/UrlStatTest.php
+++ b/Storage/tests/System/StreamWrapper/UrlStatTest.php
@@ -87,8 +87,6 @@ class UrlStatTest extends StreamWrapperTestCase
 
     public function testIsExecutable()
     {
-        // php returns false for is_executable if the file is a directory
-        // https://github.com/php/php-src/blob/master/ext/standard/filestat.c#L907
         $this->assertTrue(is_executable(self::$dirUrl));
         $this->assertFalse(is_executable(self::$fileUrl));
     }


### PR DESCRIPTION
Currently system tests are failing due to an incorrect assertion. 

# Change

`testIsExecutable` asserts on two variables: `fileUrl` and `dirUrl`. They look like below:
<img width="582" alt="Screenshot 2023-01-04 at 17 15 35" src="https://user-images.githubusercontent.com/7369612/210548302-d0fe4c24-24d8-4822-a92d-24739a8bf192.png">

On GCS page, it creates following structure:
<img width="401" alt="Screenshot 2023-01-04 at 15 37 43" src="https://user-images.githubusercontent.com/7369612/210548387-2c90a7ec-badf-4a5b-aaa4-2ecf905b2560.png">

With this change, we are aligning our test with the actual results of [is_executable](https://www.php.net/manual/en/function.is-executable.php#refsect1-function.is-executable-returnvalues) function.

# Tests

```
google-cloud-php/Storage % vendor/bin/phpunit -c phpunit-system.xml.dist --filter="UrlStatTest::testIsExecutable"
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 6.23 seconds, Memory: 12.00 MB

OK (1 test, 2 assertions)
google-cloud-php/Storage %
```

ref: [b/263473669](http://b/263473669#comment6)