### PR TITLE
fix(dev): add grpc ext to docs container

### DIFF
--- a/.kokoro/docs/docker/Dockerfile
+++ b/.kokoro/docs/docker/Dockerfile
@@ -80,6 +80,10 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         make install && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini
 
+# Install gRPC
+RUN pecl install grpc && \
+    echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini
+
 # Install composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php -r "if (hash_file('SHA384', 'composer-setup.php') === rtrim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \


### PR DESCRIPTION
Since the merging of https://github.com/googleapis/google-cloud-php/pull/6454, the docs job has occasionally failed due to the `grpc` extension not being installed in the container. This was previously not necessary, as `composer` was not being run in the components, just in the `dev` directory (which does not require grpc)

Luckily this does not actually fail the job, only the storing of artifacts in placer. 

cc @diptanshumittal