### PR TITLE
feat(Core): add retryFunction in GrpcRequestWrapper::send

### DIFF
--- a/Core/tests/Unit/GrpcRequestWrapperTest.php
+++ b/Core/tests/Unit/GrpcRequestWrapperTest.php
@@ -115,7 +115,7 @@ class GrpcRequestWrapperTest extends TestCase
         $timesCalled = 0;
         $requestWrapper->send(
             function () use (&$timesCalled) {
-                if (1 === $timesCalled++) {
+                if (2 === ++$timesCalled) {
                     // succeed on second try
                     return;
                 }


### PR DESCRIPTION
Core now allows adding `retryFunction` with `GrpcRequestWrapper::send`. This will be used in Spanner's `BeginTransaction` to retry for `Not_FOUND` errors with a custom pattern as followed in other languages.

[Code Pointer in TS](https://github.com/googleapis/nodejs-spanner/blob/02c6e599a7b744a5c610c8d801229c7299abb668/src/session-pool.ts#L223-L236)

A similar change is also being taken by Go, https://github.com/googleapis/google-cloud-go/pull/7163


## Change

1. Adding a `retryFunction` which takes in an Exception as argument and produces a bool to decide whether to retry or not.

2. Unit tests to validate cases such as whether `retryLimit` is still honored and follows the custom logic provided.

ref: [b/263775077#comment8](http://b/263775077#comment8)

