### PR TITLE
fix(Datastore): add custom routing headers

### DIFF
--- a/Datastore/src/Connection/Rest.php
+++ b/Datastore/src/Connection/Rest.php
@@ -69,6 +69,7 @@ class Rest implements ConnectionInterface
      */
     public function allocateIds(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'allocateIds', $args);
     }
 
@@ -77,6 +78,7 @@ class Rest implements ConnectionInterface
      */
     public function beginTransaction(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'beginTransaction', $args);
     }
 
@@ -85,6 +87,7 @@ class Rest implements ConnectionInterface
      */
     public function commit(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'commit', $args);
     }
 
@@ -93,6 +96,7 @@ class Rest implements ConnectionInterface
      */
     public function lookup(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'lookup', $args);
     }
 
@@ -101,6 +105,7 @@ class Rest implements ConnectionInterface
      */
     public function rollback(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'rollback', $args);
     }
 
@@ -109,6 +114,23 @@ class Rest implements ConnectionInterface
      */
     public function runQuery(array $args)
     {
+        $this->setHeader($args);
         return $this->send('projects', 'runQuery', $args);
+    }
+
+    /**
+     * Apply the x-goog-request-params header to requests for multiple databases.
+     *
+     * @param array $args
+     */
+    private function setHeader(&$args)
+    {
+        if (isset($args['projectId']) && isset($args['databaseId'])) {
+            $args['restOptions']['headers']['x-goog-request-params'] = sprintf(
+                'project_id=%s&database_id=%s',
+                $args['projectId'],
+                $args['databaseId']
+            );
+        }
     }
 }

--- a/Datastore/tests/Unit/Connection/RestTest.php
+++ b/Datastore/tests/Unit/Connection/RestTest.php
@@ -87,6 +87,44 @@ class RestTest extends TestCase
         $this->assertEquals(json_decode($this->successBody, true), $rest->$method($options));
     }
 
+    public function testSendWithRoutingHeaders()
+    {
+        $optionsWithDatabaseId = ['databaseId' => 'dbId'];
+        $optionsWithProjectId = ['projectId' => 'prodId'];
+
+        $rest = new Rest();
+        $reflector = new \ReflectionObject($rest);
+        $method = $reflector->getMethod('setHeader');
+        $method->setAccessible(true);
+
+        $args = [];
+        $method->invokeArgs($rest, [&$args]);
+        $this->assertArrayNotHasKey('restOptions', $args);
+
+        $args = $optionsWithDatabaseId;
+        $method->invokeArgs($rest, [&$args]);
+        $this->assertArrayNotHasKey('restOptions', $args);
+
+        $args = $optionsWithProjectId;
+        $method->invokeArgs($rest, [&$args]);
+        $this->assertArrayNotHasKey('restOptions', $args);
+
+        $args = $optionsWithProjectId + $optionsWithDatabaseId;
+        $method->invokeArgs($rest, [&$args]);
+        $this->assertEquals(
+            sprintf(
+                'project_id=%s&database_id=%s',
+                $args['projectId'],
+                $args['databaseId']
+            ),
+            $args['restOptions']['headers']['x-goog-request-params']
+        );
+    }
+
+
+
+
+
     public function methodProvider()
     {
         return [


### PR DESCRIPTION
Multiple databases feature in Datastore required a custom routing header `x-goog-request-params`.

## Change
1. Add custom routing headers on all relevant calls to Datastore backend.
2. Add tests to ensure a correct header is formed.

**Note:**  This change can only go once https://github.com/googleapis/google-cloud-php/pull/5998 is merged and the Core version is bumped up on this PR.