### PR TITLE
chore: pass BC check instead of skipping

### DIFF
--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -16,7 +16,8 @@ jobs:
         run: composer global require "roave/backward-compatibility-check:^8.2"
       - name: "Check for BC breaks"
         if: github.actor != 'release-please[bot]'
-        # Do not fail the build by adding the 'breaking change allowed' label to the PR.
+        # Ensure the build still passes by adding the 'breaking change allowed' label to the PR.
+        # NOTE: PR should contain a "BREAKING CHANGE JUSTIFICATION" in a comment or description
         continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change allowed') }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions
@@ -28,7 +29,8 @@ jobs:
           repository: ${{ github.repository }}
       - name: "Check for BC breaks (Next Release)"
         if: github.actor == 'release-please[bot]'
-        # Do not fail the build by adding the 'breaking change allowed' label to the PR.
+        # Ensure the build still passes by adding the 'breaking change allowed' label to the PR.
+        # NOTE: PR should contain a "BREAKING CHANGE JUSTIFICATION" in a comment or description
         continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change allowed') }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -4,8 +4,6 @@ jobs:
   # More info at https://github.com/Roave/BackwardCompatibilityCheck.
   backwards-compatibility-check:
     runs-on: ubuntu-latest
-    # Disable this check by applying the 'breaking change allowed' label to the PR.
-    if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,6 +16,8 @@ jobs:
         run: composer global require "roave/backward-compatibility-check:^8.2"
       - name: "Check for BC breaks"
         if: github.actor != 'release-please[bot]'
+        # Do not fail the build by adding the 'breaking change allowed' label to the PR.
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change allowed') }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions
       - name: Get Latest Release
@@ -28,6 +28,8 @@ jobs:
           repository: ${{ github.repository }}
       - name: "Check for BC breaks (Next Release)"
         if: github.actor == 'release-please[bot]'
+        # Do not fail the build by adding the 'breaking change allowed' label to the PR.
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change allowed') }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \
               --from=${{ steps.latest-release.outputs.release }} \


### PR DESCRIPTION
When the `breaking change allowed` label is applied to a PR, instead of skipping the check entirely, just pass the test.

This allows us to still look at the errors which were thrown as part of the test, as a way to confirm (and also reliably justify) the breaking changes