### PR TITLE
chore(Spanner): rename print_R to print_r

### DIFF
--- a/Spanner/tests/System/BackupTest.php
+++ b/Spanner/tests/System/BackupTest.php
@@ -114,7 +114,7 @@ class BackupTest extends SpannerTestCase
 
         foreach ($allInstances as $i) {
             print(PHP_EOL);
-            print_R($i->name());
+            print_r($i->name());
         }
     }
 


### PR DESCRIPTION
Seems like a typo