### PR TITLE
feat(dev): ensure repo settings are compliant for new repos

### DIFF
--- a/dev/src/Command/RepoInfoCommand.php
+++ b/dev/src/Command/RepoInfoCommand.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Dev\Command;
 
 use Google\Cloud\Dev\Component;
+use Google\Cloud\Dev\GitHub;
+use Google\Cloud\Dev\RunShell;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,8 +35,7 @@ use GuzzleHttp\Client;
  */
 class RepoInfoCommand extends Command
 {
-    private Client $http;
-    private array $headers;
+    private GitHub $github;
 
     private static $allFields = [
         'name' => 'Name',
@@ -59,14 +60,9 @@ class RepoInfoCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->http = new Client();
-        $this->headers = [
-            'Accept' => 'application/vnd.github+json',
-            'X-GitHub-Api-Version' => '2022-11-28',
-        ];
-        if ($token = $input->getOption('token')) {
-            $this->headers['Authorization'] = 'Bearer ' . $token;
-        }
+        // Create github client wrapper
+        $this->github = new GitHub(new RunShell(), new Client(), $input->getOption('token'), $output);
+
         $nextPageQuestion = new ConfirmationQuestion('Next Page (enter)', true);
         $table = (new Table($output))->setHeaders(self::$allFields);
         if ($componentName = $input->getArgument('component')) {
@@ -89,7 +85,7 @@ class RepoInfoCommand extends Command
             }
             $details = $this->getRepoDetails($component);
             if ($input->getOption('fix')) {
-                if (!$token) {
+                if (!$this->github->token) {
                     throw new \InvalidArgumentException('Token required to fix compliance');
                 }
                 $refreshDetails = false;
@@ -97,7 +93,7 @@ class RepoInfoCommand extends Command
                     $refreshDetails |= $this->askFixSettingsCompliance($input, $output, $details);
                 }
                 if (!$this->checkTeamCompliance($details)) {
-                    $refreshDetails |= $this->askFixTeamCompliance($input, $output, $details);
+                    $refreshDetails |= $this->askFixTeamCompliance($input, $output, 'googleapis/' . $details['name']);
                 }
                 if ($refreshDetails) {
                     $details = $this->getRepoDetails($component);
@@ -136,44 +132,34 @@ class RepoInfoCommand extends Command
             implode(', ', $fieldsToUpdate)
         ), true);
         if ($this->getHelper('question')->ask($input, $output, $question)) {
-            $url = 'https://api.github.com/repos/googleapis/' . $details['name'];
-            $response = $this->http->patch($url, [
-                'headers' => $this->headers,
-                'body' => json_encode(array_fill_keys($fieldsToUpdate, false)),
-            ]);
+            $this->github->updateRepoDetails(
+                'googleapis/' . $details['name'],
+                array_fill_keys($fieldsToUpdate, false)
+            );
             return true;
         }
         return false;
     }
 
-    private function askFixTeamCompliance(InputInterface $input, OutputInterface $output, array $details)
+    private function askFixTeamCompliance(InputInterface $input, OutputInterface $output, string $repoName)
     {
         $question = new ConfirmationQuestion(sprintf(
             'Repo %s does not have "yoshi-php" as an admin. Would you like to add it? (Y/n)',
-            $details['name']
+            $repoName
         ), true);
         if ($this->getHelper('question')->ask($input, $output, $question)) {
-            $url = 'https://api.github.com/orgs/googleapis/teams/yoshi-php/repos/googleapis/' . $details['name'];
-            $response = $this->http->put($url, [
-                'headers' => $this->headers,
-                'body' => '{"permission":"admin"}',
-            ]);
-            return true;
+            return $this->github->updateTeamPermission('googleapis', 'yoshi-php', $repoName, 'admin');
         }
         return false;
     }
 
     private function getRepoDetails(Component $component): array
     {
-        // get configuration fields
-        $response = $this->http->get('https://api.github.com/repos/' . $component->getRepoName(), [
-            'headers' => $this->headers
-        ]);
         // use "array_intersect_key" to filter out fields that were not requested.
         $fields = array_map(
             fn ($field) => is_bool($field) ? var_export($field, true) : $field,
             array_intersect_key(
-                json_decode((string) $response->getBody(), true),
+                $this->github->getRepoDetails($component->getRepoName()),
                 self::$allFields
             )
         );
@@ -185,22 +171,17 @@ class RepoInfoCommand extends Command
 
     private function getRepoTeamDetails(Component $component)
     {
-        if (!isset($this->headers['Authorization'])) {
+        if (!$this->github->token) {
             return '**Token Required**';
         }
         // get team fields
-        $response = $this->http->get(
-            'https://api.github.com/repos/' . $component->getRepoName() . '/teams', [
-            'headers' => $this->headers,
-            'http_errors' => false,
-        ]);
-        if ($response->getStatusCode() === 200) {
-            return implode("\n", array_map(
-                fn ($team) => $team['name'] . ': ' . $team['permission'],
-                json_decode((string) $response->getBody(), true)
-            )) . "\n";
+        $teams = $this->github->getTeams($component->getRepoName());
+        if (is_null($teams)) {
+            return '**ACCESS DENIED**';
         }
-
-        return '**ACCESS DENIED**';
+        return implode("\n", array_map(
+            fn ($team) => $team['name'] . ': ' . $team['permission'],
+            $teams
+        )) . "\n";
     }
 }

--- a/dev/src/Command/RepoInfoCommand.php
+++ b/dev/src/Command/RepoInfoCommand.php
@@ -93,7 +93,7 @@ class RepoInfoCommand extends Command
                     $refreshDetails |= $this->askFixSettingsCompliance($input, $output, $details);
                 }
                 if (!$this->checkTeamCompliance($details)) {
-                    $refreshDetails |= $this->askFixTeamCompliance($input, $output, 'googleapis/' . $details['name']);
+                    $refreshDetails |= $this->askFixTeamCompliance($input, $output, $component->getRepoName());
                 }
                 if ($refreshDetails) {
                     $details = $this->getRepoDetails($component);

--- a/dev/src/GitHub.php
+++ b/dev/src/GitHub.php
@@ -100,6 +100,9 @@ class GitHub
 
             return ($res->getStatusCode() === 200);
         } catch (\Exception $e) {
+            if ($e->getCode() === 404) {
+                return false;
+            }
             $this->logException($e);
             return null;
         }

--- a/dev/src/GitHub.php
+++ b/dev/src/GitHub.php
@@ -35,6 +35,8 @@ class GitHub
     const GITHUB_RELEASE_UPDATE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/%s';
     const GITHUB_RELEASE_GET_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/tags/%s';
     const GITHUB_WEBHOOK_CREATE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/hooks';
+    private const GITHUB_TEAMS_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/teams';
+    private const GITHUB_TEAMS_ADD_ENDPOINT = 'https://api.github.com/orgs/%s/teams/%s/repos/%s';
 
     /**
      * @var array[]
@@ -44,7 +46,7 @@ class GitHub
     public function __construct(
         private RunShell $shell,
         private Client $client,
-        private string $token,
+        public string $token,
         private ?OutputInterface $output = null
     ) {
         $this->shell = $shell;
@@ -61,13 +63,7 @@ class GitHub
      */
     public function getDefaultBranch($target)
     {
-        try {
-            $res = $this->getRepo($target);
-            return json_decode((string) $res->getBody(), true)['default_branch'];
-        } catch (\Exception $e) {
-            $this->logException($e);
-            return null;
-        }
+        return $this->getRepoDetails($target)['default_branch'] ?? null;
     }
 
     /**
@@ -79,13 +75,9 @@ class GitHub
      */
     public function isTargetEmpty($target)
     {
-        try {
-            $res = $this->getRepo($target);
-            return json_decode((string) $res->getBody(), true)['size'] === 0;
-        } catch (\Exception $e) {
-            $this->logException($e);
-            return null;
-        }
+        $res = $this->getRepoDetails($target);
+
+        return is_null($res) ? null : $res['size'] === 0;
     }
 
     /**
@@ -251,41 +243,93 @@ class GitHub
     }
 
     /**
-     * Make sure the target is formatted properly.
+     * Get repository details from the GitHub API.
      *
      * @param string $target The GitHub organization and repository ID separated
      *        by a forward slash, i.e. `organization/repository'.
-     * @return string
+     *
+     * @return array|null
      */
-    private function cleanTarget($target)
+    public function getRepoDetails($target)
     {
-        return str_replace('.git', '', $target);
+        try {
+            if (isset($this->targetInfoCache[$target])) {
+                $res = $this->targetInfoCache[$target];
+            } else {
+                $res = $this->client->get(sprintf(
+                    self::GITHUB_REPO_ENDPOINT,
+                    $this->cleanTarget($target)
+                ), [
+                    'auth' => [null, $this->token]
+                ]);
+
+                $this->targetInfoCache[$target] = $res;
+            }
+
+            return json_decode((string) $res->getBody(), true);
+        } catch (\Exception $e) {
+            $this->logException($e);
+            return null;
+        }
     }
 
-    /**
-     * Get and cache the repository object from the API
-     *
-     * @param string $target The GitHub organization and repository ID separated
-     *        by a forward slash, i.e. `organization/repository'.
-     * @return Response
-     * @throws GuzzleException
-     */
-    private function getRepo($target)
+    public function getTeams(string $repoName)
     {
-        if (isset($this->targetInfoCache[$target])) {
-            $res = $this->targetInfoCache[$target];
-        } else {
+        try {
+            // get team fields
             $res = $this->client->get(sprintf(
-                self::GITHUB_REPO_ENDPOINT,
-                $this->cleanTarget($target)
+                self::GITHUB_TEAMS_ENDPOINT,
+                $this->cleanTarget($repoName)
             ), [
                 'auth' => [null, $this->token]
             ]);
 
-            $this->targetInfoCache[$target] = $res;
+            return json_decode((string) $res->getBody(), true);
+        } catch (\Exception $e) {
+            $this->logException($e);
+            return null;
         }
+    }
 
-        return $res;
+    public function updateRepoDetails(string $repoName, array $settings): bool
+    {
+        try {
+            $res = $this->client->patch(sprintf(
+                self::GITHUB_REPO_ENDPOINT,
+                $repoName
+            ), [
+                'auth' => [null, $this->token],
+                'body' => json_encode($settings),
+            ]);
+
+            return $res->getStatusCode() === 200;
+        } catch (\Exception $e) {
+            $this->logException($e);
+            return false;
+        }
+    }
+
+    public function updateTeamPermission(
+        string $orgName,
+        string $teamName,
+        string $repoName,
+        string $permission
+    ): bool {
+        try {
+            $res = $this->client->put(sprintf(
+                self::GITHUB_TEAMS_ADD_ENDPOINT,
+                $orgName,
+                $teamName,
+                $repoName,
+            ), [
+                'auth' => [null, $this->token],
+                'body' => json_encode(['permission' => $permission]),
+            ]);
+            return $res->getStatusCode() == 204;
+        } catch (\Exception $e) {
+            $this->logException($e);
+            return false;
+        }
     }
 
     /**
@@ -320,6 +364,18 @@ class GitHub
             $this->logException($e);
             return false;
         }
+    }
+
+    /**
+     * Make sure the target is formatted properly.
+     *
+     * @param string $target The GitHub organization and repository ID separated
+     *        by a forward slash, i.e. `organization/repository'.
+     * @return string
+     */
+    private function cleanTarget($target)
+    {
+        return str_replace('.git', '', $target);
     }
 
     /**


### PR DESCRIPTION
Makes sure when a component is released, the new github repos have:
 - the `yoshi-php` team as an admin
 - issues, discussion, wiki, pages, and projects disabled (since it's considered READONLY)

In order to keep the code dry, this includes moving logic that was previously in the `RepoInfoCommand` class to the `GitHub` class, and then using that object in both `SplitCommand` and `RepoInfoCommand`.