### PR TITLE
fix: descriptor fix when protobuf extension is loaded

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,14 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         php: [ "7.4", "8.0", "8.1", "8.2" ]
-    name: PHP ${{ matrix.php }} Unit Test (${{ matrix.platform }})
+        extensions: ["grpc-1.49.0"]
+        type: ["Unit Test"]
+        include:
+          - platform: "ubuntu-latest"
+            php: "7.4"
+            extensions: "protobuf,grpc-1.49.0"
+            type: "Unit Test + protobuf extension"
+    name: PHP ${{ matrix.php }} ${{ matrix.type }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
     steps:
@@ -22,7 +29,7 @@ jobs:
       uses: shivammathur/setup-php@verbose
       with:
         php-version: ${{ matrix.php }}
-        extensions: grpc-1.49.0
+        extensions: ${{ matrix.extensions }}
     - name: Install Dependencies
       uses: nick-invision/retry@v2
       with:

--- a/BigQueryStorage/metadata/descriptor_fix.php
+++ b/BigQueryStorage/metadata/descriptor_fix.php
@@ -37,8 +37,10 @@ class DescriptorFix
           return;
         }
 
-        // add a no-op reference for "google.protobuf.DescriptorProto"
-        $pool->addMessage('google.protobuf.DescriptorProto', \Google\Protobuf\Internal\Message::class)->finalizeToPool();
+        if (method_exists($pool, 'addMessage')) {
+            // add a no-op reference for "google.protobuf.DescriptorProto"
+            $pool->addMessage('google.protobuf.DescriptorProto', \Google\Protobuf\Internal\Message::class)->finalizeToPool();
+        }
         static::$is_initialized = true;
     }
 }

--- a/BigQueryStorage/metadata/descriptor_fix.php
+++ b/BigQueryStorage/metadata/descriptor_fix.php
@@ -37,7 +37,7 @@ class DescriptorFix
           return;
         }
 
