### PR TITLE
chore: phpunit migrate configuration

### DIFF
--- a/AccessApproval/phpunit.xml.dist
+++ b/AccessApproval/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AccessContextManager/phpunit.xml.dist
+++ b/AccessContextManager/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AdvisoryNotifications/phpunit.xml.dist
+++ b/AdvisoryNotifications/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Google Cloud Advisory Notifications Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AiPlatform/phpunit.xml.dist
+++ b/AiPlatform/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AlloyDb/phpunit.xml.dist
+++ b/AlloyDb/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Google Cloud AlloyDB for PostgreSQL Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AnalyticsAdmin/phpunit.xml.dist
+++ b/AnalyticsAdmin/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AnalyticsData/phpunit.xml.dist
+++ b/AnalyticsData/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ApiGateway/phpunit.xml.dist
+++ b/ApiGateway/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ApiKeys/phpunit.xml.dist
+++ b/ApiKeys/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ApigeeConnect/phpunit.xml.dist
+++ b/ApigeeConnect/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ApigeeRegistry/phpunit.xml.dist
+++ b/ApigeeRegistry/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AppEngineAdmin/phpunit.xml.dist
+++ b/AppEngineAdmin/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ArtifactRegistry/phpunit.xml.dist
+++ b/ArtifactRegistry/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Asset/phpunit-system.xml.dist
+++ b/Asset/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Asset/phpunit.xml.dist
+++ b/Asset/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AssuredWorkloads/phpunit.xml.dist
+++ b/AssuredWorkloads/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AutoMl/phpunit-system.xml.dist
+++ b/AutoMl/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/AutoMl/phpunit.xml.dist
+++ b/AutoMl/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BareMetalSolution/phpunit.xml.dist
+++ b/BareMetalSolution/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Batch/phpunit.xml.dist
+++ b/Batch/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BeyondCorpAppConnections/phpunit.xml.dist
+++ b/BeyondCorpAppConnections/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BeyondCorpAppConnectors/phpunit.xml.dist
+++ b/BeyondCorpAppConnectors/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BeyondCorpAppGateways/phpunit.xml.dist
+++ b/BeyondCorpAppGateways/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BeyondCorpClientConnectorServices/phpunit.xml.dist
+++ b/BeyondCorpClientConnectorServices/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BeyondCorpClientGateways/phpunit.xml.dist
+++ b/BeyondCorpClientGateways/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQuery/phpunit-snippets.xml.dist
+++ b/BigQuery/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQuery/phpunit-system.xml.dist
+++ b/BigQuery/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQuery/phpunit.xml.dist
+++ b/BigQuery/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryAnalyticsHub/phpunit.xml.dist
+++ b/BigQueryAnalyticsHub/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryConnection/phpunit.xml.dist
+++ b/BigQueryConnection/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryDataExchange/phpunit.xml.dist
+++ b/BigQueryDataExchange/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryDataPolicies/phpunit.xml.dist
+++ b/BigQueryDataPolicies/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryDataTransfer/phpunit-system.xml.dist
+++ b/BigQueryDataTransfer/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryDataTransfer/phpunit.xml.dist
+++ b/BigQueryDataTransfer/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryMigration/phpunit.xml.dist
+++ b/BigQueryMigration/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryReservation/phpunit.xml.dist
+++ b/BigQueryReservation/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BigQueryStorage/phpunit.xml.dist
+++ b/BigQueryStorage/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Bigtable/phpunit-snippets.xml.dist
+++ b/Bigtable/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Bigtable/phpunit-system.xml.dist
+++ b/Bigtable/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Bigtable/phpunit.xml.dist
+++ b/Bigtable/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Billing/phpunit.xml.dist
+++ b/Billing/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BillingBudgets/phpunit.xml.dist
+++ b/BillingBudgets/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/BinaryAuthorization/phpunit.xml.dist
+++ b/BinaryAuthorization/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Build/phpunit.xml.dist
+++ b/Build/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/CertificateManager/phpunit.xml.dist
+++ b/CertificateManager/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Channel/phpunit.xml.dist
+++ b/Channel/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/CommonProtos/phpunit.xml.dist
+++ b/CommonProtos/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Compute/phpunit-system.xml.dist
+++ b/Compute/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Compute/phpunit.xml.dist
+++ b/Compute/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ContactCenterInsights/phpunit.xml.dist
+++ b/ContactCenterInsights/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Container/phpunit-system.xml.dist
+++ b/Container/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Container/phpunit.xml.dist
+++ b/Container/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ContainerAnalysis/phpunit.xml.dist
+++ b/ContainerAnalysis/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Core/phpunit-snippets.xml.dist
+++ b/Core/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Core/phpunit-system.xml.dist
+++ b/Core/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Core/phpunit.xml.dist
+++ b/Core/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DataCatalog/phpunit.xml.dist
+++ b/DataCatalog/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DataFusion/phpunit.xml.dist
+++ b/DataFusion/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DataLabeling/phpunit.xml.dist
+++ b/DataLabeling/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dataflow/phpunit.xml.dist
+++ b/Dataflow/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dataform/phpunit.xml.dist
+++ b/Dataform/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dataplex/phpunit.xml.dist
+++ b/Dataplex/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dataproc/phpunit-system.xml.dist
+++ b/Dataproc/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dataproc/phpunit.xml.dist
+++ b/Dataproc/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DataprocMetastore/phpunit.xml.dist
+++ b/DataprocMetastore/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Datastore/phpunit-snippets.xml.dist
+++ b/Datastore/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Datastore/phpunit-system.xml.dist
+++ b/Datastore/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Datastore/phpunit.xml.dist
+++ b/Datastore/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DatastoreAdmin/phpunit.xml.dist
+++ b/DatastoreAdmin/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Datastream/phpunit.xml.dist
+++ b/Datastream/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Debugger/phpunit-snippets.xml.dist
+++ b/Debugger/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Debugger/phpunit-system.xml.dist
+++ b/Debugger/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Debugger/phpunit.xml.dist
+++ b/Debugger/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Deploy/phpunit.xml.dist
+++ b/Deploy/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dialogflow/phpunit-system.xml.dist
+++ b/Dialogflow/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dialogflow/phpunit.xml.dist
+++ b/Dialogflow/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dlp/phpunit-system.xml.dist
+++ b/Dlp/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dlp/phpunit.xml.dist
+++ b/Dlp/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Dms/phpunit.xml.dist
+++ b/Dms/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/DocumentAi/phpunit.xml.dist
+++ b/DocumentAi/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Domains/phpunit.xml.dist
+++ b/Domains/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ErrorReporting/phpunit-system.xml.dist
+++ b/ErrorReporting/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ErrorReporting/phpunit.xml.dist
+++ b/ErrorReporting/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/EssentialContacts/phpunit.xml.dist
+++ b/EssentialContacts/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Eventarc/phpunit.xml.dist
+++ b/Eventarc/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/EventarcPublishing/phpunit.xml.dist
+++ b/EventarcPublishing/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Filestore/phpunit.xml.dist
+++ b/Filestore/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Firestore/phpunit-snippets.xml.dist
+++ b/Firestore/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Firestore/phpunit-system.xml.dist
+++ b/Firestore/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Firestore/phpunit.xml.dist
+++ b/Firestore/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Functions/phpunit.xml.dist
+++ b/Functions/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/GSuiteAddOns/phpunit.xml.dist
+++ b/GSuiteAddOns/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Gaming/phpunit.xml.dist
+++ b/Gaming/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/GkeBackup/phpunit.xml.dist
+++ b/GkeBackup/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage/>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>

