### PR TITLE
fix(Spanner): Spanner test fixes

### DIFF
--- a/Spanner/tests/System/BackupTest.php
+++ b/Spanner/tests/System/BackupTest.php
@@ -17,7 +17,6 @@
 
 namespace Google\Cloud\Spanner\Tests\System;
 
-use Google\Auth\Cache\InvalidArgumentException;
 use Google\Cloud\Core\Exception\BadRequestException;
 use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Core\LongRunning\LongRunningOperation;
@@ -211,10 +210,10 @@ class BackupTest extends SpannerTestCase
             $backup->create(self::$dbName1, $expireTime, [
                 'encryptionConfig' => ['kmsKeyName' => 'validKeyName'],
             ]);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\BadRequestException $e) {
         }
 
-        $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        $this->assertInstanceOf(\BadRequestException::class, $e);
         $this->assertFalse($backup->exists());
     }
 
@@ -482,14 +481,17 @@ class BackupTest extends SpannerTestCase
                     ]
                 ]
             );
-        } catch (\InvalidArgumentException $e) {
+        } catch (\BadRequestException $e) {
         }
         $database = self::$instance->database($restoreDbName);
 
-        $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        $this->assertInstanceOf(\BadRequestException::class, $e);
         $this->assertFalse($database->exists());
     }
 
+    /**
+     * @depends testCreateBackup
+     */
     public function testRestoreToNewDatabase()
     {
         $restoreDbName = uniqid('restored_db_');


### PR DESCRIPTION
Currently system tests are failing due to use of wrong expected exceptions and lack of having a backup before performing a restore.

# Change

1. Migrate from `InvalidArgumentException` to `BadRequestException` in affected tests.
2. Add test dependency of `testCreateBackup` into `testRestoreToNewDatabase`.

# Tests

```
google-cloud-php/Spanner % XDEBUG_MODE=debug vendor/bin/phpunit -c phpunit-system.xml.dist tests/System/BackupTest.php --filter="InvalidArgument"      
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

..                                                                  2 / 2 (100%)

Time: 4.94 minutes, Memory: 10.00 MB

OK (2 tests, 6 assertions)
google-cloud-php/Spanner %
```

Note: This wont fix all Spanner-> Backup tests, but will reduce failures count.

ref: [b/263759734](http://b/263759734)
