### PR TITLE
chore: remove export-ignore of repo-metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,6 @@
 /codecov.yml export-ignore
 /.github export-ignore
 /*/.github export-ignore
-/*/.repo-metadata.json export-ignore
 /*/.OwlBot.yaml export-ignore
 /*/.owlbot export-ignore
 /*/owlbot.py export-ignore


### PR DESCRIPTION
Remove ignoring `.repo-metadata.json` via `export-ignore` in `.gitattributes` for umbrella package `google/cloud` so this can be consumed by the developer tools team for our dashboards.