### PR TITLE
feat(docs): add namespace (formatted for docfx)

### DIFF
--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -95,6 +95,7 @@ class Page
             'summary' => $this->classNode->getContent(),
             'status' => $this->classNode->getStatus(),
             'type' => 'class',
+            'namespace' => implode(' \ ', explode('\\', ltrim($this->classNode->getNamespace(), '\\'))),
             'langs' => ['php'],
             'implements' => $this->classNode->getImplements(),
         ]);

--- a/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
+++ b/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
@@ -10,6 +10,7 @@ items:
 
       This class is currently experimental and may be subject to changes.
     type: class
+    namespace: 'Google \ Cloud \ SecretManager \ V1 \ Client'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AddProductToProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AddProductToProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AddProductToProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AnnotateFileRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AnnotateFileRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AnnotateFileRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AnnotateFileResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AnnotateFileResponse.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AnnotateFileResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AnnotateImageRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AnnotateImageRequest.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AnnotateImageRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AnnotateImageResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AnnotateImageResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AnnotateImageResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncAnnotateFileRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncAnnotateFileRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncAnnotateFileRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncAnnotateFileResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncAnnotateFileResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncAnnotateFileResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateFilesRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateFilesRequest.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateFilesResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateFilesResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncBatchAnnotateFilesResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateImagesRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateImagesRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateImagesResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.AsyncBatchAnnotateImagesResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.AsyncBatchAnnotateImagesResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateFilesRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateFilesRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BatchAnnotateFilesRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateFilesResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateFilesResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BatchAnnotateFilesResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateImagesRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateImagesRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BatchAnnotateImagesRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateImagesResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchAnnotateImagesResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BatchAnnotateImagesResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.State.yml
@@ -10,6 +10,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.BatchOperationMetadata.State</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ BatchOperationMetadata'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BatchOperationMetadata.yml
@@ -13,6 +13,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BatchOperationMetadata</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Block.BlockType.yml
@@ -10,6 +10,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.Block.BlockType</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ Block'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Block.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Block.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Block</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.BoundingPoly.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.BoundingPoly.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.BoundingPoly</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ColorInfo.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ColorInfo.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ColorInfo</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CreateProductRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CreateProductRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CreateProductRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CreateProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CreateProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CreateProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CreateReferenceImageRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CreateReferenceImageRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CreateReferenceImageRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CropHint.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CropHint.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CropHint</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CropHintsAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CropHintsAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CropHintsAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.CropHintsParams.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.CropHintsParams.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.CropHintsParams</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.DeleteProductRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.DeleteProductRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.DeleteProductRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.DeleteProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.DeleteProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.DeleteProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.DeleteReferenceImageRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.DeleteReferenceImageRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.DeleteReferenceImageRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.DominantColorsAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.DominantColorsAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.DominantColorsAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.EntityAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.EntityAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.EntityAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.Type.yml
@@ -14,6 +14,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.FaceAnnotation.Landmark.Type</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ FaceAnnotation \ Landmark'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.Landmark.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.FaceAnnotation.Landmark</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ FaceAnnotation'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.FaceAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.FaceAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Feature.Type.yml
@@ -10,6 +10,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.Feature.Type</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ Feature'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Feature.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Feature.yml
@@ -12,6 +12,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Feature</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.GcsDestination.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.GcsDestination.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.GcsDestination</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.GcsSource.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.GcsSource.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.GcsSource</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.GetProductRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.GetProductRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.GetProductRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.GetProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.GetProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.GetProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.GetReferenceImageRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.GetReferenceImageRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.GetReferenceImageRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Image.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Image.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Image</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotationContext.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotationContext.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImageAnnotationContext</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
@@ -48,6 +48,7 @@ items:
       }
       ```
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageContext.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageContext.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImageContext</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageProperties.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageProperties.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImageProperties</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageSource.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageSource.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImageSource</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsGcsSource.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsGcsSource.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImportProductSetsGcsSource</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsInputConfig.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsInputConfig.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImportProductSetsInputConfig</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImportProductSetsRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImportProductSetsResponse.yml
@@ -14,6 +14,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ImportProductSetsResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.InputConfig.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.InputConfig.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.InputConfig</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.LatLongRect.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.LatLongRect.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.LatLongRect</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Likelihood.yml
@@ -11,6 +11,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.Likelihood</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductSetsRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductSetsRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductSetsRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductSetsResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductSetsResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductSetsResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductsInProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductsInProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductsInProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductsInProductSetResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductsInProductSetResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductsInProductSetResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductsRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductsRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductsRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListProductsResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListProductsResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListProductsResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListReferenceImagesRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListReferenceImagesRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListReferenceImagesRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ListReferenceImagesResponse.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ListReferenceImagesResponse.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ListReferenceImagesResponse</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.LocalizedObjectAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.LocalizedObjectAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.LocalizedObjectAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.LocationInfo.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.LocationInfo.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.LocationInfo</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.NormalizedVertex.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.NormalizedVertex.yml
@@ -13,6 +13,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.NormalizedVertex</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.State.yml
@@ -10,6 +10,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.OperationMetadata.State</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ OperationMetadata'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.OperationMetadata.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.OperationMetadata</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.OutputConfig.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.OutputConfig.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.OutputConfig</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Page.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Page.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Page</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Paragraph.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Paragraph.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Paragraph</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Position.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Position.yml
@@ -13,6 +13,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Position</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Product.KeyValue.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Product.KeyValue.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Product.KeyValue</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ Product'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Product.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Product.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Product</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchClient.yml
@@ -40,6 +40,7 @@ items:
       name, and additionally a parseName method to extract the individual identifiers
       contained within formatted names that are returned by the API.
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchParams.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchParams.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSearchParams</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.GroupedResult.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.GroupedResult.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSearchResults.GroupedResult</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ ProductSearchResults'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.ObjectAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.ObjectAnnotation.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSearchResults.ObjectAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ ProductSearchResults'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.Result.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.Result.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSearchResults.Result</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ ProductSearchResults'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSearchResults.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSearchResults</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSet.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSet.yml
@@ -12,6 +12,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSet</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ProductSetPurgeConfig.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ProductSetPurgeConfig.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ProductSetPurgeConfig</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Property.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Property.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Property</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.PurgeProductsRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.PurgeProductsRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.PurgeProductsRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.ReferenceImage.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ReferenceImage.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.ReferenceImage</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.RemoveProductFromProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.RemoveProductFromProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.RemoveProductFromProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.SafeSearchAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.SafeSearchAnnotation.yml
@@ -12,6 +12,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.SafeSearchAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Symbol.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Symbol.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Symbol</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.BreakType.yml
@@ -10,6 +10,7 @@ items:
 
       Protobuf type <code>google.cloud.vision.v1.TextAnnotation.DetectedBreak.BreakType</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ TextAnnotation \ DetectedBreak'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedBreak.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.TextAnnotation.DetectedBreak</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ TextAnnotation'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedLanguage.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.DetectedLanguage.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.TextAnnotation.DetectedLanguage</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ TextAnnotation'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.TextProperty.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.TextProperty.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.TextAnnotation.TextProperty</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ TextAnnotation'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextAnnotation.yml
@@ -17,6 +17,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.TextAnnotation</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.TextDetectionParams.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.TextDetectionParams.yml
@@ -11,6 +11,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.TextDetectionParams</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.UpdateProductRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.UpdateProductRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.UpdateProductRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.UpdateProductSetRequest.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.UpdateProductSetRequest.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.UpdateProductSetRequest</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Vertex.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Vertex.yml
@@ -12,6 +12,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Vertex</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebEntity.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebEntity.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetection.WebEntity</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ WebDetection'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebImage.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebImage.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetection.WebImage</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ WebDetection'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebLabel.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebLabel.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetection.WebLabel</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ WebDetection'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebPage.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetection.WebPage.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetection.WebPage</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1 \ WebDetection'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetection.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetection.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetection</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetectionParams.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetectionParams.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.WebDetectionParams</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:

--- a/dev/tests/fixtures/docfx/Vision/V1.Word.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Word.yml
@@ -10,6 +10,7 @@ items:
 
       Generated from protobuf message <code>google.cloud.vision.v1.Word</code>
     type: class
+    namespace: 'Google \ Cloud \ Vision \ V1'
     langs:
       - php
     children:


### PR DESCRIPTION
This is a solution for adding namespaces in https://github.com/googleapis/google-cloud-php/issues/6321, and should look something like:

<img src="https://github.com/googleapis/google-cloud-php/assets/103941/d934f5b6-c443-4721-b9e1-628927c9a00d" width="400" />
