### PR TITLE
docs: misc docfx fixes

### DIFF
--- a/dev/src/DocFx/Node/DocblockTrait.php
+++ b/dev/src/DocFx/Node/DocblockTrait.php
@@ -73,6 +73,6 @@ trait DocblockTrait
 
     private function stripSnippetTag(string $content): string
     {
-        return preg_replace('/\/\/\[snippet=.*\]/', '', $content);
+        return preg_replace('/\/\/\[snippet=.*\]\n/', '', $content);
     }
 }

--- a/dev/src/DocFx/Node/ParameterNode.php
+++ b/dev/src/DocFx/Node/ParameterNode.php
@@ -90,14 +90,10 @@ class ParameterNode
 
         foreach ($nestedParameters as $param) {
             // Parse "@type string $key" syntax
-            $paramInfo = explode(' ', trim($param), 3);
-            if (count($paramInfo) < 3) {
-                // No parameter description
-                list($type, $name) = $paramInfo;
-                $description = '';
-            } else {
-                list($type, $name, $description) = $paramInfo;
+            if (!preg_match('/^([^ ]+) +([\$\w]+)(.*)?/m', trim($param), $matches)) {
+                throw new \LogicException('unable to parse nested parameter "' . $param . '"');
             }
+            list($_, $type, $name, $description) = $matches + [3 => ''];
 
             // remove "$" prefix from parameter name and add "↳ " for UX to indicate it's nested.
             $name = '↳ ' . ltrim($name, '$');

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -36,8 +36,8 @@ class NodeTest extends TestCase
 
         $params = $method->getParameters();
 
-        // Assert 5 parameters have been parsed
-        $this->assertCount(6, $params);
+        // Assert 6 parameters have been parsed
+        $this->assertCount(7, $params);
 
         // Assert parent option parameter
         $this->assertEquals('data', $params[1]->getName());
@@ -54,6 +54,14 @@ class NodeTest extends TestCase
             'This field gives the total number of pages in the file.',
             $params[4]->getDescription()
         );
+
+        // Assert nested parameter with whitespace
+        $this->assertEquals('↳ imageContext', $params[6]->getName());
+        $this->assertEquals('ImageContext', $params[6]->getType());
+        $this->assertEquals(
+            'Additional context that may accompany the image.',
+            $params[6]->getDescription()
+        );
     }
 
     public function testProtoRefInParameters()
@@ -63,8 +71,8 @@ class NodeTest extends TestCase
 
         $params = $method->getParameters();
 
-        // Assert 5 parameters have been parsed
-        $this->assertCount(6, $params);
+        // Assert 6 parameters have been parsed
+        $this->assertCount(7, $params);
 
         // Assert proto ref
         $this->assertStringContainsString(

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -149,9 +149,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -186,9 +186,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -223,9 +223,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -260,9 +260,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -297,9 +297,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -334,9 +334,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -371,9 +371,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -408,9 +408,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -445,9 +445,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -482,9 +482,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -519,9 +519,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -556,9 +556,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array
@@ -606,9 +606,9 @@ items:
           var_type: array
           description: 'Configuration Options.'
         -
-          id: '↳ '
+          id: '↳ imageContext'
           var_type: ImageContext
-          description: '$imageContext Additional context that may accompany the image.'
+          description: 'Additional context that may accompany the image.'
         -
           id: '↳ retrySettings'
           var_type: RetrySettings|array

--- a/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/V1.ImageAnnotatorClient.yml
@@ -85,21 +85,18 @@ items:
       
       Example:
       ```php
-      
       $imageResource = fopen('path/to/image.jpg', 'r');
       $image = $imageAnnotatorClient->createImageObject($imageResource);
       $response = $imageAnnotatorClient->faceDetection($image);
       ```
       
       ```
-      
       $imageData = file_get_contents('path/to/image.jpg');
       $image = $imageAnnotatorClient->createImageObject($imageData);
       $response = $imageAnnotatorClient->faceDetection($image);
       ```
       
       ```
-      
       $imageUri = "gs://my-bucket/image.jpg";
       $image = $imageAnnotatorClient->createImageObject($imageUri);
       $response = $imageAnnotatorClient->faceDetection($image);

--- a/dev/tests/fixtures/phpdoc/nestedparams.xml
+++ b/dev/tests/fixtures/phpdoc/nestedparams.xml
@@ -37,6 +37,7 @@
     @type \Google\Rpc\Status $error
           If set, represents the error message for the failed request. The
           `responses` field will not be set in this case.
+    @type ImageContext        $imageContext  Additional context that may accompany the image.
 }"
             variable="data"
             type="array"


### PR DESCRIPTION
 - remove newline for snippet annotations
 - fix nested param parsing with extra whitespace
