### PR TITLE
fix: Bump guzzlehttp/guzzle version

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.4",
         "rize/uri-template": "~0.3",
         "google/auth": "^1.18",
-        "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
+        "guzzlehttp/guzzle": "^6.5.8|^7.4.4",
         "guzzlehttp/promises": "^1.4||^2.0",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">=7.4",
         "rize/uri-template": "~0.3",
-        "guzzlehttp/guzzle": "^6.5.7|^7.4.4",
+        "guzzlehttp/guzzle": "^6.5.8|^7.4.4",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^2.0||^3.0",
         "psr/http-message": "^1.0|^2.0",


### PR DESCRIPTION
Fix for https://github.com/advisories/GHSA-25mq-v84q-4j7r and https://github.com/advisories/GHSA-q559-8m2m-g699