### PR TITLE
feat(docs): add support for static methods

### DIFF
--- a/dev/src/DocFx/Node/ClassNode.php
+++ b/dev/src/DocFx/Node/ClassNode.php
@@ -164,6 +164,11 @@ class ClassNode
             }
         }
 
+        if ($this->isServiceClass()) {
+            usort($methods, fn($a, $b) => $a->isOperationMethod() <=> $b->isOperationMethod());
+        }
+        usort($methods, fn($a, $b) => $a->isStatic() <=> $b->isStatic());
+
         return $methods;
     }
 

--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -69,6 +69,11 @@ class MethodNode
         return '';
     }
 
+    public function isStatic(): bool
+    {
+        return (string) $this->xmlNode['static'] === 'true';
+    }
+
     public function getParameters(): array
     {
         $parameters = [];

--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -71,7 +71,13 @@ class MethodNode
 
     public function isStatic(): bool
     {
-        return (string) $this->xmlNode['static'] === 'true';
+        return 'true' === (string) $this->xmlNode['static'];
+    }
+
+    public function isOperationMethod(): bool
+    {
+        return $this->getName() === 'getOperationsClient'
+            || $this->getName() === 'resumeOperation';
     }
 
     public function getParameters(): array
@@ -112,5 +118,10 @@ class MethodNode
         }
 
         return $parameters;
+    }
+
+    public function getDisplayName(): string
+    {
+        return $this->isStatic() ? 'static::' . $this->getName() : $this->getName();
     }
 }

