### PR TITLE
feat(Storage): Adding unit tests for GCS Retry

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -57,21 +57,21 @@ class ExponentialBackoff
     /**
      * @param int $retries [optional] Number of retries for a failed request.
      * @param callable $retryFunction [optional] returns bool for whether or not
-     *  to retry
+     *      to retry
      * @param callable $onRetryExceptionFunction [optional] runs before the
-     *  $retryFunction. Unlike the $retryFunction,this function isn't
-     *  responsible to decide if a retry should happen or not, but it gives the
-     *  users flexibility to consume exception messages and add custom logic.
-     *  Function definition should match:
-     *      function (\Exception $e, int $attempt, array &$arguments) : void
-     *  Ex: One might want to change headers on every retry, this function can
-     *  be used to achieve such a functionality.
-     * @param callable $onExecutionStartFunction [optional] runs before
-     *  execution of the execute function. Taken in $arguments as reference and
-     *  thus gives users, the flexibility to add custom logic before the
-     *  execution of request and override request / options in the $arguments.
-     *  Function definition should match:
-     *      function (array &$arguments) : void
+     *      $retryFunction. Unlike the $retryFunction,this function isn't
+     *      responsible to decide if a retry should happen or not, but it gives the
+     *      users flexibility to consume exception messages and add custom logic.
+     *      Function definition should match:
+     *          function (\Exception $e, int $attempt, array &$arguments) : void
+     *      Ex: One might want to change headers on every retry, this function can
+     *      be used to achieve such a functionality.
+     * @param callable $onExecutionStartFunction [optional] runs before execution
+     *      of the execute function. Taken in $arguments as reference and
+     *      thus gives users, the flexibility to add custom logic before the
+     *      execution of request and override request / options in the $arguments.
+     *      Function definition should match:
+     *          function (array &$arguments) : void
      */
     public function __construct(
         $retries = null,

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -57,21 +57,21 @@ class ExponentialBackoff
     /**
      * @param int $retries [optional] Number of retries for a failed request.
      * @param callable $retryFunction [optional] returns bool for whether or not
-     *      to retry
+     *        to retry
      * @param callable $onRetryExceptionFunction [optional] runs before the
-     *      $retryFunction. Unlike the $retryFunction,this function isn't
-     *      responsible to decide if a retry should happen or not, but it gives the
-     *      users flexibility to consume exception messages and add custom logic.
-     *      Function definition should match:
-     *          function (\Exception $e, int $attempt, array &$arguments) : void
-     *      Ex: One might want to change headers on every retry, this function can
-     *      be used to achieve such a functionality.
+     *        $retryFunction. Unlike the $retryFunction,this function isn't
+     *        responsible to decide if a retry should happen or not, but it gives the
+     *        users flexibility to consume exception messages and add custom logic.
+     *        Function definition should match:
+     *            function (\Exception $e, int $attempt, array &$arguments) : void
+     *        Ex: One might want to change headers on every retry, this function can
+     *        be used to achieve such a functionality.
      * @param callable $onExecutionStartFunction [optional] runs before execution
-     *      of the execute function. Taken in $arguments as reference and
-     *      thus gives users, the flexibility to add custom logic before the
-     *      execution of request and override request / options in the $arguments.
-     *      Function definition should match:
-     *          function (array &$arguments) : void
+     *        of the execute function. Taken in $arguments as reference and
+     *        thus gives users, the flexibility to add custom logic before the
+     *        execution of request and override request / options in the $arguments.
+     *        Function definition should match:
+     *            function (array &$arguments) : void
      */
     public function __construct(
         $retries = null,

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -56,18 +56,22 @@ class ExponentialBackoff
 
     /**
      * @param int $retries [optional] Number of retries for a failed request.
-     * @param callable $retryFunction [optional] returns bool for whether or not to retry
-     * @param callable $onRetryExceptionFunction [optional] runs before the $retryFunction. Unlike the $retryFunction,
-     *        this function isn't responsible to decide if a retry should happen or not,
-     *        but it gives the users flexibility to consume exception messages and add custom logic.
-     *        Function definition should match: function (\Exception $e, int $attempt, array &$arguments) : void
-     *        Ex: One might want to change headers on every retry, this function can be used to achieve
-     *        such a functionality.
-     * @param callable $onExecutionStartFunction [optional] runs before execution of the
-     *        execute function. Taken in $arguments as reference and thus gives users,
-     *        the flexibility to add custom logic before the execution of request
-     *        and override request / options in the $arguments.
-     *        Function definition should match: function (\Exception $e, int $attempt, array &$arguments) : void
+     * @param callable $retryFunction [optional] returns bool for whether or not
+     *  to retry
+     * @param callable $onRetryExceptionFunction [optional] runs before the
+     *  $retryFunction. Unlike the $retryFunction,this function isn't
+     *  responsible to decide if a retry should happen or not, but it gives the
+     *  users flexibility to consume exception messages and add custom logic.
+     *  Function definition should match:
+     *      function (\Exception $e, int $attempt, array &$arguments) : void
+     *  Ex: One might want to change headers on every retry, this function can
+     *  be used to achieve such a functionality.
+     * @param callable $onExecutionStartFunction [optional] runs before
+     *  execution of the execute function. Taken in $arguments as reference and
+     *  thus gives users, the flexibility to add custom logic before the
+     *  execution of request and override request / options in the $arguments.
+     *  Function definition should match:
+     *      function (array &$arguments) : void
      */
     public function __construct(
         $retries = null,

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -161,6 +161,11 @@ class ExponentialBackoffTest extends TestCase
         ];
     }
 
+    /**
+     * Tests whether `onRetryExceptionFunction()` callback is
+     * properly invoked when exception occurs and retry is attempted while
+     * executing the request.
+     */
     public function testOnRetryExceptionFunction()
     {
         $args = ['foo' => 'bar'];
@@ -190,6 +195,11 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * Tests whether `testOnExecutionStartFunction()` callback is
+     * properly invoked when execute method is invoked and before network call
+     * is executed.
+     */
     public function testOnExecutionStartFunction()
     {
         $args = ['foo' => 'bar'];

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -160,4 +160,33 @@ class ExponentialBackoffTest extends TestCase
             [10, 60000000, 60000000]
         ];
     }
+
+    public function testOnRetryExceptionFunction()
+    {
+        $args = ['foo' => 'bar'];
+        $onRetryExceptionFunction = function (
+            $ex,
+            $retryAttempt,
+            $arguments
+        ) {
+            $message = sprintf("%s, %s", $retryAttempt, $arguments[0]['foo']);
+            throw new \Exception($message);
+        };
+
+        $result = '';
+        $expected = "0, bar";
+        $backoff = new ExponentialBackoff(null, null, $onRetryExceptionFunction);
+        try {
+            $backoff->execute(
+                function ($options) use ($args) {
+                    throw new \Exception();
+                },
+                [$args]
+            );
+        } catch (\Exception $ex) {
+            $result = $ex->getMessage();
+        }
+
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -184,7 +184,7 @@ class ExponentialBackoffTest extends TestCase
         try {
             $backoff->execute(
                 function () {
-                    self::fail('Intentionally failing request');
+                    throw new \Exception('Intentionally failing request');
                 },
                 [$args]
             );
@@ -212,7 +212,7 @@ class ExponentialBackoffTest extends TestCase
         try {
             $backoff->execute(
                 function () {
-                    self::fail('Intentionally failing request');
+                    throw new \Exception('Intentionally failing request');
                 },
                 [$args]
             );

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -169,13 +169,38 @@ class ExponentialBackoffTest extends TestCase
             $retryAttempt,
             $arguments
         ) {
-            $message = sprintf("%s, %s", $retryAttempt, $arguments[0]['foo']);
+            $message = sprintf('%s, %s', $retryAttempt, $arguments[0]['foo']);
             throw new \Exception($message);
         };
 
         $result = '';
-        $expected = "0, bar";
+        $expected = '0, bar';
         $backoff = new ExponentialBackoff(null, null, $onRetryExceptionFunction);
+        try {
+            $backoff->execute(
+                function ($options) use ($args) {
+                    throw new \Exception();
+                },
+                [$args]
+            );
+        } catch (\Exception $ex) {
+            $result = $ex->getMessage();
+        }
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testOnExecutionStartFunction()
+    {
+        $args = ['foo' => 'bar'];
+        $onExecutionStartFunction = function ($arguments) {
+            $message = sprintf('%s', $arguments[0]['foo']);
+            throw new \Exception($message);
+        };
+
+        $result = '';
+        $expected = 'bar';
+        $backoff = new ExponentialBackoff(null, null, null, $onExecutionStartFunction);
         try {
             $backoff->execute(
                 function ($options) use ($args) {

--- a/Core/tests/Unit/ExponentialBackoffTest.php
+++ b/Core/tests/Unit/ExponentialBackoffTest.php
@@ -188,7 +188,7 @@ class ExponentialBackoffTest extends TestCase
                 },
                 [$args]
             );
-        } catch (AssertionFailedError $err) {
+        } catch (\Exception $err) {
             // Do nothing.
             // Catched the intentional failing call being made above:
             // "Intentionally failing request"
@@ -216,7 +216,7 @@ class ExponentialBackoffTest extends TestCase
                 },
                 [$args]
             );
-        } catch (AssertionFailedError $err) {
+        } catch (\Exception $err) {
             // Do nothing.
             // Catched the intentional failing call being made above:
             // "Intentionally failing request"

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -627,12 +627,14 @@ class RequestWrapperTest extends TestCase
     }
 
     /**
-     * This tests asserts the retry related options and callbacks are properly
-     * mapped and set in the RequestWrappers `$requestOptions` property as
-     * that property is further used down the line for the request.
+     * This test asserts that the retry related options and callbacks are
+     * properly mapped and set in the RequestWrapper's `$requestOptions`
+     * property.
      */
     public function testRetryOptionsPassingInGetRetryOptions()
     {
+        // Using Reflection instead of Prophecy because we want to test a
+        // private method's logic by verifying the output for a given input.
         $requestWrapper = new RequestWrapper();
         $reflection = new \ReflectionClass($requestWrapper);
         $reflectionMethod = $reflection->getMethod('getRetryOptions');
@@ -647,6 +649,12 @@ class RequestWrapperTest extends TestCase
         ];
 
         $result = $reflectionMethod->invoke($requestWrapper, $options);
+
+        // In the `getRetryOptions` method, the keys of $options are mapped after
+        // removing the prefix 'rest'. For example, 'restRetryFunction' becomes
+        // 'retryFunction'. Therefore, we take the substring after 4th character
+        // , convert first upper case character to lower and the use this as the
+        // new key for the respective value
         foreach ($options as $key => $value) {
             $key = lcfirst(substr($key, 4));
             $this->assertArrayHasKey($key, $result);

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -625,6 +625,29 @@ class RequestWrapperTest extends TestCase
 
         $requestWrapper->send(new Request('GET', 'http://www.example.com'));
     }
+
+    public function testRetryOptionsPassingInGetRetryOptions()
+    {
+        $requestWrapper = new RequestWrapper();
+        $reflection = new \ReflectionClass($requestWrapper);
+        $reflectionMethod = $reflection->getMethod('getRetryOptions');
+        $reflectionMethod->setAccessible(true);
+
+        $placeholderCallback = function () {
+        };
+        $options = [
+            'restRetryFunction' => $placeholderCallback,
+            'restOnRetryExceptionFunction' => $placeholderCallback,
+            'restOnExecutionStartFunction' => $placeholderCallback,
+        ];
+
+        $result = $reflectionMethod->invoke($requestWrapper, $options);
+        foreach ($options as $key => $value) {
+            $key = lcfirst(substr($key, 4));
+            $this->assertArrayHasKey($key, $result);
+            $this->assertEquals($value, $result[$key]);
+        }
+    }
 }
 
 //@codingStandardsIgnoreStart

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -626,6 +626,11 @@ class RequestWrapperTest extends TestCase
         $requestWrapper->send(new Request('GET', 'http://www.example.com'));
     }
 
