### PR TITLE
chore: fix error in deployment script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           with:
             timeout_minutes: 10
             max_attempts: 3
-            command: composer update
+            command: composer update -d dev
         - id: getTag
           name: Get Tag
           run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT

--- a/dev/src/Command/SplitCommand.php
+++ b/dev/src/Command/SplitCommand.php
@@ -161,7 +161,7 @@ class SplitCommand extends Command
                 $input->getOption('update-release-notes')
             );
             if (!$res) {
-                $errors[] = $componentId;
+                $errors[] = $component->getId();
             }
 
             $output->writeln('');


### PR DESCRIPTION
`composer` should run in the `dev` directory since the release script refactor