### PR TITLE
feat:[Spanner] CacheSessionPool::maintain deletes sessions older than 28d

### DIFF
--- a/Spanner/tests/System/SessionTest.php
+++ b/Spanner/tests/System/SessionTest.php
@@ -67,6 +67,9 @@ class SessionTest extends SpannerTestCase
 
         $this->assertPoolCounts($cache, $cacheKey, 0, 10, 0);
 
+        $pool->maintain();
+        $this->assertPoolCounts($cache, $cacheKey, 0, 10, 0);
+
         $exception = null;
         try {
             $pool->acquire();

--- a/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
@@ -217,6 +217,7 @@ class CacheSessionPoolTest extends TestCase
                 'session' => [
                     'name' => 'session',
                     'expiration' => $this->time + 3600,
+                    'creation' => $this->time,
                     'lastActive' => $this->time
                 ]
             ],
@@ -228,7 +229,8 @@ class CacheSessionPoolTest extends TestCase
             'queue' => [
                 [
                     'name' => 'session',
-                    'expiration' => $this->time + 3600
+                    'expiration' => $this->time + 3600,
+                    'creation' => $this->time,
                 ]
             ],
             'inUse' => [],
@@ -445,6 +447,7 @@ class CacheSessionPoolTest extends TestCase
                         'session0' => [
                             'name' => 'session0',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -461,7 +464,8 @@ class CacheSessionPoolTest extends TestCase
                     'queue' => [
                         [
                             'name' => 'expired',
-                            'expiration' => $time - 3000
+                            'expiration' => $time - 3000,
+                            'creation' => $time
                         ]
                     ],
                     'inUse' => [],
@@ -475,6 +479,7 @@ class CacheSessionPoolTest extends TestCase
                         'session0' => [
                             'name' => 'session0',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -494,6 +499,7 @@ class CacheSessionPoolTest extends TestCase
                         'alreadyCheckedOut' => [
                             'name' => 'alreadyCheckedOut',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -507,11 +513,13 @@ class CacheSessionPoolTest extends TestCase
                         'session0' => [
                             'name' => 'session0',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ],
                         'alreadyCheckedOut' => [
                             'name' => 'alreadyCheckedOut',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -530,11 +538,13 @@ class CacheSessionPoolTest extends TestCase
                         'expiredInUse1' => [
                             'name' => 'expiredInUse1',
                             'expiration' => $time - 5000,
+                            'creation' => $time,
                             'lastActive' => $time - 1201
                         ],
                         'expiredInUse2' => [
                             'name' => 'expiredInUse2',
                             'expiration' => $time - 5000,
+                            'creation' => $time,
                             'lastActive' => $time - 3601
                         ]
                     ],
@@ -550,6 +560,7 @@ class CacheSessionPoolTest extends TestCase
                         'session0' => [
                             'name' => 'session0',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -566,7 +577,8 @@ class CacheSessionPoolTest extends TestCase
                     'queue' => [
                         [
                             'name' => 'session',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ]
                     ],
                     'inUse' => [],
@@ -580,6 +592,7 @@ class CacheSessionPoolTest extends TestCase
                         'session' => [
                             'name' => 'session',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -596,11 +609,13 @@ class CacheSessionPoolTest extends TestCase
                     'queue' => [
                         [
                             'name' => 'expiresSoon',
-                            'expiration' => $time + 1500
+                            'expiration' => $time + 1500,
+                            'creation' => $time,
                         ],
                         [
                             'name' => 'session',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ]
                     ],
                     'inUse' => [],
@@ -614,6 +629,7 @@ class CacheSessionPoolTest extends TestCase
                         'session' => [
                             'name' => 'session',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -632,6 +648,7 @@ class CacheSessionPoolTest extends TestCase
                         'inactiveInUse1' => [
                             'name' => 'inactiveInUse1',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time - 1201
                         ]
                     ],
@@ -645,6 +662,7 @@ class CacheSessionPoolTest extends TestCase
                         'inactiveInUse1' => [
                             'name' => 'inactiveInUse1',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -661,19 +679,23 @@ class CacheSessionPoolTest extends TestCase
                     'queue' => [
                         [
                             'name' => 'session1',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ],
                         [
                             'name' => 'session2',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ],
                         [
                             'name' => 'session3',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ],
                         [
                             'name' => 'session4',
-                            'expiration' => $time + 3600
+                            'expiration' => $time + 3600,
+                            'creation' => $time,
                         ]
                     ],
                     'inUse' => [],
@@ -687,6 +709,7 @@ class CacheSessionPoolTest extends TestCase
                         'session1' => [
                             'name' => 'session1',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -696,6 +719,7 @@ class CacheSessionPoolTest extends TestCase
                 ],
                 $time
             ],
+            // Set #8: With labels
             [
                 [
                     'labels' => [
@@ -709,6 +733,7 @@ class CacheSessionPoolTest extends TestCase
                         'session0' => [
                             'name' => 'session0',
                             'expiration' => $time + 3600,
+                            'creation' => $time,
                             'lastActive' => $time
                         ]
                     ],
@@ -717,7 +742,58 @@ class CacheSessionPoolTest extends TestCase
                     'maxInUseSessions' => 1
                 ],
                 $time
-            ]
+              ],
+              // Set #9: Session expires in 28 days
+              [
+                  [],
+                  [
+                      'queue' => [
+                          [
+                              'name' => 'expiredSession',
+                              'expiration' => $time + 3600,
+                              'creation' => $time
+                                  - CacheSessionPool::DURATION_SESSION_LIFETIME,
+                          ],
+                          [
+                              'name' => 'expiresSoon',
+                              'expiration' => $time + 3600,
+                              'creation' => $time + 3600
+                                  - CacheSessionPool::DURATION_SESSION_LIFETIME,
+                          ],
+                          [
+                              'name' => 'activeSession',
+                              'expiration' => $time + 3600,
+                              'creation' => $time,
+                          ]
+                      ],
+                      'inUse' => [],
+                      'toCreate' => [],
+                      'windowStart' => $time,
+                      'maxInUseSessions' => 1
+                  ],
+                  [
+                      'queue' => [
+                          [
+                              'name' => 'activeSession',
+                              'expiration' => $time + 3600,
+                              'creation' => $time,
+                          ]
+                      ],
+                      'inUse' => [
+                          'expiresSoon' => [
+                              'name' => 'expiresSoon',
+                              'expiration' => $time + 3600,
+                              'creation' => $time + 3600
+                                  - CacheSessionPool::DURATION_SESSION_LIFETIME,
+                              'lastActive' => $time
+                          ]
+                      ],
+                      'toCreate' => [],
+                      'windowStart' => $time,
+                      'maxInUseSessions' => 1
+                  ],
+                  $time
+              ],
         ];
     }
 
@@ -808,6 +884,7 @@ class CacheSessionPoolTest extends TestCase
         return [
             'name' => basename($name),
             'expiration' => $this->time + 3600 - $age,
+            'creation' => $this->time,
         ];
     }
 
@@ -902,7 +979,35 @@ class CacheSessionPoolTest extends TestCase
         $pool->maintain();
     }
 
