### PR TITLE
feat(dev): add release-info command

### DIFF
--- a/Dlp/composer.json
+++ b/Dlp/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "google/gax": "^1.1"
+        "google/gax": "dev-middleware-enhance as v1.22.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/dev/README.md
+++ b/dev/README.md
@@ -14,5 +14,6 @@ for a list of all available commands:
 
 Additionally, there are scripts in the `sh` directory which are used in our CI:
 
-| Command          | Description                    |
+| Command             | Description                 |
+| ------------------- | --------------------------- |
 | `sh/static-analysis`| Run phpstan static ananlysis|

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,10 +1,18 @@
 # Google Cloud PHP Development Scripts
 
-The `dev` component features helpful development tools for the following:
-   - Generating new libraries (`google-cloud add-component`)
-   - Listing component information (`google-cloud component-info`)
-   - Generating DocFX documentation (`google-cloud docfx`)
-   - Splitting the monorepo into sub repositories for releases (`google-cloud split`)
-   - Testing commands (`sh/static-analysis`)
+The `dev` component features helpful development tools. Run `dev/google-cloud`
+for a list of all available commands:
 
-Run `dev/google-cloud` for a list of all available commands.
+| Command          | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `add-component`  | Generate a new library                                           |
+| `component-info` | List component information                                       |
+| `docfx`          | Generate DocFX YAML                                              |
+| `release-info`   | List components and versions for a monorepo release              |
+| `split`          | Split `google-cloud-php` into sub repositories and tag a release |
+
+
+Additionally, there are scripts in the `sh` directory which are used in our CI:
+
+| Command          | Description                    |
+| `sh/static-analysis`| Run phpstan static ananlysis|

--- a/dev/google-cloud
+++ b/dev/google-cloud
@@ -21,6 +21,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Google\Cloud\Dev\Command\AddComponentCommand;
 use Google\Cloud\Dev\Command\ComponentInfoCommand;
 use Google\Cloud\Dev\Command\DocFxCommand;
+use Google\Cloud\Dev\Command\ReleaseInfoCommand;
 use Google\Cloud\Dev\Command\SplitCommand;
 use Symfony\Component\Console\Application;
 
@@ -38,5 +39,6 @@ $app = new Application;
 $app->add(new AddComponentCommand($rootDirectory));
 $app->add(new ComponentInfoCommand());
 $app->add(new DocFxCommand());
+$app->add(new ReleaseInfoCommand());
 $app->add(new SplitCommand($rootDirectory));
 $app->run();

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -38,7 +38,7 @@ class ReleaseInfoCommand extends Command
     private Client $httpClient;
 
     /**
-     * @param string $rootPath The path to the repository root directory.
+     * @param Client $httpClient specify the HTTP client, useful for testing
      */
     public function __construct(Client $httpClient = null)
     {

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\Command;
+
+use Google\Cloud\Dev\Component;
+use Google\Cloud\Dev\GitHub;
+use Google\Cloud\Dev\ReleaseNotes;
+use Google\Cloud\Dev\RunShell;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * List component details
+ * @internal
+ */
+class ReleaseInfoCommand extends Command
+{
+    private Client $httpClient;
+
+    /**
+     * @param string $rootPath The path to the repository root directory.
+     */
+    public function __construct(Client $httpClient = null)
+    {
+        $this->httpClient = $httpClient ?: new Client();
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('release-info')
+            ->setDescription('list information for a google-cloud-php release')
+            ->addArgument('tag', InputArgument::REQUIRED, 'The git tag of the release (e.g. v0.200.0)')
+            ->addOption('token', 't', InputOption::VALUE_REQUIRED, 'Github token to use for authentication', '')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'output format, can be "json" or "shell"', 'shell')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $github = new Github(
+            new RunShell(),
+            $this->httpClient,
+            $input->getOption('token')
+        );
+
+        $changelog = $github->getChangelog(
+            'googleapis/google-cloud-php',
+            $tag = $input->getArgument('tag')
+        );
+
+        $releaseNotes = new ReleaseNotes($changelog);
+
+        $releases = [];
+        foreach (Component::getComponents() as $component) {
+            if ($version = $releaseNotes->getVersion($component->getId())) {
+                $releases[] = [
+                    'component' => $component->getName(),
+                    'id' => $component->getId(),
+                    'version' => $version,
+                ];
+            }
+        }
+
+        switch ($input->getOption('format')) {
+            case 'shell':
+                (new Table($output))
+                    ->setHeaders(['component', 'id', 'version'])
+                    ->setRows($releases)
+                    ->render();
+                break;
+            case 'json':
+                $releases = ['version' => $tag, 'releases' => $releases];
+                $output->writeln(json_encode($releases, JSON_PRETTY_PRINT));
+                break;
+            default:
+                throw new \InvalidArgumentException('invalid format');
+        }
+
+        return 0;
+    }
+}

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * List component details
+ * List release details
  * @internal
  */
 class ReleaseInfoCommand extends Command

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -37,6 +37,8 @@ class ReleaseInfoCommand extends Command
 {
     private Client $httpClient;
 
+    private const REPO_ID = 'googleapis/google-cloud-php';
+
     /**
      * @param Client $httpClient specify the HTTP client, useful for testing
      */
@@ -65,7 +67,7 @@ class ReleaseInfoCommand extends Command
         );
 
         $changelog = $github->getChangelog(
-            'googleapis/google-cloud-php',
+            self::REPO_ID,
             $tag = $input->getArgument('tag')
         );
 

