### PR TITLE
chore(gcs-conformance): retryListener option should be internal

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -118,11 +118,6 @@ class RequestWrapper
      *     @type callable $restRetryFunction Sets the conditions for whether or
      *           not a request should attempt to retry. Function signature should
      *           match: `function (\Exception $ex) : bool`.
-     *     @type callable $restRetryListener Runs after the restRetryFunction.
-     *           This might be used to simply consume the exception and
-     *           $arguments b/w retries. This returns the new $arguments thus
-     *           allowing modification on demand for $arguments. For ex:
-     *           changing the headers in b/w retries.
      *     @type callable $restDelayFunction Executes a delay, defaults to
      *           utilizing `usleep`. Function signature should match:
      *           `function (int $delay) : void`.
@@ -143,7 +138,6 @@ class RequestWrapper
             'shouldSignRequest' => true,
             'componentVersion' => null,
             'restRetryFunction' => null,
-            'restRetryListener' => null,
             'restDelayFunction' => null,
             'restCalcDelayFunction' => null
         ];


### PR DESCRIPTION
**This is for the review of https://github.com/googleapis/google-cloud-php/pull/5637**

This does the following:

 - Removes documenting this in the `RequestWrapper` constructor (supplying this value does nothing in the current implementation anyway)
 - Sets this option directly in `Storage/Connection/Rest` and `Storage/StorageObject`, instead of seeing if it exists in the options.