### PR TITLE
fix(Core): Add retry header key in Core/Retry.php

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -30,7 +30,6 @@ use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use Google\ApiCore\AgentHeader;
 
 /**
  * The RequestWrapper is responsible for delivering and signing requests.
@@ -290,7 +289,7 @@ class RequestWrapper
     {
         $headers = [
             'User-Agent' => 'gcloud-php/' . $this->componentVersion,
-            AgentHeader::AGENT_HEADER_KEY => sprintf(
+            Retry::RETRY_HEADER_KEY => sprintf(
                 'gl-php/%s gccl/%s',
                 PHP_VERSION,
                 $this->componentVersion
@@ -298,9 +297,9 @@ class RequestWrapper
         ];
 
         if (isset($options['retryHeaders'])) {
-            $headers[AgentHeader::AGENT_HEADER_KEY] = sprintf(
+            $headers[Retry::RETRY_HEADER_KEY] = sprintf(
                 '%s %s',
-                $headers[AgentHeader::AGENT_HEADER_KEY],
+                $headers[Retry::RETRY_HEADER_KEY],
                 implode(' ', $options['retryHeaders'])
             );
             unset($options['retryHeaders']);

--- a/Core/src/Retry.php
+++ b/Core/src/Retry.php
@@ -25,6 +25,8 @@ namespace Google\Cloud\Core;
  */
 class Retry
 {
+    const RETRY_HEADER_KEY = 'x-goog-api-client';
+
     /**
      * @var int
      */

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -17,10 +17,10 @@
 
 namespace Google\Cloud\Storage\Connection;
 
-use Google\ApiCore\AgentHeader;
 use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\RestTrait;
+use Google\Cloud\Core\Retry;
 use Google\Cloud\Storage\Connection\RetryTrait;
 use Google\Cloud\Core\Upload\AbstractUploader;
 use Google\Cloud\Core\Upload\MultipartUploader;
@@ -765,7 +765,7 @@ class Rest implements ConnectionInterface
         string $invocationId
     ) {
         $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);
-        $headerLine = $request->getHeaderLine(AgentHeader::AGENT_HEADER_KEY);
+        $headerLine = $request->getHeaderLine(Retry::RETRY_HEADER_KEY);
 
         // An associative array to contain final header values as
         // $headerValueKey => $headerValue
@@ -785,7 +785,7 @@ class Rest implements ConnectionInterface
         }
 
         return $request->withHeader(
-            AgentHeader::AGENT_HEADER_KEY,
+            Retry::RETRY_HEADER_KEY,
             implode(' ', $headerElements)
         );
     }

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -17,9 +17,9 @@
 
 namespace Google\Cloud\Storage\Tests\Unit\Connection;
 
-use Google\ApiCore\AgentHeader;
 use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
+use Google\Cloud\Core\Retry;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Upload\MultipartUploader;
 use Google\Cloud\Core\Upload\ResumableUploader;
@@ -508,7 +508,7 @@ class RestTest extends TestCase
         $rest->listBuckets();
 
         $this->assertNotNull($actualRequest);
-        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(AgentHeader::AGENT_HEADER_KEY));
+        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(Retry::RETRY_HEADER_KEY));
 
         $agentHeaderParts = explode(' ', $agentHeader);
         $this->assertStringStartsWith('gccl-invocation-id/', $agentHeaderParts[2]);

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -17,11 +17,11 @@
 
 namespace Google\Cloud\Storage\Tests\Unit;
 
-use Google\ApiCore\AgentHeader;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\SignBlobInterface;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\RequestWrapper;
+use Google\Cloud\Core\Retry;
 use Google\Cloud\Core\Testing\KeyPairGenerateTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Storage\Acl;
@@ -616,7 +616,7 @@ class StorageObjectTest extends TestCase
         $this->assertEquals($expectedRange, $actualOptions['headers']['Range']);
 
         $this->assertNotNull($actualRequest);
-        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(AgentHeader::AGENT_HEADER_KEY));
+        $this->assertNotNull($agentHeader = $actualRequest->getHeaderLine(Retry::RETRY_HEADER_KEY));
         $agentHeaderParts = explode(' ', $agentHeader);
         $this->assertStringStartsWith('gccl-invocation-id/', $agentHeaderParts[2]);
         $this->assertEquals('gccl-attempt-count/3', $agentHeaderParts[3]);


### PR DESCRIPTION
Fixes #6122.

See issue [6122](https://github.com/googleapis/google-cloud-php/issues/6122) for more info.

This fix adds the retry header key in `Core/Retry.php` and then uses `Retry::RETRY_HEADER_KEY` in all required places.