### PR TITLE
chore: remove deprecate warnings for prophecy

### DIFF
--- a/Vision/tests/Snippet/V1/ImageAnnotatorClientTest.php
+++ b/Vision/tests/Snippet/V1/ImageAnnotatorClientTest.php
@@ -33,6 +33,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class ImageAnnotatorClientTest extends SnippetTestCase
 {
+    use ProphecyTrait;
+
     /** @var ImageAnnotatorClient */
     private $client;
     private $transport;


### PR DESCRIPTION
Remove php warnings from tests

ref: [Test Log](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fphp%2Fgoogle-cloud-php%2Fcontinuous%2Fphp74/activity/4c895620-48df-48e1-8fd1-ad0d19cbed06/invocations/4c895620-48df-48e1-8fd1-ad0d19cbed06/targets/cloud-devrel%2Fclient-libraries%2Fphp%2Fgoogle-cloud-php%2Fcontinuous%2Fphp74/log)