--- a/dev/tests/Unit/Command/ComponentInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ComponentInfoCommandTest.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Dev\Tests\Unit\Command;
 use Google\Cloud\Dev\Command\ComponentInfoCommand;
 use Google\Cloud\Dev\Composer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 
@@ -46,9 +45,7 @@ class ComponentInfoCommandTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        $application = new Application();
-        $application->add(new ComponentInfoCommand());
-        self::$commandTester = new CommandTester($application->get('component-info'));
+        self::$commandTester = new CommandTester(new ComponentInfoCommand());
     }
 
     public function testListAll()

--- a/dev/tests/Unit/Command/DocFxCommandTest.php
+++ b/dev/tests/Unit/Command/DocFxCommandTest.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Dev\Tests\Unit\Command;
 use Google\Cloud\Dev\Command\DocFxCommand;
 use Google\Cloud\Dev\DocFx\Node\ClassNode;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Yaml\Yaml;
 use SimpleXMLElement;
@@ -200,9 +199,7 @@ class DocFxCommandTest extends TestCase
     private static function getCommandTester(): CommandTester
     {
         if (!isset(self::$commandTester)) {
-            $application = new Application();
-            $application->add(new DocFxCommand());
-            self::$commandTester = new CommandTester($application->get('docfx'));
+            self::$commandTester = new CommandTester(new DocFxCommand());
         }
         return self::$commandTester;
     }

--- a/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
@@ -54,7 +54,7 @@ class ReleaseInfoCommandTest extends TestCase
         )
             ->shouldBeCalledOnce()
             ->willReturn($response->reveal());
-;
+
         $commandTester = new CommandTester(new ReleaseInfoCommand($http->reveal()));
         $commandTester->execute(['tag' => $tag, '--format' => 'json']);
 

