### PR TITLE
fix(docs): newline between link markdown, see tags in parameter descriptions

### DIFF
--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -99,7 +99,7 @@ class MethodNode
             $parameter = new ParameterNode(
                 $parameterName,
                 (string) $parameterNode->type,
-                $this->replaceProtoRef($description)
+                $this->replaceSeeTag($this->replaceProtoRef($description))
             );
 
             $parameters[] = $parameter;

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -87,7 +87,7 @@ trait XrefTrait
     private function replaceProtoRef(string $description): string
     {
         return preg_replace_callback(
-            '/\[([^\]]*?)\]\n?\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
+            '/\[([^\]]*?)\]\s?\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
             function ($matches) {
                 list($link, $name, $package, $class) = $matches;
                 $property = $method = $constant = null;

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -87,7 +87,7 @@ trait XrefTrait
     private function replaceProtoRef(string $description): string
     {
         return preg_replace_callback(
-            '/\[([^\]]*?)\]\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
+            '/\[([^\]]*?)\]\n?\[([a-z1-9\.]*)([a-zA-Z1-9_\.]*)\]/',
             function ($matches) {
                 list($link, $name, $package, $class) = $matches;
                 $property = $method = $constant = null;

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -178,9 +178,18 @@ class NodeTest extends TestCase
             ],
             [
                 // Separation within links using newlines
-                'Required. The [Model\'s]'  . PHP_EOL . '[google.cloud.aiplatform.v1.BatchPredictionJob.model]'
-                . ' [PredictSchemata\'s]'  . PHP_EOL . '[google.cloud.aiplatform.v1.Model.predict_schemata]'
+                'Required. The [Model\'s]' . PHP_EOL . '[google.cloud.aiplatform.v1.BatchPredictionJob.model]'
+                . ' [PredictSchemata\'s]' . PHP_EOL . '[google.cloud.aiplatform.v1.Model.predict_schemata]'
                 . ' [instance_schema_uri]' . PHP_EOL . '[google.cloud.aiplatform.v1.PredictSchemata.instance_schema_uri].',
+                'Required. The <xref uid="\Google\Cloud\Aiplatform\V1\BatchPredictionJob::getModel()">Model\'s</xref>'
+                . ' <xref uid="\Google\Cloud\Aiplatform\V1\Model::getPredictSchemata()">PredictSchemata\'s</xref>'
+                . ' <xref uid="\Google\Cloud\Aiplatform\V1\PredictSchemata::getInstanceSchemaUri()">instance_schema_uri</xref>.'
+            ],
+            [
+                // Separation within links using a space - some APIs do this :/
+                'Required. The [Model\'s] [google.cloud.aiplatform.v1.BatchPredictionJob.model]'
+                . ' [PredictSchemata\'s] [google.cloud.aiplatform.v1.Model.predict_schemata]'
+                . ' [instance_schema_uri] [google.cloud.aiplatform.v1.PredictSchemata.instance_schema_uri].',
                 'Required. The <xref uid="\Google\Cloud\Aiplatform\V1\BatchPredictionJob::getModel()">Model\'s</xref>'
                 . ' <xref uid="\Google\Cloud\Aiplatform\V1\Model::getPredictSchemata()">PredictSchemata\'s</xref>'
                 . ' <xref uid="\Google\Cloud\Aiplatform\V1\PredictSchemata::getInstanceSchemaUri()">instance_schema_uri</xref>.'

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -168,13 +168,22 @@ class NodeTest extends TestCase
                 'Output only. The service account that will be used by the Log Router to access your Cloud KMS key. Before enabling CMEK for Log Router, you must first assign the cloudkms.cryptoKeyEncrypterDecrypter role to the service account that the Log Router will use to access your Cloud KMS key. Use <xref uid="\Google\Logging\V2\ConfigServiceV2Client::getCmekSettings()">GetCmekSettings</xref> to obtain the service account ID. See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.'
             ],
             [
-                // Separation using newlines
+                // Separation between links using newlines
                 'Required. The [Model\'s][google.cloud.aiplatform.v1.BatchPredictionJob.model]' . PHP_EOL
                 . '[PredictSchemata\'s][google.cloud.aiplatform.v1.Model.predict_schemata]' . PHP_EOL
                 . '[instance_schema_uri][google.cloud.aiplatform.v1.PredictSchemata.instance_schema_uri].',
                 'Required. The <xref uid="\Google\Cloud\Aiplatform\V1\BatchPredictionJob::getModel()">Model\'s</xref>' . PHP_EOL
                 . '<xref uid="\Google\Cloud\Aiplatform\V1\Model::getPredictSchemata()">PredictSchemata\'s</xref>' . PHP_EOL
                 . '<xref uid="\Google\Cloud\Aiplatform\V1\PredictSchemata::getInstanceSchemaUri()">instance_schema_uri</xref>.'
+            ],
+            [
+                // Separation within links using newlines
+                'Required. The [Model\'s]'  . PHP_EOL . '[google.cloud.aiplatform.v1.BatchPredictionJob.model]'
+                . ' [PredictSchemata\'s]'  . PHP_EOL . '[google.cloud.aiplatform.v1.Model.predict_schemata]'
+                . ' [instance_schema_uri]' . PHP_EOL . '[google.cloud.aiplatform.v1.PredictSchemata.instance_schema_uri].',
+                'Required. The <xref uid="\Google\Cloud\Aiplatform\V1\BatchPredictionJob::getModel()">Model\'s</xref>'
+                . ' <xref uid="\Google\Cloud\Aiplatform\V1\Model::getPredictSchemata()">PredictSchemata\'s</xref>'
+                . ' <xref uid="\Google\Cloud\Aiplatform\V1\PredictSchemata::getInstanceSchemaUri()">instance_schema_uri</xref>.'
             ],
             [
                 'Testing that a code sample like $foo["bar"]["baz"] does not get replaced',

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
@@ -606,8 +606,8 @@ items:
           var_type: '<xref uid="\Google\Cloud\Vision\V1\ProductSearchParams">Google\Cloud\Vision\V1\ProductSearchParams</xref>'
           description: |-
             Parameters for a product search request. Please note, this
-            value will override the {@see \Google\Cloud\Vision\V1\ProductSearchParams} in the
-            {@see \Google\Cloud\Vision\V1\ImageContext} instance if provided.
+            value will override the <xref uid="\Google\Cloud\Vision\V1\ProductSearchParams">Google\Cloud\Vision\V1\ProductSearchParams</xref> in the
+            <xref uid="\Google\Cloud\Vision\V1\ImageContext">Google\Cloud\Vision\V1\ImageContext</xref> instance if provided.
         -
           id: optionalArgs
           var_type: array


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/6317

This was due to the markdown links being wrapped for this API:

https://github.com/googleapis/googleapis/blob/77c99e43177c76ae1c1edacee7b6ac4e35a42f3d/google/identity/accesscontextmanager/v1/access_context_manager.proto#L41-L51