### PR TITLE
chore: fixes for BC checker

### DIFF
--- a/Core/src/Logger/AppEngineFlexHandler.php
+++ b/Core/src/Logger/AppEngineFlexHandler.php
@@ -25,6 +25,7 @@ use Monolog\Logger;
  *
  * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV2} instead.
  * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV3} instead.
+ * @internal
  */
 class AppEngineFlexHandler extends StreamHandler
 {

--- a/Core/src/Logger/AppEngineFlexHandlerV2.php
+++ b/Core/src/Logger/AppEngineFlexHandlerV2.php
@@ -25,6 +25,7 @@ use Monolog\Logger;
  *
  * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandler} instead.
  * If you are using Monolog 3.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV3} instead.
+ * @internal
  */
 class AppEngineFlexHandlerV2 extends StreamHandler
 {

--- a/Core/src/Logger/AppEngineFlexHandlerV3.php
+++ b/Core/src/Logger/AppEngineFlexHandlerV3.php
@@ -25,6 +25,7 @@ use Monolog\Logger;
  *
  * If you are using Monolog 1.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandler} instead.
  * If you are using Monolog 2.x, use {@see \Google\Cloud\Core\Logger\AppEngineFlexHandlerV2} instead.
+ * @internal
  */
 class AppEngineFlexHandlerV3 extends StreamHandler
 {

--- a/Core/src/PhpArray.php
+++ b/Core/src/PhpArray.php
@@ -28,6 +28,7 @@ use google\protobuf\Struct;
  * used for REST.
  * @deprecated
  * @codeCoverageIgnore
+ * @internal
  */
 class PhpArray extends Protobuf\Codec\PhpArray
 {

--- a/Core/src/Testing/GcTestListener.php
+++ b/Core/src/Testing/GcTestListener.php
@@ -22,6 +22,7 @@ use Yoast\PHPUnitPolyfills\TestListeners\TestListenerDefaultImplementation;
 
 /**
  * Garbage collector for tests
+ * @internal
  */
 class GcTestListener implements TestListener
 {

--- a/Core/src/Testing/Reflection/DescriptionFactory.php
+++ b/Core/src/Testing/Reflection/DescriptionFactory.php
@@ -60,6 +60,8 @@ use function trim;
  * If a body consists of multiple lines then this factory will also remove any superfluous whitespace at the beginning
  * of each line while maintaining any indentation that is used. This will prevent formatting parsers from tripping
  * over unexpected spaces as can be observed with tag descriptions.
+ *
+ * @internal
  */
 class DescriptionFactory extends BaseDescriptionFactory
 {

--- a/Core/src/Testing/Reflection/ReflectionHandlerV4.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV4.php
@@ -37,6 +37,8 @@ use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 /**
  * Class for running snippets using phpdocumentor/reflection:v4.
+ *
+ * @internal
  */
 class ReflectionHandlerV4
 {

--- a/Core/src/Testing/Reflection/ReflectionHandlerV5.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV5.php
@@ -40,6 +40,8 @@ use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 /**
  * Class for running snippets using phpdocumentor/reflection:v5.
+ *
+ * @internal
  */
 class ReflectionHandlerV5
 {

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -55,7 +55,7 @@ trait TransactionalReadTrait
     /**
      * @var int
      */
-    private $state = self::STATE_ACTIVE;
+    private $state = 0; // TransactionalReadInterface::STATE_ACTIVE
 
     /**
      * @var array

--- a/Trace/src/Link.php
+++ b/Trace/src/Link.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Trace;
 
-use Google\Cloud\Trace\V2\Span_Link_Type;
+use Google\Cloud\Trace\V2\Span\Link\Type;
 
 /**
  * This plain PHP class represents a Link resource. A pointer from the current
@@ -40,9 +40,9 @@ class Link
 {
     use AttributeTrait;
 
-    const TYPE_UNSPECIFIED = Span_Link_Type::TYPE_UNSPECIFIED;
-    const TYPE_CHILD_LINKED_SPAN = Span_Link_Type::CHILD_LINKED_SPAN;
-    const TYPE_PARENT_LINKED_SPAN = Span_Link_Type::PARENT_LINKED_SPAN;
+    const TYPE_UNSPECIFIED = Type::TYPE_UNSPECIFIED;
+    const TYPE_CHILD_LINKED_SPAN = Type::CHILD_LINKED_SPAN;
+    const TYPE_PARENT_LINKED_SPAN = Type::PARENT_LINKED_SPAN;
 
     /**
      * @var string The [TRACE_ID] for a trace within a project.

--- a/Trace/src/MessageEvent.php
+++ b/Trace/src/MessageEvent.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Trace;
 
-use Google\Cloud\Trace\V2\Span_TimeEvent_MessageEvent_Type;
+use Google\Cloud\Trace\V2\Span\TimeEvent\MessageEvent\Type;
 
 /**
  * This plain PHP class represents an MessageEvent resource. An event describing
@@ -37,9 +37,9 @@ use Google\Cloud\Trace\V2\Span_TimeEvent_MessageEvent_Type;
  */
 class MessageEvent extends TimeEvent
 {
-    const TYPE_UNSPECIFIED = Span_TimeEvent_MessageEvent_Type::TYPE_UNSPECIFIED;
-    const TYPE_SENT = Span_TimeEvent_MessageEvent_Type::SENT;
-    const TYPE_RECEIVED = Span_TimeEvent_MessageEvent_Type::RECEIVED;
+    const TYPE_UNSPECIFIED = Type::TYPE_UNSPECIFIED;
+    const TYPE_SENT = Type::SENT;
+    const TYPE_RECEIVED = Type::RECEIVED;
 
     /**
      * @var string Type of MessageEvent. Indicates whether the message was sent


### PR DESCRIPTION
See #5822 

Marks classes as internal which were throwing warnings. These are being fixed in a separate PR so that when we merge the breaking change detector, it will be passing.