### PR TITLE
fix: add capture and log strings to switch statement

### DIFF
--- a/Debugger/src/Agent.php
+++ b/Debugger/src/Agent.php
@@ -177,6 +177,7 @@ class Agent
 
             switch ($breakpoint->action()) {
                 case Breakpoint::ACTION_CAPTURE:
+                case 'CAPTURE':
                     stackdriver_debugger_add_snapshot(
                         $sourceLocation->path(),
                         $sourceLocation->line(),
@@ -191,6 +192,7 @@ class Agent
                     );
                     break;
                 case Breakpoint::ACTION_LOG:
+                case 'LOG':
                     stackdriver_debugger_add_logpoint(
                         $sourceLocation->path(),
                         $sourceLocation->line(),


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/2892