### PR TITLE
chore: update core version in Firestore and Datastore

### DIFF
--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.43",
+        "google/cloud-core": "^1.49.4",
         "google/gax": "^1.1"
     },
     "require-dev": {

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.39",
+        "google/cloud-core": "^1.49.4",
         "google/gax": "^1.1",
         "ramsey/uuid": "^3.0|^4.0"
     },


### PR DESCRIPTION
alternative to https://github.com/googleapis/google-cloud-php/pull/6031 and https://github.com/googleapis/google-cloud-php/pull/6032

I believe this will work, as our individual package tests are configured to use the `Core` from the same branch anyway