--- a/GkeConnectGateway/phpunit.xml.dist
+++ b/GkeConnectGateway/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/GkeHub/phpunit.xml.dist
+++ b/GkeHub/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/GkeMultiCloud/phpunit.xml.dist
+++ b/GkeMultiCloud/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Grafeas/phpunit.xml.dist
+++ b/Grafeas/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Iam/phpunit.xml.dist
+++ b/Iam/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/IamCredentials/phpunit.xml.dist
+++ b/IamCredentials/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Iap/phpunit.xml.dist
+++ b/Iap/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Ids/phpunit.xml.dist
+++ b/Ids/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Iot/phpunit-system.xml.dist
+++ b/Iot/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Iot/phpunit.xml.dist
+++ b/Iot/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Kms/phpunit-system.xml.dist
+++ b/Kms/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Kms/phpunit.xml.dist
+++ b/Kms/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/KmsInventory/phpunit.xml.dist
+++ b/KmsInventory/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Google Cloud KMS Inventory Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Language/phpunit-snippets.xml.dist
+++ b/Language/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Language/phpunit-system.xml.dist
+++ b/Language/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Language/phpunit.xml.dist
+++ b/Language/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/LifeSciences/phpunit.xml.dist
+++ b/LifeSciences/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Logging/phpunit-snippets.xml.dist
+++ b/Logging/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Logging/phpunit-system.xml.dist
+++ b/Logging/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Logging/phpunit.xml.dist
+++ b/Logging/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/LongRunning/phpunit.xml.dist
+++ b/LongRunning/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/ApiCore/LongRunning</directory>
+      <directory suffix=".php">src/LongRunning</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/ApiCore/LongRunning</directory>
-        <directory suffix=".php">src/LongRunning</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ManagedIdentities/phpunit.xml.dist
+++ b/ManagedIdentities/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/MediaTranslation/phpunit.xml.dist
+++ b/MediaTranslation/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Memcache/phpunit.xml.dist
+++ b/Memcache/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Monitoring/phpunit-system.xml.dist
+++ b/Monitoring/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Monitoring/phpunit.xml.dist
+++ b/Monitoring/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/NetworkConnectivity/phpunit.xml.dist
+++ b/NetworkConnectivity/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/NetworkManagement/phpunit.xml.dist
+++ b/NetworkManagement/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/NetworkSecurity/phpunit.xml.dist
+++ b/NetworkSecurity/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Notebooks/phpunit.xml.dist
+++ b/Notebooks/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Optimization/phpunit.xml.dist
+++ b/Optimization/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/OrchestrationAirflow/phpunit.xml.dist
+++ b/OrchestrationAirflow/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/OrgPolicy/phpunit.xml.dist
+++ b/OrgPolicy/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/OsConfig/phpunit.xml.dist
+++ b/OsConfig/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/OsLogin/phpunit-system.xml.dist
+++ b/OsLogin/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/OsLogin/phpunit.xml.dist
+++ b/OsLogin/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/PolicyTroubleshooter/phpunit.xml.dist
+++ b/PolicyTroubleshooter/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/PrivateCatalog/phpunit.xml.dist
+++ b/PrivateCatalog/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Profiler/phpunit.xml.dist
+++ b/Profiler/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/PubSub/phpunit-snippets.xml.dist
+++ b/PubSub/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/PubSub/phpunit-system.xml.dist
+++ b/PubSub/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/PubSub/phpunit.xml.dist
+++ b/PubSub/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/RecaptchaEnterprise/phpunit.xml.dist
+++ b/RecaptchaEnterprise/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/RecommendationEngine/phpunit.xml.dist
+++ b/RecommendationEngine/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Recommender/phpunit.xml.dist
+++ b/Recommender/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Redis/phpunit-system.xml.dist
+++ b/Redis/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Redis/phpunit.xml.dist
+++ b/Redis/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ResourceManager/phpunit.xml.dist
+++ b/ResourceManager/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ResourceSettings/phpunit.xml.dist
+++ b/ResourceSettings/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Retail/phpunit.xml.dist
+++ b/Retail/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Run/phpunit.xml.dist
+++ b/Run/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Scheduler/phpunit-system.xml.dist
+++ b/Scheduler/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Scheduler/phpunit.xml.dist
+++ b/Scheduler/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/SecretManager/phpunit.xml.dist
+++ b/SecretManager/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/SecurityCenter/phpunit.xml.dist
+++ b/SecurityCenter/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/SecurityPrivateCa/phpunit.xml.dist
+++ b/SecurityPrivateCa/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/SecurityPublicCA/phpunit.xml.dist
+++ b/SecurityPublicCA/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ServiceControl/phpunit.xml.dist
+++ b/ServiceControl/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ServiceDirectory/phpunit.xml.dist
+++ b/ServiceDirectory/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ServiceManagement/phpunit.xml.dist
+++ b/ServiceManagement/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/ServiceUsage/phpunit.xml.dist
+++ b/ServiceUsage/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Shell/phpunit.xml.dist
+++ b/Shell/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Spanner/phpunit-snippets.xml.dist
+++ b/Spanner/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Spanner/phpunit-system.xml.dist
+++ b/Spanner/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Spanner/phpunit.xml.dist
+++ b/Spanner/phpunit.xml.dist
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">src/*/*/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">src/*/*/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Speech/phpunit-snippets.xml.dist
+++ b/Speech/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Speech/phpunit-system.xml.dist
+++ b/Speech/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Speech/phpunit.xml.dist
+++ b/Speech/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/SqlAdmin/phpunit.xml.dist
+++ b/SqlAdmin/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Storage/phpunit-snippets.xml.dist
+++ b/Storage/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Storage/phpunit-system.xml.dist
+++ b/Storage/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Storage/phpunit.xml.dist
+++ b/Storage/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/StorageTransfer/phpunit.xml.dist
+++ b/StorageTransfer/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Talent/phpunit.xml.dist
+++ b/Talent/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Tasks/phpunit-system.xml.dist
+++ b/Tasks/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Tasks/phpunit.xml.dist
+++ b/Tasks/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/TextToSpeech/phpunit-system.xml.dist
+++ b/TextToSpeech/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/TextToSpeech/phpunit.xml.dist
+++ b/TextToSpeech/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Tpu/phpunit.xml.dist
+++ b/Tpu/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Trace/phpunit-snippets.xml.dist
+++ b/Trace/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Trace/phpunit-system.xml.dist
+++ b/Trace/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Trace/phpunit.xml.dist
+++ b/Trace/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Translate/phpunit-snippets.xml.dist
+++ b/Translate/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Translate/phpunit-system.xml.dist
+++ b/Translate/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Translate/phpunit.xml.dist
+++ b/Translate/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VideoIntelligence/phpunit-system.xml.dist
+++ b/VideoIntelligence/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VideoIntelligence/phpunit.xml.dist
+++ b/VideoIntelligence/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VideoLiveStream/phpunit.xml.dist
+++ b/VideoLiveStream/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VideoStitcher/phpunit.xml.dist
+++ b/VideoStitcher/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VideoTranscoder/phpunit.xml.dist
+++ b/VideoTranscoder/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Vision/phpunit-snippets.xml.dist
+++ b/Vision/phpunit-snippets.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
-  colors="true"
-  >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Snippets Test Suite">
       <directory>tests/Snippet</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Vision/phpunit-system.xml.dist
