### PR TITLE
chore(gcs-conformance): refactor stream so retryListener is internal

### DIFF
--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -92,7 +92,6 @@ class ExponentialBackoff
         $calcDelayFunction = $this->calcDelayFunction ?: [$this, 'calculateDelay'];
         $retryAttempt = 0;
         $exception = null;
-
         while (true) {
             try {
                 return call_user_func_array($function, $arguments);
@@ -112,9 +111,9 @@ class ExponentialBackoff
                 if ($this->retryListener) {
                     // Developer can modify the $arguments using the retryListener
                     // callback.
-                    $arguments = call_user_func_array(
+                    call_user_func_array(
                         $this->retryListener,
-                        [$exception, $retryAttempt, $arguments]
+                        [$exception, $retryAttempt, &$arguments]
                     );
                 }
             }

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -118,11 +118,6 @@ class RequestWrapper
      *     @type callable $restRetryFunction Sets the conditions for whether or
      *           not a request should attempt to retry. Function signature should
      *           match: `function (\Exception $ex) : bool`.
-     *     @type callable $restRetryListener Runs after the restRetryFunction.
-     *           This might be used to simply consume the exception and
-     *           $arguments b/w retries. This returns the new $arguments thus
-     *           allowing modification on demand for $arguments. For ex:
-     *           changing the headers in b/w retries.
      *     @type callable $restDelayFunction Executes a delay, defaults to
      *           utilizing `usleep`. Function signature should match:
      *           `function (int $delay) : void`.
@@ -143,7 +138,6 @@ class RequestWrapper
             'shouldSignRequest' => true,
             'componentVersion' => null,
             'restRetryFunction' => null,
-            'restRetryListener' => null,
             'restDelayFunction' => null,
             'restCalcDelayFunction' => null
         ];

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -31,9 +31,11 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\StorageClient;
 use Google\CRC32\Builtin;
 use Google\CRC32\CRC32;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MimeType;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Ramsey\Uuid\Uuid;
@@ -49,6 +51,13 @@ class Rest implements ConnectionInterface
     }
     use RetryTrait;
     use UriTrait;
