### PR TITLE
feat(Firestore): Expose read_time field

### DIFF
--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -21,6 +21,7 @@ use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 
 /**
@@ -265,6 +266,17 @@ class CollectionReference extends Query
             'collectionId' => $this->pathId($this->name),
             'mask' => []
         ];
+
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
 
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -195,6 +195,12 @@ class Grpc implements ConnectionInterface
      */
     public function listCollectionIds(array $args)
     {
+        if (isset($args['readTime'])) {
+            $args['readTime'] = $this->serializer->decodeMessage(
+                new ProtobufTimestamp(),
+                $args['readTime']
+            );
+        }
         return $this->send([$this->firestore, 'listCollectionIds'], [
             $this->pluck('parent', $args),
             $this->addRequestHeaders($args)

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -217,6 +217,12 @@ class Grpc implements ConnectionInterface
             : [];
 
         $args['mask'] = $this->documentMask($mask);
+        if (isset($args['readTime'])) {
+            $args['readTime'] = $this->serializer->decodeMessage(
+                new ProtobufTimestamp(),
+                $args['readTime']
+            );
+        }
 
         return $this->send([$this->firestore, 'listDocuments'], [
             $this->pluck('parent', $args),

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -254,6 +254,12 @@ class Grpc implements ConnectionInterface
             new StructuredQuery,
             $this->pluck('structuredQuery', $args)
         );
+        if (isset($args['readTime'])) {
+            $args['readTime'] = $this->serializer->decodeMessage(
+                new ProtobufTimestamp(),
+                $args['readTime']
+            );
+        }
 
         return $this->send([$this->firestore, 'runQuery'], [
             $this->pluck('parent', $args),

--- a/Firestore/src/DocumentReference.php
+++ b/Firestore/src/DocumentReference.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore;
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 
 /**
@@ -384,6 +385,16 @@ class DocumentReference
      */
     public function collections(array $options = [])
     {
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $resultLimit = $this->pluck('resultLimit', $options, false);
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -26,6 +26,7 @@ use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
 use Google\Cloud\Core\Retry;
 use Google\Cloud\Core\ValidateTrait;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\Grpc;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\StreamInterface;
@@ -290,6 +291,16 @@ class FirestoreClient
      */
     public function collections(array $options = [])
     {
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $resultLimit = $this->pluck('resultLimit', $options, false);
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Firestore;
 
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\ExponentialBackoff;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentSnapshot;
 use Google\Cloud\Firestore\FieldValue\FieldValueInterface;
@@ -189,6 +190,16 @@ class Query
      */
     public function documents(array $options = [])
     {
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $maxRetries = $this->pluck('maxRetries', $options, false);
         $maxRetries = $maxRetries === null
             ? FirestoreClient::MAX_RETRIES

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Firestore\Tests\System;
 
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\FieldPath;
 
 /**
@@ -195,6 +196,22 @@ class QueryTest extends FirestoreTestCase
         });
 
         $this->assertEquals([2, 3, 4], $res);
+    }
+
+    public function testDocumentsWithReadTime()
+    {
+        $randomVal = base64_encode(random_bytes(10));
+        $this->insertDoc(['foo' => $randomVal]);
+
+        // Creating a current timestamp and then inserting another document
+        $readTime = new Timestamp(new \DateTimeImmutable());
+        $this->insertDoc(['foo' => $randomVal]);
+
+        $resultCount = $this->query
+            ->where('foo', '=', $randomVal)
+            ->documents(['readTime' => $readTime])
+            ->size();
+        $this->assertEquals(1, $resultCount);
     }
 
     private function insertDoc(array $fields)

--- a/Firestore/tests/Unit/Connection/GrpcTest.php
+++ b/Firestore/tests/Unit/Connection/GrpcTest.php
@@ -27,7 +27,7 @@ use Google\Cloud\Firestore\V1\Document;
 use Google\Cloud\Firestore\V1\DocumentMask;
 use Google\Cloud\Firestore\V1\Precondition;
 use Google\Cloud\Firestore\V1\StructuredQuery;
-use Google\Cloud\Firestore\V1\StructuredQuery_CollectionSelector;
+use Google\Cloud\Firestore\V1\StructuredQuery\CollectionSelector;
 use Google\Cloud\Firestore\V1\TransactionOptions;
 use Google\Cloud\Firestore\V1\TransactionOptions_ReadWrite;
 use Google\Cloud\Firestore\V1\Value;
@@ -320,7 +320,7 @@ class GrpcTest extends TestCase
             'structuredQuery' => ['from' => [['collectionId' => 'parent']]]
         ];
 
-        $from = new StructuredQuery_CollectionSelector;
+        $from = new CollectionSelector();
         $from->setCollectionId('parent');
         $q = new StructuredQuery;
         $q->setFrom([$from]);
@@ -328,6 +328,35 @@ class GrpcTest extends TestCase
         $expected = [
             $args['parent'],
             ['structuredQuery' => $q] + $this->header()
+        ];
+
+        $this->sendAndAssert('runQuery', $args, $expected);
+    }
+
+    public function testRunQueryWithReadTime()
+    {
+        $args = [
+            'parent' => 'parent!',
+            'structuredQuery' => ['from' => [['collectionId' => 'parent']]],
+            'readTime' => [
+                'seconds' => (int) 123456789,
+                'nanos' => (int) 0
+            ]
+        ];
+
+        $from = new CollectionSelector();
+        $from->setCollectionId('parent');
+        $q = new StructuredQuery;
+        $q->setFrom([$from]);
+
+        $protobufTimestamp = new ProtobufTimestamp();
+        $protobufTimestamp->setSeconds($args['readTime']['seconds']);
+        $expected = [
+            $args['parent'],
+            [
+                'structuredQuery' => $q,
+                'readTime' => $protobufTimestamp
+            ] + $this->header()
         ];
 
         $this->sendAndAssert('runQuery', $args, $expected);

--- a/Firestore/tests/Unit/Connection/GrpcTest.php
+++ b/Firestore/tests/Unit/Connection/GrpcTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2017 Google Inc.
  *
@@ -226,6 +227,29 @@ class GrpcTest extends TestCase
         ];
 
         $expected = [$args['parent'], $this->header()];
+
+        $this->sendAndAssert('listCollectionIds', $args, $expected);
+    }
+
+    public function testListCollectionIdsWithReadTime()
+    {
+        $args = [
+            'parent' => sprintf(
+                'projects/%s/databases/%s/documents',
+                self::PROJECT,
+                self::DATABASE
+            ),
+            'readTime' => [
+                'seconds' => (int) 123456789,
+                'nanos' => (int) 0
+            ]
+        ];
+        $protobufTimestamp = new ProtobufTimestamp();
+        $protobufTimestamp->setSeconds($args['readTime']['seconds']);
+        $expected = [
+            $args['parent'],
+            $this->header() + ['readTime' => $protobufTimestamp]
+        ];
 
         $this->sendAndAssert('listCollectionIds', $args, $expected);
     }

--- a/Firestore/tests/Unit/Connection/GrpcTest.php
+++ b/Firestore/tests/Unit/Connection/GrpcTest.php
@@ -274,6 +274,33 @@ class GrpcTest extends TestCase
         $this->sendAndAssert('listDocuments', $args, $expected);
     }
 
+    public function testListDocumentsWithReadTime()
+    {
+        $args = [
+            'parent' => sprintf('projects/%s/databases/%s/documents', self::PROJECT, self::DATABASE),
+            'collectionId' => 'coll1',
+            'mask' => [],
+            'readTime' => [
+                'seconds' => (int) 123456789,
+                'nanos' => (int) 0
+            ]
+        ];
+
+        $protobufTimestamp = new ProtobufTimestamp();
+        $protobufTimestamp->setSeconds($args['readTime']['seconds']);
+        $expected = [
+            $args['parent'],
+            $args['collectionId'],
+            [
+                'showMissing' => true,
+                'mask' => new DocumentMask(['field_paths' => []]),
+                'readTime' => $protobufTimestamp
+            ] + $this->header()
+        ];
+
+        $this->sendAndAssert('listDocuments', $args, $expected);
+    }
+
     public function testRollback()
     {
         $args = [


### PR DESCRIPTION
Properly allow exposed APIs in handwritten layer(which have an optional `read_time` parameter) to allow passing a `readTime` parameter in `$options`.

`Google\Cloud\Core\Timestamp` is exposed to the users which is internally converted to `Google\Protobuf\Timestamp` as expected by the protos to maintain uniformity with already existings timestamp uses in the library. The converstion is done by first converting Timestamp to api format (`['seconds' => (int)<value>, 'nanos' => (int)<value>]`) using `Core\Timestamp->formatForApi()` method and then converting it to required proto format using Serialize::decodeMessage() at the connection layer.

The following protos which have a optional read_time field:-
* BatchGetDocumentsRequest
* GetDocumentsRequest
* ListCollectionIdsRequest
* ListDocumentsRequest
* PartitionQueryRequest
* RunAggregationQueryRequest
* RunQueryRequest

Out of which the following are exposed to handwritten client:-
* BatchGetDocumentsRequest(No changes/tests needed as already introduced in #5807)
* ListCollectionIdsRequest
* ListDocumentsRequest
* RunQueryRequest
