### PR TITLE
fix: [Datastore] query limit fails for string limit

### DIFF
--- a/Datastore/src/Connection/Grpc.php
+++ b/Datastore/src/Connection/Grpc.php
@@ -242,7 +242,7 @@ class Grpc implements ConnectionInterface
                 $query['filter'] = $this->convertFilterProps($query['filter']);
             }
 
-            if (isset($query['limit']) && is_int($query['limit'])) {
+            if (isset($query['limit']) && !is_array($query['limit'])) {
                 $query['limit'] = [
                     'value' => $query['limit']
                 ];

--- a/Datastore/tests/System/QueryResultPaginationTest.php
+++ b/Datastore/tests/System/QueryResultPaginationTest.php
@@ -163,6 +163,19 @@ class QueryResultPaginationTest extends DatastoreMultipleDbTestCase
     public function testQueryPaginationWithLimit(DatastoreClient $client)
     {
         $testLimit = 310;
+
+        $q = $client->query()->kind(self::$testKind)->limit($testLimit);
+
+        $this->assertQueryPageCount($testLimit, $client, $q);
+    }
+
+    /**
+     * @dataProvider defaultDbClientProvider
+     */
+    public function testQueryPaginationWithStringLimit(DatastoreClient $client)
+    {
+        $testLimit = '310';
+
         $q = $client->query()->kind(self::$testKind)->limit($testLimit);
 
         $this->assertQueryPageCount($testLimit, $client, $q);


### PR DESCRIPTION
While fixing datastore query limit for values larger than 300 per https://github.com/googleapis/google-cloud-php/pull/5592, there was an unintended bug where limit is assumed to be `int`. This could break existing clients who use `string` limits.

# Changes
1. Migrate a check on `limit` values in parsed query from `is_int` to `!is_array`

 # Tests

1. Added a new test for string limits: `testQueryPaginationWithStringLimit`
2. Tests pass on prod:

```
google-cloud-php/Datastore % vendor/bin/phpunit -c phpunit-system.xml.dist
PHPUnit 8.5.32 by Sebastian Bergmann and contributors.

................................................................. 65 / 96 ( 67%)
...............................                                   96 / 96 (100%)

Time: 2.97 minutes, Memory: 18.00 MB

OK (96 tests, 260 assertions)
google-cloud-php/Datastore %
```

