### PR TITLE
chore(lint): always use PR title

### DIFF
--- a/.github/conventional-commit-lint.yaml
+++ b/.github/conventional-commit-lint.yaml
@@ -1,0 +1,2 @@
+always_check_pr_title: true
+


### PR DESCRIPTION
Always use conventional commits PR title
See info about the configuration optionion here: https://github.com/googleapis/repo-automation-bots/tree/main/packages/conventional-commit-lint#configuration
See me complaining about this here: https://github.com/googleapis/repo-automation-bots/issues/4981