### PR TITLE
fix: Publish time conversion to timestamp for GRPC

### DIFF
--- a/PubSub/src/Connection/Grpc.php
+++ b/PubSub/src/Connection/Grpc.php
@@ -96,6 +96,9 @@ class Grpc implements ConnectionInterface
         ], [], [], [
             'google.protobuf.Duration' => function ($v) {
                 return $this->transformDuration($v);
+            },
+            'google.protobuf.Timestamp' => function ($v) {
+                return $this->formatTimestampForApi($v);
             }
         ]);
 

--- a/PubSub/tests/Unit/Connection/GrpcTest.php
+++ b/PubSub/tests/Unit/Connection/GrpcTest.php
@@ -249,6 +249,32 @@ class GrpcTest extends TestCase
         $this->sendAndAssert('publishMessage', $args, $expected);
     }
 
+    public function testPublishMessageWithPublishTime()
+    {
+        $messageData = '123';
+        $attributes = ['testing' => 123];
+        $message = new PubsubMessage([
+            'data' => $messageData,
+            'publish_time' => new Timestamp(['seconds' => 1685528173, 'nanos' => 569000000]),
+            'attributes' => $attributes
+        ]);
+
+        $args = [
+            'topic' => $this->topicName,
+            'messages' => [
+                [
+                    'data' => $messageData,
+                    'publishTime' => '2023-05-31T10:16:13.569+00:00',
+                    'attributes' => $attributes
+                ]
+            ]
+        ];
+
+        $expected = [$this->topicName, [$message], []];
+
+        $this->sendAndAssert('publishMessage', $args, $expected);
+    }
+
     public function testListSubscriptionsByTopic()
     {
         $args = ['topic' => $this->topicName] + $this->pageSize;


### PR DESCRIPTION
The serialiser is unaware of type conversion when using the GRPC connection, causing exceptions to be thrown.

This fixes the data conversion process.