-        if (method_exists($pool, 'addMessage')) {
+        if ($pool instanceof \Google\Protobuf\Internal\DescriptorPool) {
             // add a no-op reference for "google.protobuf.DescriptorProto"
             $pool->addMessage('google.protobuf.DescriptorProto', \Google\Protobuf\Internal\Message::class)->finalizeToPool();
         }

--- a/Bigtable/tests/Snippet/TableTest.php
+++ b/Bigtable/tests/Snippet/TableTest.php
@@ -200,7 +200,9 @@ class TableTest extends SnippetTestCase
             ->setEndKeyOpen('lincoln');
         $rowSet = (new RowSet())
             ->setRowRanges([$rowRange]);
-        $this->bigtableClient->readRows(self::TABLE_NAME, ['rows' => $rowSet])
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($rowSet) {
+            return $argument['rows']->serializeToJsonString() === $rowSet->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn($this->serverStream->reveal());
 
@@ -231,7 +233,9 @@ class TableTest extends SnippetTestCase
             );
         $rowSet = (new RowSet())
             ->setRowKeys(['jefferson']);
-        $this->bigtableClient->readRows(self::TABLE_NAME, ['rows' => $rowSet])
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($rowSet) {
+            return $argument['rows']->serializeToJsonString() === $rowSet->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn($this->serverStream->reveal());
         $snippet = $this->snippetFromMethod(Table::class, 'readRow');

--- a/Bigtable/tests/Unit/SmartRetriesTest.php
+++ b/Bigtable/tests/Unit/SmartRetriesTest.php
@@ -36,6 +36,7 @@ use Google\Rpc\Code;
 use Google\Rpc\Status;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
 
 /**
  * @group bigtable
@@ -209,7 +210,6 @@ class SmartRetriesTest extends TestCase
     public function testReadRowsWithRowKeys()
     {
         $args = ['rowKeys' => ['rk1', 'rk2', 'rk3', 'rk4']];
-        $expectedArgs = ['rows' => (new RowSet)->setRowKeys(['rk1', 'rk2', 'rk3', 'rk4'])] + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -221,15 +221,16 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(3, 4)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return iterator_to_array($argument['rows']->getRowKeys()) === ['rk1', 'rk2', 'rk3', 'rk4'];
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowKeys(['rk3', 'rk4'])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return iterator_to_array($argument['rows']->getRowKeys()) === ['rk3', 'rk4'];
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -245,8 +246,6 @@ class SmartRetriesTest extends TestCase
 
     public function testReadRowsRangeStartKeyOpen()
     {
-        $expectedArgs = ['rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyOpen('rk5')])]
-            + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -258,15 +257,16 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(8, 9)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === 'rk5';
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyOpen('rk7')])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === 'rk7';
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -285,8 +285,6 @@ class SmartRetriesTest extends TestCase
 
     public function testReadRowsRangeStartKeyClosed()
     {
-        $expectedArgs = ['rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyClosed('rk5')])]
-            + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -298,15 +296,16 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(7, 9)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyClosed() === 'rk5';
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyOpen('rk6')])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === 'rk6';
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -325,8 +324,6 @@ class SmartRetriesTest extends TestCase
 
     public function testReadRowsRangeEndKeyOpen()
     {
-        $expectedArgs = ['rows' => (new RowSet)->setRowRanges([(new RowRange)->setEndKeyOpen('rk7')])]
-            + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -338,15 +335,18 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(4, 6)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === ''
+                && $argument['rows']->getRowRanges()[0]->getEndKeyOpen() === 'rk7';
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyOpen('rk3')->setEndKeyOpen('rk7')])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === 'rk3'
+                && $argument['rows']->getRowRanges()[0]->getEndKeyOpen() === 'rk7';
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -365,8 +365,6 @@ class SmartRetriesTest extends TestCase
 
     public function testReadRowsRangeEndKeyClosed()
     {
-        $expectedArgs = ['rows' => (new RowSet)->setRowRanges([(new RowRange)->setEndKeyClosed('rk7')])]
-            + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -378,15 +376,18 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(4, 7)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === ''
+                && $argument['rows']->getRowRanges()[0]->getEndKeyClosed() === 'rk7';
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowRanges([(new RowRange)->setStartKeyOpen('rk3')->setEndKeyClosed('rk7')])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            return $argument['rows']->getRowRanges()[0]->getStartKeyOpen() === 'rk3'
+                && $argument['rows']->getRowRanges()[0]->getEndKeyClosed() === 'rk7';
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -405,11 +406,6 @@ class SmartRetriesTest extends TestCase
 
     public function testReadRowsRangeWithSomeCompletedRange()
     {
-        $expectedArgs = ['rows' => (new RowSet)->setRowRanges([
-            (new RowRange)->setStartKeyOpen('rk1')->setEndKeyClosed('rk3'),
-            (new RowRange)->setStartKeyClosed('rk5')->setEndKeyClosed('rk7'),
-            (new RowRange)->setStartKeyClosed('rk8')->setEndKeyClosed('rk9')
-        ])] + $this->options;
         $this->serverStream->readAll()
             ->shouldBeCalledTimes(2)
             ->willReturn(
@@ -421,18 +417,21 @@ class SmartRetriesTest extends TestCase
                     $this->generateRowsResponse(7, 9)
                 )
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            $rowRanges = $argument['rows']->getRowRanges();
+            return $rowRanges[0]->getStartKeyOpen() === 'rk1' && $rowRanges[0]->getEndKeyClosed() === 'rk3'
+                && $rowRanges[1]->getStartKeyClosed() === 'rk5' && $rowRanges[1]->getEndKeyClosed() === 'rk7'
+                && $rowRanges[2]->getStartKeyClosed() === 'rk8' && $rowRanges[2]->getEndKeyClosed() === 'rk9';
+        }))
             ->shouldBeCalledTimes(1)
             ->willReturn(
                 $this->serverStream->reveal()
             );
-        $secondCallArgument = [
-            'rows' => (new RowSet)->setRowRanges([
-                (new RowRange)->setStartKeyOpen('rk6')->setEndKeyClosed('rk7'),
-                (new RowRange)->setStartKeyClosed('rk8')->setEndKeyClosed('rk9')
-            ])
-        ] + $expectedArgs;
-        $this->bigtableClient->readRows(self::TABLE_NAME, $secondCallArgument)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) {
+            $rowRanges = $argument['rows']->getRowRanges();
+            return $rowRanges[0]->getStartKeyOpen() === 'rk6' && $rowRanges[0]->getEndKeyClosed() === 'rk7'
+                && $rowRanges[1]->getStartKeyClosed() === 'rk8' && $rowRanges[1]->getEndKeyClosed() === 'rk9';
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()

--- a/Bigtable/tests/Unit/TableTest.php
+++ b/Bigtable/tests/Unit/TableTest.php
@@ -44,6 +44,7 @@ use InvalidArgumentException;
 use Google\Rpc\Status;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
 
 /**
  * @group bigtable
@@ -378,7 +379,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -401,7 +404,10 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString()
+                && $argument['filter']->serializeToJsonString() === $expectedArgs['filter']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -425,7 +431,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -451,7 +459,10 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString()
+                && $argument['rowsLimit'] === $expectedArgs['rowsLimit'];
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -480,7 +491,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -513,7 +526,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -546,7 +561,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -579,7 +596,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()
@@ -617,7 +636,9 @@ class TableTest extends TestCase
             ->willReturn(
                 $this->arrayAsGenerator([])
             );
-        $this->bigtableClient->readRows(self::TABLE_NAME, $expectedArgs)
+        $this->bigtableClient->readRows(self::TABLE_NAME, Argument::that(function ($argument) use ($expectedArgs) {
+            return $argument['rows']->serializeToJsonString() === $expectedArgs['rows']->serializeToJsonString();
+        }))
             ->shouldBeCalled()
             ->willReturn(
                 $this->serverStream->reveal()


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/6121

When protobuf extension is enabled, the `getMessage` method does not exist on the descriptor pool.

I have ensured this doesn't happen again by [adding a test suite](https://github.com/googleapis/google-cloud-php/pull/6131) with the protobuf extension enabled. 