### PR TITLE
fix(Spanner): retry logic of ExecuteStreamingSql

### DIFF
--- a/Spanner/src/Result.php
+++ b/Spanner/src/Result.php
@@ -178,6 +178,7 @@ class Result implements \IteratorAggregate
         $call = $this->call;
         $generator = null;
         $shouldRetry = false;
+        $isResultsYielded = false;
         $backoff = new ExponentialBackoff($this->retries, function ($ex) {
             if ($ex instanceof ServiceException) {
                 return $ex->getCode() === Grpc\STATUS_UNAVAILABLE;
@@ -209,13 +210,13 @@ class Result implements \IteratorAggregate
                         list($yieldableRows, $chunkedResult) = $this->parseRowsFromBufferedResults($bufferedResults);
 
                         foreach ($yieldableRows as $row) {
+                            $isResultsYielded = true;
                             yield $this->mapper->decodeValues($this->columns, $row, $format);
                         }
                     }
 
                     // Now that we've yielded all available rows, flush the buffer.
                     $bufferedResults = [];
-                    $shouldRetry = $hasResumeToken;
 
                     // If the last item in the buffer had a chunked value let's
                     // hold on to it so we can stitch it together into a yieldable
@@ -225,6 +226,8 @@ class Result implements \IteratorAggregate
                     }
                 }
 
+                // retry without resume token when results have not yielded
+                $shouldRetry = !$isResultsYielded || $hasResumeToken;
                 $generator->next();
                 $valid = $generator->valid();
             } catch (ServiceException $ex) {


### PR DESCRIPTION
Potentially fixes https://github.com/googleapis/google-cloud-php/issues/5880, where users are seeing `ServiceException` in `ExecuteStreamingSql`.  

Currently retry is performed till default 3 attempts, if each of these satisfy:
1. `resumeToken` is present
2. `ServiceException` is thrown
3. Exception code is `Grpc\STATUS_UNAVAILABLE`

Per the fixes done in other languages [Node](https://github.com/googleapis/nodejs-spanner/pull/795) and [comment](https://github.com/googleapis/google-cloud-php/issues/5880#issuecomment-1507956944) from @olavloite , it seems we should retry by below logic (point # 1 above becomes):

1. No results have been yielded _**OR**_ a `resumeToken` is present


## Tests
Added UTs which mock the ServiceExceptions with/o the resumeTokens. 