+
+    /**
+     * Header and value that helps us identify a transcoded obj
+     * w/o making a metadata(info) call.
+     */
+    private const TRANSCODED_OBJ_HEADER_KEY = 'X-Goog-Stored-Content-Encoding';
+    private const TRANSCODED_OBJ_HEADER_VAL = 'gzip';
 
     /**
      * @deprecated
@@ -262,16 +271,68 @@ class Rest implements ConnectionInterface
      */
     public function downloadObject(array $args = [])
     {
+        // This makes sure we honour the range headers specified by the user
+        $requestedBytes = $this->getRequestedBytes($args);
+        $resultStream = Utils::streamFor(null);
+        $transcodedObj = false;
+
         list($request, $requestOptions) = $this->buildDownloadObjectParams($args);
 
+        $invocationId = Uuid::uuid4()->toString();
+        $requestOptions['retryHeaders'] = self::getRetryHeaders($invocationId, 1);
         $requestOptions['restRetryFunction'] = $this->getRestRetryFunction('objects', 'get', $requestOptions);
+        // We try to deduce if the object is a transcoded object when we receive the headers.
+        $requestOptions['restOptions']['on_headers'] = function ($response) use (&$transcodedObj) {
+            $header = $response->getHeader(self::TRANSCODED_OBJ_HEADER_KEY);
+            if (is_array($header) && in_array(self::TRANSCODED_OBJ_HEADER_VAL, $header)) {
+                $transcodedObj = true;
+            }
+        };
+        $requestOptions['restRetryListener'] = function (
+            \Exception $e,
+            $retryAttempt,
+            &$arguments
+        ) use (
+            $resultStream,
+            $requestedBytes,
+            $invocationId
+        ) {
+            // if the exception has a response for us to use
+            if ($e instanceof RequestException && $e->hasResponse()) {
+                $msg = (string) $e->getResponse()->getBody();
 
-        $requestOptions = $this->addRetryHeaderLogic($requestOptions);
+                $fetchedStream = Utils::streamFor($msg);
 
-        return $this->requestWrapper->send(
+                // add the partial response to our stream that we will return
+                Utils::copyToStream($fetchedStream, $resultStream);
+
+                // Start from the byte that was last fetched
+                $startByte = intval($requestedBytes['startByte']) + $resultStream->getSize();
+                $endByte = $requestedBytes['endByte'];
+
+                // modify the range headers to fetch the remaining data
+                $arguments[1]['headers']['Range'] = sprintf('bytes=%s-%s', $startByte, $endByte);
+                $arguments[0] = $this->modifyRequestForRetry($arguments[0], $retryAttempt, $invocationId);
+            }
+        };
+
+        $fetchedStream = $this->requestWrapper->send(
             $request,
             $requestOptions
         )->getBody();
+
+        // If our object is a transcoded object, then Range headers are not honoured.
+        // That means even if we had a partial download available, the final obj
+        // that was fetched will contain the complete object. So, we don't need to copy
+        // the partial stream, we can just return the stream we fetched.
+        if ($transcodedObj) {
+            return $fetchedStream;
+        }
+
+        Utils::copyToStream($fetchedStream, $resultStream);
+
+        $resultStream->seek(0);
+        return $resultStream;
     }
 
     /**
@@ -533,7 +594,6 @@ class Rest implements ConnectionInterface
             'restOptions' => null,
             'retries' => null,
             'restRetryFunction' => null,
-            'restRetryListener' => null,
             'restCalcDelayFunction' => null,
             'restDelayFunction' => null
         ]);
@@ -681,54 +741,77 @@ class Rest implements ConnectionInterface
         $invocationId = Uuid::uuid4()->toString();
         $args['retryHeaders'] = self::getRetryHeaders($invocationId, 1);
 
-        $currentListener = $args['restRetryListener'] ?? null;
-
         // Adding callback logic to update headers while retrying
         $args['restRetryListener'] = function (
             \Exception $e,
             $retryAttempt,
             &$arguments
         ) use (
-            $invocationId,
-            $currentListener
+            $invocationId
         ) {
-            $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);
-            $request = $arguments[0];
-            $headerLine = $request->getHeaderLine(AgentHeader::AGENT_HEADER_KEY);
-
-            // An associative array to contain final header values as
-            // $headerValueKey => $headerValue
-            $headerElements = [];
-
-            // Adding existing values
-            $headerLineValues = explode(' ', $headerLine);
-            foreach ($headerLineValues as $value) {
-                $key = explode('/', $value)[0];
-                $headerElements[$key] = $value;
-            }
-
-            // Adding changes with replacing value if $key already present
-            foreach ($changes as $change) {
-                $key = explode('/', $change)[0];
-                $headerElements[$key] = $change;
-            }
-            $arguments[0] = $request->withHeader(
-                AgentHeader::AGENT_HEADER_KEY,
-                implode(' ', $headerElements)
+            $arguments[0] = $this->modifyRequestForRetry(
+                $arguments[0],
+                $retryAttempt,
+                $invocationId
             );
-
-            // In some cases there might be a listener present
-            // So, we want to execute that after incrementing the attempt count
-            // Ex in case of downloads
-            if (!is_null($currentListener)) {
-                call_user_func_array($currentListener, [
-                    $e, $retryAttempt, &$arguments
-                ]);
-            }
-
-            return $arguments;
         };
 
         return $args;
+    }
+
+    private function modifyRequestForRetry(
+        RequestInterface $request,
+        int $retryAttempt,
+        string $invocationId
+    ) {
+        $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);
+        $headerLine = $request->getHeaderLine(AgentHeader::AGENT_HEADER_KEY);
+
+        // An associative array to contain final header values as
+        // $headerValueKey => $headerValue
+        $headerElements = [];
+
+        // Adding existing values
+        $headerLineValues = explode(' ', $headerLine);
+        foreach ($headerLineValues as $value) {
+            $key = explode('/', $value)[0];
+            $headerElements[$key] = $value;
+        }
+
+        // Adding changes with replacing value if $key already present
+        foreach ($changes as $change) {
+            $key = explode('/', $change)[0];
+            $headerElements[$key] = $change;
+        }
+
+        return $request->withHeader(
+            AgentHeader::AGENT_HEADER_KEY,
+            implode(' ', $headerElements)
+        );
+    }
+
+    /**
+     * Util function to compute the bytes requested for a download request.
+     *
+     * @param array $options Request options
+     * @return array
+     */
+    private function getRequestedBytes(array $options)
+    {
+        $startByte = 0;
+        $endByte = '';
+
+        if (isset($options['restOptions']) && isset($options['restOptions']['headers'])) {
+            $headers = $options['restOptions']['headers'];
+            if (isset($headers['Range']) || isset($headers['range'])) {
+                $header = isset($headers['Range']) ? $headers['Range'] : $headers['range'];
+                $range = explode('=', $header);
+                $bytes = explode('-', $range[1]);
+                $startByte = $bytes[0];
+                $endByte = $bytes[1];
+            }
+        }
+
+        return compact('startByte', 'endByte');
     }
 }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -687,7 +687,7 @@ class Rest implements ConnectionInterface
         $args['restRetryListener'] = function (
             \Exception $e,
             $retryAttempt,
-            $arguments
+            &$arguments
         ) use (
             $invocationId,
             $currentListener
@@ -721,8 +721,8 @@ class Rest implements ConnectionInterface
             // So, we want to execute that after incrementing the attempt count
             // Ex in case of downloads
             if (!is_null($currentListener)) {
-                $arguments = call_user_func_array($currentListener, [
-                    $e, $retryAttempt, $arguments
+                call_user_func_array($currentListener, [
+                    $e, $retryAttempt, &$arguments
                 ]);
             }
 

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -696,7 +696,7 @@ class StorageObject
             'restRetryListener' => function (
                 \Exception $e,
                 $attempt,
-                $arguments
+                &$arguments
             ) use (
                 $resultStream,
                 $requestedBytes
@@ -716,8 +716,6 @@ class StorageObject
 
                     // modify the range headers to fetch the remaining data
                     $arguments[1]['headers']['Range'] = sprintf('bytes=%s-%s', $startByte, $endByte);
-
-                    return $arguments;
                 }
             }
         ];

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
@@ -50,13 +49,6 @@ class StorageObject
      * @deprecated
      */
     const DEFAULT_DOWNLOAD_URL = SigningHelper::DEFAULT_DOWNLOAD_HOST;
-
-    /**
-     * Header and value that helps us identify a transcoded obj
-     * w/o making a metadata(info) call.
-     */
-    private const TRANSCODED_OBJ_HEADER_KEY = 'X-Goog-Stored-Content-Encoding';
-    private const TRANSCODED_OBJ_HEADER_VAL = 'gzip';
 
     /**
      * @var Acl ACL for the object.
@@ -679,67 +671,13 @@ class StorageObject
      */
     public function downloadAsStream(array $options = [])
     {
-        // This makes sure we honour the range headers specified by the user
-        $requestedBytes = $this->getRequestedBytes($options);
-        $resultStream = Utils::streamFor(null);
-        $transcodedObj = false;
-
-        // We try to deduce if the object is a transcoded object when we receive the headers.
-        $options['restOptions']['on_headers'] = function ($response) use (&$transcodedObj) {
-            $header = $response->getHeader(self::TRANSCODED_OBJ_HEADER_KEY);
-            if (is_array($header) && in_array(self::TRANSCODED_OBJ_HEADER_VAL, $header)) {
-                $transcodedObj = true;
-            }
-        };
-
-        $options += [
-            'restRetryListener' => function (
-                \Exception $e,
-                $attempt,
-                &$arguments
-            ) use (
-                $resultStream,
-                $requestedBytes
-            ) {
-                // if the exception has a response for us to use
-                if ($e instanceof RequestException && $e->hasResponse()) {
-                    $msg = (string) $e->getResponse()->getBody();
-
-                    $fetchedStream = Utils::streamFor($msg);
-
-                    // add the partial response to our stream that we will return
-                    Utils::copyToStream($fetchedStream, $resultStream);
-
-                    // Start from the byte that was last fetched
-                    $startByte = intval($requestedBytes['startByte']) + $resultStream->getSize();
-                    $endByte = $requestedBytes['endByte'];
-
-                    // modify the range headers to fetch the remaining data
-                    $arguments[1]['headers']['Range'] = sprintf('bytes=%s-%s', $startByte, $endByte);
-                }
-            }
-        ];
-
-        $fetchedStream = $this->connection->downloadObject(
+        return $this->connection->downloadObject(
             $this->formatEncryptionHeaders(
                 $options
                 + $this->encryptionData
                 + array_filter($this->identity)
             )
         );
-
-        // If our object is a transcoded object, then Range headers are not honoured.
-        // That means even if we had a partial download available, the final obj
-        // that was fetched will contain the complete object. So, we don't need to copy
-        // the partial stream, we can just return the stream we fetched.
-        if ($transcodedObj) {
-            return $fetchedStream;
-        }
-
-        Utils::copyToStream($fetchedStream, $resultStream);
-
-        $resultStream->seek(0);
-        return $resultStream;
     }
 
     /**
@@ -1334,30 +1272,5 @@ class StorageObject
             'sourceGeneration' => $this->identity['generation'],
             'userProject' => $this->identity['userProject'],
         ]) + $this->formatEncryptionHeaders($options + $this->encryptionData);
-    }
-
-    /**
-     * Util function to compute the bytes requested for a download request.
-     *
-     * @param array $options Request options
-     * @return array
-     */
-    private function getRequestedBytes(array $options)
-    {
-        $startByte = 0;
-        $endByte = '';
-
-        if (isset($options['restOptions']) && isset($options['restOptions']['headers'])) {
-            $headers = $options['restOptions']['headers'];
-            if (isset($headers['Range']) || isset($headers['range'])) {
-                $header = isset($headers['Range']) ? $headers['Range'] : $headers['range'];
-                $range = explode('=', $header);
-                $bytes = explode('-', $range[1]);
-                $startByte = $bytes[0];
-                $endByte = $bytes[1];
-            }
-        }
-
-        return compact('startByte', 'endByte');
     }
 }

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -612,8 +612,8 @@ class StorageObjectTest extends TestCase
         $stream = $object->downloadAsStream($options);
 
         $this->assertIsArray($actualOptions);
-        $this->assertArrayHasKey('headers' , $actualOptions);
-        $this->assertArrayHasKey('Range' , $actualOptions['headers']);
+        $this->assertArrayHasKey('headers', $actualOptions);
+        $this->assertArrayHasKey('Range', $actualOptions['headers']);
         $this->assertEquals($expectedRange, $actualOptions['headers']['Range']);
 
         $this->assertNotNull($actualRequest);

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\Unit;
 
+use Google\ApiCore\AgentHeader;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\SignBlobInterface;
 use Google\Cloud\Core\Exception\NotFoundException;
@@ -31,7 +32,9 @@ use Google\Cloud\Storage\SigningHelper;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Exception\RequestException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -565,6 +568,72 @@ class StorageObjectTest extends TestCase
 
         $this->assertInstanceOf(StreamInterface::class, $result);
         $this->assertEquals($string, $result);
+    }
+
+    /**
+     * This tests whether the $arguments passed to the callbacks for header
+     * updation is properly done when those callbacks are invoked in the
+     * ExponentialBackoff::execute() method.
+     *
+     * @dataProvider provideDownloadAsStreamRetryHeaders
+     */
+    public function testDownloadAsStreamRetryHeaders($expectedRange, $options)
+    {
+        $attempt = 0;
+        $responses = [
+            1 => new Response(200, [], 'ten-bytes-'),
+            2 => new Response(200, [], 'twenty-bytes--------'),
+        ];
+        $actualRequest = null;
+        $actualOptions = null;
+
+        $httpHandler = function ($request, $options) use (&$attempt, &$actualRequest, &$actualOptions, $responses) {
+            $attempt++;
+            if ($attempt < 3) {
+                throw RequestException::create($request, $responses[$attempt]);
+            }
+            $actualRequest = $request;
+            $actualOptions = $options;
+            return new Response(200, [], 'ok');
+        };
+
+        $rest = new Rest([
+            'httpHandler' => $httpHandler,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'authHttpHandler' => function () {
+                return new Response(200, [], '{"access_token": "abc"}');
+            },
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
+
+        $object = new StorageObject($rest, 'object', 'bucket');
+        $stream = $object->downloadAsStream($options);
+
+        $this->assertIsArray($actualOptions);
+        $this->assertArrayHasKey('headers' , $actualOptions);
+        $this->assertArrayHasKey('Range' , $actualOptions['headers']);
+        $this->assertEquals($expectedRange, $actualOptions['headers']['Range']);
+
+        $this->assertNotNull($actualRequest);
+        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(AgentHeader::AGENT_HEADER_KEY));
+        $agentHeaderParts = explode(' ', $agentHeader);
+        $this->assertStringStartsWith('gccl-invocation-id/', $agentHeaderParts[2]);
+        $this->assertEquals('gccl-attempt-count/3', $agentHeaderParts[3]);
+
+        // assert the resulting stream looks like we'd expect
+        $this->assertEquals('ten-bytes-twenty-bytes--------ok', (string) $stream);
+    }
+
+    public function provideDownloadAsStreamRetryHeaders()
+    {
+        return [
+            ['bytes=30-', []],
+            ['bytes=40-', ['restOptions' => ['headers' => ['Range' => 'bytes=10-']]]],
+            ['bytes=80-100', ['restOptions' => ['headers' => ['Range' => 'bytes=50-100']]]],
+            ['bytes=30-20', ['restOptions' => ['headers' => ['Range' => 'bytes=0-20']]]],
+        ];
     }
 
     public function testGetsInfo()


### PR DESCRIPTION
- Removes nesting  of `retryListener` option, which is a little bit hacky
- Moves logic in `StorageObject` into `Connection/Rest`. This seems like the correct place for this logic to be
- Passes tests added in #6072 and conformance tests