### PR TITLE
Revert "chore(Firestore): refactor read time logic"

### DIFF
--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -21,7 +21,7 @@ use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
-use Google\Cloud\Core\TimestampTrait;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 
 /**
@@ -44,7 +44,6 @@ class CollectionReference extends Query
     use ArrayTrait;
     use DebugInfoTrait;
     use PathTrait;
-    use TimestampTrait;
 
     /**
      * @var ConnectionInterface
@@ -270,7 +269,16 @@ class CollectionReference extends Query
             'mask' => []
         ];
 
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
 
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/DocumentReference.php
+++ b/Firestore/src/DocumentReference.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore;
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 
 /**
@@ -386,8 +387,16 @@ class DocumentReference
      */
     public function collections(array $options = [])
     {
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
 
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $resultLimit = $this->pluck('resultLimit', $options, false);
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -26,6 +26,7 @@ use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
 use Google\Cloud\Core\Retry;
 use Google\Cloud\Core\ValidateTrait;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\Grpc;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\StreamInterface;
@@ -292,8 +293,16 @@ class FirestoreClient
      */
     public function collections(array $options = [])
     {
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
 
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $resultLimit = $this->pluck('resultLimit', $options, false);
         return new ItemIterator(
             new PageIterator(

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Firestore;
 
 use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\ExponentialBackoff;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentSnapshot;
 use Google\Cloud\Firestore\FieldValue\FieldValueInterface;
@@ -191,8 +192,16 @@ class Query
      */
     public function documents(array $options = [])
     {
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
 
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
         $maxRetries = $this->pluck('maxRetries', $options, false);
         $maxRetries = $maxRetries === null
             ? FirestoreClient::MAX_RETRIES

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
-use Google\Cloud\Core\TimestampTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
 
@@ -34,7 +33,6 @@ trait SnapshotTrait
     use ArrayTrait;
     use PathTrait;
     use TimeTrait;
-    use TimestampTrait;
 
     /**
      * Execute a service request to retrieve a document snapshot.
@@ -108,7 +106,16 @@ trait SnapshotTrait
      */
     private function getSnapshot(ConnectionInterface $connection, $name, array $options = [])
     {
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            if (!($options['readTime'] instanceof Timestamp)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '`$options.readTime` must be an instance of %s',
+                    Timestamp::class
+                ));
+            }
+
+            $options['readTime'] = $options['readTime']->formatForApi();
+        }
 
         $snapshot = $connection->batchGetDocuments([
             'database' => $this->databaseFromName($name),


### PR DESCRIPTION
Reverts googleapis/google-cloud-php#6018

We are reverting because we need to merge this PR after a Core version upgrade. As part of current toolchain, we cannot push a change in Core as well as a product in the same release.