### PR TITLE
chore: remove assertFileNotExists

### DIFF
--- a/Storage/tests/System/StreamWrapper/DirectoryTest.php
+++ b/Storage/tests/System/StreamWrapper/DirectoryTest.php
@@ -95,7 +95,7 @@ class DirectoryTest extends StreamWrapperTestCase
     {
         $dir = self::generateUrl('test_directory/');
         $this->assertTrue(rmdir($dir));
-        $this->assertFileNotExists($dir . '/');
+        $this->assertFileDoesNotExist($dir . '/');
     }
 
     public function testMkDirCreatesBucket()

--- a/Storage/tests/System/StreamWrapper/WriteTest.php
+++ b/Storage/tests/System/StreamWrapper/WriteTest.php
@@ -39,7 +39,7 @@ class WriteTest extends StreamWrapperTestCase
 
     public function testFilePutContents()
     {
-        $this->assertFileNotExists($this->fileUrl);
+        $this->assertFileDoesNotExist($this->fileUrl);
 
         $output = 'This is a test';
         $this->assertEquals(strlen($output), file_put_contents($this->fileUrl, $output));
@@ -49,7 +49,7 @@ class WriteTest extends StreamWrapperTestCase
 
     public function testFwrite()
     {
-        $this->assertFileNotExists($this->fileUrl);
+        $this->assertFileDoesNotExist($this->fileUrl);
 
         $output = 'This is a test';
         $fd = fopen($this->fileUrl, 'w');
@@ -61,7 +61,7 @@ class WriteTest extends StreamWrapperTestCase
 
     public function testStreamingWrite()
     {
-        $this->assertFileNotExists($this->fileUrl);
+        $this->assertFileDoesNotExist($this->fileUrl);
 
         $fp = fopen($this->fileUrl, 'w');
         for ($i = 0; $i < 20000; $i++) {


### PR DESCRIPTION
Fixing the warnings system tests throw: 
> assertFileNotExists() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertFileDoesNotExist() instead.

