### PR TITLE
chore(docs): fix 404 in readme when published to cloud.google.com

### DIFF
--- a/AdvisoryNotifications/README.md
+++ b/AdvisoryNotifications/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-advisorynotifications/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/AlloyDb/README.md
+++ b/AlloyDb/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-alloydb/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/ConfidentialComputing/README.md
+++ b/ConfidentialComputing/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-confidentialcomputing/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/KmsInventory/README.md
+++ b/KmsInventory/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-kms-inventory/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/dev/src/Command/AddComponentCommand.php
+++ b/dev/src/Command/AddComponentCommand.php
@@ -152,6 +152,7 @@ class AddComponentCommand extends Command
                 'repo' => $new->githubRepo,
                 'proto_path' => $new->protoPath,
                 'version' => $new->version,
+                'github_repo' => $new->githubRepo,
                 'documentation' => $documentationUrl,
                 'product_homepage' => $productHomepage,
                 'product_documentation' => $productDocumentation,

--- a/dev/templates/README.md.twig
+++ b/dev/templates/README.md.twig
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/{{github_repo}}/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/dev/tests/fixtures/component/CustomInput/README.md
+++ b/dev/tests/fixtures/component/CustomInput/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-custom-repo/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/dev/tests/fixtures/component/SecretManager/README.md
+++ b/dev/tests/fixtures/component/SecretManager/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](samples/) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-secretmanager/tree/main/samples) for a canonical list of samples.
 
 ### Version
 


### PR DESCRIPTION
When published to `cloud.google.com`, the samples link is broken, as it's a relative link from the README. 

We should make these absolute so they are not broken when published to cloud.google.com

https://cloud.google.com/php/docs/reference/cloud-confidentialcomputing/latest