+    /**
+     * This tests asserts the retry related options and callbacks are properly
+     * mapped and set in the RequestWrappers `$requestOptions` property as
+     * that property is further used down the line for the request.
+     */
     public function testRetryOptionsPassingInGetRetryOptions()
     {
         $requestWrapper = new RequestWrapper();

--- a/Core/tests/Unit/Upload/ResumableUploaderTest.php
+++ b/Core/tests/Unit/Upload/ResumableUploaderTest.php
@@ -173,6 +173,33 @@ class ResumableUploaderTest extends TestCase
         );
     }
 
+    public function testRetryOptionsPassing()
+    {
+        // This tests whether retry related options are properly set in the
+        // abstract uploader class. Since we already had these tests for
+        // ResumableUploader class which extends the AbstractUploader class,
+        // thus testing it here would be sufficient.
+        $options = [
+            'restRetryFunction' => 'arg',
+            'onExecutionStart' => 'arg',
+            'onRetryException' => 'arg'
+        ];
+        $uploader = new ResumableUploader(
+            $this->requestWrapper->reveal(),
+            $this->stream,
+            'http://www.example.com',
+            $options
+        );
+        $reflection = new \ReflectionObject($uploader);
+        $requestOptionsProperty = $reflection->getProperty('requestOptions');
+        $requestOptionsProperty->setAccessible(true);
+        $requestOptions = $requestOptionsProperty->getValue($uploader);
+        foreach ($options as $key => $value) {
+            $this->assertArrayHasKey($key, $requestOptions);
+            $this->assertEquals($value, $requestOptions[$key]);
+        }
+    }
+
     public function testThrowsExceptionWhenAttemptsAsyncUpload()
     {
         $this->expectException('Google\Cloud\Core\Exception\GoogleException');

--- a/Core/tests/Unit/Upload/ResumableUploaderTest.php
+++ b/Core/tests/Unit/Upload/ResumableUploaderTest.php
@@ -173,12 +173,14 @@ class ResumableUploaderTest extends TestCase
         );
     }
 
