### PR TITLE
fix(Core): Change gax to non-dev dependency 

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -7,6 +7,7 @@
         "php": ">=7.4",
         "rize/uri-template": "~0.3",
         "google/auth": "^1.18",
+        "google/gax": "^1.9",
         "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7|^2.0",
@@ -19,7 +20,6 @@
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^5.0",
         "erusev/parsedown": "^1.6",
-        "google/gax": "^1.9",
         "opis/closure": "^3",
         "google/cloud-common-protos": "^0.4"
     },


### PR DESCRIPTION
Fixed #6122.

See issue [6122](https://github.com/googleapis/google-cloud-php/issues/6122) for more details.

Changes `gax` to prod dependency so the core and produxt files can use `AgentHeader` inside it in prod.