--- a/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Dev\Composer;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -43,10 +44,14 @@ class ReleaseInfoCommandTest extends TestCase
     public function testReleaseInfo()
     {
         $tag = 'v0.1000.0';
+        $body = $this->prophesize(StreamInterface::class);
+        $body->__toString()
+            ->shouldBeCalledOnce()
+            ->willReturn(json_encode(self::$mockResponse));
         $response = $this->prophesize(ResponseInterface::class);
         $response->getBody()
             ->shouldBeCalledOnce()
-            ->willReturn(json_encode(self::$mockResponse));
+            ->willReturn($body->reveal());
         $http = $this->prophesize(Client::class);
         $http->get(
             'https://api.github.com/repos/googleapis/google-cloud-php/releases/tags/' . $tag,

--- a/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\Tests\Unit\Command;
+
+use Google\Cloud\Dev\Command\ReleaseInfoCommand;
+use Google\Cloud\Dev\Composer;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * @group dev
+ */
+class ReleaseInfoCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private static array $mockResponse = [
+        'body' => '<details><summary>google\/cloud-billing-budgets: 1.2.0<\/summary>' .
+            '### Features\r\n\r\n* Add resource_ancestors field to support filtering by folders & organizations ' .
+            '([#6320](https:\/\/github.com\/googleapis\/google-cloud-php\/issues\/6320))<\/details>' .
+            '<details><summary>google\/cloud-build: 0.7.2<\/summary><\/details>' .
+            '\r\n\r\n---\r\nThis PR was generated with Release Please.',
+    ];
+
+    public function testReleaseInfo()
+    {
+        $tag = 'v0.1000.0';
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()
+            ->shouldBeCalledOnce()
+            ->willReturn(json_encode(self::$mockResponse));
+        $http = $this->prophesize(Client::class);
+        $http->get(
+            'https://api.github.com/repos/googleapis/google-cloud-php/releases/tags/' . $tag,
+            ['auth' => [null, null]]
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($response->reveal());
+;
+        $commandTester = new CommandTester(new ReleaseInfoCommand($http->reveal()));
+        $commandTester->execute(['tag' => $tag, '--format' => 'json']);
+
+        $display = $commandTester->getDisplay();
+        $json = json_decode($display, true);
+
+        $this->assertArrayHasKey('version', $json);
+        $this->assertEquals($tag, $json['version']);
+        $this->assertArrayHasKey('releases', $json);
+        $this->assertCount(2, $json['releases']);
+        $this->assertEquals([
+            'component' => 'BillingBudgets',
+            'id' => 'cloud-billing-budgets',
+            'version' => '1.2.0'
+        ], $json['releases'][0]);
+        $this->assertEquals([
+            'component' => 'Build',
+            'id' => 'cloud-build',
+            'version' => '0.7.2'
+        ], $json['releases'][1]);
+    }
+}

--- a/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ReleaseInfoCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Command to display information about a released tag:

```
$ ./google-cloud release-info v0.208.0 
+--------------------------+--------------------------------+---------+
| component                | id                             | version |
+--------------------------+--------------------------------+---------+
| BillingBudgets           | cloud-billing-budgets          | 1.2.0   |
| Build                    | cloud-build                    | 0.7.2   |
| Container                | cloud-container                | 1.15.0  |
| Debugger                 | cloud-debugger                 | 1.5.1   |
| Deploy                   | cloud-deploy                   | 0.8.0   |
| DiscoveryEngine          | cloud-discoveryengine          | 0.3.0   |
| PubSub                   | cloud-pubsub                   | 1.43.1  |
| RapidMigrationAssessment | cloud-rapidmigrationassessment | 0.1.0   |
| Spanner                  | cloud-spanner                  | 1.61.0  |
+--------------------------+--------------------------------+---------+
```

The `--format=json` option can be used to parse the output from another script:

```
$ ./google-cloud release-info v0.208.0 --format=json
{
    "version": "v0.208.0",
    "releases": [
        {
            "component": "BillingBudgets",
            "id": "cloud-billing-budgets",
            "version": "1.2.0"
        },
        {
            "component": "Build",
            "id": "cloud-build",
            "version": "0.7.2"
        },
        {
            "component": "Container",
            "id": "cloud-container",
            "version": "1.15.0"
        },
        {
            "component": "Debugger",
            "id": "cloud-debugger",
            "version": "1.5.1"
        },
        {
            "component": "Deploy",
            "id": "cloud-deploy",
            "version": "0.8.0"
        },
        {
            "component": "DiscoveryEngine",
            "id": "cloud-discoveryengine",
            "version": "0.3.0"
        },
        {
            "component": "PubSub",
            "id": "cloud-pubsub",
            "version": "1.43.1"
        },
        {
            "component": "RapidMigrationAssessment",
            "id": "cloud-rapidmigrationassessment",
            "version": "0.1.0"
        },
        {
            "component": "Spanner",
            "id": "cloud-spanner",
            "version": "1.61.0"
        }
    ]
}
```