### PR TITLE
docs: [PubSub] Add clarification in validateMessage docblock

### DIFF
--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -642,7 +642,7 @@ class PubSubClient
      *     for definition. The array representation allows for validation of
      *     messages using ad-hoc schema; these do not have to exist in the
      *     current project in order to be used for validation.
-     * @param string $message The message to validate.
+     * @param string $message The base64 encoded message to validate.
      * @param string $encoding Either `JSON` or `BINARY`.
      * @param array $options [optional] Configuration options
      * @return void


### PR DESCRIPTION
Hi,

I've created a minor change in the doc block of the validateMessage method. 
This method validates messages against a schema. 

Since I was developing locally with the Pubsub emulator it took me some time before I found out that the message string is supposed to be base64 encoded. This was due to two facts; 
1. The Pubsub emulator only reports that the message is not valid. It does not tell why it is not. 
2. The doc block did not mention the message is supposed to be base64 encode. 

I hope that this change will save time for other developers. 