### PR TITLE
chore(docs): use unordered lists for see tags

### DIFF
--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -167,8 +167,9 @@ class MethodNode
             }
         }
         if ($links) {
-            $prefix = "\nSee also: ";
-            $content .= "\n" . $prefix . implode($prefix, $links);
+            // Add links as an unordered list
+            $content = "\nSee also:";
+            $content .= "\n - " . implode("\n - ", $links);
         }
 
         return $content;

--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -167,7 +167,8 @@ class MethodNode
             }
         }
         if ($links) {
-            $content .= "\n\nSee: " . implode(', ', $links);
+            $prefix = "\nSee also: ";
+            $content .= "\n" . $prefix . implode($prefix, $links);
         }
 
         return $content;

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -124,9 +124,10 @@ EOF;
 
         $content = $method->getContent();
         $this->assertStringContainsString(
-            'See also: <a href="https://wwww.testlink.com">Cool External Resource</a>' . "\n" .
-            'See also: <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient">\Google\Cloud\Vision\V1\ImageAnnotatorClient</xref>' . "\n" .
-            'See also: <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()">Resume Operation method</xref>',
+            'See also:' . "\n" .
+            ' - <a href="https://wwww.testlink.com">Cool External Resource</a>' . "\n" .
+            ' - <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient">\Google\Cloud\Vision\V1\ImageAnnotatorClient</xref>' . "\n" .
+            ' - <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()">Resume Operation method</xref>',
             $content
         );
     }

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -124,9 +124,9 @@ EOF;
 
         $content = $method->getContent();
         $this->assertStringContainsString(
-            'See: <a href="https://wwww.testlink.com">Cool External Resource</a>, ' .
-            '<xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient">\Google\Cloud\Vision\V1\ImageAnnotatorClient</xref>, ' .
-            '<xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()">Resume Operation method</xref>',
+            'See also: <a href="https://wwww.testlink.com">Cool External Resource</a>' . "\n" .
+            'See also: <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient">\Google\Cloud\Vision\V1\ImageAnnotatorClient</xref>' . "\n" .
+            'See also: <xref uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient::resumeOperation()">Resume Operation method</xref>',
             $content
         );
     }


### PR DESCRIPTION
Small improvement on #6628 

Multiple `@see` tags look off in the docs with the way they're currently rendered (for example, [StorageObject::downloadAsString](https://cloud.google.com/php/docs/reference/cloud-storage/latest/StorageObject#_Google_Cloud_Storage_StorageObject__downloadAsString__)) because sometimes the link text terminates with a period, which looks odd with the comma:

<kbd>
<img width="540" alt="Screenshot 2023-09-19 at 8 10 44 AM" src="https://github.com/googleapis/google-cloud-php/assets/103941/7bf45f97-d937-4c4b-bc56-1f9c60b270a2">
</kbd>


This PR changes See tags into an unordered list, so it will render in our public docs like this instead:

<kbd>
<img width="451" alt="Screenshot 2023-09-19 at 8 13 40 AM" src="https://github.com/googleapis/google-cloud-php/assets/103941/fe80b7fd-b1eb-4678-9ca8-bccdc8c98e0a">
</kbd>


Todo:

 - [x] verify html renders as expected in doc-templates