### PR TITLE
chore(tests): fix snippet parsing

### DIFF
--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -676,7 +676,7 @@ class CacheSessionPool implements SessionPoolInterface
      * Creates sessions up to the count provided.
      *
      * @param int $count
-     * @return [ array[] $sessions, \Exception $ex = null ]
+     * @return array{0: array[], 1: \Exception|null }
      */
     private function createSessions($count)
     {

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -487,7 +487,7 @@ class ValueMapper
      *
      * @param StructValue|array|null $value The struct value.
      * @param StructType $type The struct type.
-     * @return [array, array] An array containing the value and type.
+     * @return array{0: array, 1: array} An array containing the value and type.
      */
     private function structParam($value, StructType $type)
     {
@@ -630,7 +630,7 @@ class ValueMapper
      * @param bool $allowMixedArrayType [optional] If true, array values may be of mixed type.
      *        This is useful when reading against complex keys containing multiple
      *        elements of differing types.
-     * @return [array, array] An array containing the value and type.
+     * @return array{0: array, 1: array} An array containing the value and type.
      */
     private function arrayParam($value, ArrayType $arrayObj, $allowMixedArrayType = false)
     {
@@ -701,7 +701,7 @@ class ValueMapper
         if (is_null($typeCode) && count($inferredTypes) > 0 && isset($inferredTypes[0]['code'])) {
             $typeCode = $inferredTypes[0]['code'];
         }
-        
+
         if (is_null($typeAnnotationCode) && count($inferredTypes) > 0 && isset($inferredTypes[0]['typeAnnotation'])) {
             $typeAnnotationCode = $inferredTypes[0]['typeAnnotation'];
         }
@@ -731,7 +731,7 @@ class ValueMapper
      * Handle query parameter mappings for various types of objects.
      *
      * @param mixed $value The parameter value.
-     * @return [array, array] An array containing the value and type.
+     * @return array{0: array, 1: array} An array containing the value and type.
      */
     private function objectParam($value)
     {
@@ -775,7 +775,7 @@ class ValueMapper
      *        the structure of an array or struct type.
      * @param string $nestedDefinitionType [optional] Either `arrayElementType`
      *        or `structType`.
-     * @return array
+     * @return array{0: array, 1: array}
      */
     private function typeObject(
         $type,


### PR DESCRIPTION
We are getting parse errors in our snippets tests because of invalid `@return` statements. I believe this is due to a version of `phpdocumentor` throwing errors where previously it was not. 

According to the documentation on [Array Shapes](https://psalm.dev/docs/annotating_code/type_syntax/array_types/#array-shapes), the format we had was invalid. This PR updates them to be compliant.