### PR TITLE
chore: remove php5.6 tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,6 @@ jobs:
         phpunit-filename: [phpunit]
         include:
           - platform: ubuntu-latest
-            php: "5.6"
-            phpunit-filename: phpunit-php5
-          - platform: ubuntu-latest
             php: "7.0"
             phpunit-filename: phpunit
     name: PHP ${{ matrix.php }} Unit Test (${{ matrix.platform }})


### PR DESCRIPTION
Removing php5.6 tests because it interferes with the new upcoming features in CNDB.