--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -171,12 +171,11 @@ class Page
         }
         $methodItem = array_filter([
             'uid' => $method->getFullname(),
-            'name' => $name,
+            'name' => $method->getDisplayName(),
             'id' => $name,
             'summary' => $content,
             'parent'  => $this->classNode->getFullname(),
             'type' => 'method',
-            'static' => $method->isStatic(),
             'langs' => ['php'],
             'example' => $sample
                 ? [$sample]

--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -153,22 +153,20 @@ class Page
     private function getMethodItems(): array
     {
         $methods = [];
-        $isServiceClass = $this->classNode->isServiceClass();
-
         foreach ($this->classNode->getMethods() as $method) {
-            $methodItem = $this->getMethodItem($method, $isServiceClass);
+            $methodItem = $this->getMethodItem($method);
             $methods[$methodItem['uid']] = $methodItem;
         }
 
         return $methods;
     }
 
-    private function getMethodItem(MethodNode $method, bool $isServiceClass): array
+    private function getMethodItem(MethodNode $method): array
     {
         $content = $method->getContent();
         $name = $method->getName();
         $sample = null;
-        if ($isServiceClass) {
+        if ($this->classNode->isServiceClass()) {
             list($content, $sample) = $this->handleSample($content, $name);
         }
         $methodItem = array_filter([

--- a/dev/tests/fixtures/docfx/NewClient/V1.Client.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/NewClient/V1.Client.ImageAnnotatorClient.yml
@@ -15,118 +15,16 @@ items:
     langs:
       - php
     children:
-      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::getOperationsClient()'
-      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::resumeOperation()'
-      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::productSetName()'
-      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::parseName()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::__construct()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::__call()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::asyncBatchAnnotateFiles()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::asyncBatchAnnotateImages()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::batchAnnotateFiles()'
       - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::batchAnnotateImages()'
-  -
-    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::getOperationsClient()'
-    name: getOperationsClient
-    id: getOperationsClient
-    summary: 'Return an OperationsClient object with the same endpoint as $this.'
-    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
-  -
-    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::resumeOperation()'
-    name: resumeOperation
-    id: resumeOperation
-    summary: |-
-      Resume an existing long running operation that was previously started by a long
-      running API method. If $methodName is not provided, or does not match a long
-      running API method, then the operation can still be resumed, but the
-      OperationResponse object will not deserialize the final response.
-    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: operationName
-          var_type: string
-          description: 'The name of the long running operation'
-        -
-          id: methodName
-          var_type: string
-          description: 'The name of the method used to start the operation'
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
-  -
-    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::productSetName()'
-    name: productSetName
-    id: productSetName
-    summary: |-
-      Formats a string containing the fully-qualified path to represent a product_set
-      resource.
-    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: project
-          var_type: string
-          description: ''
-        -
-          id: location
-          var_type: string
-          description: ''
-        -
-          id: productSet
-          var_type: string
-          description: ''
-      returns:
-        -
-          var_type: string
-          description: 'The formatted product_set resource.'
-  -
-    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::parseName()'
-    name: parseName
-    id: parseName
-    summary: |-
-      Parses a formatted name string and returns an associative array of the components in the name.
-
-      The following name formats are supported:
-      Template: Pattern
-      - productSet: projects/{project}/locations/{location}/productSets/{product_set}
-
-      The optional $template argument can be supplied to specify a particular pattern,
-      and must match one of the templates listed above. If no $template argument is
-      provided, or if the $template argument does not match one of the templates
-      listed, then parseName will check each of the supported templates, and return
-      the first match.
-    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: formattedName
-          var_type: string
-          description: 'The formatted name string'
-        -
-          id: template
-          var_type: string
-          description: 'Optional name of template to match'
-      returns:
-        -
-          var_type: array
-          description: 'An associative array from name component IDs to component values.'
+      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::getOperationsClient()'
+      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::resumeOperation()'
+      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::productSetName()'
+      - '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::parseName()'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::__construct()'
     name: __construct
@@ -330,3 +228,105 @@ items:
       returns:
         -
           var_type: '<xref uid="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse">Google\Cloud\Vision\V1\BatchAnnotateImagesResponse</xref>'
+  -
+    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::getOperationsClient()'
+    name: getOperationsClient
+    id: getOperationsClient
+    summary: 'Return an OperationsClient object with the same endpoint as $this.'
+    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
+  -
+    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::resumeOperation()'
+    name: resumeOperation
+    id: resumeOperation
+    summary: |-
+      Resume an existing long running operation that was previously started by a long
+      running API method. If $methodName is not provided, or does not match a long
+      running API method, then the operation can still be resumed, but the
+      OperationResponse object will not deserialize the final response.
+    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: operationName
+          var_type: string
+          description: 'The name of the long running operation'
+        -
+          id: methodName
+          var_type: string
+          description: 'The name of the method used to start the operation'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
+  -
+    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::productSetName()'
+    name: 'static::productSetName'
+    id: productSetName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a product_set
+      resource.
+    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: location
+          var_type: string
+          description: ''
+        -
+          id: productSet
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted product_set resource.'
+  -
+    uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::parseName()'
+    name: 'static::parseName'
+    id: parseName
+    summary: |-
+      Parses a formatted name string and returns an associative array of the components in the name.
+
+      The following name formats are supported:
+      Template: Pattern
+      - productSet: projects/{project}/locations/{location}/productSets/{product_set}
+
+      The optional $template argument can be supplied to specify a particular pattern,
+      and must match one of the templates listed above. If no $template argument is
+      provided, or if the $template argument does not match one of the templates
+      listed, then parseName will check each of the supported templates, and return
+      the first match.
+    parent: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: formattedName
+          var_type: string
+          description: 'The formatted name string'
+        -
+          id: template
+          var_type: string
+          description: 'Optional name of template to match'
+      returns:
+        -
+          var_type: array
+          description: 'An associative array from name component IDs to component values.'

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
@@ -22,11 +22,10 @@ items:
       - '\Google\Cloud\Vision\V1\BatchOperationMetadata\State::CANCELLED'
   -
     uid: '\Google\Cloud\Vision\V1\BatchOperationMetadata\State::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -37,11 +36,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\BatchOperationMetadata\State::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
@@ -26,6 +26,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -40,6 +41,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\BatchOperationMetadata\State
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
@@ -23,11 +23,10 @@ items:
       - '\Google\Cloud\Vision\V1\Block\BlockType::BARCODE'
   -
     uid: '\Google\Cloud\Vision\V1\Block\BlockType::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\Block\BlockType
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -38,11 +37,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\Block\BlockType::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\Block\BlockType
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
@@ -27,6 +27,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\Block\BlockType
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -41,6 +42,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\Block\BlockType
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
@@ -62,6 +62,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -76,6 +77,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
@@ -58,11 +58,10 @@ items:
       - '\Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type::RIGHT_CHEEK_CENTER'
   -
     uid: '\Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -73,11 +72,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\FaceAnnotation\Landmark\Type
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
@@ -34,6 +34,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\Feature\Type
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -48,6 +49,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\Feature\Type
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
@@ -30,11 +30,10 @@ items:
       - '\Google\Cloud\Vision\V1\Feature\Type::OBJECT_LOCALIZATION'
   -
     uid: '\Google\Cloud\Vision\V1\Feature\Type::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\Feature\Type
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -45,11 +44,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\Feature\Type::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\Feature\Type
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
@@ -65,13 +65,13 @@ items:
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::webDetection()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::objectLocalization()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::productSearch()'
-      - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::getOperationsClient()'
-      - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::__construct()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::asyncBatchAnnotateFiles()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::asyncBatchAnnotateImages()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::batchAnnotateFiles()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::batchAnnotateImages()'
+      - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::getOperationsClient()'
+      - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::SERVICE_NAME'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::SERVICE_ADDRESS'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::DEFAULT_SERVICE_PORT'
@@ -624,45 +624,6 @@ items:
         -
           var_type: '<xref uid="\Google\Cloud\Vision\V1\AnnotateImageResponse">Google\Cloud\Vision\V1\AnnotateImageResponse</xref>'
   -
-    uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::getOperationsClient()'
-    name: getOperationsClient
-    id: getOperationsClient
-    summary: 'Return an OperationsClient object with the same endpoint as $this.'
-    parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
-  -
-    uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()'
-    name: resumeOperation
-    id: resumeOperation
-    summary: |-
-      Resume an existing long running operation that was previously started by a long
-      running API method. If $methodName is not provided, or does not match a long
-      running API method, then the operation can still be resumed, but the
-      OperationResponse object will not deserialize the final response.
-    parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-    type: method
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: operationName
-          var_type: string
-          description: 'The name of the long running operation'
-        -
-          id: methodName
-          var_type: string
-          description: 'The name of the method used to start the operation'
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
-  -
     uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::__construct()'
     name: __construct
     id: __construct
@@ -1022,6 +983,45 @@ items:
       returns:
         -
           var_type: '<xref uid="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse">Google\Cloud\Vision\V1\BatchAnnotateImagesResponse</xref>'
+  -
+    uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::getOperationsClient()'
+    name: getOperationsClient
+    id: getOperationsClient
+    summary: 'Return an OperationsClient object with the same endpoint as $this.'
+    parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
+  -
+    uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()'
+    name: resumeOperation
+    id: resumeOperation
+    summary: |-
+      Resume an existing long running operation that was previously started by a long
+      running API method. If $methodName is not provided, or does not match a long
+      running API method, then the operation can still be resumed, but the
+      OperationResponse object will not deserialize the final response.
+    parent: \Google\Cloud\Vision\V1\ImageAnnotatorClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: operationName
+          var_type: string
+          description: 'The name of the long running operation'
+        -
+          id: methodName
+          var_type: string
+          description: 'The name of the method used to start the operation'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ImageAnnotatorClient::SERVICE_NAME'
     name: SERVICE_NAME

--- a/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
@@ -24,11 +24,10 @@ items:
       - '\Google\Cloud\Vision\V1\Likelihood::VERY_LIKELY'
   -
     uid: '\Google\Cloud\Vision\V1\Likelihood::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\Likelihood
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -39,11 +38,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\Likelihood::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\Likelihood
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
@@ -28,6 +28,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\Likelihood
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -42,6 +43,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\Likelihood
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
@@ -22,11 +22,10 @@ items:
       - '\Google\Cloud\Vision\V1\OperationMetadata\State::CANCELLED'
   -
     uid: '\Google\Cloud\Vision\V1\OperationMetadata\State::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\OperationMetadata\State
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -37,11 +36,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\OperationMetadata\State::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\OperationMetadata\State
     type: method
-    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
@@ -26,6 +26,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\OperationMetadata\State
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -40,6 +41,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\OperationMetadata\State
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
@@ -43,13 +43,6 @@ items:
     langs:
       - php
     children:
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::locationName()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::productName()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::productSetName()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::referenceImageName()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::parseName()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::getOperationsClient()'
-      - '\Google\Cloud\Vision\V1\ProductSearchClient::resumeOperation()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::__construct()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::addProductToProductSet()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::createProduct()'
@@ -70,207 +63,17 @@ items:
       - '\Google\Cloud\Vision\V1\ProductSearchClient::removeProductFromProductSet()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::updateProduct()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::updateProductSet()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::getOperationsClient()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::resumeOperation()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::locationName()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::productName()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::productSetName()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::referenceImageName()'
+      - '\Google\Cloud\Vision\V1\ProductSearchClient::parseName()'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::SERVICE_NAME'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::SERVICE_ADDRESS'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::DEFAULT_SERVICE_PORT'
       - '\Google\Cloud\Vision\V1\ProductSearchClient::CODEGEN_NAME'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::locationName()'
-    name: locationName
-    id: locationName
-    summary: |-
-      Formats a string containing the fully-qualified path to represent a location
-      resource.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    static: true
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: project
-          var_type: string
-          description: ''
-        -
-          id: location
-          var_type: string
-          description: ''
-      returns:
-        -
-          var_type: string
-          description: 'The formatted location resource.'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::productName()'
-    name: productName
-    id: productName
-    summary: |-
-      Formats a string containing the fully-qualified path to represent a product
-      resource.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    static: true
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: project
-          var_type: string
-          description: ''
-        -
-          id: location
-          var_type: string
-          description: ''
-        -
-          id: product
-          var_type: string
-          description: ''
-      returns:
-        -
-          var_type: string
-          description: 'The formatted product resource.'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::productSetName()'
-    name: productSetName
-    id: productSetName
-    summary: |-
-      Formats a string containing the fully-qualified path to represent a product_set
-      resource.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    static: true
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: project
-          var_type: string
-          description: ''
-        -
-          id: location
-          var_type: string
-          description: ''
-        -
-          id: productSet
-          var_type: string
-          description: ''
-      returns:
-        -
-          var_type: string
-          description: 'The formatted product_set resource.'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::referenceImageName()'
-    name: referenceImageName
-    id: referenceImageName
-    summary: |-
-      Formats a string containing the fully-qualified path to represent a
-      reference_image resource.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    static: true
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: project
-          var_type: string
-          description: ''
-        -
-          id: location
-          var_type: string
-          description: ''
-        -
-          id: product
-          var_type: string
-          description: ''
-        -
-          id: referenceImage
-          var_type: string
-          description: ''
-      returns:
-        -
-          var_type: string
-          description: 'The formatted reference_image resource.'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::parseName()'
-    name: parseName
-    id: parseName
-    summary: |-
-      Parses a formatted name string and returns an associative array of the components in the name.
-
-      The following name formats are supported:
-      Template: Pattern
-      - location: projects/{project}/locations/{location}
-      - product: projects/{project}/locations/{location}/products/{product}
-      - productSet: projects/{project}/locations/{location}/productSets/{product_set}
-      - referenceImage: projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}
-
-      The optional $template argument can be supplied to specify a particular pattern,
-      and must match one of the templates listed above. If no $template argument is
-      provided, or if the $template argument does not match one of the templates
-      listed, then parseName will check each of the supported templates, and return
-      the first match.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    static: true
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: formattedName
-          var_type: string
-          description: 'The formatted name string'
-        -
-          id: template
-          var_type: string
-          description: 'Optional name of template to match'
-      returns:
-        -
-          var_type: array
-          description: 'An associative array from name component IDs to component values.'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::getOperationsClient()'
-    name: getOperationsClient
-    id: getOperationsClient
-    summary: 'Return an OperationsClient object with the same endpoint as $this.'
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    langs:
-      - php
-    syntax:
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
-  -
-    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::resumeOperation()'
-    name: resumeOperation
-    id: resumeOperation
-    summary: |-
-      Resume an existing long running operation that was previously started by a long
-      running API method. If $methodName is not provided, or does not match a long
-      running API method, then the operation can still be resumed, but the
-      OperationResponse object will not deserialize the final response.
-    parent: \Google\Cloud\Vision\V1\ProductSearchClient
-    type: method
-    langs:
-      - php
-    syntax:
-      parameters:
-        -
-          id: operationName
-          var_type: string
-          description: 'The name of the long running operation'
-        -
-          id: methodName
-          var_type: string
-          description: 'The name of the method used to start the operation'
-      returns:
-        -
-          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchClient::__construct()'
     name: __construct
@@ -2002,6 +1805,198 @@ items:
       returns:
         -
           var_type: '<xref uid="\Google\Cloud\Vision\V1\ProductSet">Google\Cloud\Vision\V1\ProductSet</xref>'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::getOperationsClient()'
+    name: getOperationsClient
+    id: getOperationsClient
+    summary: 'Return an OperationsClient object with the same endpoint as $this.'
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/LongRunning/OperationsClient">Google\ApiCore\LongRunning\OperationsClient</a>'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::resumeOperation()'
+    name: resumeOperation
+    id: resumeOperation
+    summary: |-
+      Resume an existing long running operation that was previously started by a long
+      running API method. If $methodName is not provided, or does not match a long
+      running API method, then the operation can still be resumed, but the
+      OperationResponse object will not deserialize the final response.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: operationName
+          var_type: string
+          description: 'The name of the long running operation'
+        -
+          id: methodName
+          var_type: string
+          description: 'The name of the method used to start the operation'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/OperationResponse">Google\ApiCore\OperationResponse</a>'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::locationName()'
+    name: 'static::locationName'
+    id: locationName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a location
+      resource.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: location
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted location resource.'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::productName()'
+    name: 'static::productName'
+    id: productName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a product
+      resource.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: location
+          var_type: string
+          description: ''
+        -
+          id: product
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted product resource.'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::productSetName()'
+    name: 'static::productSetName'
+    id: productSetName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a product_set
+      resource.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: location
+          var_type: string
+          description: ''
+        -
+          id: productSet
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted product_set resource.'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::referenceImageName()'
+    name: 'static::referenceImageName'
+    id: referenceImageName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a
+      reference_image resource.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: location
+          var_type: string
+          description: ''
+        -
+          id: product
+          var_type: string
+          description: ''
+        -
+          id: referenceImage
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted reference_image resource.'
+  -
+    uid: '\Google\Cloud\Vision\V1\ProductSearchClient::parseName()'
+    name: 'static::parseName'
+    id: parseName
+    summary: |-
+      Parses a formatted name string and returns an associative array of the components in the name.
+
+      The following name formats are supported:
+      Template: Pattern
+      - location: projects/{project}/locations/{location}
+      - product: projects/{project}/locations/{location}/products/{product}
+      - productSet: projects/{project}/locations/{location}/productSets/{product_set}
+      - referenceImage: projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}
+
+      The optional $template argument can be supplied to specify a particular pattern,
+      and must match one of the templates listed above. If no $template argument is
+      provided, or if the $template argument does not match one of the templates
+      listed, then parseName will check each of the supported templates, and return
+      the first match.
+    parent: \Google\Cloud\Vision\V1\ProductSearchClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: formattedName
+          var_type: string
+          description: 'The formatted name string'
+        -
+          id: template
+          var_type: string
+          description: 'Optional name of template to match'
+      returns:
+        -
+          var_type: array
+          description: 'An associative array from name component IDs to component values.'
   -
     uid: '\Google\Cloud\Vision\V1\ProductSearchClient::SERVICE_NAME'
     name: SERVICE_NAME

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
@@ -83,6 +83,7 @@ items:
       resource.
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -108,6 +109,7 @@ items:
       resource.
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -137,6 +139,7 @@ items:
       resource.
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -166,6 +169,7 @@ items:
       reference_image resource.
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -211,6 +215,7 @@ items:
       the first match.
     parent: \Google\Cloud\Vision\V1\ProductSearchClient
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
@@ -27,6 +27,7 @@ items:
     id: name
     parent: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType
     type: method
+    static: true
     langs:
       - php
     syntax:
@@ -41,6 +42,7 @@ items:
     id: value
     parent: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType
     type: method
+    static: true
     langs:
       - php
     syntax:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
@@ -23,11 +23,10 @@ items:
       - '\Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType::LINE_BREAK'
   -
     uid: '\Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType::name()'
-    name: name
+    name: 'static::name'
     id: name
     parent: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType
     type: method
-    static: true
     langs:
       - php
     syntax:
@@ -38,11 +37,10 @@ items:
           description: ''
   -
     uid: '\Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType::value()'
-    name: value
+    name: 'static::value'
     id: value
     parent: \Google\Cloud\Vision\V1\TextAnnotation\DetectedBreak\BreakType
     type: method
-    static: true
     langs:
       - php
     syntax:


### PR DESCRIPTION
 - Order static methods to bottom and change their name to `static::methodName` for clarity
 - Also orders `getOperationsClient` and `resumeOperation` to the bottom, so the RPC methods are at the top for client classes
Here is a preview of what this should look like:
<img width="1227" alt="Screenshot 2023-05-15 at 4 43 28 PM" src="https://github.com/googleapis/google-cloud-php/assets/103941/2fec0131-0349-4aa3-8e9d-e60963b01d93">
