### PR TITLE
fix(Core): enable custom headers to REST::send

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -202,7 +202,7 @@ class RequestWrapper
 
         try {
             return $backoff->execute($this->httpHandler, [
-                $this->applyHeaders($request),
+                $this->applyHeaders($request, $options),
                 $this->getRequestOptions($options)
             ]);
         } catch (\Exception $ex) {
@@ -276,14 +276,18 @@ class RequestWrapper
      * Applies headers to the request.
      *
      * @param RequestInterface $request A PSR-7 request.
+     * @param array $options Configuration options.
      * @return RequestInterface
      */
-    private function applyHeaders(RequestInterface $request)
+    private function applyHeaders(RequestInterface $request, $options = [])
     {
         $headers = [
             'User-Agent' => 'gcloud-php/' . $this->componentVersion,
             'x-goog-api-client' => 'gl-php/' . PHP_VERSION . ' gccl/' . $this->componentVersion,
         ];
+        $headers += isset($options['restOptions']['headers'])
+            ? $options['restOptions']['headers']
+            : [];
 
         if ($this->shouldSignRequest) {
             $quotaProject = $this->quotaProject;

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -279,6 +279,28 @@ class RequestWrapperTest extends TestCase
         );
     }
 
+    public function testAddsCustomHeadersToRequest()
+    {
+        $headers = [
+            'header-_key' => 'test header-_val'
+        ];
+        $requestWrapper = new RequestWrapper([
+            'httpHandler' => function ($request, $options = []) use ($headers) {
+                $headerVal = $request->getHeaderLine('header-_key');
+                $this->assertEquals($headers['header-_key'], $headerVal);
+                return new Response(200);
+            },
+            'accessToken' => 'abc'
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com'),
+            [
+                'restOptions' => ['headers' => $headers]
+            ]
+        );
+    }
+
     public function testRequestUsesApiKeyInsteadOfAuthHeader()
     {
         $version = '1.0.0';


### PR DESCRIPTION
`REST::send` enables sending custom headers using `restOptions->headers` by using optional arguments, but those are actually used in the Request.

## Changes
1. Add custom headers into REST request before sending
2. UT to cover this scenario

## Tests
1. UTs pass locally