### PR TITLE
fix(dev): regex match for shortname

### DIFF
--- a/dev/src/NewComponent.php
+++ b/dev/src/NewComponent.php
@@ -132,7 +132,7 @@ class NewComponent
     private static function extractShortNameFromProtoContents(string $protoContents): string
     {
         if (!preg_match(
-            '/option \(google.api.default_host\) = "(.*).googleapis.com";/',
+            '/option \(google.api.default_host\) =[\n\r\s]+"(.*).googleapis.com";/',
             $protoContents,
             $matches)
         ) {


### PR DESCRIPTION
Will match shortnames like 

```proto
service ConsumerProcurementService {
  option (google.api.default_host) =
      "cloudcommerceconsumerprocurement.googleapis.com";
}
```

instead of just when they're on a single line