### PR TITLE
fix(Datastore): query fails when no results and limit is set

### DIFF
--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -527,7 +527,8 @@ class Operation
                 $remainingLimit = $remainingLimit['value'];
             }
             if (!is_null($remainingLimit)) {
-                $remainingLimit -= count($res['batch']['entityResults']);
+                // entityResults is not present in REST mode for empty query results
+                $remainingLimit -= count($res['batch']['entityResults'] ?? []);
             }
 
             return $res;

--- a/Datastore/tests/System/RunQueryTest.php
+++ b/Datastore/tests/System/RunQueryTest.php
@@ -304,6 +304,22 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
     /**
      * @dataProvider defaultDbClientProvider
      */
+    public function testQueryWithEmptyResult(DatastoreClient $client)
+    {
+        $query = $client->query()
+            ->kind(self::$kind)
+            ->filter('lastName', '=', 'does_not_exist');
+
+        $results = $this->runQueryAndSortResults($client, $query);
+        $resultsWithLimit = $this->runQueryAndSortResults($client, $query->limit(1));
+
+        $this->assertCount(0, $results);
+        $this->assertCount(0, $resultsWithLimit);
+    }
+
+    /**
+     * @dataProvider defaultDbClientProvider
+     */
     public function testGqlQueryWithBindings(DatastoreClient $client)
     {
         $query = $client->gqlQuery('SELECT * From Person WHERE lastName = @lastName', [


### PR DESCRIPTION
Potentially fixes https://github.com/googleapis/google-cloud-php/issues/5834 and adds a test for covering this scenario for future.

## Scenario

In REST mode, if query has zero results, it doesn't contain `entityResults`. We depend on this field for calculating the limit values since we need to paginate for every 300 results. So, if the query has a limit set, it will throw an invalid key exception.

## Fix
Added a default empty array for cases when `entityResults` is not present.

## Test 

1. passes on PROD:

```
google-cloud-php/Datastore % vendor/bin/phpunit -c phpunit-system.xml.dist --filter="testQueryWithEmptyResult"
PHPUnit 9.6.7 by Sebastian Bergmann and contributors.

..                                                                  2 / 2 (100%)

Time: 00:02.486, Memory: 12.00 MB

OK (2 tests, 4 assertions)
google-cloud-php/Datastore %
```
