### PR TITLE
chore(docs): fix see tags in PubSub phpdoc

### DIFF
--- a/PubSub/src/BatchPublisher.php
+++ b/PubSub/src/BatchPublisher.php
@@ -78,8 +78,7 @@ class BatchPublisher
     /**
      * @param string $topicName The topic name.
      * @param array $options [optional] {
-     *        Please {@see PubSub\Topic::batchPublisher()} for
-     *        configuration details.
+     *        Please see {@see Topic::batchPublisher()} for configuration details.
      *        @type bool $enableCompression Flag to enable compression of messages
      *              before publishing. Set the flag to `true` to enable compression.
      *              Defaults to `false`. Messsages are compressed if their total
@@ -116,7 +115,7 @@ class BatchPublisher
      * ```
      *
      * @param Message|array $message An instance of
-     *        {@see Google\Cloud\PubSub\Message}, or an array in the correct
+     *        {@see Message}, or an array in the correct
      *        [Message Format](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage).
      * @return void
      */

--- a/PubSub/src/Message.php
+++ b/PubSub/src/Message.php
@@ -215,7 +215,7 @@ class Message
      * Get the message ackId.
      *
      * This is only set when message is obtained via
-     * {@see Google\Cloud\PubSub\Subscription::pull()}.
+     * {@see Subscription::pull()}.
      *
      * Example:
      * ```

--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -169,9 +169,9 @@ class PubSubClient
     /**
      * Create a topic.
      *
-     * Unlike {@see Google\Cloud\PubSub\PubSubClient::topic()}, this method will send an API call to
+     * Unlike {@see PubSubClient::topic()}, this method will send an API call to
      * create the topic. If the topic already exists, an exception will be
-     * thrown. When in doubt, use {@see Google\Cloud\PubSub\PubSubClient::topic()}.
+     * thrown. When in doubt, use {@see PubSubClient::topic()}.
      *
      * Example:
      * ```
@@ -184,7 +184,7 @@ class PubSubClient
      * @param string $name The topic name
      * @param array $options [optional] Configuration Options. For available
      *        configuration options, refer to
