### PR TITLE
fix(dev): mutliple code blocks in phpdoc

### DIFF
--- a/dev/src/DocFx/Node/FencedCodeBlockTrait.php
+++ b/dev/src/DocFx/Node/FencedCodeBlockTrait.php
@@ -29,9 +29,12 @@ trait FencedCodeBlockTrait
     private function addPhpLanguageHintToFencedCodeBlock(string $description): string
     {
         return preg_replace_callback(
-            '/^(\s+)?```\n((.|\n)*)\n^(\s+)?```$/m',
+            '/^(\s+)?```(\w+)?\n((.|\n)*)\n^(\s+)?```$/mU',
             function ($matches) {
-                list($codeblock, $leadingWhitespace, $contents, $_, $trailingWhitespace) = $matches + [4 => ''];
+                list($codeblock, $leadingWhitespace, $existingTypehint, $contents, $_, $trailingWhitespace) = $matches + [5 => ''];
+                if ($existingTypehint) {
+                    return $codeblock;
+                }
                 return sprintf("%s```php\n%s\n%s```",
                     $leadingWhitespace,
                     $contents,

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -291,6 +291,75 @@ EOF;
             "\n    ```\n",
             $fencedCodeBlock->replace($descriptionWithIndent)
         );
+
+        $descriptionWithMultipleCodeblocks = <<<EOF
+This is a test fenced codeblock
+
+```
+// first codeblock
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+
+```
+// second codeblock
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+EOF;
+
+        $expected = <<<EOF
+This is a test fenced codeblock
+
+```php
+// first codeblock
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+
+```php
+// second codeblock
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+EOF;
+        // Ensure the string does not change
+        $this->assertEquals(
+            $expected,
+            $fencedCodeBlock->replace($descriptionWithMultipleCodeblocks)
+        );
+
+        $descriptionWithDifferentLanguageHint = <<<EOF
+This is a test fenced codeblock
+
+```sh
+pecl install grpc
+```
+
+```
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+EOF;
+
+        $expected = <<<EOF
+This is a test fenced codeblock
+
+```sh
+pecl install grpc
+```
+
+```php
+use Some\TestFoo;
+\$n = new TestFoo();
+```
+EOF;
+
+        // Ensure the string does not change
+        $this->assertEquals(
+            $expected,
+            $fencedCodeBlock->replace($descriptionWithDifferentLanguageHint)
+        );
     }
 
     /**

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -323,7 +323,7 @@ use Some\TestFoo;
 \$n = new TestFoo();
 ```
 EOF;
-        // Ensure the string does not change
+        // Ensure the "php" language hint is added to both fenced code blocks.
         $this->assertEquals(
             $expected,
             $fencedCodeBlock->replace($descriptionWithMultipleCodeblocks)
@@ -355,7 +355,7 @@ use Some\TestFoo;
 ```
 EOF;
 
-        // Ensure the string does not change
+        // Ensure the "php" language hint is added only to the second fenced code block.
         $this->assertEquals(
             $expected,
             $fencedCodeBlock->replace($descriptionWithDifferentLanguageHint)

--- a/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.ImageAnnotatorClient.yml
@@ -91,13 +91,13 @@ items:
       $response = $imageAnnotatorClient->faceDetection($image);
       ```
 
-      ```
+      ```php
       $imageData = file_get_contents('path/to/image.jpg');
       $image = $imageAnnotatorClient->createImageObject($imageData);
       $response = $imageAnnotatorClient->faceDetection($image);
       ```
 
-      ```
+      ```php
       $imageUri = "gs://my-bucket/image.jpg";
       $image = $imageAnnotatorClient->createImageObject($imageUri);
       $response = $imageAnnotatorClient->faceDetection($image);


### PR DESCRIPTION
See the broken formatting in our [PubSubClient reference docs](https://cloud.google.com/php/docs/reference/cloud-pubsub/latest/PubSubClient)

The top of the page is completely broken because the regex matching doesn't work for multiple fenced codeblocks in a single description. 

This PR fixes the RegEx and adds tests to ensure it's now parsed as expected.