### PR TITLE
chore(Core): move retry delay to ServiceException

### DIFF
--- a/Core/src/Exception/AbortedException.php
+++ b/Core/src/Exception/AbortedException.php
@@ -22,24 +22,5 @@ namespace Google\Cloud\Core\Exception;
  */
 class AbortedException extends ServiceException
 {
-    /**
-     * Return the delay in seconds and nanos before retrying the failed request.
-     *
-     * @return array
-     */
-    public function getRetryDelay()
-    {
-        $metadata = array_filter($this->metadata, function ($metadataItem) {
-            return array_key_exists('retryDelay', $metadataItem);
-        });
 
-        if (count($metadata) === 0) {
-            return ['seconds' => 0, 'nanos' => 0];
-        }
-
-        return $metadata[0]['retryDelay'] + [
-            'seconds' => 0,
-            'nanos' => 0
-        ];
-    }
 }

--- a/Core/src/Exception/ServiceException.php
+++ b/Core/src/Exception/ServiceException.php
@@ -153,6 +153,26 @@ class ServiceException extends GoogleException
         return $this->errorReason;
     }
 
+    /**
+     * Return the delay in seconds and nanos before retrying the failed request.
+     *
+     * @return array
+     */
+    public function getRetryDelay()
+    {
+        $metadata = array_filter($this->metadata, function ($metadataItem) {
+            return array_key_exists('retryDelay', $metadataItem);
+        });
+
+        if (count($metadata) === 0) {
+            return ['seconds' => 0, 'nanos' => 0];
+        }
+
+        return $metadata[0]['retryDelay'] + [
+            'seconds' => 0,
+            'nanos' => 0
+        ];
+    }
 
     /**
      * Helper to return the error info from an exception


### PR DESCRIPTION
Move the logic of retry delay from AbortedException to it's parent ServiceException.
This unblocks https://github.com/googleapis/google-cloud-php/pull/5938.

