### PR TITLE
chore(gcs-conformance): add test for downloadAsStream retry headers

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -92,7 +92,6 @@ class ExponentialBackoff
         $calcDelayFunction = $this->calcDelayFunction ?: [$this, 'calculateDelay'];
         $retryAttempt = 0;
         $exception = null;
-
         while (true) {
             try {
                 return call_user_func_array($function, $arguments);
@@ -112,9 +111,9 @@ class ExponentialBackoff
                 if ($this->retryListener) {
                     // Developer can modify the $arguments using the retryListener
                     // callback.
-                    $arguments = call_user_func_array(
+                    call_user_func_array(
                         $this->retryListener,
-                        [$exception, $retryAttempt, $arguments]
+                        [$exception, $retryAttempt, &$arguments]
                     );
                 }
             }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -687,7 +687,7 @@ class Rest implements ConnectionInterface
         $args['restRetryListener'] = function (
             \Exception $e,
             $retryAttempt,
-            $arguments
+            &$arguments
         ) use (
             $invocationId,
             $currentListener
@@ -721,8 +721,8 @@ class Rest implements ConnectionInterface
             // So, we want to execute that after incrementing the attempt count
             // Ex in case of downloads
             if (!is_null($currentListener)) {
-                $arguments = call_user_func_array($currentListener, [
-                    $e, $retryAttempt, $arguments
+                call_user_func_array($currentListener, [
+                    $e, $retryAttempt, &$arguments
                 ]);
             }
 

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -696,7 +696,7 @@ class StorageObject
             'restRetryListener' => function (
                 \Exception $e,
                 $attempt,
-                $arguments
+                &$arguments
             ) use (
                 $resultStream,
                 $requestedBytes
@@ -716,8 +716,6 @@ class StorageObject
 
                     // modify the range headers to fetch the remaining data
                     $arguments[1]['headers']['Range'] = sprintf('bytes=%s-%s', $startByte, $endByte);
-
-                    return $arguments;
                 }
             }
         ];

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\Unit;
 
+use Google\ApiCore\AgentHeader;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\SignBlobInterface;
 use Google\Cloud\Core\Exception\NotFoundException;
@@ -31,7 +32,9 @@ use Google\Cloud\Storage\SigningHelper;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Exception\RequestException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -565,6 +568,72 @@ class StorageObjectTest extends TestCase
 
         $this->assertInstanceOf(StreamInterface::class, $result);
         $this->assertEquals($string, $result);
+    }
+
+    /**
+     * This tests whether the $arguments passed to the callbacks for header
+     * updation is properly done when those callbacks are invoked in the
+     * ExponentialBackoff::execute() method.
+     *
+     * @dataProvider provideDownloadAsStreamRetryHeaders
+     */
+    public function testDownloadAsStreamRetryHeaders($expectedRange, $options)
+    {
+        $attempt = 0;
+        $responses = [
+            1 => new Response(200, [], 'ten-bytes-'),
+            2 => new Response(200, [], 'twenty-bytes--------'),
+        ];
+        $actualRequest = null;
+        $actualOptions = null;
+
+        $httpHandler = function ($request, $options) use (&$attempt, &$actualRequest, &$actualOptions, $responses) {
+            $attempt++;
+            if ($attempt < 3) {
+                throw RequestException::create($request, $responses[$attempt]);
+            }
+            $actualRequest = $request;
+            $actualOptions = $options;
+            return new Response(200, [], 'ok');
+        };
+
+        $rest = new Rest([
+            'httpHandler' => $httpHandler,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'authHttpHandler' => function () {
+                return new Response(200, [], '{"access_token": "abc"}');
+            },
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
+
+        $object = new StorageObject($rest, 'object', 'bucket');
+        $stream = $object->downloadAsStream($options);
+
+        $this->assertIsArray($actualOptions);
+        $this->assertArrayHasKey('headers' , $actualOptions);
+        $this->assertArrayHasKey('Range' , $actualOptions['headers']);
+        $this->assertEquals($expectedRange, $actualOptions['headers']['Range']);
+
+        $this->assertNotNull($actualRequest);
+        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(AgentHeader::AGENT_HEADER_KEY));
+        $agentHeaderParts = explode(' ', $agentHeader);
+        $this->assertStringStartsWith('gccl-invocation-id/', $agentHeaderParts[2]);
+        $this->assertEquals('gccl-attempt-count/3', $agentHeaderParts[3]);
+
+        // assert the resulting stream looks like we'd expect
+        $this->assertEquals('ten-bytes-twenty-bytes--------ok', (string) $stream);
+    }
+
+    public function provideDownloadAsStreamRetryHeaders()
+    {
+        return [
+            ['bytes=30-', []],
+            ['bytes=40-', ['restOptions' => ['headers' => ['Range' => 'bytes=10-']]]],
+            ['bytes=80-100', ['restOptions' => ['headers' => ['Range' => 'bytes=50-100']]]],
+            ['bytes=30-20', ['restOptions' => ['headers' => ['Range' => 'bytes=0-20']]]],
+        ];
     }
 
     public function testGetsInfo()


### PR DESCRIPTION
**This is for the review of https://github.com/googleapis/google-cloud-php/pull/5637**

There was previously no coverage for the changes made to `StorageObject::downloadAsStream` to ensure the range headers were retried as expected