### PR TITLE
feat(docs): upgrade phpdoc to latest version, add magic methods

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
       id: extract
       uses: shrink/actions-docker-extract@v2
       with:
-        image: "phpdoc/phpdoc:202301112131087e6028"
+        image: "phpdoc/phpdoc:20230522201300af6fb5"
         path: "/opt/phpdoc/."
     - name: Symlink phpDocumentor
       run: ln -s $(pwd)/${{ steps.extract.outputs.destination }}/bin/phpdoc /usr/local/bin/phpdoc

--- a/.kokoro/docs/docker/Dockerfile
+++ b/.kokoro/docs/docker/Dockerfile
@@ -88,7 +88,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
 # Use phpDocumentor from HEAD until they create a new release
 # TODO: Remove once phpDocumentor tags a new release
 # @see https://github.com/phpDocumentor/phpDocumentor/issues/3434
-COPY --from=phpdoc/phpdoc:202301112131087e6028 /opt/phpdoc /opt/phpdoc
+COPY --from=phpdoc/phpdoc:20230522201300af6fb5 /opt/phpdoc /opt/phpdoc
 RUN ln -s /opt/phpdoc/bin/phpdoc /usr/local/bin/phpdoc
 ENV PHPDOC_ENV=prod
 
@@ -112,4 +112,3 @@ RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
 # Install docsuploader
 COPY requirements.txt .
 RUN python3.9 -m pip install --require-hashes -r requirements.txt
-

--- a/dev/src/DocFx/Node/ClassNode.php
+++ b/dev/src/DocFx/Node/ClassNode.php
@@ -81,6 +81,13 @@ class ClassNode
         return false;
     }
 
