### PR TITLE
chore: remove php 7.3 from CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,15 +10,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        php: [ "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
-        phpunit-filename: [phpunit]
-        include:
-          - platform: ubuntu-latest
-            php: "5.6"
-            phpunit-filename: phpunit-php5
-          - platform: ubuntu-latest
-            php: "7.0"
-            phpunit-filename: phpunit
+        php: [ "7.4", "8.0", "8.1", "8.2" ]
     name: PHP ${{ matrix.php }} Unit Test (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
@@ -38,20 +30,20 @@ jobs:
     - if: ${{ matrix.platform == 'windows-latest' }}
       name: Run Unit Test Suite (Windows)
       run: |
-        vendor/bin/phpunit -c ${{ matrix.phpunit-filename }}.xml.dist
+        vendor/bin/phpunit -c phpunit.xml.dist
         if ( "$?" -ne "0" )
         {
           echo "*** RETRYING FLAKEY PHPUNIT ON WINDOWS ***"
-          vendor/bin/phpunit -c ${{ matrix.phpunit-filename }}.xml.dist
+          vendor/bin/phpunit -c phpunit.xml.dist
         }
     - if: ${{ matrix.platform != 'windows-latest' }}
       name: Run Unit Test Suite
       run: |
-        vendor/bin/phpunit -c ${{ matrix.phpunit-filename }}.xml.dist
+        vendor/bin/phpunit -c phpunit.xml.dist
     - if: ${{ matrix.platform != 'windows-latest' }}
       name: Run Snippet Test Suite
       run: |
-        vendor/bin/phpunit -c ${{ matrix.phpunit-filename }}-snippets.xml.dist --verbose
+        vendor/bin/phpunit -c phpunit-snippets.xml.dist --verbose
 
   test_package:
     name: Package Tests

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.4",
         "rize/uri-template": "~0.3",
         "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/psr7": "^1.7|^2.0",


### PR DESCRIPTION
This is a subset of #6014. It removes PHP 7.3 and below from the CI so we can review other PRs without having to be blocked by the main PR.