+    /**
+     * This tests whether retry related options are properly set in the
+     * abstract uploader class. Since we already had these tests for
+     * ResumableUploader class which extends the AbstractUploader class,
+     * thus testing it here would be sufficient.
+     */
     public function testRetryOptionsPassing()
     {
-        // This tests whether retry related options are properly set in the
-        // abstract uploader class. Since we already had these tests for
-        // ResumableUploader class which extends the AbstractUploader class,
-        // thus testing it here would be sufficient.
         $options = [
             'restRetryFunction' => 'arg',
             'onExecutionStart' => 'arg',

--- a/Core/tests/Unit/Upload/ResumableUploaderTest.php
+++ b/Core/tests/Unit/Upload/ResumableUploaderTest.php
@@ -192,6 +192,9 @@ class ResumableUploaderTest extends TestCase
             'http://www.example.com',
             $options
         );
+
+        // Using Reflection instead of Prophecy because we want to test a
+        // private method's logic by verifying the output for a given input.
         $reflection = new \ReflectionObject($uploader);
         $requestOptionsProperty = $reflection->getProperty('requestOptions');
         $requestOptionsProperty->setAccessible(true);

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -743,12 +743,12 @@ class Rest implements ConnectionInterface
      *
      * @param string $headerLine The header line to update.
      * @param array &$arguments The arguments array(passed by reference) used by
-     * execute method of ExponentialBackoff object.
+     *        execute method of ExponentialBackoff object.
      * @param string $value The value to be ammended in the header line.
      * @param bool $getHeaderFromRequest [optional] A flag which determines if
-     *  existing header value is read from $request or from $options. It's useful
-     *  to read from $options incase we update multiple values to a single
-     *  header key.
+     *        existing header value is read from $request or from $options. It's
+     *        useful to read from $options incase we update multiple values to a
+     *        single header key.
      */
     private function updateHeader(
         $headerLine,

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -751,9 +751,9 @@ class Rest implements ConnectionInterface
      *  header key.
      */
     private function updateHeader(
-        string $headerLine,
-        array &$arguments,
-        string $value,
+        $headerLine,
+        &$arguments,
+        $value,
         $getHeaderFromRequest = true
     ) {
         // Fetch request and options

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -667,7 +667,8 @@ class Rest implements ConnectionInterface
     }
 
     /**
-     * Adds callbacks to $args which amend retry hash and attempt to headers.
+     * Adds the callback methods to $args which amends retry hash and attempt
+     * count to the headers.
      * @param array $args
      *
      * @return array

--- a/Storage/tests/Conformance/RetryConformanceTest.php
+++ b/Storage/tests/Conformance/RetryConformanceTest.php
@@ -118,7 +118,7 @@ class RetryConformanceTest extends TestCase
         // These scenario IDs will be run.
         // Omit certain IDs for debugging or testing only
         // certain cases.
-        $scenarios = [1,2,3,4,5,6,7,8];
+        $scenarios = [1, 2, 3, 4, 5, 6, 7, 8];
 
         $cases = [];
 

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -646,11 +646,10 @@ class RestTest extends TestCase
             $case = $retryCase;
             $case[3]['retryStrategy'] = RetryTrait::$RETRY_STRATEGY_ALWAYS;
             $case[6] = $this->assignExpectedOutcome(true, $retryCase);
-            if (
-                !in_array(
-                    $retryCase[4],
-                    RetryTrait::$httpRetryCodes
-                ) || $retryCase[5] > 3
+            if (!in_array(
+                $retryCase[4],
+                RetryTrait::$httpRetryCodes
+            ) || $retryCase[5] > 3
             ) {
                 $case[6] = $this->assignExpectedOutcome(false, $retryCase);
             }
@@ -690,8 +689,7 @@ class RestTest extends TestCase
      */
     private function assignExpectedOutcome($expected, $retryCase)
     {
-        if (
-            isset($retryCase[3]['restRetryFunction'])
+        if (isset($retryCase[3]['restRetryFunction'])
             || isset($retryCase[2]['restRetryFunction'])
         ) {
             return $retryCase[6];

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -479,6 +479,8 @@ class RestTest extends TestCase
         $currAttempt,
         $expected
     ) {
+        // Using Reflection instead of Prophecy because we want to test a
+        // private method's logic by verifying the output for a given input.
         $rest = new Rest($restConfig);
         $reflector = new \ReflectionClass('Google\Cloud\Storage\Connection\Rest');
         $method = $reflector->getMethod('isPreConditionSupplied');
@@ -540,6 +542,8 @@ class RestTest extends TestCase
         $currentAttempt = 1;
         $headerLineName = RequestWrapper::HEADER_API_CLIENT_IDENTIFICATION;
 
+        // Using Reflection instead of Prophecy because we want to test a
+        // private method's logic by verifying the output for a given input.
         $rest = new Rest();
         $reflection = new \ReflectionClass(Rest::class);
         $reflectionMethod = $reflection->getMethod('updateRetryheaders');


### PR DESCRIPTION
Fixed #5954 

Adding unit tests for testing Retry Invocation ID and attempt count addition to the request headers. 

> The testing for the whole system has been done and it was verfied that headers were indeed getting added to the backend by packet sniffing in the emulator.

> Resumable Uploading and Custom Retry Strategy features are tested in the Conformance testing thus adding unit tests for them seems unnecessary as the changes are minimial and the process of these features are more related to how the whole system works.