### PR TITLE
chore(Core): Ignore phpstan static analysis for Guzzel5HttpHandler

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -467,7 +467,7 @@ class RequestWrapper
     private function buildDefaultAsyncHandler()
     {
         $isGuzzleHandler = $this->httpHandler instanceof Guzzle6HttpHandler
-            || $this->httpHandler instanceof Guzzle5HttpHandler;
+            || $this->httpHandler instanceof Guzzle5HttpHandler; // @phpstan-ignore-line
 
         return $isGuzzleHandler
             ? [$this->httpHandler, 'async']

--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -436,7 +436,7 @@ class ServiceBuilder
 
         if (!isset($config['asyncHttpHandler'])) {
             $isGuzzleHandler = $config['httpHandler'] instanceof Guzzle6HttpHandler
-                || $config['httpHandler'] instanceof Guzzle5HttpHandler;
+                || $config['httpHandler'] instanceof Guzzle5HttpHandler; // @phpstan-ignore-line
             $config['asyncHttpHandler'] = $isGuzzleHandler
                 ? [$config['httpHandler'], 'async']
                 : [HttpHandlerFactory::build(), 'async'];


### PR DESCRIPTION
As this class is deprecated and we use `phpstan-deprecation-rules`, thus it's usage is giving static analysis failure. ([fails](https://github.com/googleapis/google-cloud-php/actions/workflows/lint.yaml))