### PR TITLE
chore: fix phpstan for latest version of google/auth

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -19,7 +19,6 @@ namespace Google\Cloud\Core;
 
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\GetQuotaProjectInterface;
-use Google\Auth\HttpHandler\Guzzle5HttpHandler;
 use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\Core\Exception\ServiceException;
@@ -466,10 +465,7 @@ class RequestWrapper
      */
     private function buildDefaultAsyncHandler()
     {
-        $isGuzzleHandler = $this->httpHandler instanceof Guzzle6HttpHandler
-            || $this->httpHandler instanceof Guzzle5HttpHandler;
-
-        return $isGuzzleHandler
+        return $this->httpHandler instanceof Guzzle6HttpHandler
             ? [$this->httpHandler, 'async']
             : [HttpHandlerFactory::build(), 'async'];
     }

--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -17,7 +17,6 @@
 
 namespace Google\Cloud\Core;
 
-use Google\Auth\HttpHandler\Guzzle5HttpHandler;
 use Google\Auth\HttpHandler\Guzzle6HttpHandler;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\BigQuery\BigQueryClient;
@@ -435,9 +434,7 @@ class ServiceBuilder
         }
 
         if (!isset($config['asyncHttpHandler'])) {
-            $isGuzzleHandler = $config['httpHandler'] instanceof Guzzle6HttpHandler
-                || $config['httpHandler'] instanceof Guzzle5HttpHandler;
-            $config['asyncHttpHandler'] = $isGuzzleHandler
+            $config['asyncHttpHandler'] = $config['httpHandler'] instanceof Guzzle6HttpHandler
                 ? [$config['httpHandler'], 'async']
                 : [HttpHandlerFactory::build(), 'async'];
         }


### PR DESCRIPTION
Removes `Guzzle5Handler` logic, as Guzzle 5 is no longer supported (and the auth library removed them so we are getting static analysis errors)