### PR TITLE
fix: @return description to "Returns a reference to the Job instance used to fetch the query results"

### DIFF
--- a/BigQuery/src/QueryResults.php
+++ b/BigQuery/src/QueryResults.php
@@ -338,7 +338,7 @@ class QueryResults implements \IteratorAggregate
      * $job = $queryResults->job();
      * ```
      *
-     * @return array
+     * @return Google\Cloud\BigQuery\Job
      */
     public function job()
     {


### PR DESCRIPTION
Correct the @return description in the `job()` method to provide an accurate explanation of its purpose.