+++ b/Vision/phpunit-system.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/google/cloud-core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Vision/phpunit.xml.dist
+++ b/Vision/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VmMigration/phpunit.xml.dist
+++ b/VmMigration/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VmwareEngine/phpunit.xml.dist
+++ b/VmwareEngine/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/VpcAccess/phpunit.xml.dist
+++ b/VpcAccess/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/WebRisk/phpunit.xml.dist
+++ b/WebRisk/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/WebSecurityScanner/phpunit.xml.dist
+++ b/WebSecurityScanner/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/Workflows/phpunit.xml.dist
+++ b/Workflows/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Unit Test Suite">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/dev/phpunit-docfx.xml.dist
+++ b/dev/phpunit-docfx.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage/>
   <testsuites>
     <testsuite name="DocFX Test Suite">
       <directory>./tests/Unit/DocFx</directory>
@@ -7,4 +8,3 @@
     </testsuite>
   </testsuites>
 </phpunit>
-

--- a/phpunit-perf.xml.dist
+++ b/phpunit-perf.xml.dist
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./Core/perf-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Core/perf-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include/>
+    <exclude>
+      <directory suffix=".php">*/src/V[!a-zA-Z]*</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="Perf Test Suite">
       <directory>*/tests/Perf</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <exclude>
-        <directory suffix=".php">*/src/V[!a-zA-Z]*</directory>
-      </exclude>
-    </whitelist>
-  </filter>
   <php>
     <ini name="memory_limit" value="2048M"/>
   </php>