+    public function isServiceBaseClass(): bool
+    {
+        // returns true if the class extends a generated GAPIC client
+        return 'GapicClient' === substr($this->getName(), -11)
+            || 'BaseClient' === substr($this->getName(), -10);
+    }
+
     public function isV2ServiceClass(): bool
     {
         // returns true if the class extends a generated V2 GAPIC client

--- a/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
+++ b/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
@@ -1,0 +1,1336 @@
+### YamlMime:UniversalReference
+items:
+  -
+    uid: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    name: SecretManagerServiceClient
+    friendlyApiName: 'Secret Manager V1 Client'
+    id: SecretManagerServiceClient
+    summary: |-
+      Service Description: Secret Manager Service
+
+      This class is currently experimental and may be subject to changes.
+    type: class
+    langs:
+      - php
+    children:
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicyAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersionsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicyAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissionsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::projectName()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::secretName()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::secretVersionName()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::parseName()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::__construct()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::__call()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::accessSecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::addSecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::createSecret()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::deleteSecret()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::destroySecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::disableSecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::enableSecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getIamPolicy()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecret()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretVersion()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretVersions()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecrets()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::setIamPolicy()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::testIamPermissions()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::updateSecret()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::accessSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::addSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::createSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::deleteSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::destroySecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::disableSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::enableSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getIamPolicyAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretVersionAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretVersionsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::setIamPolicyAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::testIamPermissionsAsync()'
+      - '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::updateSecretAsync()'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersionAsync()'
+    name: accessSecretVersionAsync
+    id: accessSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest">Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersionAsync()'
+    name: addSecretVersionAsync
+    id: addSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AddSecretVersionRequest">Google\Cloud\SecretManager\V1\AddSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecretAsync()'
+    name: createSecretAsync
+    id: createSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\CreateSecretRequest">Google\Cloud\SecretManager\V1\CreateSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecretAsync()'
+    name: deleteSecretAsync
+    id: deleteSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DeleteSecretRequest">Google\Cloud\SecretManager\V1\DeleteSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersionAsync()'
+    name: destroySecretVersionAsync
+    id: destroySecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest">Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersionAsync()'
+    name: disableSecretVersionAsync
+    id: disableSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest">Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersionAsync()'
+    name: enableSecretVersionAsync
+    id: enableSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest">Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicyAsync()'
+    name: getIamPolicyAsync
+    id: getIamPolicyAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/GetIamPolicyRequest">Google\Cloud\Iam\V1\GetIamPolicyRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretAsync()'
+    name: getSecretAsync
+    id: getSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretRequest">Google\Cloud\SecretManager\V1\GetSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersionAsync()'
+    name: getSecretVersionAsync
+    id: getSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretVersionRequest">Google\Cloud\SecretManager\V1\GetSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersionsAsync()'
+    name: listSecretVersionsAsync
+    id: listSecretVersionsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest">Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretsAsync()'
+    name: listSecretsAsync
+    id: listSecretsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretsRequest">Google\Cloud\SecretManager\V1\ListSecretsRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicyAsync()'
+    name: setIamPolicyAsync
+    id: setIamPolicyAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/SetIamPolicyRequest">Google\Cloud\Iam\V1\SetIamPolicyRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissionsAsync()'
+    name: testIamPermissionsAsync
+    id: testIamPermissionsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/TestIamPermissionsRequest">Google\Cloud\Iam\V1\TestIamPermissionsRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecretAsync()'
+    name: updateSecretAsync
+    id: updateSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\UpdateSecretRequest">Google\Cloud\SecretManager\V1\UpdateSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::projectName()'
+    name: projectName
+    id: projectName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a project
+      resource.
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted project resource.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::secretName()'
+    name: secretName
+    id: secretName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a secret
+      resource.
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: secret
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted secret resource.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::secretVersionName()'
+    name: secretVersionName
+    id: secretVersionName
+    summary: |-
+      Formats a string containing the fully-qualified path to represent a
+      secret_version resource.
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: project
+          var_type: string
+          description: ''
+        -
+          id: secret
+          var_type: string
+          description: ''
+        -
+          id: secretVersion
+          var_type: string
+          description: ''
+      returns:
+        -
+          var_type: string
+          description: 'The formatted secret_version resource.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::parseName()'
+    name: parseName
+    id: parseName
+    summary: |-
+      Parses a formatted name string and returns an associative array of the components in the name.
+
+      The following name formats are supported:
+      Template: Pattern
+      - project: projects/{project}
+      - secret: projects/{project}/secrets/{secret}
+      - secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+      The optional $template argument can be supplied to specify a particular pattern,
+      and must match one of the templates listed above. If no $template argument is
+      provided, or if the $template argument does not match one of the templates
+      listed, then parseName will check each of the supported templates, and return
+      the first match.
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: formattedName
+          var_type: string
+          description: 'The formatted name string'
+        -
+          id: template
+          var_type: string
+          description: 'Optional name of template to match'
+      returns:
+        -
+          var_type: array
+          description: 'An associative array from name component IDs to component values.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::__construct()'
+    name: __construct
+    id: __construct
+    summary: Constructor.
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: options
+          var_type: array
+          description: 'Optional. Options for configuring the service API wrapper.'
+        -
+          id: '↳ apiEndpoint'
+          var_type: string
+          description: 'The address of the API remote host. May optionally include the port, formatted as "<uri>:<port>". Default ''secretmanager.googleapis.com:443''.'
+        -
+          id: '↳ credentials'
+          var_type: string|array|FetchAuthTokenInterface|CredentialsWrapper
+          description: 'The credentials to be used by the client to authorize API calls. This option accepts either a path to a credentials file, or a decoded credentials file as a PHP array. *Advanced usage*: In addition, this option can also accept a pre-constructed <a href="https://googleapis.github.io/google-auth-library-php/main/Google/Auth/FetchAuthTokenInterface">Google\Auth\FetchAuthTokenInterface</a> object or <a href="https://googleapis.github.io/gax-php#Google/ApiCore/CredentialsWrapper">Google\ApiCore\CredentialsWrapper</a> object. Note that when one of these objects are provided, any settings in $credentialsConfig will be ignored.'
+        -
+          id: '↳ credentialsConfig'
+          var_type: array
+          description: 'Options used to configure credentials, including auth token caching, for the client. For a full list of supporting configuration options, see <a href="https://googleapis.github.io/gax-php#Google/ApiCore/CredentialsWrapper#method_build">Google\ApiCore\CredentialsWrapper::build()</a> .'
+        -
+          id: '↳ disableRetries'
+          var_type: bool
+          description: 'Determines whether or not retries defined by the client configuration should be disabled. Defaults to `false`.'
+        -
+          id: '↳ clientConfig'
+          var_type: string|array
+          description: 'Client method configuration, including retry settings. This option can be either a path to a JSON file, or a PHP array containing the decoded JSON data. By default this settings points to the default client config file, which is provided in the resources folder.'
+        -
+          id: '↳ transport'
+          var_type: string|TransportInterface
+          description: 'The transport used for executing network requests. May be either the string `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system. *Advanced usage*: Additionally, it is possible to pass in an already instantiated <a href="https://googleapis.github.io/gax-php#Google/ApiCore/Transport/TransportInterface">Google\ApiCore\Transport\TransportInterface</a> object. Note that when this object is provided, any settings in $transportConfig, and any $apiEndpoint setting, will be ignored.'
+        -
+          id: '↳ transportConfig'
+          var_type: array
+          description: 'Configuration options that will be used to construct the transport. Options for each supported transport type should be passed in a key for that transport. For example: $transportConfig = [ ''grpc'' => [...], ''rest'' => [...], ]; See the <a href="https://googleapis.github.io/gax-php#Google/ApiCore/Transport/GrpcTransport#method_build">Google\ApiCore\Transport\GrpcTransport::build()</a> and <a href="https://googleapis.github.io/gax-php#Google/ApiCore/Transport/RestTransport#method_build">Google\ApiCore\Transport\RestTransport::build()</a> methods for the supported options.'
+        -
+          id: '↳ clientCertSource'
+          var_type: callable
+          description: 'A callable which returns the client cert as a string. This can be used to provide a certificate and private key to the transport layer for mTLS.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::__call()'
+    name: __call
+    id: __call
+    summary: 'Handles execution of the async variants for each documented method.'
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: method
+          var_type: mixed
+          description: ''
+        -
+          id: args
+          var_type: mixed
+          description: ''
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::accessSecretVersion()'
+    name: accessSecretVersion
+    id: accessSecretVersion
+    summary: |-
+      Accesses a <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>. This call returns the secret data.
+
+      `projects/*/secrets/*/versions/latest` is an alias to the most recently
+      created <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::accessSecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::accessSecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest">Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AccessSecretVersionResponse">Google\Cloud\SecretManager\V1\AccessSecretVersionResponse</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::addSecretVersion()'
+    name: addSecretVersion
+    id: addSecretVersion
+    summary: |-
+      Creates a new <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref> containing secret data and attaches
+      it to an existing <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::addSecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::addSecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AddSecretVersionRequest">Google\Cloud\SecretManager\V1\AddSecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\SecretVersion">Google\Cloud\SecretManager\V1\SecretVersion</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::createSecret()'
+    name: createSecret
+    id: createSecret
+    summary: |-
+      Creates a new <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref> containing no <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersions</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::createSecretAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::createSecretAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\CreateSecretRequest">Google\Cloud\SecretManager\V1\CreateSecretRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\Secret">Google\Cloud\SecretManager\V1\Secret</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::deleteSecret()'
+    name: deleteSecret
+    id: deleteSecret
+    summary: |-
+      Deletes a <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::deleteSecretAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::deleteSecretAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DeleteSecretRequest">Google\Cloud\SecretManager\V1\DeleteSecretRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::destroySecretVersion()'
+    name: destroySecretVersion
+    id: destroySecretVersion
+    summary: |-
+      Destroys a <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      Sets the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion::getState()">state</xref> of the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref> to
+      <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersionClient::state()">DESTROYED</xref> and irrevocably destroys the
+      secret data.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::destroySecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::destroySecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest">Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\SecretVersion">Google\Cloud\SecretManager\V1\SecretVersion</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::disableSecretVersion()'
+    name: disableSecretVersion
+    id: disableSecretVersion
+    summary: |-
+      Disables a <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      Sets the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion::getState()">state</xref> of the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref> to
+      <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersionClient::state()">DISABLED</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::disableSecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::disableSecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest">Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\SecretVersion">Google\Cloud\SecretManager\V1\SecretVersion</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::enableSecretVersion()'
+    name: enableSecretVersion
+    id: enableSecretVersion
+    summary: |-
+      Enables a <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      Sets the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion::getState()">state</xref> of the <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref> to
+      <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersionClient::state()">ENABLED</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::enableSecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::enableSecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest">Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\SecretVersion">Google\Cloud\SecretManager\V1\SecretVersion</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getIamPolicy()'
+    name: getIamPolicy
+    id: getIamPolicy
+    summary: |-
+      Gets the access control policy for a secret.
+
+      Returns empty policy if the secret exists and does not have a policy set.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::getIamPolicyAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::getIamPolicyAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/GetIamPolicyRequest">Google\Cloud\Iam\V1\GetIamPolicyRequest</a>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/Policy">Google\Cloud\Iam\V1\Policy</a>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecret()'
+    name: getSecret
+    id: getSecret
+    summary: |-
+      Gets metadata for a given <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretRequest">Google\Cloud\SecretManager\V1\GetSecretRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\Secret">Google\Cloud\SecretManager\V1\Secret</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretVersion()'
+    name: getSecretVersion
+    id: getSecretVersion
+    summary: |-
+      Gets metadata for a <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      `projects/*/secrets/*/versions/latest` is an alias to the most recently
+      created <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersion</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretVersionAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretVersionAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretVersionRequest">Google\Cloud\SecretManager\V1\GetSecretVersionRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\SecretVersion">Google\Cloud\SecretManager\V1\SecretVersion</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretVersions()'
+    name: listSecretVersions
+    id: listSecretVersions
+    summary: |-
+      Lists <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersions</xref>. This call does not return secret
+      data.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretVersionsAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretVersionsAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest">Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/PagedListResponse">Google\ApiCore\PagedListResponse</a>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecrets()'
+    name: listSecrets
+    id: listSecrets
+    summary: |-
+      Lists <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secrets</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretsAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretsAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretsRequest">Google\Cloud\SecretManager\V1\ListSecretsRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/gax-php#Google/ApiCore/PagedListResponse">Google\ApiCore\PagedListResponse</a>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::setIamPolicy()'
+    name: setIamPolicy
+    id: setIamPolicy
+    summary: |-
+      Sets the access control policy on the specified secret. Replaces any
+      existing policy.
+
+      Permissions on <xref uid="\Google\Cloud\Secretmanager\V1\SecretVersion">SecretVersions</xref> are enforced according
+      to the policy set on the associated <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::setIamPolicyAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::setIamPolicyAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/SetIamPolicyRequest">Google\Cloud\Iam\V1\SetIamPolicyRequest</a>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/Policy">Google\Cloud\Iam\V1\Policy</a>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::testIamPermissions()'
+    name: testIamPermissions
+    id: testIamPermissions
+    summary: |-
+      Returns permissions that a caller has for the specified secret.
+
+      If the secret does not exist, this call returns an empty set of
+      permissions, not a NOT_FOUND error.
+
+      Note: This operation is designed to be used for building permission-aware
+      UIs and command-line tools, not for authorization checking. This operation
+      may "fail open" without warning.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::testIamPermissionsAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::testIamPermissionsAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/TestIamPermissionsRequest">Google\Cloud\Iam\V1\TestIamPermissionsRequest</a>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/TestIamPermissionsResponse">Google\Cloud\Iam\V1\TestIamPermissionsResponse</a>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::updateSecret()'
+    name: updateSecret
+    id: updateSecret
+    summary: |-
+      Updates metadata of an existing <xref uid="\Google\Cloud\Secretmanager\V1\Secret">Secret</xref>.
+
+      The async variant is <xref uid="\Google\Cloud\SecretManager\V1\Client\BaseClient\self::updateSecretAsync()">Google\Cloud\SecretManager\V1\Client\BaseClient\self::updateSecretAsync()</xref> .
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\UpdateSecretRequest">Google\Cloud\SecretManager\V1\UpdateSecretRequest</xref>'
+          description: 'A request to house fields associated with the call.'
+        -
+          id: callOptions
+          var_type: array
+          description: Optional.
+        -
+          id: '↳ retrySettings'
+          var_type: RetrySettings|array
+          description: 'Retry settings to use for this call. Can be a <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> object, or an associative array of retry settings parameters. See the documentation on <a href="https://googleapis.github.io/gax-php#Google/ApiCore/RetrySettings">Google\ApiCore\RetrySettings</a> for example usage.'
+      returns:
+        -
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\Secret">Google\Cloud\SecretManager\V1\Secret</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::accessSecretVersionAsync()'
+    name: accessSecretVersionAsync
+    id: accessSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest">Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::addSecretVersionAsync()'
+    name: addSecretVersionAsync
+    id: addSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\AddSecretVersionRequest">Google\Cloud\SecretManager\V1\AddSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::createSecretAsync()'
+    name: createSecretAsync
+    id: createSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\CreateSecretRequest">Google\Cloud\SecretManager\V1\CreateSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::deleteSecretAsync()'
+    name: deleteSecretAsync
+    id: deleteSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DeleteSecretRequest">Google\Cloud\SecretManager\V1\DeleteSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::destroySecretVersionAsync()'
+    name: destroySecretVersionAsync
+    id: destroySecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest">Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::disableSecretVersionAsync()'
+    name: disableSecretVersionAsync
+    id: disableSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest">Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::enableSecretVersionAsync()'
+    name: enableSecretVersionAsync
+    id: enableSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest">Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getIamPolicyAsync()'
+    name: getIamPolicyAsync
+    id: getIamPolicyAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/GetIamPolicyRequest">Google\Cloud\Iam\V1\GetIamPolicyRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretAsync()'
+    name: getSecretAsync
+    id: getSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretRequest">Google\Cloud\SecretManager\V1\GetSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretVersionAsync()'
+    name: getSecretVersionAsync
+    id: getSecretVersionAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\GetSecretVersionRequest">Google\Cloud\SecretManager\V1\GetSecretVersionRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretVersionsAsync()'
+    name: listSecretVersionsAsync
+    id: listSecretVersionsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest">Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretsAsync()'
+    name: listSecretsAsync
+    id: listSecretsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\ListSecretsRequest">Google\Cloud\SecretManager\V1\ListSecretsRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::setIamPolicyAsync()'
+    name: setIamPolicyAsync
+    id: setIamPolicyAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/SetIamPolicyRequest">Google\Cloud\Iam\V1\SetIamPolicyRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::testIamPermissionsAsync()'
+    name: testIamPermissionsAsync
+    id: testIamPermissionsAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<a href="https://googleapis.github.io/common-protos-php#Google/Cloud/Iam/V1/TestIamPermissionsRequest">Google\Cloud\Iam\V1\TestIamPermissionsRequest</a>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+  -
+    uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::updateSecretAsync()'
+    name: updateSecretAsync
+    id: updateSecretAsync
+    parent: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+    type: method
+    langs:
+      - php
+    syntax:
+      parameters:
+        -
+          id: request
+          var_type: '<xref uid="\Google\Cloud\SecretManager\V1\UpdateSecretRequest">Google\Cloud\SecretManager\V1\UpdateSecretRequest</xref>'
+          description: ''
+        -
+          id: 'optionalArgs = []'
+          var_type: array
+          description: ''
+      returns:
+        -
+          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'

--- a/dev/tests/fixtures/docfx/NewClient/toc.yml
+++ b/dev/tests/fixtures/docfx/NewClient/toc.yml
@@ -1,21 +1,33 @@
 -
-  uid: google-cloud-vision
-  name: google/cloud-vision
+  uid: google-cloud-secret-manager
+  name: google/cloud-secret-manager
   items:
     -
       name: Overview
       href: index.md
     -
-      name: Google\Cloud\Vision\V1
-      uid: 'ns:Google\Cloud\Vision\V1'
+      name: Google\Cloud\SecretManager\V1
+      uid: 'ns:Google\Cloud\SecretManager\V1'
       items:
         -
           name: Services
-          uid: 'services:Google\Cloud\Vision\V1'
+          uid: 'services:Google\Cloud\SecretManager\V1'
           items:
             -
-              uid: \Google\Cloud\Vision\V1\Client\ImageAnnotatorClient
-              name: 'ImageAnnotatorClient (new)'
+              uid: \Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient
+              name: 'SecretManagerServiceClient (new)'
             -
-              uid: \Google\Cloud\Vision\V1\ImageAnnotatorClient
-              name: 'ImageAnnotatorClient (previous)'
+              uid: \Google\Cloud\SecretManager\V1\SecretManagerServiceClient
+              name: 'SecretManagerServiceClient (previous)'
+    -
+      name: Google\Cloud\SecretManager\V1beta1
+      uid: 'ns:Google\Cloud\SecretManager\V1beta1'
+      items:
+        -
+          name: Services
+          uid: 'services:Google\Cloud\SecretManager\V1beta1'
+          items:
+            -
+              uid: \Google\Cloud\SecretManager\V1beta1\SecretManagerServiceClient
+              name: 'SecretManagerServiceClient (previous)'
+              status: beta

--- a/dev/tests/fixtures/phpdoc/newclient.xml
+++ b/dev/tests/fixtures/phpdoc/newclient.xml
@@ -1,31 +1,30 @@
-<?xml version="1.0"?>
-<project name="Documentation">
-                <file path="V1/Client/BaseClient/ImageAnnotatorBaseClient.php" hash="a71510c5a6e6b6f30c9a0c47ca42a9be">
+<?xml version="1.0"?><project name="Documentation"><file path="V1/Client/BaseClient/SecretManagerServiceBaseClient.php" hash="ab970e8a0b26004df12785086b3fb98d">
             <docblock line="0">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
             </docblock>
 
 
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1\Client\BaseClient"/>
+            
 
-                            <namespace-alias name="\Google\Cloud\Vision\V1\Client\BaseClient"/>
+            
+                        
+                        
+                                        <class final="false" abstract="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="97">
+                    <name>SecretManagerServiceBaseClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</full_name>
+                    <docblock line="97">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description>Manages secrets and operations using those secrets. Implements a REST
+model with the following objects:
 
+* [Secret][google.cloud.secretmanager.v1.Secret]
+* [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
 
-
-
-
-                                        <class final="false" abstract="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="74">
-                    <name>ImageAnnotatorBaseClient</name>
-                    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</full_name>
-                    <docblock line="74">
-    <description>Service Description: Service that performs Google Cloud Vision API detection tasks over client
-images, such as face, landmark, logo, label, and text detection. The
-ImageAnnotator service returns detected entities from the images.</description>
-    <long-description>This class provides the ability to make remote calls to the backing service through method
+This class provides the ability to make remote calls to the backing service through method
 calls that map to API methods.
 
 Many parameters require resource names to be formatted in a particular way. To
@@ -34,2827 +33,6058 @@ name, and additionally a parseName method to extract the individual identifiers
 contained within formatted names that are returned by the API.
 
 This class is currently experimental and may be subject to changes.</long-description>
-                    <tag
-                name="experimental"
-                description=""
-                                                                                                />
-                            <tag
-                name="internal"
-                description=""
-                                                                                                />
-                            <tag
-                name="method"
-                description=""
-                                                                                 method_name="asyncBatchAnnotateFilesAsync"                />
-                <tag
-                name="method"
-                description=""
-                                                                                 method_name="asyncBatchAnnotateImagesAsync"                />
-                <tag
-                name="method"
-                description=""
-                                                                                 method_name="batchAnnotateFilesAsync"                />
-                <tag
-                name="method"
-                description=""
-                                                                                 method_name="batchAnnotateImagesAsync"                />
-                            <tag
-                name="package"
-                description="Application"
-                                                                                                />
+                    <tag name="experimental" description=""/>
+                            <tag name="internal" description=""/>
+                            <tag name="method" description="" method_name="accessSecretVersionAsync"/>
+                <tag name="method" description="" method_name="addSecretVersionAsync"/>
+                <tag name="method" description="" method_name="createSecretAsync"/>
+                <tag name="method" description="" method_name="deleteSecretAsync"/>
+                <tag name="method" description="" method_name="destroySecretVersionAsync"/>
+                <tag name="method" description="" method_name="disableSecretVersionAsync"/>
+                <tag name="method" description="" method_name="enableSecretVersionAsync"/>
+                <tag name="method" description="" method_name="getIamPolicyAsync"/>
+                <tag name="method" description="" method_name="getSecretAsync"/>
+                <tag name="method" description="" method_name="getSecretVersionAsync"/>
+                <tag name="method" description="" method_name="listSecretVersionsAsync"/>
+                <tag name="method" description="" method_name="listSecretsAsync"/>
+                <tag name="method" description="" method_name="setIamPolicyAsync"/>
+                <tag name="method" description="" method_name="testIamPermissionsAsync"/>
+                <tag name="method" description="" method_name="updateSecretAsync"/>
+                            <tag name="package" description="Application"/>
                         </docblock>
 
-
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="80" visibility="private">
+                    
+                    
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="103" visibility="private">
     <name>SERVICE_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::SERVICE_NAME</full_name>
-    <value>&#039;google.cloud.vision.v1.ImageAnnotator&#039;</value>
-        <docblock line="80">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secretmanager.v1.SecretManagerService'</value>
+        <docblock line="103">
     <description>The name of the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="83" visibility="private">
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="106" visibility="private">
     <name>SERVICE_ADDRESS</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::SERVICE_ADDRESS</full_name>
-    <value>&#039;vision.googleapis.com&#039;</value>
-        <docblock line="83">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+        <docblock line="106">
     <description>The default address of the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="86" visibility="private">
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="109" visibility="private">
     <name>DEFAULT_SERVICE_PORT</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::DEFAULT_SERVICE_PORT</full_name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::DEFAULT_SERVICE_PORT</full_name>
     <value>443</value>
-        <docblock line="86">
-    <description>The default port of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="89" visibility="private">
-    <name>CODEGEN_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::CODEGEN_NAME</full_name>
-    <value>&#039;gapic&#039;</value>
-        <docblock line="89">
-    <description>The name of the code generator, to be included in the agent header.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="92" visibility="public">
-    <name>serviceScopes</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::$serviceScopes</full_name>
-    <default>[&#039;https://www.googleapis.com/auth/cloud-platform&#039;, &#039;https://www.googleapis.com/auth/cloud-vision&#039;]</default>
-        <docblock line="92">
-    <description>The default scopes required by the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="97" visibility="private">
-    <name>operationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::$operationsClient</full_name>
-    <default></default>
-        <docblock line="97">
-    <description></description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="99" visibility="private" returnByReference="false">
-    <name>getClientDefaults</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::getClientDefaults()</full_name>
-    <value></value>
-            <docblock line="99">
-    <description></description>
-    <long-description></long-description>
-                </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="123" visibility="public" returnByReference="false">
-    <name>getOperationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::getOperationsClient()</full_name>
-    <value></value>
-            <docblock line="123">
-    <description>Return an OperationsClient object with the same endpoint as $this.</description>
-    <long-description></long-description>
-                    <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\LongRunning\OperationsClient"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="139" visibility="public" returnByReference="false">
-    <name>resumeOperation</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::resumeOperation()</full_name>
-    <value></value>
-                <argument line="139" by_reference="false">
-    <name>operationName</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="139" by_reference="false">
-    <name>methodName</name>
-    <default>null</default>
-    <type>string</type>
-</argument>
-
-        <docblock line="139">
-    <description>Resume an existing long running operation that was previously started by a long
-running API method. If $methodName is not provided, or does not match a long
-running API method, then the operation can still be resumed, but the
-OperationResponse object will not deserialize the final response.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="The name of the long running operation"
-                                                                 variable="operationName"                                 type="string"/>
-                <tag
-                name="param"
-                description="The name of the method used to start the operation"
-                                                                 variable="methodName"                                 type="string"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="157" visibility="public" returnByReference="false">
-    <name>productSetName</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::productSetName()</full_name>
-    <value></value>
-                <argument line="157" by_reference="false">
-    <name>project</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="157" by_reference="false">
-    <name>location</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="157" by_reference="false">
-    <name>productSet</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-        <docblock line="157">
-    <description>Formats a string containing the fully-qualified path to represent a product_set
-resource.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="project"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="location"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="productSet"                                 type="string"/>
-                            <tag
-                name="return"
-                description="The formatted product_set resource."
-                                                                                                 type="string"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="185" visibility="public" returnByReference="false">
-    <name>parseName</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::parseName()</full_name>
-    <value></value>
-                <argument line="185" by_reference="false">
-    <name>formattedName</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="185" by_reference="false">
-    <name>template</name>
-    <default>null</default>
-    <type>string</type>
-</argument>
-
-        <docblock line="185">
-    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
-    <long-description>The following name formats are supported:
-Template: Pattern
-- productSet: projects/{project}/locations/{location}/productSets/{product_set}
-
-The optional $template argument can be supplied to specify a particular pattern,
-and must match one of the templates listed above. If no $template argument is
-provided, or if the $template argument does not match one of the templates
-listed, then parseName will check each of the supported templates, and return
-the first match.</long-description>
-                    <tag
-                name="param"
-                description="The formatted name string"
-                                                                 variable="formattedName"                                 type="string"/>
-                <tag
-                name="param"
-                description="Optional name of template to match"
-                                                                 variable="template"                                 type="string"/>
-                            <tag
-                name="return"
-                description="An associative array from name component IDs to component values."
-                                                                                                 type="array"/>
-                            <tag
-                name="throws"
-                description="If $formattedName could not be matched."
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="244" visibility="public" returnByReference="false">
-    <name>__construct</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::__construct()</full_name>
-    <value></value>
-                <argument line="244" by_reference="false">
-    <name>options</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="244">
-    <description>Constructor.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default &#039;vision.googleapis.com:443&#039;.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              &#039;grpc&#039; =&gt; [...],&#10;              &#039;rest&#039; =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}"
-                                                                 variable="options"                                 type="array"/>
-                            <tag
-                name="throws"
-                description=""
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="252" visibility="public" returnByReference="false">
-    <name>__call</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::__call()</full_name>
-    <value></value>
-                <argument line="252" by_reference="false">
-    <name>method</name>
-    <default></default>
-    <type>mixed</type>
-</argument>
-
-            <argument line="252" by_reference="false">
-    <name>args</name>
-    <default></default>
-    <type>mixed</type>
-</argument>
-
-        <docblock line="252">
-    <description>Handles execution of the async variants for each documented method.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="286" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::asyncBatchAnnotateFiles()</full_name>
-    <value></value>
-                <argument line="286" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest</type>
-</argument>
-
-            <argument line="286" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="286">
-    <description>Run asynchronous image detection and annotation for a list of generic
-files, such as PDF files, which may contain multiple pages and multiple
-images per page. Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.</description>
-    <long-description>`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::asyncBatchAnnotateFilesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="318" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::asyncBatchAnnotateImages()</full_name>
-    <value></value>
-                <argument line="318" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest</type>
-</argument>
-
-            <argument line="318" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="318">
-    <description>Run asynchronous image detection and annotation for a list of images.</description>
-    <long-description>Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.
-`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
-
-This service will write image annotation outputs to json files in customer
-GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::asyncBatchAnnotateImagesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="348" visibility="public" returnByReference="false">
-    <name>batchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::batchAnnotateFiles()</full_name>
-    <value></value>
-                <argument line="348" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\BatchAnnotateFilesRequest</type>
-</argument>
-
-            <argument line="348" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="348">
-    <description>Service that performs image detection and annotation for a batch of files.</description>
-    <long-description>Now only &quot;application/pdf&quot;, &quot;image/tiff&quot; and &quot;image/gif&quot; are supported.
-
-This service will extract at most 5 (customers can specify which 5 in
-AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
-file provided and perform detection and annotation for each image
-extracted.
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::batchAnnotateFilesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="372" visibility="public" returnByReference="false">
-    <name>batchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::batchAnnotateImages()</full_name>
-    <value></value>
-                <argument line="372" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\BatchAnnotateImagesRequest</type>
-</argument>
-
-            <argument line="372" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="372">
-    <description>Run image detection and annotation for a batch of images.</description>
-    <long-description>The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::batchAnnotateImagesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                                        </class>
-
-
-
-            <parse_markers></parse_markers>
-        </file>
-<file path="V1/Client/ImageAnnotatorClient.php" hash="26b34af8b1ac316fa3b6dd5b1566b14f">
-            <docblock line="0">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
-            </docblock>
-
-
-
-                            <namespace-alias name="\Google\Cloud\Vision\V1\Client"/>
-
-
-
-
-
-                                        <class final="true" abstract="false" namespace="\Google\Cloud\Vision\V1\Client" line="36">
-                    <name>ImageAnnotatorClient</name>
-                    <full_name>\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient</full_name>
-                    <docblock line="36">
-    <description>Service Description: Service that performs Google Cloud Vision API detection tasks over client
-images, such as face, landmark, logo, label, and text detection. The
-ImageAnnotator service returns detected entities from the images.</description>
-    <long-description>This class is currently experimental and may be subject to changes.</long-description>
-                    <tag
-                name="experimental"
-                description=""
-                                                                                                />
-                            <tag
-                name="package"
-                description="Application"
-                                                                                                />
-                        </docblock>
-
-                                            <extends>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</extends>
-
-                                                                <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="80" visibility="private">
-    <name>SERVICE_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::SERVICE_NAME</full_name>
-    <value>&#039;google.cloud.vision.v1.ImageAnnotator&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="80">
-    <description>The name of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="83" visibility="private">
-    <name>SERVICE_ADDRESS</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::SERVICE_ADDRESS</full_name>
-    <value>&#039;vision.googleapis.com&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="83">
-    <description>The default address of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="86" visibility="private">
-    <name>DEFAULT_SERVICE_PORT</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::DEFAULT_SERVICE_PORT</full_name>
-    <value>443</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="86">
-    <description>The default port of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="89" visibility="private">
-    <name>CODEGEN_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::CODEGEN_NAME</full_name>
-    <value>&#039;gapic&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="89">
-    <description>The name of the code generator, to be included in the agent header.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-
-                                                                <property namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="92" visibility="public">
-    <name>serviceScopes</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::$serviceScopes</full_name>
-    <default>[&#039;https://www.googleapis.com/auth/cloud-platform&#039;, &#039;https://www.googleapis.com/auth/cloud-vision&#039;]</default>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="92">
-    <description>The default scopes required by the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient" line="97" visibility="private">
-    <name>operationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::$operationsClient</full_name>
-    <default></default>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>    <docblock line="97">
-    <description></description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-
-                                                                <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="99" visibility="private" returnByReference="false">
-    <name>getClientDefaults</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::getClientDefaults()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>        <docblock line="99">
-    <description></description>
-    <long-description></long-description>
-                </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="123" visibility="public" returnByReference="false">
-    <name>getOperationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::getOperationsClient()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>        <docblock line="123">
-    <description>Return an OperationsClient object with the same endpoint as $this.</description>
-    <long-description></long-description>
-                    <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\LongRunning\OperationsClient"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="139" visibility="public" returnByReference="false">
-    <name>resumeOperation</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::resumeOperation()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="139" by_reference="false">
-    <name>operationName</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="139" by_reference="false">
-    <name>methodName</name>
-    <default>null</default>
-    <type>string</type>
-</argument>
-
-        <docblock line="139">
-    <description>Resume an existing long running operation that was previously started by a long
-running API method. If $methodName is not provided, or does not match a long
-running API method, then the operation can still be resumed, but the
-OperationResponse object will not deserialize the final response.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="The name of the long running operation"
-                                                                 variable="operationName"                                 type="string"/>
-                <tag
-                name="param"
-                description="The name of the method used to start the operation"
-                                                                 variable="methodName"                                 type="string"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="157" visibility="public" returnByReference="false">
-    <name>productSetName</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::productSetName()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="157" by_reference="false">
-    <name>project</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="157" by_reference="false">
-    <name>location</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="157" by_reference="false">
-    <name>productSet</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-        <docblock line="157">
-    <description>Formats a string containing the fully-qualified path to represent a product_set
-resource.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="project"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="location"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="productSet"                                 type="string"/>
-                            <tag
-                name="return"
-                description="The formatted product_set resource."
-                                                                                                 type="string"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="185" visibility="public" returnByReference="false">
-    <name>parseName</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::parseName()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="185" by_reference="false">
-    <name>formattedName</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="185" by_reference="false">
-    <name>template</name>
-    <default>null</default>
-    <type>string</type>
-</argument>
-
-        <docblock line="185">
-    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
-    <long-description>The following name formats are supported:
-Template: Pattern
-- productSet: projects/{project}/locations/{location}/productSets/{product_set}
-
-The optional $template argument can be supplied to specify a particular pattern,
-and must match one of the templates listed above. If no $template argument is
-provided, or if the $template argument does not match one of the templates
-listed, then parseName will check each of the supported templates, and return
-the first match.</long-description>
-                    <tag
-                name="param"
-                description="The formatted name string"
-                                                                 variable="formattedName"                                 type="string"/>
-                <tag
-                name="param"
-                description="Optional name of template to match"
-                                                                 variable="template"                                 type="string"/>
-                            <tag
-                name="return"
-                description="An associative array from name component IDs to component values."
-                                                                                                 type="array"/>
-                            <tag
-                name="throws"
-                description="If $formattedName could not be matched."
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="244" visibility="public" returnByReference="false">
-    <name>__construct</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::__construct()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="244" by_reference="false">
-    <name>options</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="244">
-    <description>Constructor.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default &#039;vision.googleapis.com:443&#039;.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              &#039;grpc&#039; =&gt; [...],&#10;              &#039;rest&#039; =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}"
-                                                                 variable="options"                                 type="array"/>
-                            <tag
-                name="throws"
-                description=""
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="252" visibility="public" returnByReference="false">
-    <name>__call</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::__call()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="252" by_reference="false">
-    <name>method</name>
-    <default></default>
-    <type>mixed</type>
-</argument>
-
-            <argument line="252" by_reference="false">
-    <name>args</name>
-    <default></default>
-    <type>mixed</type>
-</argument>
-
-        <docblock line="252">
-    <description>Handles execution of the async variants for each documented method.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="286" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::asyncBatchAnnotateFiles()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="286" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest</type>
-</argument>
-
-            <argument line="286" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="286">
-    <description>Run asynchronous image detection and annotation for a list of generic
-files, such as PDF files, which may contain multiple pages and multiple
-images per page. Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.</description>
-    <long-description>`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::asyncBatchAnnotateFilesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\AsyncBatchAnnotateFilesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="318" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::asyncBatchAnnotateImages()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="318" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest</type>
-</argument>
-
-            <argument line="318" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="318">
-    <description>Run asynchronous image detection and annotation for a list of images.</description>
-    <long-description>Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.
-`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
-
-This service will write image annotation outputs to json files in customer
-GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::asyncBatchAnnotateImagesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\AsyncBatchAnnotateImagesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="348" visibility="public" returnByReference="false">
-    <name>batchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::batchAnnotateFiles()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="348" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\BatchAnnotateFilesRequest</type>
-</argument>
-
-            <argument line="348" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="348">
-    <description>Service that performs image detection and annotation for a batch of files.</description>
-    <long-description>Now only &quot;application/pdf&quot;, &quot;image/tiff&quot; and &quot;image/gif&quot; are supported.
-
-This service will extract at most 5 (customers can specify which 5 in
-AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
-file provided and perform detection and annotation for each image
-extracted.
-
-The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::batchAnnotateFilesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Client\BaseClient" line="372" visibility="public" returnByReference="false">
-    <name>batchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient::batchAnnotateImages()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Client\BaseClient\ImageAnnotatorBaseClient</inherited_from>            <argument line="372" by_reference="false">
-    <name>request</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\BatchAnnotateImagesRequest</type>
-</argument>
-
-            <argument line="372" by_reference="false">
-    <name>callOptions</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="372">
-    <description>Run image detection and annotation for a batch of images.</description>
-    <long-description>The async variant is {@see \Google\Cloud\Vision\V1\Client\BaseClient\self::batchAnnotateImagesAsync()} .</long-description>
-                    <tag
-                name="param"
-                description="A request to house fields associated with the call."
-                                                                 variable="request"                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesRequest"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="callOptions"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse"/>
-                            <tag
-                name="throws"
-                description="Thrown if the API call fails."
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                    </class>
-
-
-
-            <parse_markers></parse_markers>
-        </file>
-        <file path="V1/ImageAnnotatorClient.php" hash="b54a881228332e0b4516718fac9fed7e">
-            <docblock line="0">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
-            </docblock>
-
-
-
-                            <namespace-alias name="\Google\Cloud\Vision\V1"/>
-
-
-
-
-
-                                        <class final="false" abstract="false" namespace="\Google\Cloud\Vision\V1" line="38">
-                    <name>ImageAnnotatorClient</name>
-                    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient</full_name>
-                    <docblock line="38">
-    <description>Service Description: Service that performs Google Cloud Vision API detection tasks over client
-images, such as face, landmark, logo, label, and text detection. The
-ImageAnnotator service returns detected entities from the images.</description>
-    <long-description></long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
-                        </docblock>
-
-                                            <extends>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</extends>
-
-                                                                <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="100" visibility="public">
-    <name>SERVICE_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::SERVICE_NAME</full_name>
-    <value>&#039;google.cloud.vision.v1.ImageAnnotator&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="100">
-    <description>The name of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="103" visibility="public">
-    <name>SERVICE_ADDRESS</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::SERVICE_ADDRESS</full_name>
-    <value>&#039;vision.googleapis.com&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="103">
-    <description>The default address of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="106" visibility="public">
-    <name>DEFAULT_SERVICE_PORT</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::DEFAULT_SERVICE_PORT</full_name>
-    <value>443</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="106">
-    <description>The default port of the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="109" visibility="public">
-    <name>CODEGEN_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::CODEGEN_NAME</full_name>
-    <value>&#039;gapic&#039;</value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="109">
-    <description>The name of the code generator, to be included in the agent header.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</constant>
-
-
-                                                                <property namespace="\Google\Cloud\Vision\VisionHelpersTrait" line="38" visibility="private">
-    <name>urlSchemes</name>
-    <full_name>\Google\Cloud\Vision\VisionHelpersTrait::$urlSchemes</full_name>
-    <default>[&#039;http&#039;, &#039;https&#039;, &#039;gs&#039;]</default>
-    <inherited_from>\Google\Cloud\Vision\VisionHelpersTrait</inherited_from>    <docblock line="38">
-    <description>A list of allowed url schemes.</description>
-    <long-description></long-description>
-                    <tag
-                name="var"
-                description=""
-                                                                                                 type="array"/>
-                        </docblock>
-
-</property>
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="112" visibility="public">
-    <name>serviceScopes</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::$serviceScopes</full_name>
-    <default>[&#039;https://www.googleapis.com/auth/cloud-platform&#039;, &#039;https://www.googleapis.com/auth/cloud-vision&#039;]</default>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="112">
-    <description>The default scopes required by the service.</description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="117" visibility="private">
-    <name>operationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::$operationsClient</full_name>
-    <default></default>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>    <docblock line="117">
-    <description></description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="74" visibility="public" returnByReference="false">
-    <name>createImageObject</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::createImageObject()</full_name>
-    <value></value>
-                <argument line="74" by_reference="false">
-    <name>imageInput</name>
-    <default></default>
-    <type>resource|string</type>
-</argument>
-
-        <docblock line="74">
-    <description>Creates an Image object that can be used as part of an image annotation request.</description>
-    <long-description>Example:
-```
-//[snippet=resource]
-$imageResource = fopen(&#039;path/to/image.jpg&#039;, &#039;r&#039;);
-$image = $imageAnnotatorClient-&gt;createImageObject($imageResource);
-$response = $imageAnnotatorClient-&gt;faceDetection($image);
-```
-
-```
-//[snippet=data]
-$imageData = file_get_contents(&#039;path/to/image.jpg&#039;);
-$image = $imageAnnotatorClient-&gt;createImageObject($imageData);
-$response = $imageAnnotatorClient-&gt;faceDetection($image);
-```
-
-```
-//[snippet=url]
-$imageUri = &quot;gs://my-bucket/image.jpg&quot;;
-$image = $imageAnnotatorClient-&gt;createImageObject($imageUri);
-$response = $imageAnnotatorClient-&gt;faceDetection($image);
-```</long-description>
-                    <tag
-                name="param"
-                description="An image to configure with&#10;the given settings. This parameter will accept a resource, a&#10;string of bytes, or the URI of an image in a publicly-accessible&#10;web location."
-                                                                 variable="imageInput"                                 type="resource|string"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\Image"/>
-                            <tag
-                name="throws"
-                description=""
-                                                                                                 type="\InvalidArgumentException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="109" visibility="public" returnByReference="false">
-    <name>annotateImage</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::annotateImage()</full_name>
-    <value></value>
-                <argument line="109" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
-</argument>
-
-            <argument line="109" by_reference="false">
-    <name>features</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\Feature[]|int[]</type>
-</argument>
-
-            <argument line="109" by_reference="false">
-    <name>optionalArgs</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
         <docblock line="109">
-    <description>Run image detection and annotation for an image.</description>
-    <long-description>Example:
-```
-use Google\Cloud\Vision\V1\Feature;
-use Google\Cloud\Vision\V1\Feature\Type;
+    <description>The default port of the service.</description>
+    <long-description/>
+                            </docblock>
 
-$imageResource = fopen(&#039;path/to/image.jpg&#039;, &#039;r&#039;);
-$features = [Type::FACE_DETECTION];
-$response = $imageAnnotatorClient-&gt;annotateImage($imageResource, $features);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="Requested features."
-                                                                 variable="features"                                 type="\Google\Cloud\Vision\V1\Feature[]|int[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="112" visibility="private">
+    <name>CODEGEN_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+        <docblock line="112">
+    <description>The name of the code generator, to be included in the agent header.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                        
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="115" visibility="public">
+    <name>serviceScopes</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+        <docblock line="115">
+    <description>The default scopes required by the service.</description>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                        
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="119" visibility="private" returnByReference="false">
+    <name>getClientDefaults</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getClientDefaults()</full_name>
+    <value/>
+            <docblock line="119">
+    <description/>
+    <long-description/>
+                </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="146" visibility="public" returnByReference="false">
-    <name>faceDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::faceDetection()</full_name>
-    <value></value>
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="146" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::projectName()</full_name>
+    <value/>
                 <argument line="146" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
-</argument>
-
-            <argument line="146" by_reference="false">
-    <name>optionalArgs</name>
-    <default>[]</default>
-    <type>array</type>
+    <name>project</name>
+    <default/>
+    <type>string</type>
 </argument>
 
         <docblock line="146">
-    <description>Run face detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;faceDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="180" visibility="public" returnByReference="false">
-    <name>landmarkDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::landmarkDetection()</full_name>
-    <value></value>
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="162" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::secretName()</full_name>
+    <value/>
+                <argument line="162" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="162" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="162">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="180" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::secretVersionName()</full_name>
+    <value/>
                 <argument line="180" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+    <name>project</name>
+    <default/>
+    <type>string</type>
 </argument>
 
             <argument line="180" by_reference="false">
-    <name>optionalArgs</name>
-    <default>[]</default>
-    <type>array</type>
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="180" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
 </argument>
 
         <docblock line="180">
-    <description>Run landmark detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;landmarkDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="214" visibility="public" returnByReference="false">
-    <name>logoDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::logoDetection()</full_name>
-    <value></value>
-                <argument line="214" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="210" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::parseName()</full_name>
+    <value/>
+                <argument line="210" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
 </argument>
 
-            <argument line="214" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="210" by_reference="false">
+    <name>template</name>
+    <default>null</default>
+    <type>string</type>
+</argument>
+
+        <docblock line="210">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="269" visibility="public" returnByReference="false">
+    <name>__construct</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::__construct()</full_name>
+    <value/>
+                <argument line="269" by_reference="false">
+    <name>options</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="214">
-    <description>Run logo detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;logoDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="269">
+    <description>Constructor.</description>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="248" visibility="public" returnByReference="false">
-    <name>labelDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::labelDetection()</full_name>
-    <value></value>
-                <argument line="248" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="276" visibility="public" returnByReference="false">
+    <name>__call</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::__call()</full_name>
+    <value/>
+                <argument line="276" by_reference="false">
+    <name>method</name>
+    <default/>
+    <type>mixed</type>
 </argument>
 
-            <argument line="248" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="276" by_reference="false">
+    <name>args</name>
+    <default/>
+    <type>mixed</type>
+</argument>
+
+        <docblock line="276">
+    <description>Handles execution of the async variants for each documented method.</description>
+    <long-description/>
+                            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="308" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersion()</full_name>
+    <value/>
+                <argument line="308" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</type>
+</argument>
+
+            <argument line="308" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="248">
-    <description>Run label detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;labelDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="308">
+    <description>Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::accessSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="282" visibility="public" returnByReference="false">
-    <name>textDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::textDetection()</full_name>
-    <value></value>
-                <argument line="282" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="333" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersion()</full_name>
+    <value/>
+                <argument line="333" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AddSecretVersionRequest</type>
 </argument>
 
-            <argument line="282" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="333" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="282">
-    <description>Run text detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;textDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="333">
+    <description>Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::addSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\AddSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="316" visibility="public" returnByReference="false">
-    <name>documentTextDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::documentTextDetection()</full_name>
-    <value></value>
-                <argument line="316" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="357" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecret()</full_name>
+    <value/>
+                <argument line="357" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\CreateSecretRequest</type>
 </argument>
 
-            <argument line="316" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="357" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="316">
-    <description>Run document text detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;documentTextDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="357">
+    <description>Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::createSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\CreateSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="350" visibility="public" returnByReference="false">
-    <name>safeSearchDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::safeSearchDetection()</full_name>
-    <value></value>
-                <argument line="350" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="379" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecret()</full_name>
+    <value/>
+                <argument line="379" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DeleteSecretRequest</type>
 </argument>
 
-            <argument line="350" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="379" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="350">
-    <description>Run safe search detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;safeSearchDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="379">
+    <description>Deletes a [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::deleteSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DeleteSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="384" visibility="public" returnByReference="false">
-    <name>imagePropertiesDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::imagePropertiesDetection()</full_name>
-    <value></value>
-                <argument line="384" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="407" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersion()</full_name>
+    <value/>
+                <argument line="407" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</type>
 </argument>
 
-            <argument line="384" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="407" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="384">
-    <description>Run image properties detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;imagePropertiesDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="407">
+    <description>Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::destroySecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="418" visibility="public" returnByReference="false">
-    <name>cropHintsDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::cropHintsDetection()</full_name>
-    <value></value>
-                <argument line="418" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="434" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersion()</full_name>
+    <value/>
+                <argument line="434" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</type>
 </argument>
 
-            <argument line="418" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="434" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="418">
-    <description>Run crop hints detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;cropHintsDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="434">
+    <description>Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::disableSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="452" visibility="public" returnByReference="false">
-    <name>webDetection</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::webDetection()</full_name>
-    <value></value>
-                <argument line="452" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="461" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersion()</full_name>
+    <value/>
+                <argument line="461" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</type>
 </argument>
 
-            <argument line="452" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="461" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="452">
-    <description>Run web detection for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;webDetection($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="461">
+    <description>Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::enableSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="486" visibility="public" returnByReference="false">
-    <name>objectLocalization</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::objectLocalization()</full_name>
-    <value></value>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="486" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicy()</full_name>
+    <value/>
                 <argument line="486" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\GetIamPolicyRequest</type>
 </argument>
 
             <argument line="486" by_reference="false">
-    <name>optionalArgs</name>
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
         <docblock line="486">
-    <description>Run object localization for an image.</description>
-    <long-description>Example:
-```
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$response = $imageAnnotatorClient-&gt;objectLocalization($imageContent);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getIamPolicyAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\GetIamPolicyRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="532" visibility="public" returnByReference="false">
-    <name>productSearch</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::productSearch()</full_name>
-    <value></value>
-                <argument line="532" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>resource|string|\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="510" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecret()</full_name>
+    <value/>
+                <argument line="510" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretRequest</type>
 </argument>
 
-            <argument line="532" by_reference="false">
-    <name>productSearchParams</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\ProductSearchParams</type>
-</argument>
-
-            <argument line="532" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="510" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="532">
-    <description>Run product search for an image.</description>
-    <long-description>Example:
-```
-use Google\Cloud\Vision\V1\ProductSearchClient;
-use Google\Cloud\Vision\V1\ProductSearchParams;
-
-$imageContent = file_get_contents(&#039;path/to/image.jpg&#039;);
-$productSetName = ProductSearchClient::productSetName(&#039;PROJECT_ID&#039;, &#039;LOC_ID&#039;, &#039;PRODUCT_SET_ID&#039;);
-$productSearchParams = (new ProductSearchParams)
-    -&gt;setProductSet($productSetName);
-$response = $imageAnnotatorClient-&gt;productSearch(
-    $imageContent,
-    $productSearchParams
-);
-```</long-description>
-                    <tag
-                name="param"
-                description="The image to be processed."
-                                                                 variable="image"                                 type="resource|string|\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description="Parameters for a product search request. Please note, this&#10;value will override the {@see \Google\Cloud\Vision\V1\ProductSearchParams} in the&#10;{@see \Google\Cloud\Vision\V1\ImageContext} instance if provided."
-                                                                 variable="productSearchParams"                                 type="\Google\Cloud\Vision\V1\ProductSearchParams"/>
-                <tag
-                name="param"
-                description="{&#10;    Configuration Options.&#10;&#10;    @type ImageContext        $imageContext  Additional context that may accompany the image.&#10;    @type RetrySettings|array $retrySettings&#10;         Retry settings to use for this call. Can be a&#10;         {@see \Google\ApiCore\RetrySettings} object, or an associative array&#10;         of retry settings parameters. See the documentation on&#10;         {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="510">
+    <description>Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\GetSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1" line="554" visibility="private" returnByReference="false">
-    <name>annotateSingleFeature</name>
-    <full_name>\Google\Cloud\Vision\V1\ImageAnnotatorClient::annotateSingleFeature()</full_name>
-    <value></value>
-                <argument line="554" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\Image</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="537" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersion()</full_name>
+    <value/>
+                <argument line="537" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretVersionRequest</type>
 </argument>
 
-            <argument line="554" by_reference="false">
-    <name>featureType</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\Feature|int</type>
-</argument>
-
-            <argument line="554" by_reference="false">
-    <name>optionalArgs</name>
-    <default></default>
-    <type>array</type>
-</argument>
-
-        <docblock line="554">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="image"                                 type="\Google\Cloud\Vision\V1\Image"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="featureType"                                 type="\Google\Cloud\Vision\V1\Feature|int"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse"/>
-                        </docblock>
-
-</method>
-
-                                                                <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision" line="52" visibility="private" returnByReference="false">
-    <name>annotateImageHelper</name>
-    <full_name>\Google\Cloud\Vision\VisionHelpersTrait::annotateImageHelper()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\VisionHelpersTrait</inherited_from>            <argument line="52" by_reference="false">
-    <name>callback</name>
-    <default></default>
-    <type>callable</type>
-</argument>
-
-            <argument line="52" by_reference="false">
-    <name>requestClass</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateImageRequest|mixed</type>
-</argument>
-
-            <argument line="52" by_reference="false">
-    <name>image</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\Image|mixed</type>
-</argument>
-
-            <argument line="52" by_reference="false">
-    <name>features</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\Feature[]|int[]</type>
-</argument>
-
-            <argument line="52" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="537" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="52">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="callback"                                 type="callable"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="requestClass"                                 type="\Google\Cloud\Vision\V1\AnnotateImageRequest|mixed"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="image"                                 type="\Google\Cloud\Vision\Image|mixed"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="features"                                 type="\Google\Cloud\Vision\V1\Feature[]|int[]"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\AnnotateImageResponse|mixed"/>
+        <docblock line="537">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\GetSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision" line="75" visibility="private" returnByReference="false">
-    <name>buildFeatureList</name>
-    <full_name>\Google\Cloud\Vision\VisionHelpersTrait::buildFeatureList()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\VisionHelpersTrait</inherited_from>            <argument line="75" by_reference="false">
-    <name>featureClass</name>
-    <default></default>
-    <type>string</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="562" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersions()</full_name>
+    <value/>
+                <argument line="562" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</type>
 </argument>
 
-            <argument line="75" by_reference="false">
-    <name>featureTypes</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\Feature[]|int[]</type>
-</argument>
-
-        <docblock line="75">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="featureClass"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="featureTypes"                                 type="\Google\Cloud\Vision\V1\Feature[]|int[]"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\Feature[]|array"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision" line="96" visibility="private" returnByReference="false">
-    <name>createImageHelper</name>
-    <full_name>\Google\Cloud\Vision\VisionHelpersTrait::createImageHelper()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\VisionHelpersTrait</inherited_from>            <argument line="96" by_reference="false">
-    <name>imageClass</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="96" by_reference="false">
-    <name>imageSourceClass</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="96" by_reference="false">
-    <name>imageInput</name>
-    <default></default>
-    <type>string|resource|\Google\Cloud\Vision\Image|mixed</type>
-</argument>
-
-        <docblock line="96">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description=""
-                                                                 variable="imageClass"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="imageSourceClass"                                 type="string"/>
-                <tag
-                name="param"
-                description=""
-                                                                 variable="imageInput"                                 type="string|resource|\Google\Cloud\Vision\Image|mixed"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\Image|mixed"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Gapic" line="119" visibility="private" returnByReference="false">
-    <name>getClientDefaults</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::getClientDefaults()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>        <docblock line="119">
-    <description></description>
-    <long-description></long-description>
-                </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="149" visibility="public" returnByReference="false">
-    <name>getOperationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::getOperationsClient()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>        <docblock line="149">
-    <description>Return an OperationsClient object with the same endpoint as $this.</description>
-    <long-description></long-description>
-                    <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\LongRunning\OperationsClient"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="165" visibility="public" returnByReference="false">
-    <name>resumeOperation</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::resumeOperation()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="165" by_reference="false">
-    <name>operationName</name>
-    <default></default>
-    <type>string</type>
-</argument>
-
-            <argument line="165" by_reference="false">
-    <name>methodName</name>
-    <default>null</default>
-    <type>string</type>
-</argument>
-
-        <docblock line="165">
-    <description>Resume an existing long running operation that was previously started by a long
-running API method. If $methodName is not provided, or does not match a long
-running API method, then the operation can still be resumed, but the
-OperationResponse object will not deserialize the final response.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="The name of the long running operation"
-                                                                 variable="operationName"                                 type="string"/>
-                <tag
-                name="param"
-                description="The name of the method used to start the operation"
-                                                                 variable="methodName"                                 type="string"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="233" visibility="public" returnByReference="false">
-    <name>__construct</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::__construct()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="233" by_reference="false">
-    <name>options</name>
+            <argument line="562" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="233">
-    <description>Constructor.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default &#039;vision.googleapis.com:443&#039;.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              &#039;grpc&#039; =&gt; [...],&#10;              &#039;rest&#039; =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}"
-                                                                 variable="options"                                 type="array"/>
-                            <tag
-                name="throws"
-                description=""
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
+        <docblock line="562">
+    <description>Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretVersionsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="311" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::asyncBatchAnnotateFiles()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="311" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncAnnotateFileRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="586" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecrets()</full_name>
+    <value/>
+                <argument line="586" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretsRequest</type>
 </argument>
 
-            <argument line="311" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="586" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="311">
-    <description>Run asynchronous image detection and annotation for a list of generic
-files, such as PDF files, which may contain multiple pages and multiple
-images per page. Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.</description>
-    <long-description>`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-
-Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationResponse-&gt;pollUntilComplete();
-    if ($operationResponse-&gt;operationSucceeded()) {
-        $result = $operationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $operationResponse-&gt;getError();
-        // handleError($error)
-    }
-    // Alternatively:
-    // start the operation, keep the operation name, and resume later
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationName = $operationResponse-&gt;getName();
-    // ... do other work
-    $newOperationResponse = $imageAnnotatorClient-&gt;resumeOperation($operationName, &#039;asyncBatchAnnotateFiles&#039;);
-    while (!$newOperationResponse-&gt;isDone()) {
-        // ... do other work
-        $newOperationResponse-&gt;reload();
-    }
-    if ($newOperationResponse-&gt;operationSucceeded()) {
-        $result = $newOperationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $newOperationResponse-&gt;getError();
-        // handleError($error)
-    }
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual async file annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AsyncAnnotateFileRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="586">
+    <description>Lists [Secrets][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\ListSecretsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="411" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::asyncBatchAnnotateImages()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="411" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateImageRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="614" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicy()</full_name>
+    <value/>
+                <argument line="614" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\SetIamPolicyRequest</type>
 </argument>
 
-            <argument line="411" by_reference="false">
-    <name>outputConfig</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\OutputConfig</type>
-</argument>
-
-            <argument line="411" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="614" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="411">
-    <description>Run asynchronous image detection and annotation for a list of images.</description>
-    <long-description>Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.
-`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
+        <docblock line="614">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secretmanager.v1.Secret].
 
-This service will write image annotation outputs to json files in customer
-GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
-
-Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $outputConfig = new OutputConfig();
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateImages($requests, $outputConfig);
-    $operationResponse-&gt;pollUntilComplete();
-    if ($operationResponse-&gt;operationSucceeded()) {
-        $result = $operationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $operationResponse-&gt;getError();
-        // handleError($error)
-    }
-    // Alternatively:
-    // start the operation, keep the operation name, and resume later
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateImages($requests, $outputConfig);
-    $operationName = $operationResponse-&gt;getName();
-    // ... do other work
-    $newOperationResponse = $imageAnnotatorClient-&gt;resumeOperation($operationName, &#039;asyncBatchAnnotateImages&#039;);
-    while (!$newOperationResponse-&gt;isDone()) {
-        // ... do other work
-        $newOperationResponse-&gt;reload();
-    }
-    if ($newOperationResponse-&gt;operationSucceeded()) {
-        $result = $newOperationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $newOperationResponse-&gt;getError();
-        // handleError($error)
-    }
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual image annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateImageRequest[]"/>
-                <tag
-                name="param"
-                description="Required. The desired output location and metadata (e.g. format)."
-                                                                 variable="outputConfig"                                 type="\Google\Cloud\Vision\V1\OutputConfig"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::setIamPolicyAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\SetIamPolicyRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="487" visibility="public" returnByReference="false">
-    <name>batchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::batchAnnotateFiles()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="487" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateFileRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="644" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissions()</full_name>
+    <value/>
+                <argument line="644" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\TestIamPermissionsRequest</type>
 </argument>
 
-            <argument line="487" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="644" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="487">
-    <description>Service that performs image detection and annotation for a batch of files.</description>
-    <long-description>Now only &quot;application/pdf&quot;, &quot;image/tiff&quot; and &quot;image/gif&quot; are supported.
+        <docblock line="644">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
 
-This service will extract at most 5 (customers can specify which 5 in
-AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
-file provided and perform detection and annotation for each image
-extracted.
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
 
-Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $response = $imageAnnotatorClient-&gt;batchAnnotateFiles($requests);
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. The list of file annotation requests. Right now we support only one&#10;AnnotateFileRequest in BatchAnnotateFilesRequest."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateFileRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::testIamPermissionsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\TestIamPermissionsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="552" visibility="public" returnByReference="false">
-    <name>batchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::batchAnnotateImages()</full_name>
-    <value></value>
-    <inherited_from>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</inherited_from>            <argument line="552" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateImageRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="668" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecret()</full_name>
+    <value/>
+                <argument line="668" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\UpdateSecretRequest</type>
 </argument>
 
-            <argument line="552" by_reference="false">
-    <name>optionalArgs</name>
+            <argument line="668" by_reference="false">
+    <name>callOptions</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="552">
-    <description>Run image detection and annotation for a batch of images.</description>
-    <long-description>Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $response = $imageAnnotatorClient-&gt;batchAnnotateImages($requests);
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual image annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateImageRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+        <docblock line="668">
+    <description>Updates metadata of an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::updateSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\UpdateSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
                         </docblock>
+
+</method>
+
+                                                                                    <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>accessSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>addSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AddSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>createSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\CreateSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>deleteSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DeleteSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>destroySecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>disableSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>enableSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getIamPolicyAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicyAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\GetIamPolicyRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>listSecretVersionsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersionsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>listSecretsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>setIamPolicyAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicyAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\SetIamPolicyRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>testIamPermissionsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissionsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\TestIamPermissionsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>updateSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\UpdateSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
 
 </method>
 
                                     </class>
-
-
-
-            <parse_markers></parse_markers>
-        </file>
-<file path="V1/Gapic/ImageAnnotatorGapicClient.php" hash="89b00d3ca2b68f914a9bb9316e343904">
+            
+                        
+            
+            <parse_markers/>
+        </file><file path="V1/Client/SecretManagerServiceClient.php" hash="ca6121cc608459c99711cb149f885e7e">
             <docblock line="0">
-    <description></description>
-    <long-description></long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
             </docblock>
 
 
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1\Client"/>
+            
 
-                            <namespace-alias name="\Google\Cloud\Vision\V1\Gapic"/>
-
-
-
-
-
-                                        <class final="false" abstract="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="95">
-                    <name>ImageAnnotatorGapicClient</name>
-                    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient</full_name>
-                    <docblock line="95">
-    <description>Service Description: Service that performs Google Cloud Vision API detection tasks over client
-images, such as face, landmark, logo, label, and text detection. The
-ImageAnnotator service returns detected entities from the images.</description>
-    <long-description>This class provides the ability to make remote calls to the backing service through method
-calls that map to API methods. Sample code to get started:
-
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationResponse-&gt;pollUntilComplete();
-    if ($operationResponse-&gt;operationSucceeded()) {
-        $result = $operationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $operationResponse-&gt;getError();
-        // handleError($error)
-    }
-    // Alternatively:
-    // start the operation, keep the operation name, and resume later
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationName = $operationResponse-&gt;getName();
-    // ... do other work
-    $newOperationResponse = $imageAnnotatorClient-&gt;resumeOperation($operationName, &#039;asyncBatchAnnotateFiles&#039;);
-    while (!$newOperationResponse-&gt;isDone()) {
-        // ... do other work
-        $newOperationResponse-&gt;reload();
-    }
-    if ($newOperationResponse-&gt;operationSucceeded()) {
-        $result = $newOperationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $newOperationResponse-&gt;getError();
-        // handleError($error)
-    }
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="package"
-                description="Application"
-                                                                                                />
+            
+                        
+                        
+                                        <class final="true" abstract="false" namespace="\Google\Cloud\SecretManager\V1\Client" line="36">
+                    <name>SecretManagerServiceClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient</full_name>
+                    <docblock line="36">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description>This class is currently experimental and may be subject to changes.</long-description>
+                    <tag name="experimental" description=""/>
+                            <tag name="package" description="Application"/>
                         </docblock>
 
-
-
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="100" visibility="public">
+                                            <extends>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</extends> 
+                    
+                                                                <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="103" visibility="private">
     <name>SERVICE_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::SERVICE_NAME</full_name>
-    <value>&#039;google.cloud.vision.v1.ImageAnnotator&#039;</value>
-        <docblock line="100">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secretmanager.v1.SecretManagerService'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>    <docblock line="103">
     <description>The name of the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="103" visibility="public">
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="106" visibility="private">
     <name>SERVICE_ADDRESS</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::SERVICE_ADDRESS</full_name>
-    <value>&#039;vision.googleapis.com&#039;</value>
-        <docblock line="103">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>    <docblock line="106">
     <description>The default address of the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="106" visibility="public">
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="109" visibility="private">
     <name>DEFAULT_SERVICE_PORT</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::DEFAULT_SERVICE_PORT</full_name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::DEFAULT_SERVICE_PORT</full_name>
     <value>443</value>
-        <docblock line="106">
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>    <docblock line="109">
     <description>The default port of the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-                                            <constant namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="109" visibility="public">
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="112" visibility="private">
     <name>CODEGEN_NAME</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::CODEGEN_NAME</full_name>
-    <value>&#039;gapic&#039;</value>
-        <docblock line="109">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>    <docblock line="112">
     <description>The name of the code generator, to be included in the agent header.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </constant>
 
-
-                                            <property namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="112" visibility="public">
+                    
+                                                                <property namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient" line="115" visibility="public">
     <name>serviceScopes</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::$serviceScopes</full_name>
-    <default>[&#039;https://www.googleapis.com/auth/cloud-platform&#039;, &#039;https://www.googleapis.com/auth/cloud-vision&#039;]</default>
-        <docblock line="112">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>    <docblock line="115">
     <description>The default scopes required by the service.</description>
-    <long-description></long-description>
+    <long-description/>
                             </docblock>
 
 </property>
 
-                                            <property namespace="\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient" line="117" visibility="private">
-    <name>operationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::$operationsClient</full_name>
-    <default></default>
-        <docblock line="117">
-    <description></description>
-    <long-description></long-description>
-                            </docblock>
-
-</property>
-
-
-                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\Vision\V1\Gapic" line="119" visibility="private" returnByReference="false">
+                    
+                                                                <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="119" visibility="private" returnByReference="false">
     <name>getClientDefaults</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::getClientDefaults()</full_name>
-    <value></value>
-            <docblock line="119">
-    <description></description>
-    <long-description></long-description>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getClientDefaults()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>        <docblock line="119">
+    <description/>
+    <long-description/>
                 </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="149" visibility="public" returnByReference="false">
-    <name>getOperationsClient</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::getOperationsClient()</full_name>
-    <value></value>
-            <docblock line="149">
-    <description>Return an OperationsClient object with the same endpoint as $this.</description>
-    <long-description></long-description>
-                    <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\LongRunning\OperationsClient"/>
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="146" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::projectName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="146" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="146">
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="165" visibility="public" returnByReference="false">
-    <name>resumeOperation</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::resumeOperation()</full_name>
-    <value></value>
-                <argument line="165" by_reference="false">
-    <name>operationName</name>
-    <default></default>
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="162" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::secretName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="162" by_reference="false">
+    <name>project</name>
+    <default/>
     <type>string</type>
 </argument>
 
-            <argument line="165" by_reference="false">
-    <name>methodName</name>
+            <argument line="162" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="162">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="180" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::secretVersionName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="180" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="180" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="180" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="180">
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="210" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::parseName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="210" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="210" by_reference="false">
+    <name>template</name>
     <default>null</default>
     <type>string</type>
 </argument>
 
-        <docblock line="165">
-    <description>Resume an existing long running operation that was previously started by a long
-running API method. If $methodName is not provided, or does not match a long
-running API method, then the operation can still be resumed, but the
-OperationResponse object will not deserialize the final response.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="The name of the long running operation"
-                                                                 variable="operationName"                                 type="string"/>
-                <tag
-                name="param"
-                description="The name of the method used to start the operation"
-                                                                 variable="methodName"                                 type="string"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
+        <docblock line="210">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="233" visibility="public" returnByReference="false">
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="269" visibility="public" returnByReference="false">
     <name>__construct</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::__construct()</full_name>
-    <value></value>
-                <argument line="233" by_reference="false">
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::__construct()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="269" by_reference="false">
     <name>options</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="233">
+        <docblock line="269">
     <description>Constructor.</description>
-    <long-description></long-description>
-                    <tag
-                name="param"
-                description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default &#039;vision.googleapis.com:443&#039;.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              &#039;grpc&#039; =&gt; [...],&#10;              &#039;rest&#039; =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}"
-                                                                 variable="options"                                 type="array"/>
-                            <tag
-                name="throws"
-                description=""
-                                                                                                 type="\Google\ApiCore\ValidationException"/>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="311" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::asyncBatchAnnotateFiles()</full_name>
-    <value></value>
-                <argument line="311" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AsyncAnnotateFileRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="276" visibility="public" returnByReference="false">
+    <name>__call</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::__call()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="276" by_reference="false">
+    <name>method</name>
+    <default/>
+    <type>mixed</type>
 </argument>
 
-            <argument line="311" by_reference="false">
+            <argument line="276" by_reference="false">
+    <name>args</name>
+    <default/>
+    <type>mixed</type>
+</argument>
+
+        <docblock line="276">
+    <description>Handles execution of the async variants for each documented method.</description>
+    <long-description/>
+                            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="308" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="308" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</type>
+</argument>
+
+            <argument line="308" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="308">
+    <description>Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::accessSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="333" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="333" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AddSecretVersionRequest</type>
+</argument>
+
+            <argument line="333" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="333">
+    <description>Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::addSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\AddSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="357" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="357" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\CreateSecretRequest</type>
+</argument>
+
+            <argument line="357" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="357">
+    <description>Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::createSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\CreateSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="379" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="379" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DeleteSecretRequest</type>
+</argument>
+
+            <argument line="379" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="379">
+    <description>Deletes a [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::deleteSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DeleteSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="407" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="407" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</type>
+</argument>
+
+            <argument line="407" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="407">
+    <description>Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::destroySecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="434" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="434" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</type>
+</argument>
+
+            <argument line="434" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="434">
+    <description>Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::disableSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="461" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="461" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</type>
+</argument>
+
+            <argument line="461" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="461">
+    <description>Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::enableSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="486" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="486" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\GetIamPolicyRequest</type>
+</argument>
+
+            <argument line="486" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="486">
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getIamPolicyAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\GetIamPolicyRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="510" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="510" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretRequest</type>
+</argument>
+
+            <argument line="510" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="510">
+    <description>Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\GetSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="537" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="537" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretVersionRequest</type>
+</argument>
+
+            <argument line="537" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="537">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::getSecretVersionAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\GetSecretVersionRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="562" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="562" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</type>
+</argument>
+
+            <argument line="562" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="562">
+    <description>Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretVersionsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="586" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecrets()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="586" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretsRequest</type>
+</argument>
+
+            <argument line="586" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="586">
+    <description>Lists [Secrets][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::listSecretsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\ListSecretsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="614" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="614" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\SetIamPolicyRequest</type>
+</argument>
+
+            <argument line="614" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="614">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secretmanager.v1.Secret].
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::setIamPolicyAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\SetIamPolicyRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="644" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="644" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\TestIamPermissionsRequest</type>
+</argument>
+
+            <argument line="644" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="644">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
+
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
+
+The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::testIamPermissionsAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\Iam\V1\TestIamPermissionsRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Client\BaseClient" line="668" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient</inherited_from>            <argument line="668" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\UpdateSecretRequest</type>
+</argument>
+
+            <argument line="668" by_reference="false">
+    <name>callOptions</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="668">
+    <description>Updates metadata of an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>The async variant is {@see \Google\Cloud\SecretManager\V1\Client\BaseClient\self::updateSecretAsync()} .</long-description>
+                    <tag name="param" description="A request to house fields associated with the call." variable="request" type="\Google\Cloud\SecretManager\V1\UpdateSecretRequest"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="callOptions" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="Thrown if the API call fails." type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                                                <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>accessSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::accessSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AccessSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>addSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::addSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\AddSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>createSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::createSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\CreateSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>deleteSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::deleteSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DeleteSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>destroySecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::destroySecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DestroySecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>disableSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::disableSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\DisableSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>enableSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::enableSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\EnableSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getIamPolicyAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getIamPolicyAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\GetIamPolicyRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>getSecretVersionAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::getSecretVersionAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\GetSecretVersionRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>listSecretVersionsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretVersionsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretVersionsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>listSecretsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::listSecretsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\ListSecretsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>setIamPolicyAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::setIamPolicyAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\SetIamPolicyRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>testIamPermissionsAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::testIamPermissionsAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\TestIamPermissionsRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="" line="0" visibility="public" returnByReference="false">
+    <name>updateSecretAsync</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Client\BaseClient\SecretManagerServiceBaseClient::updateSecretAsync()</full_name>
+    <value/>
+                <argument line="0" by_reference="false">
+    <name>request</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\UpdateSecretRequest</type>
+</argument>
+
+            <argument line="0" by_reference="false">
+    <name>optionalArgs = []</name>
+    <default/>
+    <type>array</type>
+</argument>
+
+        <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="return" description="" type="\GuzzleHttp\Promise\PromiseInterface"/>
+            </docblock>
+
+</method>
+
+                                    </class>
+            
+                        
+            
+            <parse_markers/>
+        </file><file path="V1/Gapic/SecretManagerServiceGapicClient.php" hash="1349337902e29a3e01df4753284e65b6">
+            <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+            </docblock>
+
+
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1\Gapic"/>
+            
+
+            
+                        
+                        
+                                        <class final="false" abstract="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="90">
+                    <name>SecretManagerServiceGapicClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</full_name>
+                    <docblock line="90">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description>Manages secrets and operations using those secrets. Implements a REST
+model with the following objects:
+
+* [Secret][google.cloud.secretmanager.v1.Secret]
+* [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
+
+This class provides the ability to make remote calls to the backing service through method
+calls that map to API methods. Sample code to get started:
+
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```
+
+Many parameters require resource names to be formatted in a particular way. To
+assist with these names, this class includes a format method for each type of
+name, and additionally a parseName method to extract the individual identifiers
+contained within formatted names that are returned by the API.</long-description>
+                    <tag name="package" description="Application"/>
+                        </docblock>
+
+                    
+                    
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="95" visibility="public">
+    <name>SERVICE_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secretmanager.v1.SecretManagerService'</value>
+        <docblock line="95">
+    <description>The name of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="98" visibility="public">
+    <name>SERVICE_ADDRESS</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+        <docblock line="98">
+    <description>The default address of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="101" visibility="public">
+    <name>DEFAULT_SERVICE_PORT</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::DEFAULT_SERVICE_PORT</full_name>
+    <value>443</value>
+        <docblock line="101">
+    <description>The default port of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="104" visibility="public">
+    <name>CODEGEN_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+        <docblock line="104">
+    <description>The name of the code generator, to be included in the agent header.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                        
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="107" visibility="public">
+    <name>serviceScopes</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+        <docblock line="107">
+    <description>The default scopes required by the service.</description>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="111" visibility="private">
+    <name>projectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$projectNameTemplate</full_name>
+    <default/>
+        <docblock line="111">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="113" visibility="private">
+    <name>secretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$secretNameTemplate</full_name>
+    <default/>
+        <docblock line="113">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="115" visibility="private">
+    <name>secretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$secretVersionNameTemplate</full_name>
+    <default/>
+        <docblock line="115">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="117" visibility="private">
+    <name>pathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$pathTemplateMap</full_name>
+    <default/>
+        <docblock line="117">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                        
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="119" visibility="private" returnByReference="false">
+    <name>getClientDefaults</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getClientDefaults()</full_name>
+    <value/>
+            <docblock line="119">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="138" visibility="private" returnByReference="false">
+    <name>getProjectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getProjectNameTemplate()</full_name>
+    <value/>
+            <docblock line="138">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="147" visibility="private" returnByReference="false">
+    <name>getSecretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretNameTemplate()</full_name>
+    <value/>
+            <docblock line="147">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="156" visibility="private" returnByReference="false">
+    <name>getSecretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretVersionNameTemplate()</full_name>
+    <value/>
+            <docblock line="156">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="165" visibility="private" returnByReference="false">
+    <name>getPathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getPathTemplateMap()</full_name>
+    <value/>
+            <docblock line="165">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="186" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::projectName()</full_name>
+    <value/>
+                <argument line="186" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="186">
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="202" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::secretName()</full_name>
+    <value/>
+                <argument line="202" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="202" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="202">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="220" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::secretVersionName()</full_name>
+    <value/>
+                <argument line="220" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="220" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="220" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="220">
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="250" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::parseName()</full_name>
+    <value/>
+                <argument line="250" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="250" by_reference="false">
+    <name>template</name>
+    <default>null</default>
+    <type>string</type>
+</argument>
+
+        <docblock line="250">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="326" visibility="public" returnByReference="false">
+    <name>__construct</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::__construct()</full_name>
+    <value/>
+                <argument line="326" by_reference="false">
+    <name>options</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="326">
+    <description>Constructor.</description>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="367" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::accessSecretVersion()</full_name>
+    <value/>
+                <argument line="367" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="367" by_reference="false">
     <name>optionalArgs</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="311">
-    <description>Run asynchronous image detection and annotation for a list of generic
-files, such as PDF files, which may contain multiple pages and multiple
-images per page. Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.</description>
-    <long-description>`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+        <docblock line="367">
+    <description>Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
 Sample code:
 ```
-$imageAnnotatorClient = new ImageAnnotatorClient();
+$secretManagerServiceClient = new SecretManagerServiceClient();
 try {
-    $requests = [];
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationResponse-&gt;pollUntilComplete();
-    if ($operationResponse-&gt;operationSucceeded()) {
-        $result = $operationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $operationResponse-&gt;getError();
-        // handleError($error)
-    }
-    // Alternatively:
-    // start the operation, keep the operation name, and resume later
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateFiles($requests);
-    $operationName = $operationResponse-&gt;getName();
-    // ... do other work
-    $newOperationResponse = $imageAnnotatorClient-&gt;resumeOperation($operationName, &#039;asyncBatchAnnotateFiles&#039;);
-    while (!$newOperationResponse-&gt;isDone()) {
-        // ... do other work
-        $newOperationResponse-&gt;reload();
-    }
-    if ($newOperationResponse-&gt;operationSucceeded()) {
-        $result = $newOperationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $newOperationResponse-&gt;getError();
-        // handleError($error)
-    }
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
 } finally {
-    $imageAnnotatorClient-&gt;close();
+    $secretManagerServiceClient-&gt;close();
 }
 ```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual async file annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AsyncAnnotateFileRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently&#10;created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="411" visibility="public" returnByReference="false">
-    <name>asyncBatchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::asyncBatchAnnotateImages()</full_name>
-    <value></value>
-                <argument line="411" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateImageRequest[]</type>
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="410" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::addSecretVersion()</full_name>
+    <value/>
+                <argument line="410" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
 </argument>
 
-            <argument line="411" by_reference="false">
-    <name>outputConfig</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\OutputConfig</type>
+            <argument line="410" by_reference="false">
+    <name>payload</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\SecretPayload</type>
 </argument>
 
-            <argument line="411" by_reference="false">
+            <argument line="410" by_reference="false">
     <name>optionalArgs</name>
     <default>[]</default>
     <type>array</type>
 </argument>
 
-        <docblock line="411">
-    <description>Run asynchronous image detection and annotation for a list of images.</description>
-    <long-description>Progress and results can be retrieved through the
-`google.longrunning.Operations` interface.
-`Operation.metadata` contains `OperationMetadata` (metadata).
-`Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
-
-This service will write image annotation outputs to json files in customer
-GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
-
-Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $outputConfig = new OutputConfig();
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateImages($requests, $outputConfig);
-    $operationResponse-&gt;pollUntilComplete();
-    if ($operationResponse-&gt;operationSucceeded()) {
-        $result = $operationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $operationResponse-&gt;getError();
-        // handleError($error)
-    }
-    // Alternatively:
-    // start the operation, keep the operation name, and resume later
-    $operationResponse = $imageAnnotatorClient-&gt;asyncBatchAnnotateImages($requests, $outputConfig);
-    $operationName = $operationResponse-&gt;getName();
-    // ... do other work
-    $newOperationResponse = $imageAnnotatorClient-&gt;resumeOperation($operationName, &#039;asyncBatchAnnotateImages&#039;);
-    while (!$newOperationResponse-&gt;isDone()) {
-        // ... do other work
-        $newOperationResponse-&gt;reload();
-    }
-    if ($newOperationResponse-&gt;operationSucceeded()) {
-        $result = $newOperationResponse-&gt;getResult();
-    // doSomethingWith($result)
-    } else {
-        $error = $newOperationResponse-&gt;getError();
-        // handleError($error)
-    }
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual image annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateImageRequest[]"/>
-                <tag
-                name="param"
-                description="Required. The desired output location and metadata (e.g. format)."
-                                                                 variable="outputConfig"                                 type="\Google\Cloud\Vision\V1\OutputConfig"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\ApiCore\OperationResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="487" visibility="public" returnByReference="false">
-    <name>batchAnnotateFiles</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::batchAnnotateFiles()</full_name>
-    <value></value>
-                <argument line="487" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateFileRequest[]</type>
-</argument>
-
-            <argument line="487" by_reference="false">
-    <name>optionalArgs</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="487">
-    <description>Service that performs image detection and annotation for a batch of files.</description>
-    <long-description>Now only &quot;application/pdf&quot;, &quot;image/tiff&quot; and &quot;image/gif&quot; are supported.
-
-This service will extract at most 5 (customers can specify which 5 in
-AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
-file provided and perform detection and annotation for each image
-extracted.
-
-Sample code:
-```
-$imageAnnotatorClient = new ImageAnnotatorClient();
-try {
-    $requests = [];
-    $response = $imageAnnotatorClient-&gt;batchAnnotateFiles($requests);
-} finally {
-    $imageAnnotatorClient-&gt;close();
-}
-```</long-description>
-                    <tag
-                name="param"
-                description="Required. The list of file annotation requests. Right now we support only one&#10;AnnotateFileRequest in BatchAnnotateFilesRequest."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateFileRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateFilesResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
-                        </docblock>
-
-</method>
-
-                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\Vision\V1\Gapic" line="552" visibility="public" returnByReference="false">
-    <name>batchAnnotateImages</name>
-    <full_name>\Google\Cloud\Vision\V1\Gapic\ImageAnnotatorGapicClient::batchAnnotateImages()</full_name>
-    <value></value>
-                <argument line="552" by_reference="false">
-    <name>requests</name>
-    <default></default>
-    <type>\Google\Cloud\Vision\V1\AnnotateImageRequest[]</type>
-</argument>
-
-            <argument line="552" by_reference="false">
-    <name>optionalArgs</name>
-    <default>[]</default>
-    <type>array</type>
-</argument>
-
-        <docblock line="552">
-    <description>Run image detection and annotation for a batch of images.</description>
+        <docblock line="410">
+    <description>Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
     <long-description>Sample code:
 ```
-$imageAnnotatorClient = new ImageAnnotatorClient();
+$secretManagerServiceClient = new SecretManagerServiceClient();
 try {
-    $requests = [];
-    $response = $imageAnnotatorClient-&gt;batchAnnotateImages($requests);
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $payload = new SecretPayload();
+    $response = $secretManagerServiceClient-&gt;addSecretVersion($formattedParent, $payload);
 } finally {
-    $imageAnnotatorClient-&gt;close();
+    $secretManagerServiceClient-&gt;close();
 }
 ```</long-description>
-                    <tag
-                name="param"
-                description="Required. Individual image annotation requests for this batch."
-                                                                 variable="requests"                                 type="\Google\Cloud\Vision\V1\AnnotateImageRequest[]"/>
-                <tag
-                name="param"
-                description="{&#10;    Optional.&#10;&#10;    @type string $parent&#10;          Optional. Target project and location to make a call.&#10;&#10;          Format: `projects/{project-id}/locations/{location-id}`.&#10;&#10;          If no parent is specified, a region will be chosen automatically.&#10;&#10;          Supported location-ids:&#10;          `us`: USA country only,&#10;          `asia`: East asia areas, like Japan, Taiwan,&#10;          `eu`: The European Union.&#10;&#10;          Example: `projects/project-A/locations/eu`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}"
-                                                                 variable="optionalArgs"                                 type="array"/>
-                            <tag
-                name="return"
-                description=""
-                                                                                                 type="\Google\Cloud\Vision\V1\BatchAnnotateImagesResponse"/>
-                            <tag
-                name="throws"
-                description="if the remote call fails"
-                                                                                                 type="\Google\ApiCore\ApiException"/>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] to associate with the&#10;[SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format `projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. The secret payload of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="payload" type="\Google\Cloud\SecretManager\V1\SecretPayload"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="459" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::createSecret()</full_name>
+    <value/>
+                <argument line="459" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>secretId</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\Secret</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="459">
+    <description>Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    $secretId = 'secret_id';
+    $secret = new Secret();
+    $response = $secretManagerServiceClient-&gt;createSecret($formattedParent, $secretId, $secret);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project to associate with the&#10;[Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. This must be unique within the project.&#10;&#10;A secret ID is a string with a maximum length of 255 characters and can&#10;contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and&#10;underscore (`_`) characters." variable="secretId" type="string"/>
+                <tag name="param" description="Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial field values." variable="secret" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="503" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::deleteSecret()</full_name>
+    <value/>
+                <argument line="503" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="503" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="503">
+    <description>Deletes a [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $secretManagerServiceClient-&gt;deleteSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format&#10;`projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [Secret][google.cloud.secretmanager.v1.Secret]. The request succeeds if it matches&#10;          the etag of the currently stored secret object. If the etag is omitted,&#10;          the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="555" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::destroySecretVersion()</full_name>
+    <value/>
+                <argument line="555" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="555" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="555">
+    <description>Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;destroySecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="606" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::disableSecretVersion()</full_name>
+    <value/>
+                <argument line="606" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="606" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="606">
+    <description>Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;disableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="657" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::enableSecretVersion()</full_name>
+    <value/>
+                <argument line="657" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="657" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="657">
+    <description>Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;enableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="705" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getIamPolicy()</full_name>
+    <value/>
+                <argument line="705" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="705" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="705">
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $response = $secretManagerServiceClient-&gt;getIamPolicy($resource);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type GetPolicyOptions $options&#10;          OPTIONAL: A `GetPolicyOptions` object for specifying options to&#10;          `GetIamPolicy`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="748" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecret()</full_name>
+    <value/>
+                <argument line="748" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="748" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="748">
+    <description>Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $response = $secretManagerServiceClient-&gt;getSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="794" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretVersion()</full_name>
+    <value/>
+                <argument line="794" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="794" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="794">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;getSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently&#10;created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="863" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::listSecretVersions()</full_name>
+    <value/>
+                <argument line="863" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="863" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="863">
+    <description>Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] associated with the&#10;[SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in the format&#10;`projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type string $filter&#10;          Optional. Filter string, adhering to the rules in&#10;          [List-operation&#10;          filtering](https://cloud.google.com/secret-manager/docs/filtering). List&#10;          only secret versions matching the filter. If filter is empty, all secret&#10;          versions are listed.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="942" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::listSecrets()</full_name>
+    <value/>
+                <argument line="942" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="942" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="942">
+    <description>Lists [Secrets][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project associated with the&#10;[Secrets][google.cloud.secretmanager.v1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type string $filter&#10;          Optional. Filter string, adhering to the rules in&#10;          [List-operation&#10;          filtering](https://cloud.google.com/secret-manager/docs/filtering). List&#10;          only secrets matching the filter. If filter is empty, all secrets are&#10;          listed.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1009" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::setIamPolicy()</full_name>
+    <value/>
+                <argument line="1009" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1009" by_reference="false">
+    <name>policy</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\Policy</type>
+</argument>
+
+            <argument line="1009" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1009">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secretmanager.v1.Secret].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $policy = new Policy();
+    $response = $secretManagerServiceClient-&gt;setIamPolicy($resource, $policy);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being specified.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="REQUIRED: The complete policy to be applied to the `resource`. The size of&#10;the policy is limited to a few 10s of KB. An empty policy is a&#10;valid policy but certain Cloud Platform services (such as Projects)&#10;might reject them." variable="policy" type="\Google\Cloud\Iam\V1\Policy"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type FieldMask $updateMask&#10;          OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only&#10;          the fields in the mask will be modified. If no mask is provided, the&#10;          following default mask is used:&#10;&#10;          `paths: &quot;bindings, etag&quot;`&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1065" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::testIamPermissions()</full_name>
+    <value/>
+                <argument line="1065" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1065" by_reference="false">
+    <name>permissions</name>
+    <default/>
+    <type>string[]</type>
+</argument>
+
+            <argument line="1065" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1065">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
+
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $permissions = [];
+    $response = $secretManagerServiceClient-&gt;testIamPermissions($resource, $permissions);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy detail is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="The set of permissions to check for the `resource`. Permissions with&#10;wildcards (such as '*' or 'storage.*') are not allowed. For more&#10;information see&#10;[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)." variable="permissions" type="string[]"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1107" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::updateSecret()</full_name>
+    <value/>
+                <argument line="1107" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\Secret</type>
+</argument>
+
+            <argument line="1107" by_reference="false">
+    <name>updateMask</name>
+    <default/>
+    <type>\Google\Protobuf\FieldMask</type>
+</argument>
+
+            <argument line="1107" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1107">
+    <description>Updates metadata of an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $secret = new Secret();
+    $updateMask = new FieldMask();
+    $response = $secretManagerServiceClient-&gt;updateSecret($secret, $updateMask);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. [Secret][google.cloud.secretmanager.v1.Secret] with updated field values." variable="secret" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                <tag name="param" description="Required. Specifies the fields to be updated." variable="updateMask" type="\Google\Protobuf\FieldMask"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                                                            </class>
+            
+                        
+            
+            <parse_markers/>
+        </file><file path="V1/SecretManagerServiceClient.php" hash="a19b7b01b849739b559b46e07914fccd">
+            <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+            </docblock>
+
+
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1"/>
+            
+
+            
+                        
+                        
+                                        <class final="false" abstract="false" namespace="\Google\Cloud\SecretManager\V1" line="30">
+                    <name>SecretManagerServiceClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1\SecretManagerServiceClient</full_name>
+                    <docblock line="30">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+                        </docblock>
+
+                                            <extends>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</extends> 
+                    
+                                                                <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="95" visibility="public">
+    <name>SERVICE_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secretmanager.v1.SecretManagerService'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="95">
+    <description>The name of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="98" visibility="public">
+    <name>SERVICE_ADDRESS</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="98">
+    <description>The default address of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="101" visibility="public">
+    <name>DEFAULT_SERVICE_PORT</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::DEFAULT_SERVICE_PORT</full_name>
+    <value>443</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="101">
+    <description>The default port of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="104" visibility="public">
+    <name>CODEGEN_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="104">
+    <description>The name of the code generator, to be included in the agent header.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                    
+                                                                <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="107" visibility="public">
+    <name>serviceScopes</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="107">
+    <description>The default scopes required by the service.</description>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="111" visibility="private">
+    <name>projectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$projectNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="111">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="113" visibility="private">
+    <name>secretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$secretNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="113">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="115" visibility="private">
+    <name>secretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$secretVersionNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="115">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient" line="117" visibility="private">
+    <name>pathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::$pathTemplateMap</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="117">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                    
+                                                                <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="119" visibility="private" returnByReference="false">
+    <name>getClientDefaults</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getClientDefaults()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="119">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="138" visibility="private" returnByReference="false">
+    <name>getProjectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getProjectNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="138">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="147" visibility="private" returnByReference="false">
+    <name>getSecretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="147">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="156" visibility="private" returnByReference="false">
+    <name>getSecretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretVersionNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="156">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="165" visibility="private" returnByReference="false">
+    <name>getPathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getPathTemplateMap()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="165">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="186" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::projectName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="186" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="186">
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="202" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::secretName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="202" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="202" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="202">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="220" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::secretVersionName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="220" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="220" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="220" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="220">
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="250" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::parseName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="250" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="250" by_reference="false">
+    <name>template</name>
+    <default>null</default>
+    <type>string</type>
+</argument>
+
+        <docblock line="250">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="326" visibility="public" returnByReference="false">
+    <name>__construct</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::__construct()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="326" by_reference="false">
+    <name>options</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="326">
+    <description>Constructor.</description>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="367" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::accessSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="367" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="367" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="367">
+    <description>Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently&#10;created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="410" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::addSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="410" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="410" by_reference="false">
+    <name>payload</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\SecretPayload</type>
+</argument>
+
+            <argument line="410" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="410">
+    <description>Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $payload = new SecretPayload();
+    $response = $secretManagerServiceClient-&gt;addSecretVersion($formattedParent, $payload);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] to associate with the&#10;[SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format `projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. The secret payload of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="payload" type="\Google\Cloud\SecretManager\V1\SecretPayload"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="459" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::createSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="459" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>secretId</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\Secret</type>
+</argument>
+
+            <argument line="459" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="459">
+    <description>Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    $secretId = 'secret_id';
+    $secret = new Secret();
+    $response = $secretManagerServiceClient-&gt;createSecret($formattedParent, $secretId, $secret);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project to associate with the&#10;[Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. This must be unique within the project.&#10;&#10;A secret ID is a string with a maximum length of 255 characters and can&#10;contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and&#10;underscore (`_`) characters." variable="secretId" type="string"/>
+                <tag name="param" description="Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial field values." variable="secret" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="503" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::deleteSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="503" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="503" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="503">
+    <description>Deletes a [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $secretManagerServiceClient-&gt;deleteSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format&#10;`projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [Secret][google.cloud.secretmanager.v1.Secret]. The request succeeds if it matches&#10;          the etag of the currently stored secret object. If the etag is omitted,&#10;          the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="555" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::destroySecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="555" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="555" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="555">
+    <description>Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;destroySecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="606" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::disableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="606" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="606" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="606">
+    <description>Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;disableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="657" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::enableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="657" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="657" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="657">
+    <description>Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+[ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;enableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type string $etag&#10;          Optional. Etag of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches&#10;          the etag of the currently stored secret version object. If the etag is&#10;          omitted, the request succeeds.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="705" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="705" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="705" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="705">
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $response = $secretManagerServiceClient-&gt;getIamPolicy($resource);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type GetPolicyOptions $options&#10;          OPTIONAL: A `GetPolicyOptions` object for specifying options to&#10;          `GetIamPolicy`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="748" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="748" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="748" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="748">
+    <description>Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $response = $secretManagerServiceClient-&gt;getSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="794" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::getSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="794" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="794" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="794">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently
+created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;getSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the most recently&#10;created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="863" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::listSecretVersions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="863" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="863" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="863">
+    <description>Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secretmanager.v1.Secret] associated with the&#10;[SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in the format&#10;`projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type string $filter&#10;          Optional. Filter string, adhering to the rules in&#10;          [List-operation&#10;          filtering](https://cloud.google.com/secret-manager/docs/filtering). List&#10;          only secret versions matching the filter. If filter is empty, all secret&#10;          versions are listed.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="942" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::listSecrets()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="942" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="942" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="942">
+    <description>Lists [Secrets][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project associated with the&#10;[Secrets][google.cloud.secretmanager.v1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type string $filter&#10;          Optional. Filter string, adhering to the rules in&#10;          [List-operation&#10;          filtering](https://cloud.google.com/secret-manager/docs/filtering). List&#10;          only secrets matching the filter. If filter is empty, all secrets are&#10;          listed.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1009" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::setIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="1009" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1009" by_reference="false">
+    <name>policy</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\Policy</type>
+</argument>
+
+            <argument line="1009" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1009">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secretmanager.v1.Secret].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $policy = new Policy();
+    $response = $secretManagerServiceClient-&gt;setIamPolicy($resource, $policy);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being specified.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="REQUIRED: The complete policy to be applied to the `resource`. The size of&#10;the policy is limited to a few 10s of KB. An empty policy is a&#10;valid policy but certain Cloud Platform services (such as Projects)&#10;might reject them." variable="policy" type="\Google\Cloud\Iam\V1\Policy"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type FieldMask $updateMask&#10;          OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only&#10;          the fields in the mask will be modified. If no mask is provided, the&#10;          following default mask is used:&#10;&#10;          `paths: &quot;bindings, etag&quot;`&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1065" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::testIamPermissions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="1065" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1065" by_reference="false">
+    <name>permissions</name>
+    <default/>
+    <type>string[]</type>
+</argument>
+
+            <argument line="1065" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1065">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
+
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $permissions = [];
+    $response = $secretManagerServiceClient-&gt;testIamPermissions($resource, $permissions);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy detail is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="The set of permissions to check for the `resource`. Permissions with&#10;wildcards (such as '*' or 'storage.*') are not allowed. For more&#10;information see&#10;[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)." variable="permissions" type="string[]"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1\Gapic" line="1107" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient::updateSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="1107" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1\Secret</type>
+</argument>
+
+            <argument line="1107" by_reference="false">
+    <name>updateMask</name>
+    <default/>
+    <type>\Google\Protobuf\FieldMask</type>
+</argument>
+
+            <argument line="1107" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1107">
+    <description>Updates metadata of an existing [Secret][google.cloud.secretmanager.v1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $secret = new Secret();
+    $updateMask = new FieldMask();
+    $response = $secretManagerServiceClient-&gt;updateSecret($secret, $updateMask);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. [Secret][google.cloud.secretmanager.v1.Secret] with updated field values." variable="secret" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                <tag name="param" description="Required. Specifies the fields to be updated." variable="updateMask" type="\Google\Protobuf\FieldMask"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
                         </docblock>
 
 </method>
 
                                                         </class>
+            
+                        
+            
+            <parse_markers/>
+        </file><file path="V1beta1/Gapic/SecretManagerServiceGapicClient.php" hash="3851ffb1aa2e686ab4bd40944854f78b">
+            <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+            </docblock>
 
 
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1beta1\Gapic"/>
+            
 
-            <parse_markers></parse_markers>
-        </file>
-            <namespace name="Google" full_name="\Google">
-            <namespace name="Cloud" full_name="\Google\Cloud">
-            <namespace name="Vision" full_name="\Google\Cloud\Vision">
+            
+                        
+                        
+                                        <class final="false" abstract="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="94">
+                    <name>SecretManagerServiceGapicClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</full_name>
+                    <docblock line="94">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description>Manages secrets and operations using those secrets. Implements a REST
+model with the following objects:
 
-            <namespace name="V1" full_name="\Google\Cloud\Vision\V1">
-            <namespace name="Client" full_name="\Google\Cloud\Vision\V1\Client">
-            <namespace name="BaseClient" full_name="\Google\Cloud\Vision\V1\Client\BaseClient" />
+* [Secret][google.cloud.secrets.v1beta1.Secret]
+* [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]
 
-    </namespace>
-    </namespace>
+This class provides the ability to make remote calls to the backing service through method
+calls that map to API methods. Sample code to get started:
 
-    </namespace>
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```
 
-    </namespace>
+Many parameters require resource names to be formatted in a particular way. To
+assist with these names, this class includes a format method for each type of
+name, and additionally a parseName method to extract the individual identifiers
+contained within formatted names that are returned by the API.</long-description>
+                    <tag name="experimental" description=""/>
+                            <tag name="package" description="Application"/>
+                        </docblock>
 
-    </namespace>
+                    
+                    
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="99" visibility="public">
+    <name>SERVICE_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secrets.v1beta1.SecretManagerService'</value>
+        <docblock line="99">
+    <description>The name of the service.</description>
+    <long-description/>
+                            </docblock>
 
-    </project>
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="102" visibility="public">
+    <name>SERVICE_ADDRESS</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+        <docblock line="102">
+    <description>The default address of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="105" visibility="public">
+    <name>DEFAULT_SERVICE_PORT</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::DEFAULT_SERVICE_PORT</full_name>
+    <value>443</value>
+        <docblock line="105">
+    <description>The default port of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="108" visibility="public">
+    <name>CODEGEN_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+        <docblock line="108">
+    <description>The name of the code generator, to be included in the agent header.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                        
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="111" visibility="public">
+    <name>serviceScopes</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+        <docblock line="111">
+    <description>The default scopes required by the service.</description>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="115" visibility="private">
+    <name>projectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$projectNameTemplate</full_name>
+    <default/>
+        <docblock line="115">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="117" visibility="private">
+    <name>secretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$secretNameTemplate</full_name>
+    <default/>
+        <docblock line="117">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="119" visibility="private">
+    <name>secretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$secretVersionNameTemplate</full_name>
+    <default/>
+        <docblock line="119">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="121" visibility="private">
+    <name>pathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$pathTemplateMap</full_name>
+    <default/>
+        <docblock line="121">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                        
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="123" visibility="private" returnByReference="false">
+    <name>getClientDefaults</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getClientDefaults()</full_name>
+    <value/>
+            <docblock line="123">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="142" visibility="private" returnByReference="false">
+    <name>getProjectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getProjectNameTemplate()</full_name>
+    <value/>
+            <docblock line="142">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="151" visibility="private" returnByReference="false">
+    <name>getSecretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretNameTemplate()</full_name>
+    <value/>
+            <docblock line="151">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="160" visibility="private" returnByReference="false">
+    <name>getSecretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretVersionNameTemplate()</full_name>
+    <value/>
+            <docblock line="160">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="169" visibility="private" returnByReference="false">
+    <name>getPathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getPathTemplateMap()</full_name>
+    <value/>
+            <docblock line="169">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="192" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::projectName()</full_name>
+    <value/>
+                <argument line="192" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="192">
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="210" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::secretName()</full_name>
+    <value/>
+                <argument line="210" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="210" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="210">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="230" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::secretVersionName()</full_name>
+    <value/>
+                <argument line="230" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="230" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="230" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="230">
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="262" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::parseName()</full_name>
+    <value/>
+                <argument line="262" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="262" by_reference="false">
+    <name>template</name>
+    <default>null</default>
+    <type>string</type>
+</argument>
+
+        <docblock line="262">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="340" visibility="public" returnByReference="false">
+    <name>__construct</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::__construct()</full_name>
+    <value/>
+                <argument line="340" by_reference="false">
+    <name>options</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="340">
+    <description>Constructor.</description>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="380" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::accessSecretVersion()</full_name>
+    <value/>
+                <argument line="380" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="380" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="380">
+    <description>Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`
+[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="425" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::addSecretVersion()</full_name>
+    <value/>
+                <argument line="425" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="425" by_reference="false">
+    <name>payload</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\SecretPayload</type>
+</argument>
+
+            <argument line="425" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="425">
+    <description>Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $payload = new SecretPayload();
+    $response = $secretManagerServiceClient-&gt;addSecretVersion($formattedParent, $payload);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the&#10;[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]." variable="payload" type="\Google\Cloud\SecretManager\V1beta1\SecretPayload"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="476" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::createSecret()</full_name>
+    <value/>
+                <argument line="476" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>secretId</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\Secret</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="476">
+    <description>Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    $secretId = 'secret_id';
+    $secret = new Secret();
+    $response = $secretManagerServiceClient-&gt;createSecret($formattedParent, $secretId, $secret);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project to associate with the&#10;[Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. This must be unique within the project.&#10;&#10;A secret ID is a string with a maximum length of 255 characters and can&#10;contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and&#10;underscore (`_`) characters." variable="secretId" type="string"/>
+                <tag name="param" description="Required. A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values." variable="secret" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="518" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::deleteSecret()</full_name>
+    <value/>
+                <argument line="518" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="518" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="518">
+    <description>Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $secretManagerServiceClient-&gt;deleteSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format&#10;`projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="564" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::destroySecretVersion()</full_name>
+    <value/>
+                <argument line="564" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="564" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="564">
+    <description>Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;destroySecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="609" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::disableSecretVersion()</full_name>
+    <value/>
+                <argument line="609" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="609" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="609">
+    <description>Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;disableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="654" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::enableSecretVersion()</full_name>
+    <value/>
+                <argument line="654" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="654" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="654">
+    <description>Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;enableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="700" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getIamPolicy()</full_name>
+    <value/>
+                <argument line="700" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="700" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="700">
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $response = $secretManagerServiceClient-&gt;getIamPolicy($resource);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type GetPolicyOptions $options&#10;          OPTIONAL: A `GetPolicyOptions` object for specifying options to&#10;          `GetIamPolicy`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="745" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecret()</full_name>
+    <value/>
+                <argument line="745" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="745" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="745">
+    <description>Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $response = $secretManagerServiceClient-&gt;getSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="792" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretVersion()</full_name>
+    <value/>
+                <argument line="792" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="792" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="792">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`
+[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;getSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`&#10;[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="857" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::listSecretVersions()</full_name>
+    <value/>
+                <argument line="857" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="857" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="857">
+    <description>Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the&#10;[SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format&#10;`projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="928" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::listSecrets()</full_name>
+    <value/>
+                <argument line="928" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="928" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="928">
+    <description>Lists [Secrets][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project associated with the&#10;[Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="993" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::setIamPolicy()</full_name>
+    <value/>
+                <argument line="993" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="993" by_reference="false">
+    <name>policy</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\Policy</type>
+</argument>
+
+            <argument line="993" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="993">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $policy = new Policy();
+    $response = $secretManagerServiceClient-&gt;setIamPolicy($resource, $policy);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being specified.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="REQUIRED: The complete policy to be applied to the `resource`. The size of&#10;the policy is limited to a few 10s of KB. An empty policy is a&#10;valid policy but certain Cloud Platform services (such as Projects)&#10;might reject them." variable="policy" type="\Google\Cloud\Iam\V1\Policy"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type FieldMask $updateMask&#10;          OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only&#10;          the fields in the mask will be modified. If no mask is provided, the&#10;          following default mask is used:&#10;&#10;          `paths: &quot;bindings, etag&quot;`&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="1051" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::testIamPermissions()</full_name>
+    <value/>
+                <argument line="1051" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1051" by_reference="false">
+    <name>permissions</name>
+    <default/>
+    <type>string[]</type>
+</argument>
+
+            <argument line="1051" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1051">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
+
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $permissions = [];
+    $response = $secretManagerServiceClient-&gt;testIamPermissions($resource, $permissions);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy detail is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="The set of permissions to check for the `resource`. Permissions with&#10;wildcards (such as '*' or 'storage.*') are not allowed. For more&#10;information see&#10;[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)." variable="permissions" type="string[]"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="1095" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::updateSecret()</full_name>
+    <value/>
+                <argument line="1095" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\Secret</type>
+</argument>
+
+            <argument line="1095" by_reference="false">
+    <name>updateMask</name>
+    <default/>
+    <type>\Google\Protobuf\FieldMask</type>
+</argument>
+
+            <argument line="1095" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1095">
+    <description>Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $secret = new Secret();
+    $updateMask = new FieldMask();
+    $response = $secretManagerServiceClient-&gt;updateSecret($secret, $updateMask);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values." variable="secret" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                <tag name="param" description="Required. Specifies the fields to be updated." variable="updateMask" type="\Google\Protobuf\FieldMask"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                                                            </class>
+            
+                        
+            
+            <parse_markers/>
+        </file><file path="V1beta1/SecretManagerServiceClient.php" hash="839aafc2834fc9aeb541bb591dca7631">
+            <docblock line="0">
+    <description/>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+            </docblock>
+
+
+            
+                            <namespace-alias name="\Google\Cloud\SecretManager\V1beta1"/>
+            
+
+            
+                        
+                        
+                                        <class final="false" abstract="false" namespace="\Google\Cloud\SecretManager\V1beta1" line="32">
+                    <name>SecretManagerServiceClient</name>
+                    <full_name>\Google\Cloud\SecretManager\V1beta1\SecretManagerServiceClient</full_name>
+                    <docblock line="32">
+    <description>Service Description: Secret Manager Service</description>
+    <long-description/>
+                    <tag name="package" description="Application"/>
+                        </docblock>
+
+                                            <extends>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</extends> 
+                    
+                                                                <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="99" visibility="public">
+    <name>SERVICE_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::SERVICE_NAME</full_name>
+    <value>'google.cloud.secrets.v1beta1.SecretManagerService'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="99">
+    <description>The name of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="102" visibility="public">
+    <name>SERVICE_ADDRESS</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::SERVICE_ADDRESS</full_name>
+    <value>'secretmanager.googleapis.com'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="102">
+    <description>The default address of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="105" visibility="public">
+    <name>DEFAULT_SERVICE_PORT</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::DEFAULT_SERVICE_PORT</full_name>
+    <value>443</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="105">
+    <description>The default port of the service.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                                            <constant namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="108" visibility="public">
+    <name>CODEGEN_NAME</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::CODEGEN_NAME</full_name>
+    <value>'gapic'</value>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="108">
+    <description>The name of the code generator, to be included in the agent header.</description>
+    <long-description/>
+                            </docblock>
+
+</constant>
+
+                    
+                                                                <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="111" visibility="public">
+    <name>serviceScopes</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$serviceScopes</full_name>
+    <default>['https://www.googleapis.com/auth/cloud-platform']</default>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="111">
+    <description>The default scopes required by the service.</description>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="115" visibility="private">
+    <name>projectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$projectNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="115">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="117" visibility="private">
+    <name>secretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$secretNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="117">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="119" visibility="private">
+    <name>secretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$secretVersionNameTemplate</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="119">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                                            <property namespace="\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient" line="121" visibility="private">
+    <name>pathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::$pathTemplateMap</full_name>
+    <default/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>    <docblock line="121">
+    <description/>
+    <long-description/>
+                            </docblock>
+
+</property>
+
+                    
+                                                                <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="123" visibility="private" returnByReference="false">
+    <name>getClientDefaults</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getClientDefaults()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="123">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="142" visibility="private" returnByReference="false">
+    <name>getProjectNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getProjectNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="142">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="151" visibility="private" returnByReference="false">
+    <name>getSecretNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="151">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="160" visibility="private" returnByReference="false">
+    <name>getSecretVersionNameTemplate</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretVersionNameTemplate()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="160">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="169" visibility="private" returnByReference="false">
+    <name>getPathTemplateMap</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getPathTemplateMap()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>        <docblock line="169">
+    <description/>
+    <long-description/>
+                </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="192" visibility="public" returnByReference="false">
+    <name>projectName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::projectName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="192" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="192">
+    <description>Formats a string containing the fully-qualified path to represent a project
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                            <tag name="return" description="The formatted project resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="210" visibility="public" returnByReference="false">
+    <name>secretName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::secretName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="210" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="210" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="210">
+    <description>Formats a string containing the fully-qualified path to represent a secret
+resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                            <tag name="return" description="The formatted secret resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="230" visibility="public" returnByReference="false">
+    <name>secretVersionName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::secretVersionName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="230" by_reference="false">
+    <name>project</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="230" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="230" by_reference="false">
+    <name>secretVersion</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+        <docblock line="230">
+    <description>Formats a string containing the fully-qualified path to represent a
+secret_version resource.</description>
+    <long-description/>
+                    <tag name="param" description="" variable="project" type="string"/>
+                <tag name="param" description="" variable="secret" type="string"/>
+                <tag name="param" description="" variable="secretVersion" type="string"/>
+                            <tag name="return" description="The formatted secret_version resource." type="string"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="true" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="262" visibility="public" returnByReference="false">
+    <name>parseName</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::parseName()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="262" by_reference="false">
+    <name>formattedName</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="262" by_reference="false">
+    <name>template</name>
+    <default>null</default>
+    <type>string</type>
+</argument>
+
+        <docblock line="262">
+    <description>Parses a formatted name string and returns an associative array of the components in the name.</description>
+    <long-description>The following name formats are supported:
+Template: Pattern
+- project: projects/{project}
+- secret: projects/{project}/secrets/{secret}
+- secretVersion: projects/{project}/secrets/{secret}/versions/{secret_version}
+
+The optional $template argument can be supplied to specify a particular pattern,
+and must match one of the templates listed above. If no $template argument is
+provided, or if the $template argument does not match one of the templates
+listed, then parseName will check each of the supported templates, and return
+the first match.</long-description>
+                    <tag name="param" description="The formatted name string" variable="formattedName" type="string"/>
+                <tag name="param" description="Optional name of template to match" variable="template" type="string"/>
+                            <tag name="return" description="An associative array from name component IDs to component values." type="array"/>
+                            <tag name="throws" description="If $formattedName could not be matched." type="\Google\ApiCore\ValidationException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="340" visibility="public" returnByReference="false">
+    <name>__construct</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::__construct()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="340" by_reference="false">
+    <name>options</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="340">
+    <description>Constructor.</description>
+    <long-description/>
+                    <tag name="param" description="{&#10;    Optional. Options for configuring the service API wrapper.&#10;&#10;    @type string $apiEndpoint&#10;          The address of the API remote host. May optionally include the port, formatted&#10;          as &quot;&lt;uri&gt;:&lt;port&gt;&quot;. Default 'secretmanager.googleapis.com:443'.&#10;    @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials&#10;          The credentials to be used by the client to authorize API calls. This option&#10;          accepts either a path to a credentials file, or a decoded credentials file as a&#10;          PHP array.&#10;          *Advanced usage*: In addition, this option can also accept a pre-constructed&#10;          {@see \Google\Auth\FetchAuthTokenInterface} object or&#10;          {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these&#10;          objects are provided, any settings in $credentialsConfig will be ignored.&#10;    @type array $credentialsConfig&#10;          Options used to configure credentials, including auth token caching, for the&#10;          client. For a full list of supporting configuration options, see&#10;          {@see \Google\ApiCore\CredentialsWrapper::build()} .&#10;    @type bool $disableRetries&#10;          Determines whether or not retries defined by the client configuration should be&#10;          disabled. Defaults to `false`.&#10;    @type string|array $clientConfig&#10;          Client method configuration, including retry settings. This option can be either&#10;          a path to a JSON file, or a PHP array containing the decoded JSON data. By&#10;          default this settings points to the default client config file, which is&#10;          provided in the resources folder.&#10;    @type string|TransportInterface $transport&#10;          The transport used for executing network requests. May be either the string&#10;          `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.&#10;          *Advanced usage*: Additionally, it is possible to pass in an already&#10;          instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note&#10;          that when this object is provided, any settings in $transportConfig, and any&#10;          $apiEndpoint setting, will be ignored.&#10;    @type array $transportConfig&#10;          Configuration options that will be used to construct the transport. Options for&#10;          each supported transport type should be passed in a key for that transport. For&#10;          example:&#10;          $transportConfig = [&#10;              'grpc' =&gt; [...],&#10;              'rest' =&gt; [...],&#10;          ];&#10;          See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and&#10;          {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the&#10;          supported options.&#10;    @type callable $clientCertSource&#10;          A callable which returns the client cert as a string. This can be used to&#10;          provide a certificate and private key to the transport layer for mTLS.&#10;}" variable="options" type="array"/>
+                            <tag name="throws" description="" type="\Google\ApiCore\ValidationException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="380" visibility="public" returnByReference="false">
+    <name>accessSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::accessSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="380" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="380" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="380">
+    <description>Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`
+[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;accessSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\AccessSecretVersionResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="425" visibility="public" returnByReference="false">
+    <name>addSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::addSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="425" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="425" by_reference="false">
+    <name>payload</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\SecretPayload</type>
+</argument>
+
+            <argument line="425" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="425">
+    <description>Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
+it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $payload = new SecretPayload();
+    $response = $secretManagerServiceClient-&gt;addSecretVersion($formattedParent, $payload);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the&#10;[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]." variable="payload" type="\Google\Cloud\SecretManager\V1beta1\SecretPayload"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="476" visibility="public" returnByReference="false">
+    <name>createSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::createSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="476" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>secretId</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\Secret</type>
+</argument>
+
+            <argument line="476" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="476">
+    <description>Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    $secretId = 'secret_id';
+    $secret = new Secret();
+    $response = $secretManagerServiceClient-&gt;createSecret($formattedParent, $secretId, $secret);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project to associate with the&#10;[Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="Required. This must be unique within the project.&#10;&#10;A secret ID is a string with a maximum length of 255 characters and can&#10;contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and&#10;underscore (`_`) characters." variable="secretId" type="string"/>
+                <tag name="param" description="Required. A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values." variable="secret" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="518" visibility="public" returnByReference="false">
+    <name>deleteSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::deleteSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="518" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="518" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="518">
+    <description>Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $secretManagerServiceClient-&gt;deleteSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format&#10;`projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="564" visibility="public" returnByReference="false">
+    <name>destroySecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::destroySecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="564" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="564" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="564">
+    <description>Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+secret data.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;destroySecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="609" visibility="public" returnByReference="false">
+    <name>disableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::disableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="609" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="609" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="609">
+    <description>Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;disableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="654" visibility="public" returnByReference="false">
+    <name>enableSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::enableSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="654" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="654" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="654">
+    <description>Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
+[ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;enableSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="700" visibility="public" returnByReference="false">
+    <name>getIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="700" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="700" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="700">
+    <description>Gets the access control policy for a secret.</description>
+    <long-description>Returns empty policy if the secret exists and does not have a policy set.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $response = $secretManagerServiceClient-&gt;getIamPolicy($resource);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type GetPolicyOptions $options&#10;          OPTIONAL: A `GetPolicyOptions` object for specifying options to&#10;          `GetIamPolicy`.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="745" visibility="public" returnByReference="false">
+    <name>getSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="745" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="745" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="745">
+    <description>Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    $response = $secretManagerServiceClient-&gt;getSecret($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/&amp;#42;/secrets/*`." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="792" visibility="public" returnByReference="false">
+    <name>getSecretVersion</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::getSecretVersion()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="792" by_reference="false">
+    <name>name</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="792" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="792">
+    <description>Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].</description>
+    <long-description>`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`
+[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedName = $secretManagerServiceClient-&gt;secretVersionName('[PROJECT]', '[SECRET]', '[SECRET_VERSION]');
+    $response = $secretManagerServiceClient-&gt;getSecretVersion($formattedName);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/*`.&#10;`projects/&amp;#42;/secrets/&amp;#42;/versions/latest` is an alias to the `latest`&#10;[SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]." variable="name" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\SecretVersion"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="857" visibility="public" returnByReference="false">
+    <name>listSecretVersions</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::listSecretVersions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="857" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="857" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="857">
+    <description>Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+data.</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;secretName('[PROJECT]', '[SECRET]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecretVersions($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the&#10;[SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format&#10;`projects/&amp;#42;/secrets/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="928" visibility="public" returnByReference="false">
+    <name>listSecrets</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::listSecrets()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="928" by_reference="false">
+    <name>parent</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="928" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="928">
+    <description>Lists [Secrets][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $formattedParent = $secretManagerServiceClient-&gt;projectName('[PROJECT]');
+    // Iterate over pages of elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iteratePages() as $page) {
+        foreach ($page as $element) {
+            // doSomethingWith($element);
+        }
+    }
+    // Alternatively:
+    // Iterate through all elements
+    $pagedResponse = $secretManagerServiceClient-&gt;listSecrets($formattedParent);
+    foreach ($pagedResponse-&gt;iterateAllElements() as $element) {
+        // doSomethingWith($element);
+    }
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. The resource name of the project associated with the&#10;[Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`." variable="parent" type="string"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type int $pageSize&#10;          The maximum number of resources contained in the underlying API&#10;          response. The API may return fewer values in a page, even if&#10;          there are additional values to be retrieved.&#10;    @type string $pageToken&#10;          A page token is used to specify a page of values to be returned.&#10;          If no page token is specified (the default), the first page&#10;          of values will be returned. Any page token used here must have&#10;          been generated by a previous call to the API.&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\ApiCore\PagedListResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="993" visibility="public" returnByReference="false">
+    <name>setIamPolicy</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::setIamPolicy()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="993" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="993" by_reference="false">
+    <name>policy</name>
+    <default/>
+    <type>\Google\Cloud\Iam\V1\Policy</type>
+</argument>
+
+            <argument line="993" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="993">
+    <description>Sets the access control policy on the specified secret. Replaces any
+existing policy.</description>
+    <long-description>Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
+to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $policy = new Policy();
+    $response = $secretManagerServiceClient-&gt;setIamPolicy($resource, $policy);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy is being specified.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="REQUIRED: The complete policy to be applied to the `resource`. The size of&#10;the policy is limited to a few 10s of KB. An empty policy is a&#10;valid policy but certain Cloud Platform services (such as Projects)&#10;might reject them." variable="policy" type="\Google\Cloud\Iam\V1\Policy"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type FieldMask $updateMask&#10;          OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only&#10;          the fields in the mask will be modified. If no mask is provided, the&#10;          following default mask is used:&#10;&#10;          `paths: &quot;bindings, etag&quot;`&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\Policy"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="1051" visibility="public" returnByReference="false">
+    <name>testIamPermissions</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::testIamPermissions()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="1051" by_reference="false">
+    <name>resource</name>
+    <default/>
+    <type>string</type>
+</argument>
+
+            <argument line="1051" by_reference="false">
+    <name>permissions</name>
+    <default/>
+    <type>string[]</type>
+</argument>
+
+            <argument line="1051" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1051">
+    <description>Returns permissions that a caller has for the specified secret.</description>
+    <long-description>If the secret does not exist, this call returns an empty set of
+permissions, not a NOT_FOUND error.
+
+Note: This operation is designed to be used for building permission-aware
+UIs and command-line tools, not for authorization checking. This operation
+may "fail open" without warning.
+
+Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $resource = 'resource';
+    $permissions = [];
+    $response = $secretManagerServiceClient-&gt;testIamPermissions($resource, $permissions);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="REQUIRED: The resource for which the policy detail is being requested.&#10;See the operation documentation for the appropriate value for this field." variable="resource" type="string"/>
+                <tag name="param" description="The set of permissions to check for the `resource`. Permissions with&#10;wildcards (such as '*' or 'storage.*') are not allowed. For more&#10;information see&#10;[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)." variable="permissions" type="string[]"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\Iam\V1\TestIamPermissionsResponse"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                            <method final="false" abstract="false" static="false" namespace="\Google\Cloud\SecretManager\V1beta1\Gapic" line="1095" visibility="public" returnByReference="false">
+    <name>updateSecret</name>
+    <full_name>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient::updateSecret()</full_name>
+    <value/>
+    <inherited_from>\Google\Cloud\SecretManager\V1beta1\Gapic\SecretManagerServiceGapicClient</inherited_from>            <argument line="1095" by_reference="false">
+    <name>secret</name>
+    <default/>
+    <type>\Google\Cloud\SecretManager\V1beta1\Secret</type>
+</argument>
+
+            <argument line="1095" by_reference="false">
+    <name>updateMask</name>
+    <default/>
+    <type>\Google\Protobuf\FieldMask</type>
+</argument>
+
+            <argument line="1095" by_reference="false">
+    <name>optionalArgs</name>
+    <default>[]</default>
+    <type>array</type>
+</argument>
+
+        <docblock line="1095">
+    <description>Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].</description>
+    <long-description>Sample code:
+```
+$secretManagerServiceClient = new SecretManagerServiceClient();
+try {
+    $secret = new Secret();
+    $updateMask = new FieldMask();
+    $response = $secretManagerServiceClient-&gt;updateSecret($secret, $updateMask);
+} finally {
+    $secretManagerServiceClient-&gt;close();
+}
+```</long-description>
+                    <tag name="param" description="Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values." variable="secret" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                <tag name="param" description="Required. Specifies the fields to be updated." variable="updateMask" type="\Google\Protobuf\FieldMask"/>
+                <tag name="param" description="{&#10;    Optional.&#10;&#10;    @type RetrySettings|array $retrySettings&#10;          Retry settings to use for this call. Can be a {@see \Google\ApiCore\RetrySettings} object, or an&#10;          associative array of retry settings parameters. See the documentation on&#10;          {@see \Google\ApiCore\RetrySettings} for example usage.&#10;}" variable="optionalArgs" type="array"/>
+                            <tag name="return" description="" type="\Google\Cloud\SecretManager\V1beta1\Secret"/>
+                            <tag name="throws" description="if the remote call fails" type="\Google\ApiCore\ApiException"/>
+                            <tag name="experimental" description=""/>
+                        </docblock>
+
+</method>
+
+                                                        </class>
+            
+                        
+            
+            <parse_markers/>
+        </file></project>


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/6245 by upgrading PHPDoc with changes from https://github.com/phpDocumentor/phpDocumentor/pull/3514
adds missing `Async` magic methods for new clients