### PR TITLE
fix(Core): Fix TestCase dependency

### DIFF
--- a/Core/tests/Unit/Report/CloudRunMetadataProviderTest.php
+++ b/Core/tests/Unit/Report/CloudRunMetadataProviderTest.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Core\Tests\Unit\Report;
 
 use Google\Cloud\Core\Report\CloudRunMetadataProvider;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core


### PR DESCRIPTION
Replaced `Yoast\PHPUnitPolyfills\TestCases\TestCase`  to `PHPUnit\Framework\TestCase` as we now don't use PHPUnitPolyfills.