### PR TITLE
chore: remove unnecessary experimental tag removal

### DIFF
--- a/Asset/owlbot.py
+++ b/Asset/owlbot.py
@@ -28,11 +28,6 @@ src = Path(f"../{php.STAGING_DIR}/Asset").resolve()
 dest = Path().resolve()
 
 php.owlbot_main(src=src, dest=dest)
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/AutoMl/owlbot.py
+++ b/AutoMl/owlbot.py
@@ -28,11 +28,6 @@ dest = Path().resolve()
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Fix class references in gapic samples
 versions = ['V1', 'V1beta1']

--- a/BigQueryDataTransfer/owlbot.py
+++ b/BigQueryDataTransfer/owlbot.py
@@ -38,11 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/BigQueryStorage/owlbot.py
+++ b/BigQueryStorage/owlbot.py
@@ -28,11 +28,6 @@ dest = Path().resolve()
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Billing/owlbot.py
+++ b/Billing/owlbot.py
@@ -34,11 +34,6 @@ php.owlbot_main(src=src, dest=dest)
 
 
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Container/owlbot.py
+++ b/Container/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Fix class references in gapic samples
 for version in ['V1']:

--- a/DataCatalog/owlbot.py
+++ b/DataCatalog/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Dataproc/owlbot.py
+++ b/Dataproc/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/Iot/owlbot.py
+++ b/Iot/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/Kms/owlbot.py
+++ b/Kms/owlbot.py
@@ -37,11 +37,6 @@ php.owlbot_main(
         src / "*/src/V1/KeyManagementServiceClient.php"
     ]
 )
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # fix copyright year
 s.replace(

--- a/OsLogin/owlbot.py
+++ b/OsLogin/owlbot.py
@@ -31,11 +31,6 @@ dest = Path().resolve()
 _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # fix copyright year
 s.replace(

--- a/RecaptchaEnterprise/owlbot.py
+++ b/RecaptchaEnterprise/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Recommender/owlbot.py
+++ b/Recommender/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Redis/owlbot.py
+++ b/Redis/owlbot.py
@@ -38,11 +38,6 @@ php.owlbot_main(
         src / "*/src/V1beta1/CloudRedisClient.php"
     ]
 )
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/Scheduler/owlbot.py
+++ b/Scheduler/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/SecretManager/owlbot.py
+++ b/SecretManager/owlbot.py
@@ -31,11 +31,6 @@ dest = Path().resolve()
 _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/SecurityCenter/owlbot.py
+++ b/SecurityCenter/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Use new namespace in the doc sample. See
 # https://github.com/googleapis/gapic-generator/issues/2141

--- a/Speech/owlbot.py
+++ b/Speech/owlbot.py
@@ -41,11 +41,6 @@ php.owlbot_main(
         src / "*/src/V2/SpeechClient.php"
     ]
 )
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/TextToSpeech/owlbot.py
+++ b/TextToSpeech/owlbot.py
@@ -31,11 +31,6 @@ dest = Path().resolve()
 _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 ### [START] protoc backwards compatibility fixes
 

--- a/Vision/owlbot.py
+++ b/Vision/owlbot.py
@@ -38,11 +38,6 @@ php.owlbot_main(
         src / "*/src/V1/ImageAnnotatorClient.php",
     ]
 )
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Change the wording for the deprecation warning.
 s.replace(

--- a/WebRisk/owlbot.py
+++ b/WebRisk/owlbot.py
@@ -32,11 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# V1 is GA, so remove @experimental tags
-s.replace(
-    'src/V1/**/*Client.php',
-    r'^(\s+\*\n)?\s+\*\s@experimental\n',
-    '')
 
 # Fix class references in gapic samples
 for version in ['V1', 'V1beta1']:


### PR DESCRIPTION
The PHP gapic generator only generates the `@experimental` tag when the proto package of the service contains `alpha` or `beta`. By virtue of being a `vN` package, it will not have an `@experimental` tag generated.

This is actually interfering with out ability to apply the `@experimental` tag to the upcoming iteration of the PHP gapic surface, which will start as `@experimental` until it is approved for a broad launch.