-     *        {@see Google\Cloud\PubSub\Topic::create()} {
+     *        {@see Topic::create()} {
      *        @type bool $enableCompression Flag to enable compression of messages
      *              before publishing. Set the flag to `true` to enable compression.
      *              Defaults to `false`. Messsages are compressed if their total
@@ -209,7 +209,7 @@ class PubSubClient
      * Lazily instantiate a topic with a topic name.
      *
      * No API requests are made by this method. If you want to create a new
-     * topic, use {@see Google\Cloud\PubSub\Topic::createTopic()}.
+     * topic, use {@see Topic::createTopic()}.
      *
      * Example:
      * ```
@@ -289,9 +289,9 @@ class PubSubClient
      * Create a Subscription. If the subscription does not exist, it will be
      * created.
      *
-     * Use {@see Google\Cloud\PubSub\PubSubClient::subscription()} to create a subscription object
+     * Use {@see PubSubClient::subscription()} to create a subscription object
      * without any API requests. If the topic already exists, an exception will
-     * be thrown. When in doubt, use {@see Google\Cloud\PubSub\PubSubClient::subscription()}.
+     * be thrown. When in doubt, use {@see PubSubClient::subscription()}.
      *
      * Example:
      * ```
@@ -303,7 +303,7 @@ class PubSubClient
      *
      * @param string $name A subscription name
      * @param Topic|string $topic The topic to which the new subscription will be subscribed.
-     * @param array  $options [optional] Please see {@see Google\Cloud\PubSub\Subscription::create()}
+     * @param array  $options [optional] Please see {@see Subscription::create()}
      *        for configuration details.
      * @return Subscription
      */
@@ -319,7 +319,7 @@ class PubSubClient
      * Lazily instantiate a subscription with a subscription name.
      *
      * This method will NOT perform any API calls. If you wish to create a new
-     * subscription, use {@see Google\Cloud\PubSub\PubSubClient::subscribe()}.
+     * subscription, use {@see PubSubClient::subscribe()}.
      *
      * Unless you are sure the subscription exists, you should check its
      * existence before using it.
@@ -541,7 +541,7 @@ class PubSubClient
      * Lists all schemas in the current project.
      *
      * Please note that the schemas returned will not contain the entire resource.
-     * If you need details on the full resource, call {@see Google\Cloud\PubSub\Schema::reload()}
+     * If you need details on the full resource, call {@see Schema::reload()}
      * on the resource in question, or set `$options.view` to `FULL`.
      *
      * Example:
@@ -658,7 +658,7 @@ class PubSubClient
      * @param Schema|string|array $schema The schema to validate against. If a
      *     string is given, it should be a fully-qualified schema name, e.g.
      *     `projects/my-project/schemas/my-schema`. If an instance of
-     *     {@see Google\Cloud\PubSub\Schema} is provided, it must exist in the
+     *     {@see Schema} is provided, it must exist in the
      *     current project. If an array is given, see
      *     [Schema](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.schemas#Schema)
      *     for definition. The array representation allows for validation of

--- a/PubSub/src/Schema.php
+++ b/PubSub/src/Schema.php
@@ -105,11 +105,11 @@ class Schema
      * Get schema information.
      *
      * Since this method will throw an exception if the schema is not found, you
-     * may find that {@see Google\Cloud\PubSub\Schema::exists()} is a better fit
+     * may find that {@see Schema::exists()} is a better fit
      * for a true/false check.
      *
      * This method will use the previously cached result, if available. To force
-     * a refresh from the API, use {@see Google\Cloud\PubSub\Schema::reload()}.
+     * a refresh from the API, use {@see Schema::reload()}.
      *
      * Example:
      * ```
@@ -138,11 +138,11 @@ class Schema
      * Get schema information from the API.
      *
      * Since this method will throw an exception if the schema is not found, you
-     * may find that {@see Google\Cloud\PubSub\Schema::exists()} is a better fit
+     * may find that {@see Schema::exists()} is a better fit
      * for a true/false check.
      *
      * This method will retrieve a new result from the API. To use a previously
-     * cached result, if one exists, use {@see Google\Cloud\PubSub\Schema::info()}.
+     * cached result, if one exists, use {@see Schema::info()}.
      *
      * Example:
      * ```

--- a/PubSub/src/Subscription.php
+++ b/PubSub/src/Subscription.php
@@ -238,7 +238,7 @@ class Subscription
      * Execute a service request creating the subscription.
      *
      * The suggested way of creating a subscription is by calling through
-     * {@see Google\Cloud\PubSub\Topic::subscribe()} or {@see Google\Cloud\PubSub\Topic::subscription()}.
+     * {@see Topic::subscribe()} or {@see Topic::subscription()}.
      *
      * Returns subscription info in the format detailed in the documentation
      * for a [subscription](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions#Subscription).
@@ -284,7 +284,7 @@ class Subscription
      *           delivery attempts for any message. The value must be between 5
      *           and 100.
      *     @type bool $enableMessageOrdering If true, messages published with
-     *           the same `orderingKey` in {@see Google\Cloud\PubSub\Message}
+     *           the same `orderingKey` in {@see Message}
      *           will be delivered to the subscribers in the order in which they
      *           are received by the Pub/Sub system. Otherwise, they may be
      *           delivered in any order.
@@ -467,7 +467,7 @@ class Subscription
      *           delivery attempts for any message. The value must be between 5
      *           and 100.
      *     @type bool $enableMessageOrdering If true, messages published with
-     *           the same `orderingKey` in {@see Google\Cloud\PubSub\Message}
+     *           the same `orderingKey` in {@see Message}
      *           will be delivered to the subscribers in the order in which they
      *           are received by the Pub/Sub system. Otherwise, they may be
      *           delivered in any order.
@@ -636,10 +636,10 @@ class Subscription
      *
      * Service errors will NOT bubble up from this method. It will always return
      * a boolean value. If you want to check for errors, use
-     * {@see Google\Cloud\PubSub\Subscription::info()}.
+     * {@see Subscription::info()}.
      *
      * If you need to re-check the existence of a subscription that is already
-     * downloaded, call {@see Google\Cloud\PubSub\Subscription::reload()} first
+     * downloaded, call {@see Subscription::reload()} first
      * to refresh the cached information.
      *
      * Example:
@@ -666,7 +666,7 @@ class Subscription
      * Get info on a subscription
      *
      * If the info is already cached on the object, it will return that result.
-     * To fetch a fresh result, use {@see Google\Cloud\PubSub\Subscription::reload()}.
+     * To fetch a fresh result, use {@see Subscription::reload()}.
      *
      * Example:
      * ```
@@ -759,7 +759,7 @@ class Subscription
     /**
      * Acknowledge receipt of a message.
      *
-     * Use {@see Google\Cloud\PubSub\Subscription::acknowledgeBatch()} to
+     * Use {@see Subscription::acknowledgeBatch()} to
      * acknowledge multiple messages at once.
      *
      * Example:
@@ -804,7 +804,7 @@ class Subscription
     /**
      * Acknowledge receipt of multiple messages at once.
      *
-     * Use {@see Google\Cloud\PubSub\Subscription::acknowledge()} to acknowledge
+     * Use {@see Subscription::acknowledge()} to acknowledge
      * a single message.
      *
      * Example:
@@ -882,7 +882,7 @@ class Subscription
     /**
      * Set the acknowledge deadline for a single ackId.
      *
-     * Use {@see Google\Cloud\PubSub\Subscription::modifyAckDeadlineBatch()} to
+     * Use {@see Subscription::modifyAckDeadlineBatch()} to
      * modify the ack deadline for multiple messages at once.
      *
      * Example:
@@ -930,7 +930,7 @@ class Subscription
     /**
      * Set the acknowledge deadline for multiple ackIds.
      *
-     * Use {@see Google\Cloud\PubSub\Subscription::modifyAckDeadline()} to
+     * Use {@see Subscription::modifyAckDeadline()} to
      * modify the ack deadline for a single message.
      *
      * Example:

--- a/PubSub/src/Topic.php
+++ b/PubSub/src/Topic.php
@@ -212,10 +212,10 @@ class Topic
      *           allowed, and is not a valid configuration.
      *     @type string|Schema $schemaSettings.schema The name of a schema that
      *           messages published should be validated against, or an instance
-     *           of {@see Google\Cloud\PubSub\Schema}.
+     *           of {@see Schema}.
      *     @type string $schemaSettings.encoding The encoding of messages
      *           validated against schema. For allowed values, see constants
-     *           defined on {@see Google\Cloud\PubSub\V1\Encoding}.
+     *           defined on {@see Encoding}.
      * }
      *
      * @return array Topic information
@@ -279,10 +279,10 @@ class Topic
      *          allowed, and is not a valid configuration.
      *     @type string|Schema $schemaSettings.schema The name of a schema that
      *           messages published should be validated against, or an instance
-     *           of {@see Google\Cloud\PubSub\Schema}.
+     *           of {@see Schema}.
      *     @type string $schemaSettings.encoding The encoding of messages
      *           validated against schema. For allowed values, see constants
-     *           defined on {@see Google\Cloud\PubSub\V1\Encoding}.
+     *           defined on {@see V1\Encoding}.
      * }
      * @param array $options [optional] {
      *     Configuration options.
@@ -361,7 +361,7 @@ class Topic
      *
      * Service errors will NOT bubble up from this method. It will always return
      * a boolean value. If you want to check for errors, use
-     * {@see Google\Cloud\PubSub\Topic::info()}.
+     * {@see Topic::info()}.
      *
      * Example:
      * ```
@@ -393,7 +393,7 @@ class Topic
      * may find that Topic::exists() is a better fit for a true/false check.
      *
      * This method will use the previously cached result, if available. To force
-     * a refresh from the API, use {@see Google\Cloud\PubSub\Topic::reload()}.
+     * a refresh from the API, use {@see Topic::reload()}.
      *
      * Example:
      * ```
@@ -427,7 +427,7 @@ class Topic
      * may find that Topic::exists() is a better fit for a true/false check.
      *
      * This method will retrieve a new result from the API. To use a previously
-     * cached result, if one exists, use {@see Google\Cloud\PubSub\Topic::info()}.
+     * cached result, if one exists, use {@see Topic::info()}.
      *
      * Example:
      * ```
@@ -470,7 +470,7 @@ class Topic
      * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish Publish Message
      *
      * @param Message|array $message An instance of
-     *        {@see Google\Cloud\PubSub\Message}, or an array in the correct
+     *        {@see Message}, or an array in the correct
      *        [Message Format](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage).
      * @param array $options [optional] Configuration Options
      * @return array A list of message IDs
@@ -512,7 +512,7 @@ class Topic
      *
      * @param Message[]|array[] $messages A list of messages. Each message must be in the correct
      *        [Message Format](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage),
-     *        or be an instance of {@see Google\Cloud\PubSub\Message}.
+     *        or be an instance of {@see Message}.
      * @param array $options [optional] Configuration Options
      * @return array A list of message IDs.
      */
@@ -617,7 +617,7 @@ class Topic
      * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create Create Subscription
      *
      * @param string $name The subscription name
-     * @param array $options [optional] Please see {@see Google\Cloud\PubSub\Subscription::create()}
+     * @param array $options [optional] Please see {@see Subscription::create()}
      *        for configuration details.
      * @return Subscription
      */


### PR DESCRIPTION
See https://cloud.google.com/php/docs/reference/cloud-pubsub/latest/PubSubClient

The documentation on many of these docs pages contain wrong/broken class paths and links due to improperly formatted `@see` tags.