### PR TITLE
Revert "chore(datastore): refactor read time logic"

### DIFF
--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -18,7 +18,6 @@
 namespace Google\Cloud\Datastore;
 
 use Google\Cloud\Core\Timestamp;
-use Google\Cloud\Core\TimestampTrait;
 use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Query\Query;
@@ -40,7 +39,6 @@ class Operation
 {
     use DatastoreTrait;
     use ValidateTrait;
-    use TimestampTrait;
 
     /**
      * @var ConnectionInterface
@@ -268,12 +266,13 @@ class Operation
     public function beginTransaction($transactionOptions, array $options = [])
     {
         // Read Only option might not be present or empty
+        // Parse only when Read Time is valid
         if (isset($transactionOptions['readOnly']) &&
-            is_array($transactionOptions['readOnly'])
+            is_array($transactionOptions['readOnly']) &&
+            isset($transactionOptions['readOnly']['readTime'])
         ) {
-            $transactionOptions['readOnly'] = $this->formatReadTimeOption(
-                $transactionOptions['readOnly']
-            );
+            $readTime = $transactionOptions['readOnly']['readTime'];
+            $transactionOptions['readOnly']['readTime'] = $this->parseCoreTimestamp($readTime);
         }
         $res = $this->connection->beginTransaction($options + [
             'projectId' => $this->projectId,
@@ -789,7 +788,9 @@ class Operation
             'readTime' => null
         ];
 
-        $options = $this->formatReadTimeOption($options);
+        if (isset($options['readTime'])) {
+            $options['readTime'] = $this->parseCoreTimestamp($options['readTime']);
+        }
 
         $readOptions = array_filter([
             'readConsistency' => $options['readConsistency'],
@@ -800,6 +801,23 @@ class Operation
         return array_filter([
             'readOptions' => $readOptions,
         ]);
+    }
+
+    /**
+     * Format the timestamp.
+     *
+     * @param Timestamp $time
+     * @return array
+     */
+    private function parseCoreTimestamp($time)
+    {
+        if (!$time instanceof Timestamp) {
+            throw new \InvalidArgumentException(
+                'Read Time must be an instance of `Google\\Cloud\\Core\\Timestamp`'
+            );
+        }
+
+        return $time->formatForApi();
     }
 
     /**


### PR DESCRIPTION
Reverts googleapis/google-cloud-php#6026

We are reverting because we need to merge this PR after a Core version upgrade. As part of current toolchain, we cannot push a change in Core as well as a product in the same release.