### PR TITLE
feat!: test BREAKING_CHANGE_REASON for breaking labels

### DIFF
--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -22,8 +22,15 @@ jobs:
         # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
         continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
         run: |
-          ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions \
-              && "${{ !contains(github.event.pull_request.title, '!:') }}"
+          ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions
+      - name: "Check for BC label"
+        # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
+        continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
+        run: |
+          if [[ "${{ contains(github.event.pull_request.title, '!:') }}" ]]; then
+            echo "Breaking change label found in PR title"
+            exit 1
+          fi
       - name: Get Latest Release
         if: github.event.pull_request.user.login == 'release-please[bot]'
         id: latest-release

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -27,7 +27,7 @@ jobs:
         # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
         continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
         run: |
-          if [[ "${{ contains(github.event.pull_request.title, '!:') }}" ]]; then
+          if [[ "true" == "${{ contains(github.event.pull_request.title, '!:') }}" ]]; then
             echo "Breaking change label found in PR title"
             exit 1
           fi

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -22,7 +22,8 @@ jobs:
         # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
         continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
         run: |
-          ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions
+          ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions \
+              && "${{ !contains(github.event.pull_request.title, '!:') }}"
       - name: Get Latest Release
         if: github.event.pull_request.user.login == 'release-please[bot]'
         id: latest-release


### PR DESCRIPTION
Testing out https://github.com/googleapis/google-cloud-php/pull/6503

This should fail the breaking change detector because we haven't included a breaking change reason