### PR TITLE
fix(Datastore): migrate to env var PROJECT_ID

### DIFF
--- a/Datastore/tests/System/DatastoreMultipleDbTestCase.php
+++ b/Datastore/tests/System/DatastoreMultipleDbTestCase.php
@@ -46,7 +46,7 @@ class DatastoreMultipleDbTestCase extends DatastoreTestCase
         if (self::$hasSetUp) {
             return;
         }
-        self::$projectId = getenv('GOOGLE_PROJECT_ID');
+        self::$projectId = getenv('PROJECT_ID');
 
         $config = [
             'keyFilePath' => getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH'),


### PR DESCRIPTION
Currently system tests are failing due to use of wrong env var.

# Change

Move from `GOOGLE_PROJECT_ID` instead of `PROJECT_ID`.

# Tests

```
google-cloud-php/Datastore % XDEBUG_MODE=debug vendor/bin/phpunit -c phpunit-system.xml.dist           
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

................................................................. 65 / 86 ( 75%)
.....................                                             86 / 86 (100%)

Time: 1.54 minutes, Memory: 16.00 MB

OK (86 tests, 236 assertions)
google-cloud-php/Datastore % 
```

Note: We are also seeing auth issues due to faulty FS admin URLs while checking/creating test DB. This PR will help discover any remaining auth issues.

ref: [b/264530286](http://b/264530286)