-     /**
+    /**
+     * @dataProvider maintainDataProvider
+     */
+    public function testMaintainServerDeletedSessions(
+        $maintainInterval,
+        $initialItems,
+        $expectedItems,
+        $config = [],
+        $data = []
+    ) {
+        $cacheData = $this->cacheData($initialItems, $maintainInterval);
+        $expiredTime = $this->time - 28*24*60*60; // 28 days
+        foreach ($cacheData['queue'] as $k => $v) {
+            $cacheData['queue'][$k]['creation'] = $expiredTime;
+        }
+        // all expired sessions should be deleted
+        $expectedItems = [];
+
+        $cache = $this->getCacheItemPool($data + $cacheData);
+        $config += ['minSessions' => count($initialItems)];
+        $pool = new CacheSessionPoolStub($cache, $config, $this->time);
+        $pool->setDatabase($this->getDatabase());
+        $pool->maintain();
+        $data = $pool->cacheItemPool()->getItem($this->cacheKey)->get();
+        $expectedQueue = $this->queue($expectedItems);
+        $this->assertEquals($expectedQueue, $data['queue']);
+    }
+
+    /**
      * @dataProvider maintainDataProvider
      */
     public function testMaintainQueue($maintainInterval, $initialItems, $expectedItems, $config = [], $data = [])
@@ -979,10 +1084,12 @@ class CacheSessionPoolTest extends TestCase
                 [
                     'name' => 'existing1',
                     'expiration' => $this->time + 3000,
+                    'creation' => $this->time,
                 ],
                 [
                     'name' => 'existing2',
                     'expiration' => $this->time + 3000,
+                    'creation' => $this->time,
                 ],
             ],
             'inUse' => [],


### PR DESCRIPTION
Potentially fixes: https://github.com/googleapis/google-cloud-php/issues/5827

# Changes
1. Adds a check in `maintain()` to purge sessions older than 28d.
2. Also modifies checks in `CacheSessionPool::isSessionValid(..)`
3. Other changes necessary to retain `['creation']` param, which is set to time in seconds when session was created and only used to check for expiration.
4. Relevant additions to system and unit tests

# Tests

Both UT and System tests are passing in prod.