--- a/phpunit-system.xml.dist
+++ b/phpunit-system.xml.dist
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./Core/system-bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Core/system-bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">*/src</directory>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">*/src/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">*/src/*/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">*/src/*/*/V[!a-zA-Z]*</directory>
+      <directory suffix=".php">Core/src/Testing</directory>
+      <directory suffix=".php">dev</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>*/tests/System</directory>
       <directory>tests/System</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">*/src</directory>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix=".php">*/src/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">*/src/*/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">*/src/*/*/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">Core/src/Testing</directory>
-        <directory suffix=".php">dev</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
PhpUnit throws the following error / suggestion, hence upgrading all it's configs by using `--migrate-configuration`:
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Here's the script to do this migration:

<details>
<summary>Bash script to migrate PhpUnit configs </summary>

```
#!/bin/bash
# Copyright 2023 Google Inc.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# first argument can be a directory
DIRS=$(find * -maxdepth 1 -type d -name '[A-Z]*' -not -path '*/vendor/*')
if [ "$#" -eq 1 ]; then
    DIRS=$1
elif [ "$#" -ne 1 ]; then
    echo "Running for all Product directories"
fi

FAILED_FILE=$(mktemp -d)/failed
for DIR in ${DIRS}; do {
    echo "Running $DIR composer update"
    # Update composer to use local packages
    for i in bigquery,BigQuery core,Core logging,Logging, pubsub,PubSub storage,Storage; do
        IFS=","; set -- $i;
        if grep -q "\"google/cloud-$1\":" ${DIR}/composer.json; then
            composer config repositories.$1 "{\"type\": \"path\", \"url\": \"../$2\", \"options\":{\"versions\":{\"google/cloud-$1\":\"1.100\"}}}" -d ${DIR}
        fi
    done
    composer -q --no-interaction --no-ansi --no-progress update -d ${DIR};
    if [ $? != 0 ]; then
        echo "$DIR: composer install failed" >> "${FAILED_FILE}"
        continue
    fi

    PHPUNIT_CONFIG_FILES=$(find "$DIR" -maxdepth 1 -type f -name 'phpunit*xml.dist' -not -path '*/vendor/*')
    IFS=$'\n'
    for PHPUNIT_CONFIG_FILE in ${PHPUNIT_CONFIG_FILES}; do {
        echo "Running $PHPUNIT_CONFIG_FILE migration"
        ${DIR}/vendor/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --migrate-configuration;
        if [ $? != 0 ]; then
            echo "$PHPUNIT_CONFIG_FILE: migration failed" >> "${FAILED_FILE}"
        fi
    }; done
}; done
echo "Migration complete"
echo "Deleting backup files"
PHPUNIT_CONFIG_BACKUP_FILES=$(find . -maxdepth 4 -type f -name 'phpunit*xml.dist.bak' -not -path '*/vendor/*')
for PHPUNIT_CONFIG_BACKUP_FILE in ${PHPUNIT_CONFIG_BACKUP_FILES}; do {
        echo "Deleting $PHPUNIT_CONFIG_BACKUP_FILE after migration"
        rm $PHPUNIT_CONFIG_BACKUP_FILE;
        if [ $? != 0 ]; then
            echo "$PHPUNIT_CONFIG_BACKUP_FILE: deletion failed" >> "${FAILED_FILE}"
        fi
    }; done
echo "Deletion completed"

if [ -f "${FAILED_FILE}" ]; then
    echo "--------- Failed tests --------------"
    cat "${FAILED_FILE}"
    echo "-------------------------------------"
fi
# add all changed phpunit configs to staged
git add .
# removes composer.json
find . -maxdepth 4 -type f -name "composer.json" -not -path '*/vendor/*' | xargs git reset
```
</details>

Note:
1. This PR covers all types of phpunit configs:
  - phpunit-conformance.xml.dist
  - phpunit-docfx.xml.dist
  - phpunit-perf.xml.dist
  - phpunit-snippets.xml.dist
  - phpunit-system.xml.dist
  - phpunit.xml.dist
2. Certain phpunit configs (ex: root `/phpunit.dist.xml` or `/dev/phpunit.dist.xml`) didn't need any upgrade, so those are not changed.