### PR TITLE
chore(docs): rename see Google to see \Google

### DIFF
--- a/Bigtable/src/DataUtil.php
+++ b/Bigtable/src/DataUtil.php
@@ -40,8 +40,8 @@ class DataUtil
     }
 
     /**
-     * Check if {@see Google\Cloud\Bigtable\DataUtil::intToByteString()} and
-     * {@see Google\Cloud\Bigtable\DataUtil::byteStringToInt()} supported on
+     * Check if {@see \Google\Cloud\Bigtable\DataUtil::intToByteString()} and
+     * {@see \Google\Cloud\Bigtable\DataUtil::byteStringToInt()} supported on
      * the current platform.
      *
      * @return bool

--- a/Bigtable/src/Filter.php
+++ b/Bigtable/src/Filter.php
@@ -34,8 +34,8 @@ use Google\Cloud\Bigtable\V2\RowFilter;
 /**
  * This class houses static factory methods which can be used to create a
  * hierarchy of filters for use with
- * {@see Google\Cloud\Bigtable\Table::checkAndMutateRow()} or
- * {@see Google\Cloud\Bigtable\Table::readRows()}.
+ * {@see \Google\Cloud\Bigtable\Table::checkAndMutateRow()} or
+ * {@see \Google\Cloud\Bigtable\Table::readRows()}.
  *
  * Filters are used to take an input row and produce an alternate view of the
  * row based on the specified rules. For example, a filter might trim down a row
@@ -51,7 +51,7 @@ use Google\Cloud\Bigtable\V2\RowFilter;
  *
  * True filters alter the input row by excluding some of its cells wholesale
  * from the output row. An example of a true filter is
- * {@see Google\Cloud\Bigtable\Filter\Builder\ValueFilter::regex()}, which excludes
+ * {@see \Google\Cloud\Bigtable\Filter\Builder\ValueFilter::regex()}, which excludes
  * cells whose values don't match the specified pattern. All regex true filters
  * use [RE2 syntax](https://github.com/google/re2/wiki/Syntax) in raw byte mode
  * (RE2::Latin1), and are evaluated as full matches. An important point to keep
@@ -60,7 +60,7 @@ use Google\Cloud\Bigtable\V2\RowFilter;
  *
  * Transformers alter the input row by changing the values of some of its cells
  * in the output, without excluding them completely. An example of such a
- * transformer is {@see Google\Cloud\Bigtable\Filter\Builder\ValueFilter::strip()}.
+ * transformer is {@see \Google\Cloud\Bigtable\Filter\Builder\ValueFilter::strip()}.
  *
  * The total serialized size of a filter message must not
  * exceed 4096 bytes, and filters may not be nested within each other
@@ -92,7 +92,7 @@ class Filter
      * Creates an empty chain filter.
      *
      * Filters can be added to the chain by invoking
-     * {@see Google\Cloud\Bigtable\Filter\ChainFilter::addFilter()}.
+     * {@see \Google\Cloud\Bigtable\Filter\ChainFilter::addFilter()}.
      *
      * The filters are applied in sequence, progressively narrowing the results.
      * The full chain is executed atomically.
@@ -120,7 +120,7 @@ class Filter
      * Creates an empty interleave filter.
      *
      * Filters can be added to the interleave by invoking
-     * {@see Google\Cloud\Bigtable\Filter\InterleaveFilter::addFilter()}.
+     * {@see \Google\Cloud\Bigtable\Filter\InterleaveFilter::addFilter()}.
      *
      * The supplied filters all process a copy of the input row, and the
      * results are pooled, sorted, and combined into a single output row. If
@@ -169,19 +169,19 @@ class Filter
      * Creates a condition filter.
      *
      * If the result of predicate filter outputs any cells the filter configured
-     * by {@see Google\Cloud\Bigtable\Filter\ConditionFilter::then()} will be
+     * by {@see \Google\Cloud\Bigtable\Filter\ConditionFilter::then()} will be
      * applied. Conversely, if the predicate results in no cells, the filter
      * configured by
-     * {@see Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()} will
+     * {@see \Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()} will
      * then be applied instead.
      *
      * IMPORTANT NOTE: The predicate filter does not execute atomically with the
-     * {@see Google\Cloud\Bigtable\Filter\ConditionFilter::then()}
-     * and {@see Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()}
+     * {@see \Google\Cloud\Bigtable\Filter\ConditionFilter::then()}
+     * and {@see \Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()}
      * filters, which may lead to inconsistent or unexpected results.
-     * Additionally, {@see Google\Cloud\Bigtable\Filter\ConditionFilter} may
+     * Additionally, {@see \Google\Cloud\Bigtable\Filter\ConditionFilter} may
      * have poor performance, especially when filters are set for the
-     * {@see Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()}.
+     * {@see \Google\Cloud\Bigtable\Filter\ConditionFilter::otherwise()}.
      *
      * Example:
      * ```
@@ -397,9 +397,9 @@ class Filter
      *
      * Due to technical limitation, it is not currently possible to apply
      * multiple labels to a cell. As a result, a
-     * {@see Google\Cloud\Bigtable\Filter\ChainFilter} may have no more than one
+     * {@see \Google\Cloud\Bigtable\Filter\ChainFilter} may have no more than one
      * sub-filter which contains a label. It is okay for a
-     * {@see Google\Cloud\Bigtable\Filter\InterleaveFilter} to contain multiple
+     * {@see \Google\Cloud\Bigtable\Filter\InterleaveFilter} to contain multiple
      * labels, as they will be applied to separate copies of the input. This may
      * be relaxed in the future.
      *

--- a/Bigtable/src/Filter/Builder/LimitFilter.php
+++ b/Bigtable/src/Filter/Builder/LimitFilter.php
@@ -35,7 +35,7 @@ class LimitFilter
     /**
      * Matches only the first N cells of each row. If duplicate cells are
      * present, as is possible when using an
-     * {@see Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
+     * {@see \Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
      * cell is counted separately.
      *
      * Example:
@@ -59,7 +59,7 @@ class LimitFilter
      * timestamps 10 and 9 skip all earlier cells in `foo:bar`, and then begin
      * matching again in column `foo:bar2`. If duplicate cells are present, as
      * is possible when using an
-     * {@see Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
+     * {@see \Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
      * cell is counted separately.
      *
      * Example:

--- a/Bigtable/src/Filter/Builder/OffsetFilter.php
+++ b/Bigtable/src/Filter/Builder/OffsetFilter.php
@@ -35,7 +35,7 @@ class OffsetFilter
     /**
      * Skips the first N cells of each row, matching all subsequent cells. If
      * duplicate cells are present, as is possible when using an
-     * {@see Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
+     * {@see \Google\Cloud\Bigtable\Filter\InterleaveFilter}, each copy of the
      * cell is counted separately.
      *
      * Example:

--- a/Bigtable/src/Filter/SimpleFilter.php
+++ b/Bigtable/src/Filter/SimpleFilter.php
@@ -21,7 +21,7 @@ use Google\Cloud\Bigtable\V2\RowFilter;
 
 /**
  * A simple filter. Instead of constructing this class manually please
- * utilize the static builders found in {@see Google\Cloud\Bigtable\Filter}.
+ * utilize the static builders found in {@see \Google\Cloud\Bigtable\Filter}.
  *
  * @internal
  */

--- a/Bigtable/src/ReadModifyWriteRowRules.php
+++ b/Bigtable/src/ReadModifyWriteRowRules.php
@@ -24,7 +24,7 @@ use Google\Cloud\Bigtable\V2\ReadModifyWriteRule;
  * the specified rows contents are to be transformed into writes. Entries are
  * applied in order, meaning that earlier rules will affect the results of later
  * ones. This is intended to be used in combination with
- * {@see Google\Cloud\Bigtable\Table::readModifyWriteRow()}.
+ * {@see \Google\Cloud\Bigtable\Table::readModifyWriteRow()}.
  */
 class ReadModifyWriteRowRules
 {

--- a/Bigtable/src/Table.php
+++ b/Bigtable/src/Table.php
@@ -80,9 +80,9 @@ class Table
      *           replication. **Defaults to** the "default" application profile.
      *     @type array $headers Headers to be passed with each request.
      *     @type int $retries Number of times to retry. **Defaults to** `3`.
-     *           This settings only applies to {@see Google\Cloud\Bigtable\Table::mutateRows()},
-     *           {@see Google\Cloud\Bigtable\Table::upsert()} and
-     *           {@see Google\Cloud\Bigtable\Table::readRows()}.
+     *           This settings only applies to {@see \Google\Cloud\Bigtable\Table::mutateRows()},
+     *           {@see \Google\Cloud\Bigtable\Table::upsert()} and
+     *           {@see \Google\Cloud\Bigtable\Table::readRows()}.
      * }
      */
     public function __construct(
@@ -111,7 +111,7 @@ class Table
      *
      * @param array $rowMutations An associative array with the key being the
      *        row key and the value being the
-     *        {@see Google\Cloud\Bigtable\Mutations} to perform.
+     *        {@see \Google\Cloud\Bigtable\Mutations} to perform.
      * @param array $options [optional] Configuration options.
      * @return void
      * @throws ApiException|BigtableDataOperationException If the remote call fails or operation fails.
@@ -253,7 +253,7 @@ class Table
      *           (`endKeyOpen` or `endKeyClosed`).
      *     @type FilterInterface $filter A filter used to take an input row and
      *           produce an alternate view of the row based on the specified rules.
-     *           To learn more please see {@see Google\Cloud\Bigtable\Filter} which
+     *           To learn more please see {@see \Google\Cloud\Bigtable\Filter} which
      *           provides static factory methods for the various filter types.
      *     @type int $rowsLimit The number of rows to scan.
      *     @type int $retries Number of times to retry. **Defaults to** `3`.
@@ -447,10 +447,10 @@ class Table
      *           row. Depending on whether or not any results are yielded, either the
      *           trueMutations or falseMutations will be executed. If unset, checks that the
      *           row contains any values at all. Only a single condition can be set, however
-     *           that filter can be {@see Google\Cloud\Bigtable\Filter::chain()} or
-     *           {@see Google\Cloud\Bigtable\Filter::interleave()} which can wrap multiple other
+     *           that filter can be {@see \Google\Cloud\Bigtable\Filter::chain()} or
+     *           {@see \Google\Cloud\Bigtable\Filter::interleave()} which can wrap multiple other
      *           filters.
-     *           WARNING: {@see Google\Cloud\Bigtable\Filter::condition()} is not supported.
+     *           WARNING: {@see \Google\Cloud\Bigtable\Filter::condition()} is not supported.
      *     @type Mutations $trueMutations Mutations to be atomically applied when the predicate
      *           filter's condition yields at least one cell when applied to the row. Please note
      *           either `trueMutations` or `falseMutations` must be provided.
@@ -462,9 +462,9 @@ class Table
      * @return bool Returns true if predicate filter yielded any output, false otherwise.
      * @throws ApiException If the remote call fails or operation fails
      * @throws \InvalidArgumentException If neither of $trueMutations or $falseMutations is set.
-     *         If $predicateFilter is not instance of {@see Google\Cloud\Bigtable\Filter\FilterInterface}.
-     *         If $trueMutations is set and is not instance of {@see Google\Cloud\Bigtable\Mutations}.
-     *         If $falseMutations is set and is not instance of {@see Google\Cloud\Bigtable\Mutations}.
+     *         If $predicateFilter is not instance of {@see \Google\Cloud\Bigtable\Filter\FilterInterface}.
+     *         If $trueMutations is set and is not instance of {@see \Google\Cloud\Bigtable\Mutations}.
+     *         If $falseMutations is set and is not instance of {@see \Google\Cloud\Bigtable\Mutations}.
      */
     public function checkAndMutateRow($rowKey, array $options = [])
     {

--- a/Core/src/Batch/BatchTrait.php
+++ b/Core/src/Batch/BatchTrait.php
@@ -161,7 +161,7 @@ trait BatchTrait
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      * }
      * @throws \InvalidArgumentException

--- a/Core/src/Batch/QueueOverflowException.php
+++ b/Core/src/Batch/QueueOverflowException.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Core\Batch;
 
 /**
- * Exception thrown in {@see Google\Cloud\Core\Batch\SysvProcessor::submit()}
+ * Exception thrown in {@see \Google\Cloud\Core\Batch\SysvProcessor::submit()}
  * method when it cannot add an item to the message queue.
  * Possible causes include:
  *

--- a/Core/src/Batch/SerializableClientTrait.php
+++ b/Core/src/Batch/SerializableClientTrait.php
@@ -48,7 +48,7 @@ trait SerializableClientTrait
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      *     @type array $clientConfig A config used to construct the client upon
      *           which requests will be made.

--- a/Core/src/Batch/SimpleJobTrait.php
+++ b/Core/src/Batch/SimpleJobTrait.php
@@ -55,7 +55,7 @@ trait SimpleJobTrait
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      * }
      */

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -135,7 +135,7 @@ class ExponentialBackoff
 
     /**
      * If not set, defaults to using
-     * {@see Google\Cloud\Core\ExponentialBackoff::calculateDelay()}.
+     * {@see \Google\Cloud\Core\ExponentialBackoff::calculateDelay()}.
      *
      * @param callable $calcDelayFunction
      * @return void

--- a/Core/src/GrpcRequestWrapper.php
+++ b/Core/src/GrpcRequestWrapper.php
@@ -74,7 +74,7 @@ class GrpcRequestWrapper
     /**
      * @param array $config [optional] {
      *     Configuration options. Please see
-     *     {@see Google\Cloud\Core\RequestWrapperTrait::setCommonDefaults()} for
+     *     {@see \Google\Cloud\Core\RequestWrapperTrait::setCommonDefaults()} for
      *     the other available options.
      *
      *     @type callable $authHttpHandler A handler used to deliver Psr7

--- a/Core/src/Iam/Iam.php
+++ b/Core/src/Iam/Iam.php
@@ -23,7 +23,7 @@ namespace Google\Cloud\Core\Iam;
  * This class is not meant to be used directly. It should be accessed
  * through other objects which support IAM.
  *
- * Policies can be created using the {@see Google\Cloud\Core\Iam\PolicyBuilder}
+ * Policies can be created using the {@see \Google\Cloud\Core\Iam\PolicyBuilder}
  * to help ensure their validity.
  *
  * Example:
@@ -98,7 +98,7 @@ class Iam
      *
      * If a policy has already been retrieved from the API, it will be returned.
      * To fetch a fresh copy of the policy, use
-     * {@see Google\Cloud\Core\Iam\Iam::reload()}.
+     * {@see \Google\Cloud\Core\Iam\Iam::reload()}.
      *
      * Example:
      * ```
@@ -136,7 +136,7 @@ class Iam
      * ```
      *
      * @param  array|PolicyBuilder $policy The new policy, as an array or an
-     *         instance of {@see Google\Cloud\Core\Iam\PolicyBuilder}.
+     *         instance of {@see \Google\Cloud\Core\Iam\PolicyBuilder}.
      * @param  array $options Configuration Options
      * @return array An array of policy data
      * @throws \InvalidArgumentException If the given policy is not an array or PolicyBuilder.

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -95,7 +95,7 @@ class RequestWrapper
     /**
      * @param array $config [optional] {
      *     Configuration options. Please see
-     *     {@see Google\Cloud\Core\RequestWrapperTrait::setCommonDefaults()} for
+     *     {@see \Google\Cloud\Core\RequestWrapperTrait::setCommonDefaults()} for
      *     the other available options.
      *
      *     @type string $componentVersion The current version of the component from

--- a/Core/src/Retry.php
+++ b/Core/src/Retry.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Core;
 /**
  * Retry implementation.
  *
- * Unlike {@see Google\Cloud\Core\ExponentialBackoff}, Retry requires an implementor
+ * Unlike {@see \Google\Cloud\Core\ExponentialBackoff}, Retry requires an implementor
  * to supply wait times for each iteration.
  */
 class Retry

--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -110,10 +110,10 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      *     @type string $location If provided, determines the default geographic
      *           location used when creating datasets and managing jobs. Please
@@ -141,10 +141,10 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * @return DatastoreClient
      */
@@ -165,10 +165,10 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * @return FirestoreClient
      */
@@ -189,7 +189,7 @@ class ServiceBuilder
      * ```
      *
      * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
+     *        {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
      * @return LoggingClient
      */
     public function logging(array $config = [])
@@ -210,7 +210,7 @@ class ServiceBuilder
      * ```
      *
      * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
+     *        {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
      * @return LanguageClient
      */
     public function language(array $config = [])
@@ -230,7 +230,7 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type string $transport The transport type used for requests. May be
      *           either `grpc` or `rest`. **Defaults to** `grpc` if gRPC support
@@ -254,10 +254,10 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * }
      * @return SpannerClient
@@ -282,7 +282,7 @@ class ServiceBuilder
      *
      * @param array $config [optional] {
      *     Configuration options. See
-     *     {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
+     *     {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the other available options.
      *
      *     @type string $languageCode The language of the content to
      *           be recognized. Only BCP-47 (e.g., `"en-US"`, `"es-ES"`)
@@ -307,7 +307,7 @@ class ServiceBuilder
      * ```
      *
      * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
+     *        {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
      * @return StorageClient
      */
     public function storage(array $config = [])
@@ -327,7 +327,7 @@ class ServiceBuilder
      * ```
      *
      * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
+     *        {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
      * @return TraceClient
      */
     public function trace(array $config = [])
@@ -347,7 +347,7 @@ class ServiceBuilder
      * ```
      *
      * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
+     *        {@see \Google\Cloud\Core\ServiceBuilder::__construct()} for the available options.
      * @return VisionClient
      */
     public function vision(array $config = [])

--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -52,8 +52,8 @@ class ResumableUploader extends AbstractUploader
 
     /**
      * Classes extending ResumableUploader may provide request headers to be
-     * included in {@see Google\Cloud\Core\Upload\ResumableUploader::upload()}
-     * and {@see Google\Cloud\Core\Upload\ResumableUploader::createResumeUri{}}.
+     * included in {@see \Google\Cloud\Core\Upload\ResumableUploader::upload()}
+     * and {@see \Google\Cloud\Core\Upload\ResumableUploader::createResumeUri{}}.
      *
      * @var array
      */
@@ -142,7 +142,7 @@ class ResumableUploader extends AbstractUploader
      * Triggers the upload process.
      *
      * Errors are of form [`google.rpc.Status`](https://cloud.google.com/apis/design/errors#error_model),
-     * and may be obtained via {@see Google\Cloud\Core\Exception\ServiceException::getMetadata()}.
+     * and may be obtained via {@see \Google\Cloud\Core\Exception\ServiceException::getMetadata()}.
      *
      * @return array
      * @throws ServiceException

--- a/Datastore/src/DatastoreClient.php
+++ b/Datastore/src/DatastoreClient.php
@@ -147,7 +147,7 @@ class DatastoreClient
      *           [Multitenant Projects](https://cloud.google.com/datastore/docs/concepts/multitenancy).
      *     @type string $databaseId ID of the database to which the entities belong.
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * }
      * @throws \InvalidArgumentException
@@ -283,7 +283,7 @@ class DatastoreClient
      * requires a complex key elementPath, you must create the key separately.
      *
      * In complex applications you may want to create your own entity types.
-     * Google Cloud PHP supports subclassing of {@see Google\Cloud\Datastore\Entity}.
+     * Google Cloud PHP supports subclassing of {@see \Google\Cloud\Datastore\Entity}.
      * If the name of a subclass of Entity is given in the options array, an
      * entity will be created with that class rather than the default class.
      *
@@ -382,8 +382,8 @@ class DatastoreClient
      *
      *     @type string $className If set, the given class will be returned.
      *           Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type array $excludeFromIndexes A list of entity keys to exclude from
      *           datastore indexes.
      * }
@@ -608,7 +608,7 @@ class DatastoreClient
      * An entity with incomplete keys will be allocated an ID prior to insertion.
      *
      * Insert by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::insert()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::insert()}.
      *
      * Example:
      * ```
@@ -637,7 +637,7 @@ class DatastoreClient
      * Any entity with incomplete keys will be allocated an ID prior to insertion.
      *
      * Insert by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::insertBatch()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::insertBatch()}.
      *
      * Example:
      * ```
@@ -675,7 +675,7 @@ class DatastoreClient
      * possible by first retrieving the entire entity in its existing state.
      *
      * Update by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::update()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::update()}.
      *
      * Example:
      * ```
@@ -716,7 +716,7 @@ class DatastoreClient
      * possible by first retrieving the entire entity in its existing state.
      *
      * Update by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::updateBatch()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::updateBatch()}.
      *
      * Example:
      * ```
@@ -772,7 +772,7 @@ class DatastoreClient
      * An entity with incomplete keys will be allocated an ID prior to insertion.
      *
      * Upsert by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::upsert()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::upsert()}.
      *
      * Example:
      * ```
@@ -809,7 +809,7 @@ class DatastoreClient
      * Any entity with incomplete keys will be allocated an ID prior to insertion.
      *
      * Upsert by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::upsertBatch()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::upsertBatch()}.
      *
      * Example:
      * ```
@@ -847,7 +847,7 @@ class DatastoreClient
      * Delete an entity
      *
      * Deletion by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::delete()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::delete()}.
      *
      * Example:
      * ```
@@ -880,7 +880,7 @@ class DatastoreClient
      * Delete multiple entities
      *
      * Deletion by this method is non-transactional. If you need transaction
-     * support, use {@see Google\Cloud\Datastore\Transaction::deleteBatch()}.
+     * support, use {@see \Google\Cloud\Datastore\Transaction::deleteBatch()}.
      *
      * Example:
      * ```
@@ -923,7 +923,7 @@ class DatastoreClient
      * Retrieve an entity from the datastore
      *
      * To lookup an entity inside a transaction, use
-     * {@see Google\Cloud\Datastore\Transaction::lookup()}.
+     * {@see \Google\Cloud\Datastore\Transaction::lookup()}.
      *
      * Example:
      * ```
@@ -954,8 +954,8 @@ class DatastoreClient
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type string $className If set, the given class will be returned.
      *           Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type string $databaseId ID of the database to which the entities belong.
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
      * }
@@ -974,7 +974,7 @@ class DatastoreClient
      * Get multiple entities
      *
      * To lookup entities inside a transaction, use
-     * {@see Google\Cloud\Datastore\Transaction::lookupBatch()}.
+     * {@see \Google\Cloud\Datastore\Transaction::lookupBatch()}.
      *
      * Example:
      * ```
@@ -1013,11 +1013,11 @@ class DatastoreClient
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type string|array $className If a string, the given class will be
      *           returned. Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}.
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value must implement
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type bool $sort If set to true, results in each set will be sorted
      *           to match the order given in $keys. **Defaults to** `false`.
      *     @type string $databaseId ID of the database to which the entities belong.
@@ -1025,8 +1025,8 @@ class DatastoreClient
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of
-     *         {@see Google\Cloud\Datastore\Entity}. Members of `missing` and
-     *         `deferred` will be instance of {@see Google\Cloud\Datastore\Key}.
+     *         {@see \Google\Cloud\Datastore\Entity}. Members of `missing` and
+     *         `deferred` will be instance of {@see \Google\Cloud\Datastore\Key}.
      */
     public function lookupBatch(array $keys, array $options = [])
     {
@@ -1076,7 +1076,7 @@ class DatastoreClient
      * Create a GqlQuery object.
      *
      * Returns a Query object which can be executed using
-     * {@see Google\Cloud\Datastore\DatastoreClient::runQuery()}.
+     * {@see \Google\Cloud\Datastore\DatastoreClient::runQuery()}.
      *
      * Example:
      * ```
@@ -1134,7 +1134,7 @@ class DatastoreClient
      *           Queries using Named Bindings should provide a key/value set,
      *           while queries using Positional Bindings must provide a simple
      *           array. Query cursors may be provided using instances of
-     *           {@see Google\Cloud\Datastore\Cursor}.
+     *           {@see \Google\Cloud\Datastore\Cursor}.
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      * }
@@ -1149,7 +1149,7 @@ class DatastoreClient
      * Run a query and return entities
      *
      * To query datastore inside a transaction, use
-     * {@see Google\Cloud\Datastore\Transaction::runQuery()}.
+     * {@see \Google\Cloud\Datastore\Transaction::runQuery()}.
      *
      * Example:
      * ```
@@ -1176,8 +1176,8 @@ class DatastoreClient
      *
      *     @type string $className If set, the given class will be returned.
      *           Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
@@ -1193,7 +1193,7 @@ class DatastoreClient
      * Run an aggregation query and return results.
      *
      * To query datastore inside a transaction, use
-     * {@see Google\Cloud\Datastore\Transaction::runAggregationQuery()}.
+     * {@see \Google\Cloud\Datastore\Transaction::runAggregationQuery()}.
      *
      * Example:
      * ```

--- a/Datastore/src/Entity.php
+++ b/Datastore/src/Entity.php
@@ -32,11 +32,11 @@ use InvalidArgumentException;
  * | **PHP Type**                               | **Datastore Value Type**             |
  * |--------------------------------------------|--------------------------------------|
  * | `\DateTimeInterface`                       | `timestampValue`                     |
- * | {@see Google\Cloud\Datastore\Key}          | `keyValue`                           |
- * | {@see Google\Cloud\Datastore\GeoPoint}     | `geoPointValue`                      |
- * | {@see Google\Cloud\Datastore\Entity}       | `entityValue`                        |
- * | {@see Google\Cloud\Datastore\Blob}         | `blobValue`                          |
- * | {@see Google\Cloud\Core\Int64}             | `integerValue`                       |
+ * | {@see \Google\Cloud\Datastore\Key}          | `keyValue`                           |
+ * | {@see \Google\Cloud\Datastore\GeoPoint}     | `geoPointValue`                      |
+ * | {@see \Google\Cloud\Datastore\Entity}       | `entityValue`                        |
+ * | {@see \Google\Cloud\Datastore\Blob}         | `blobValue`                          |
+ * | {@see \Google\Cloud\Core\Int64}             | `integerValue`                       |
  * | Associative Array                          | `entityValue` (No Key)               |
  * | Non-Associative Array                      | `arrayValue`                         |
  * | `float`                                    | `doubleValue`                        |

--- a/Datastore/src/EntityInterface.php
+++ b/Datastore/src/EntityInterface.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Datastore;
 /**
  * Defines an interface for Datastore Entities.
  *
- * This interface is fulfilled by {@see Google\Cloud\Datastore\EntityTrait},
+ * This interface is fulfilled by {@see \Google\Cloud\Datastore\EntityTrait},
  * and it is recommended that classes implementing EntityInterface make use of that
  * trait to ensure proper configuration.
  */
@@ -44,10 +44,10 @@ interface EntityInterface
      *
      *     @type string $cursor Set only when the entity is obtained by a query
      *           result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\EntityInterface::cursor()}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface::cursor()}.
      *     @type string $baseVersion Set only when the entity is obtained by a
      *           query result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\EntityInterface::baseVersion()}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface::baseVersion()}.
      *     @type array $excludeFromIndexes A list of entity keys to exclude from
      *           datastore indexes.
      *     @type array $meanings A list of meaning values for entity properties.
@@ -61,14 +61,14 @@ interface EntityInterface
      * Defines embedded entity mappings.
      *
      * Embedded entities are converted to instances of
-     * {@see Google\Cloud\Datastore\Entity}, or to associative arrays by default.
+     * {@see \Google\Cloud\Datastore\Entity}, or to associative arrays by default.
      * By providing mappings, you can define the types to use in your application.
      *
-     * Types must implement {@see Google\Cloud\Datastore\EntityInterface}.
+     * Types must implement {@see \Google\Cloud\Datastore\EntityInterface}.
      *
      * @return array An associative array, where the key is the property name,
      *         and the value is the fully-qualified name of a PHP class
-     *         implementing {@see Google\Cloud\Datastore\EntityInterface}.
+     *         implementing {@see \Google\Cloud\Datastore\EntityInterface}.
      */
     public static function mappings();
 

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Datastore;
 use Google\Cloud\Core\Iterator\ItemIteratorTrait;
 
 /**
- * Iterates over a set of {@see Google\Cloud\Datastore\Entity} items.
+ * Iterates over a set of {@see \Google\Cloud\Datastore\Entity} items.
  */
 class EntityIterator implements \Iterator
 {

--- a/Datastore/src/EntityMapper.php
+++ b/Datastore/src/EntityMapper.php
@@ -24,7 +24,7 @@ use Google\Cloud\Datastore\GeoPoint;
 use Google\Cloud\Datastore\Key;
 
 /**
- * Utility methods for mapping between datastore and {@see Google\Cloud\Datastore\Entity}.
+ * Utility methods for mapping between datastore and {@see \Google\Cloud\Datastore\Entity}.
  */
 class EntityMapper
 {
@@ -55,7 +55,7 @@ class EntityMapper
      * @param string $projectId The datastore project ID
      * @param bool $encode Whether to encode blobs as base64.
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility.
      */
     public function __construct($projectId, $encode, $returnInt64AsObject)
@@ -70,10 +70,10 @@ class EntityMapper
      *
      * @param array $entityData The incoming entity
      * @param string $className The name of a class to use as the entity. Must
-     *        implement {@see Google\Cloud\Datastore\EntityInterface}.
+     *        implement {@see \Google\Cloud\Datastore\EntityInterface}.
      * @return array
      * @throws \InvalidArgumentException If the value of $className does not
-     *       implement {@see Google\Cloud\Datastore\EntityInterface}.
+     *       implement {@see \Google\Cloud\Datastore\EntityInterface}.
      * @throws \InvalidArgumentException If the custom entity type containts invalid
      *       mappings for embedded entities.
      */

--- a/Datastore/src/EntityOptionsTrait.php
+++ b/Datastore/src/EntityOptionsTrait.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Datastore;
 /**
  * Methods for handling Datastore Entity options boilerplate.
  *
- * This trait partially implements {@see Google\Cloud\Datastore\EntityInterface}
+ * This trait partially implements {@see \Google\Cloud\Datastore\EntityInterface}
  * and is useful when your application requires custom entities with non-standard
  * objects.
  */

--- a/Datastore/src/EntityPageIterator.php
+++ b/Datastore/src/EntityPageIterator.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Datastore;
 use Google\Cloud\Core\Iterator\PageIteratorTrait;
 
 /**
- * Iterates over a set of pages containing {@see Google\Cloud\Datastore\Entity}
+ * Iterates over a set of pages containing {@see \Google\Cloud\Datastore\Entity}
  * items.
  */
 class EntityPageIterator implements \Iterator

--- a/Datastore/src/EntityTrait.php
+++ b/Datastore/src/EntityTrait.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Datastore;
 /**
  * A trait to provide Datastore Entity functionality to classes.
  *
- * This class fulfills the {@see Google\Cloud\Datastore\EntityInterface} requirements.
+ * This class fulfills the {@see \Google\Cloud\Datastore\EntityInterface} requirements.
  */
 trait EntityTrait
 {
@@ -45,10 +45,10 @@ trait EntityTrait
      *
      *     @type string $cursor Set only when the entity is obtained by a query
      *           result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\Entity::cursor()}.
+     *           {@see \Google\Cloud\Datastore\Entity::cursor()}.
      *     @type string $baseVersion Set only when the entity is obtained by a
      *           query result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\Entity::baseVersion()}.
+     *           {@see \Google\Cloud\Datastore\Entity::baseVersion()}.
      *     @type array $excludeFromIndexes A list of entity keys to exclude from
      *           datastore indexes.
      *     @type array $meanings A list of meaning values for entity properties.
@@ -80,10 +80,10 @@ trait EntityTrait
      *
      *     @type string $cursor Set only when the entity is obtained by a query
      *           result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\Entity::cursor()}.
+     *           {@see \Google\Cloud\Datastore\Entity::cursor()}.
      *     @type string $baseVersion Set only when the entity is obtained by a
      *           query result. If set, the entity cursor can be retrieved from
-     *           {@see Google\Cloud\Datastore\Entity::baseVersion()}.
+     *           {@see \Google\Cloud\Datastore\Entity::baseVersion()}.
      *     @type array $excludeFromIndexes A list of entity keys to exclude from
      *           datastore indexes.
      *     @type array $meanings A list of meaning values for entity properties.

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -30,13 +30,13 @@ use Google\Cloud\Datastore\V1\QueryResultBatch\MoreResultsType;
 /**
  * Run lookups and queries and commit changes.
  *
- * This class is used by {@see Google\Cloud\Datastore\DatastoreClient}
- * and {@see Google\Cloud\Datastore\Transaction} and is not intended to be used
+ * This class is used by {@see \Google\Cloud\Datastore\DatastoreClient}
+ * and {@see \Google\Cloud\Datastore\Transaction} and is not intended to be used
  * directly.
  *
  * Examples are omitted for brevity. Detailed usage examples can be found in
- * {@see Google\Cloud\Datastore\DatastoreClient} and
- * {@see Google\Cloud\Datastore\Transaction}.
+ * {@see \Google\Cloud\Datastore\DatastoreClient} and
+ * {@see \Google\Cloud\Datastore\Transaction}.
  */
 class Operation
 {
@@ -206,10 +206,10 @@ class Operation
      *
      * In certain cases, you may want to create your own entity types.
      * Google Cloud PHP supports custom types implementing
-     * {@see Google\Cloud\Datastore\EntityInterface}. If the name of an
+     * {@see \Google\Cloud\Datastore\EntityInterface}. If the name of an
      * `EntityInterface` implementation is given in the options array, an
      * instance of that class will be returned instead of
-     * {@see Google\Cloud\Datastore\Entity}.
+     * {@see \Google\Cloud\Datastore\Entity}.
      *
      * @see https://cloud.google.com/datastore/reference/rest/v1/Entity Entity
      *
@@ -223,8 +223,8 @@ class Operation
      *
      *     @type string $className If set, the given class will be returned.
      *           Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type array $excludeFromIndexes A list of entity keys to exclude from
      *           datastore indexes.
      * }
@@ -359,11 +359,11 @@ class Operation
      *           run in a transaction.
      *     @type string|array $className If a string, the given class will be
      *           returned. Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}.
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value must implement
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type bool $sort If set to true, results in each set will be sorted
      *           to match the order given in $keys. **Defaults to** `false`.
      *     @type string $databaseId ID of the database to which the entities belong.
@@ -371,8 +371,8 @@ class Operation
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of
-     *         {@see Google\Cloud\Datastore\Entity}. Members of `missing` and
-     *         `deferred` will be instance of {@see Google\Cloud\Datastore\Key}.
+     *         {@see \Google\Cloud\Datastore\Entity}. Members of `missing` and
+     *         `deferred` will be instance of {@see \Google\Cloud\Datastore\Key}.
      * @throws \InvalidArgumentException
      */
     public function lookup(array $keys, array $options = [])
@@ -450,8 +450,8 @@ class Operation
      *           run in a transaction.
      *     @type string $className If set, the given class will be returned.
      *           Value must be the name of a class implementing
-     *           {@see Google\Cloud\Datastore\EntityInterface}. **Defaults to**
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\EntityInterface}. **Defaults to**
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type string $databaseId ID of the database to which the entities belong.
@@ -750,11 +750,11 @@ class Operation
      *
      * @param array $result The EntityResult from a Lookup.
      * @param string|array $class If a string, the name of the class to return results as.
-     *        Must implement {@see Google\Cloud\Datastore\EntityInterface}.
-     *        If not set, {@see Google\Cloud\Datastore\Entity} will be used.
+     *        Must implement {@see \Google\Cloud\Datastore\EntityInterface}.
+     *        If not set, {@see \Google\Cloud\Datastore\Entity} will be used.
      *        If an array is given, it must be an associative array, where
      *        the key is a Kind and the value is an object implementing
-     *        {@see Google\Cloud\Datastore\EntityInterface}.
+     *        {@see \Google\Cloud\Datastore\EntityInterface}.
      * @return EntityInterface
      */
     private function mapEntityResult(array $result, $class)

--- a/Datastore/src/Query/GqlQuery.php
+++ b/Datastore/src/Query/GqlQuery.php
@@ -30,7 +30,7 @@ use Google\Cloud\Datastore\EntityMapper;
  * `$options['allowLiterals']` to `true`. As with any SQL dialect, using
  * parameter binding is highly recommended.
  *
- * Idiomatic usage is via {@see Google\Cloud\Datastore\DatastoreClient::gqlQuery()}.
+ * Idiomatic usage is via {@see \Google\Cloud\Datastore\DatastoreClient::gqlQuery()}.
  *
  *
  * Example:

--- a/Datastore/src/Query/Query.php
+++ b/Datastore/src/Query/Query.php
@@ -307,7 +307,7 @@ class Query implements QueryInterface
     /**
      * Query for entities by their ancestors.
      *
-     * Keys can be provided either via a {@see Google\Cloud\Datastore\Key}
+     * Keys can be provided either via a {@see \Google\Cloud\Datastore\Key}
      * object, or by providing a kind, identifier and (optionally) an identifier
      * type.
      *

--- a/Datastore/src/ReadOnlyTransaction.php
+++ b/Datastore/src/ReadOnlyTransaction.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Datastore;
  *
  * Transactions are an **optional** feature of Google Cloud Datastore. Queries,
  * lookups and mutations can be executed outside of a Transaction from
- * {@see Google\Cloud\Datastore\DatastoreClient}.
+ * {@see \Google\Cloud\Datastore\DatastoreClient}.
  *
  * Example:
  * ```

--- a/Datastore/src/Transaction.php
+++ b/Datastore/src/Transaction.php
@@ -31,7 +31,7 @@ namespace Google\Cloud\Datastore;
  *
  * Mutations (i.e. insert, update and delete) are not executed immediately.
  * Calls to those methods (and their batch equivalents) will enqueue a new
- * mutation. Calling {@see Google\Cloud\Datastore\Transaction::commit()} will
+ * mutation. Calling {@see \Google\Cloud\Datastore\Transaction::commit()} will
  * execute all the mutations in the order they were enqueued, and end the
  * transaction.
  *
@@ -40,7 +40,7 @@ namespace Google\Cloud\Datastore;
  *
  * Transactions are an **optional** feature of Google Cloud Datastore. Queries,
  * lookups and mutations can be executed outside of a Transaction from
- * {@see Google\Cloud\Datastore\DatastoreClient}.
+ * {@see \Google\Cloud\Datastore\DatastoreClient}.
  *
  * Example:
  * ```
@@ -66,7 +66,7 @@ class Transaction
      * Insert an entity.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * If entities with incomplete keys are provided, this method will immediately
@@ -93,7 +93,7 @@ class Transaction
      * Insert multiple entities.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * If entities with incomplete keys are provided, this method will immediately
@@ -127,7 +127,7 @@ class Transaction
      * Update an entity.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Example:
@@ -166,7 +166,7 @@ class Transaction
      * Update multiple entities.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Example:
@@ -211,7 +211,7 @@ class Transaction
      * Upsert an entity.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Upsert will create a record if one does not already exist, or overwrite
@@ -241,7 +241,7 @@ class Transaction
      * Upsert multiple entities.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Upsert will create a record if one does not already exist, or overwrite
@@ -283,7 +283,7 @@ class Transaction
      * Delete a record.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Example:
@@ -306,7 +306,7 @@ class Transaction
      * Delete multiple records.
      *
      * Changes are not immediately committed to Cloud Datastore when calling
-     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * this method. Use {@see \Google\Cloud\Datastore\Transaction::commit()} to
      * commit changes and end the transaction.
      *
      * Example:

--- a/Datastore/src/TransactionTrait.php
+++ b/Datastore/src/TransactionTrait.php
@@ -75,8 +75,8 @@ trait TransactionTrait
      *     Configuration Options
      *
      *     @type string $className The name of the class to return results as.
-     *           Must be a subclass of {@see Google\Cloud\Datastore\Entity}.
-     *           If not set, {@see Google\Cloud\Datastore\Entity} will be used.
+     *           Must be a subclass of {@see \Google\Cloud\Datastore\Entity}.
+     *           If not set, {@see \Google\Cloud\Datastore\Entity} will be used.
      * }
      * @return EntityInterface|null
      */
@@ -111,18 +111,18 @@ trait TransactionTrait
      *     Configuration Options
      *
      *     @type string|array $className If a string, the name of the class to return results as.
-     *           Must be a subclass of {@see Google\Cloud\Datastore\Entity}.
-     *           If not set, {@see Google\Cloud\Datastore\Entity} will be used.
+     *           Must be a subclass of {@see \Google\Cloud\Datastore\Entity}.
+     *           If not set, {@see \Google\Cloud\Datastore\Entity} will be used.
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value is the name of a subclass of
-     *           {@see Google\Cloud\Datastore\Entity}.
+     *           {@see \Google\Cloud\Datastore\Entity}.
      *     @type bool $sort If set to true, results in each set will be sorted
      *           to match the order given in $keys. **Defaults to** `false`.
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of
-     *         {@see Google\Cloud\Datastore\Entity}. Members of `missing` and
-     *         `deferred` will be instance of {@see Google\Cloud\Datastore\Key}.
+     *         {@see \Google\Cloud\Datastore\Entity}. Members of `missing` and
+     *         `deferred` will be instance of {@see \Google\Cloud\Datastore\Key}.
      */
     public function lookupBatch(array $keys, array $options = [])
     {
@@ -148,8 +148,8 @@ trait TransactionTrait
      *     Configuration Options
      *
      *     @type string $className The name of the class to return results as.
-     *           Must be a subclass of {@see Google\Cloud\Datastore\Entity}.
-     *           If not set, {@see Google\Cloud\Datastore\Entity} will be used.
+     *           Must be a subclass of {@see \Google\Cloud\Datastore\Entity}.
+     *           If not set, {@see \Google\Cloud\Datastore\Entity} will be used.
      * }
      * @return EntityIterator<EntityInterface>
      */

--- a/Debugger/src/Daemon.php
+++ b/Debugger/src/Daemon.php
@@ -94,7 +94,7 @@ class Daemon
      *            **Defaults to** the current working directory.
      *      @type array $clientConfig The options to instantiate the default
      *            DebuggerClient.
-     *            {@see Google\Cloud\Debugger\DebuggerClient::__construct()}
+     *            {@see \Google\Cloud\Debugger\DebuggerClient::__construct()}
      *            for the available options.
      *      @type array $sourceContext The source code identifier. **Defaults
      *            to** values autodetected from the environment.
@@ -119,7 +119,7 @@ class Daemon
      *            responsible for serializing closures used in the
      *            `$clientConfig`. This is especially important when using the
      *            batch daemon. **Defaults to**
-     *            {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *            {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *            `opis/closure` library is installed.
      *      @type bool $register Whether to start the worker in the background
      *            using the BatchRunner. **Defaults to** false.

--- a/Debugger/src/Debuggee.php
+++ b/Debugger/src/Debuggee.php
@@ -290,7 +290,7 @@ class Debuggee
      *
      * @param Breakpoint $breakpoint The modified breakpoint.
      * @param array $options [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        {@see \Google\Cloud\Core\RequestWrapper::__construct()} for
      *        configuration options which apply to all network requests.
      * @return void
      * @throws ServiceException
@@ -319,9 +319,9 @@ class Debuggee
      * @param string $path Path to the source file.
      * @param int $line Line within the source file.
      * @param array $options [optional] Array of Breakpoint constructor arguments. See
-     *        {@see Google\Cloud\Debugger\Breakpoint::__construct()} for
+     *        {@see \Google\Cloud\Debugger\Breakpoint::__construct()} for
      *        configuration details. See
-     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        {@see \Google\Cloud\Core\RequestWrapper::__construct()} for
      *        configuration options which apply to all network requests.
      */
     public function setBreakpoint($path, $line, array $options = [])
@@ -350,7 +350,7 @@ class Debuggee
      *
      * @param Breakpoint[] $breakpoints The modified breakpoints.
      * @param array $options [optional] Configuration options. See
-     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        {@see \Google\Cloud\Core\RequestWrapper::__construct()} for
      *        configuration options which apply to all network requests.
      * @return void
      * @throws ServiceException

--- a/Debugger/src/DebuggerClient.php
+++ b/Debugger/src/DebuggerClient.php
@@ -118,7 +118,7 @@ class DebuggerClient
     /**
      * Lazily instantiate a debuggee. There are no network requests made at this
      * point. To see the operations that can be performed on a debuggee, please
-     * see {@see Google\Cloud\Debugger\Debuggee}.
+     * see {@see \Google\Cloud\Debugger\Debuggee}.
      *
      * Example:
      * ```

--- a/Firestore/src/BulkWriter.php
+++ b/Firestore/src/BulkWriter.php
@@ -33,9 +33,9 @@ use Google\Rpc\Code;
  *
  * This class may be used directly for multiple non-transactional writes with
  * automatic retry on failure. To run changes in a transaction (with automatic
- * retry/rollback on failure), use {@see Google\Cloud\Firestore\Transaction}.
+ * retry/rollback on failure), use {@see \Google\Cloud\Firestore\Transaction}.
  * Single modifications can be made using the various methods on
- * {@see Google\Cloud\Firestore\DocumentReference}.
+ * {@see \Google\Cloud\Firestore\DocumentReference}.
  *
  * Example:
  * ```
@@ -337,7 +337,7 @@ class BulkWriter
      *        name. Field data must be provided in the `$fields` argument.
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
-     *        Note that unlike {@see Google\Cloud\Firestore\DocumentReference::update()},
+     *        Note that unlike {@see \Google\Cloud\Firestore\DocumentReference::update()},
      *        field paths are NOT supported by this method.
      * @param array $options Configuration options
      * @return BulkWriter
@@ -400,7 +400,7 @@ class BulkWriter
      *        name. Field data must be provided in the `$fields` argument.
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
-     *        Note that unlike {@see Google\Cloud\Firestore\BulkWriter::update()},
+     *        Note that unlike {@see \Google\Cloud\Firestore\BulkWriter::update()},
      *        field paths are NOT supported by this method.
      * @param array $options {
      *     Configuration Options
@@ -471,11 +471,11 @@ class BulkWriter
      *
      * This method supports various sentinel values, to perform special operations
      * on fields. Available sentinel values are provided as methods, found in
-     * {@see Google\Cloud\Firestore\FieldValue}.
+     * {@see \Google\Cloud\Firestore\FieldValue}.
      *
      * Note that field names must be provided using field paths, encoded either
      * as a dot-delimited string (i.e. `foo.bar`), or an instance of
-     * {@see Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
+     * {@see \Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
      *
      * Please note that conflicting paths will result in an exception. Paths
      * conflict when one path indicates a location nested within another path.
@@ -506,7 +506,7 @@ class BulkWriter
      *
      * ```
      * // If your field names contain special characters (such as `.`, or symbols),
-     * // using {@see Google\Cloud\Firestore\FieldPath} will properly escape each element.
+     * // using {@see \Google\Cloud\Firestore\FieldPath} will properly escape each element.
      *
      * use Google\Cloud\Firestore\FieldPath;
      *
@@ -1344,7 +1344,7 @@ class BulkWriter
     }
 
     /**
-     * Convert a set of {@see Google\Cloud\Firestore\FieldPath} objects to strings.
+     * Convert a set of {@see \Google\Cloud\Firestore\FieldPath} objects to strings.
      *
      * @param FieldPath[] $paths The input paths.
      * @param FieldValueInterface[] $sentinels Sentinel values.

--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -104,8 +104,8 @@ class CollectionReference extends Query
      * `projects/<project-id>/databases/<database-id>/documents/<relative-path>`.
      *
      * Other methods are available to retrieve different parts of a collection name:
-     * * {@see Google\Cloud\Firestore\CollectionReference::id()} Returns the last element.
-     * * {@see Google\Cloud\Firestore\CollectionReference::path()} Returns the path, relative to the database.
+     * * {@see \Google\Cloud\Firestore\CollectionReference::id()} Returns the last element.
+     * * {@see \Google\Cloud\Firestore\CollectionReference::path()} Returns the path, relative to the database.
      *
      * Example:
      * ```
@@ -125,7 +125,7 @@ class CollectionReference extends Query
      * Paths identify the location of a collection, relative to the database name.
      *
      * To retrieve the collection ID (the last element of the path), use
-     * {@see Google\Cloud\Firestore\CollectionReference::id()}.
+     * {@see \Google\Cloud\Firestore\CollectionReference::id()}.
      *
      * Example:
      * ```
@@ -144,7 +144,7 @@ class CollectionReference extends Query
      *
      * IDs are the path element which identifies a resource. To retrieve the
      * full path to a resource (the resource name), use
-     * {@see Google\Cloud\Firestore\CollectionReference::name()}.
+     * {@see \Google\Cloud\Firestore\CollectionReference::name()}.
      *
      * Example:
      * ```
@@ -178,10 +178,10 @@ class CollectionReference extends Query
      * Get a document reference with a randomly generated document ID.
      *
      * If you wish to create a document reference with a specified name, use
-     * {@see Google\Cloud\Firestore\CollectionReference::document()}.
+     * {@see \Google\Cloud\Firestore\CollectionReference::document()}.
      *
      * This method does NOT insert the document until you call
-     * {@see Google\Cloud\Firestore\DocumentReference::create()}.
+     * {@see \Google\Cloud\Firestore\DocumentReference::create()}.
      *
      * Example:
      * ```
@@ -200,14 +200,14 @@ class CollectionReference extends Query
      *
      * This method will generate a random document name. If you wish to create a
      * document with a specified name, create a reference with
-     * {@see Google\Cloud\Firestore\CollectionReference::document()}, then call
-     * {@see Google\Cloud\Firestore\DocumentReference::create()} to insert the
+     * {@see \Google\Cloud\Firestore\CollectionReference::document()}, then call
+     * {@see \Google\Cloud\Firestore\DocumentReference::create()} to insert the
      * document.
      *
      * This method immediately inserts the document. If you wish for lazy
      * creation of a Document instance, refer to
-     * {@see Google\Cloud\Firestore\CollectionReference::document()} or
-     * {@see Google\Cloud\Firestore\CollectionReference::newDocument()}.
+     * {@see \Google\Cloud\Firestore\CollectionReference::document()} or
+     * {@see \Google\Cloud\Firestore\CollectionReference::newDocument()}.
      *
      * Example:
      * ```

--- a/Firestore/src/DocumentReference.php
+++ b/Firestore/src/DocumentReference.php
@@ -101,8 +101,8 @@ class DocumentReference
      * `projects/<project-id>/databases/<database-id>/documents/<relative-path>`.
      *
      * Other methods are available to retrieve different parts of a collection name:
-     * * {@see Google\Cloud\Firestore\DocumentReference::id()} Returns the last element.
-     * * {@see Google\Cloud\Firestore\DocumentReference::path()} Returns the path, relative to the database.
+     * * {@see \Google\Cloud\Firestore\DocumentReference::id()} Returns the last element.
+     * * {@see \Google\Cloud\Firestore\DocumentReference::path()} Returns the path, relative to the database.
      *
      * Example:
      * ```
@@ -122,7 +122,7 @@ class DocumentReference
      * Paths identify the location of a document, relative to the database name.
      *
      * To retrieve the document ID (the last element of the path), use
-     * {@see Google\Cloud\Firestore\DocumentReference::id()}.
+     * {@see \Google\Cloud\Firestore\DocumentReference::id()}.
      *
      * Example:
      * ```
@@ -141,7 +141,7 @@ class DocumentReference
      *
      * IDs are the path element which identifies a resource. To retrieve the
      * path of a resource, relative to the database name, use
-     * {@see Google\Cloud\Firestore\DocumentReference::path()}.
+     * {@see \Google\Cloud\Firestore\DocumentReference::path()}.
      *
      * Example:
      * ```
@@ -173,7 +173,7 @@ class DocumentReference
      *
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
-     *        Note that unlike {@see Google\Cloud\Firestore\DocumentReference::update()},
+     *        Note that unlike {@see \Google\Cloud\Firestore\DocumentReference::update()},
      *        field paths are NOT supported by this method.
      * @param array $options Configuration Options.
      * @return array [WriteResult](https://cloud.google.com/firestore/docs/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.WriteResult)
@@ -209,7 +209,7 @@ class DocumentReference
      *
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
-     *        Note that unlike {@see Google\Cloud\Firestore\DocumentReference::update()},
+     *        Note that unlike {@see \Google\Cloud\Firestore\DocumentReference::update()},
      *        field paths are NOT supported by this method.
      * @param array $options {
      *     Configuration Options
@@ -240,11 +240,11 @@ class DocumentReference
      *
      * This method supports various sentinel values, to perform special operations
      * on fields. Available sentinel values are provided as methods, found in
-     * {@see Google\Cloud\Firestore\FieldValue}.
+     * {@see \Google\Cloud\Firestore\FieldValue}.
      *
      * Note that field names must be provided using field paths, encoded either
      * as a dot-delimited string (i.e. `foo.bar`), or an instance of
-     * {@see Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
+     * {@see \Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
      *
      * Please note that conflicting paths will result in an exception. Paths
      * conflict when one path indicates a location nested within another path.
@@ -275,7 +275,7 @@ class DocumentReference
      *
      * ```
      * // If your field names contain special characters (such as `.`, or symbols),
-     * // using {@see Google\Cloud\Firestore\FieldPath} will properly escape each element.
+     * // using {@see \Google\Cloud\Firestore\FieldPath} will properly escape each element.
      *
      * use Google\Cloud\Firestore\FieldPath;
      *

--- a/Firestore/src/DocumentSnapshot.php
+++ b/Firestore/src/DocumentSnapshot.php
@@ -110,8 +110,8 @@ class DocumentSnapshot implements \ArrayAccess
      * `projects/<project-id>/databases/<database-id>/documents/<relative-path>`.
      *
      * Other methods are available to retrieve different parts of a collection name:
-     * * {@see Google\Cloud\Firestore\DocumentSnapshot::id()} Returns the last element.
-     * * {@see Google\Cloud\Firestore\DocumentSnapshot::path()} Returns the path, relative to the database.
+     * * {@see \Google\Cloud\Firestore\DocumentSnapshot::id()} Returns the last element.
+     * * {@see \Google\Cloud\Firestore\DocumentSnapshot::path()} Returns the path, relative to the database.
      *
      * Example:
      * ```
@@ -131,7 +131,7 @@ class DocumentSnapshot implements \ArrayAccess
      * Paths identify the location of a document, relative to the database name.
      *
      * To retrieve the document ID (the last element of the path), use
-     * {@see Google\Cloud\Firestore\DocumentSnapshot::id()}.
+     * {@see \Google\Cloud\Firestore\DocumentSnapshot::id()}.
      *
      * Example:
      * ```
@@ -150,7 +150,7 @@ class DocumentSnapshot implements \ArrayAccess
      *
      * IDs are the path element which identifies a resource. To retrieve the
      * full path to a resource (the resource name), use
-     * {@see Google\Cloud\Firestore\DocumentSnapshot::name()}.
+     * {@see \Google\Cloud\Firestore\DocumentSnapshot::name()}.
      *
      * Example:
      * ```

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Firestore\FieldValue;
  * Represents an ArrayRemove DocumentTransform.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
+ * {@see \Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
  *
  * @internal
  */

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Firestore\FieldValue;
  * Represents an ArrayUnion DocumentTransform.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::arrayUnion()} for usage.
+ * {@see \Google\Cloud\Firestore\FieldValue::arrayUnion()} for usage.
  *
  * @internal
  */

--- a/Firestore/src/FieldValue/DeleteFieldValue.php
+++ b/Firestore/src/FieldValue/DeleteFieldValue.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Firestore\FieldValue;
  * Represents a field to be deleted.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
+ * {@see \Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
  *
  * @internal
  */

--- a/Firestore/src/FieldValue/DocumentTransformInterface.php
+++ b/Firestore/src/FieldValue/DocumentTransformInterface.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Firestore\FieldValue;
  * Represents a DocumentTransform value.
  *
  * A DocumentTransformInterface instance defines the structure of a
- * {@see Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform}
+ * {@see \Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform}
  * message. `$key` defines the `oneof transformType` key, and `$args` defines
  * the transformType message data.
  */

--- a/Firestore/src/FieldValue/FieldValueInterface.php
+++ b/Firestore/src/FieldValue/FieldValueInterface.php
@@ -25,7 +25,7 @@ use Google\Cloud\Firestore\FieldPath;
  * A special field value which is handled by the client to accomplish a specific
  * task, such as field deletion. Instances of `FieldValueInterface` do not
  * enqueue a DocumentTransform mutation. to enqueue a transform, use
- * {@see Google\Cloud\Firestore\FieldValue\DocumentTransformInterface}.
+ * {@see \Google\Cloud\Firestore\FieldValue\DocumentTransformInterface}.
  */
 interface FieldValueInterface
 {

--- a/Firestore/src/FieldValue/IncrementValue.php
+++ b/Firestore/src/FieldValue/IncrementValue.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Firestore\FieldValue;
  * Represents an increment DocumentTransform.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::increment()} for usage.
+ * {@see \Google\Cloud\Firestore\FieldValue::increment()} for usage.
  *
  * @internal
  */

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -23,7 +23,7 @@ use Google\Cloud\Firestore\V1\DocumentTransform\FieldTransform\ServerValue;
  * Represents a ServerTimestamp DocumentTransform.
  *
  * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
+ * {@see \Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
  *
  * @internal
  */

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -129,7 +129,7 @@ class FirestoreClient
      *     @type string $quotaProject Specifies a user project to bill for
      *           access charges associated with the request.
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * }
      * @throws \InvalidArgumentException
@@ -163,7 +163,7 @@ class FirestoreClient
     /**
      * Get a Batch Writer
      *
-     * The {@see Google\Cloud\Firestore\WriteBatch} allows more performant
+     * The {@see \Google\Cloud\Firestore\WriteBatch} allows more performant
      * multi-document, atomic updates.
      *
      * Example:
@@ -172,7 +172,7 @@ class FirestoreClient
      * ```
      *
      * @return WriteBatch
-     * @deprecated Please use {@see Google\Cloud\Firestore\BulkWriter} instead.
+     * @deprecated Please use {@see \Google\Cloud\Firestore\BulkWriter} instead.
      */
     public function batch()
     {
@@ -192,7 +192,7 @@ class FirestoreClient
     /**
      * Get a Bulk Writer
      *
-     * {@see Google\Cloud\Firestore\BulkWriter} allows scheduling multiple
+     * {@see \Google\Cloud\Firestore\BulkWriter} allows scheduling multiple
      * writes with auto-retries in batches. Please note:
      *     - This method is blocking and may execute many sequential batch write requests.
      *     - Gradually ramps up writes as specified by the 500/50/5 rule.
@@ -346,7 +346,7 @@ class FirestoreClient
      * requested, except in case of error.
      *
      * Note that this method will **always** return instances of
-     * {@see Google\Cloud\Firestore\DocumentSnapshot}, even if the documents
+     * {@see \Google\Cloud\Firestore\DocumentSnapshot}, even if the documents
      * requested do not exist. It is highly recommended that you check for
      * existence before accessing document data.
      *

--- a/Firestore/src/PathTrait.php
+++ b/Firestore/src/PathTrait.php
@@ -69,7 +69,7 @@ trait PathTrait
      * Return the database name from a fully-qualified path name.
      *
      * This method returns a fully-qualified path. For the database ID, use
-     * {@see Google\Cloud\Firestore\PathTrait::databaseIdFromName()}.
+     * {@see \Google\Cloud\Firestore\PathTrait::databaseIdFromName()}.
      *
      * @param string $name
      * @return string
@@ -84,7 +84,7 @@ trait PathTrait
      * Return the database ID from a fully-qualified path name.
      *
      * This method returns a bare database ID. For the fully-qualified database
-     * name, use {@see Google\Cloud\Firestore\PathTrait::databaseFromName()}.
+     * name, use {@see \Google\Cloud\Firestore\PathTrait::databaseFromName()}.
      *
      * @param string $name
      * @return string|null

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -363,12 +363,12 @@ class Query
      * Add a WHERE clause to the Query.
      *
      * For a list of all available operators, see
-     * {@see Google\Cloud\Firestore\V1\StructuredQuery\FieldFilter\Operator}.
+     * {@see \Google\Cloud\Firestore\V1\StructuredQuery\FieldFilter\Operator}.
      * This method also supports a number of comparison operators which you will
      * be familiar with, such as `=`, `>`, `<`, `<=` and `>=`. For array fields,
      * the `array-contains`, `IN` and `array-contains-any` operators are also
      * available.
-     * This method also supports usage of Filters (see {@see Google\Cloud\Firestore\Filter}).
+     * This method also supports usage of Filters (see {@see \Google\Cloud\Firestore\Filter}).
      * The Filter class helps to create complex queries using AND and OR operators.
      *
      * Example:
@@ -558,7 +558,7 @@ class Query
      * ```
      *
      * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
-     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        instance of {@see \Google\Cloud\Firestore\DocumentSnapshot}
      *        defining the query starting point.
      * @return Query A new instance of Query with the given changes applied.
      */
@@ -586,7 +586,7 @@ class Query
      * ```
      *
      * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
-     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        instance of {@see \Google\Cloud\Firestore\DocumentSnapshot}
      *        defining the query starting point.
      * @return Query A new instance of Query with the given changes applied.
      */
@@ -614,7 +614,7 @@ class Query
      * ```
      *
      * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
-     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        instance of {@see \Google\Cloud\Firestore\DocumentSnapshot}
      *        defining the query end point.
      * @return Query A new instance of Query with the given changes applied.
      */
@@ -642,7 +642,7 @@ class Query
      * ```
      *
      * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
-     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        instance of {@see \Google\Cloud\Firestore\DocumentSnapshot}
      *        defining the query end point.
      * @return Query A new instance of Query with the given changes applied.
      */
@@ -682,7 +682,7 @@ class Query
      *
      * @param string $key The query key.
      * @param mixed[]|DocumentSnapshot $fieldValues An array of values, or an
-     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        instance of {@see \Google\Cloud\Firestore\DocumentSnapshot}
      *        to use as the query boundary.
      * @param bool $before Whether the query boundary lies just before or after
      *        the provided data.

--- a/Firestore/src/Transaction.php
+++ b/Firestore/src/Transaction.php
@@ -25,7 +25,7 @@ use Google\Cloud\Firestore\Connection\ConnectionInterface;
  * Represents a Firestore transaction.
  *
  * This class should be accessed inside a transaction callable, obtained via
- * {@see Google\Cloud\Firestore\FirestoreClient::runTransaction()}.
+ * {@see \Google\Cloud\Firestore\FirestoreClient::runTransaction()}.
  *
  * Note that method examples, while shown as being called directly for the sake
  * of brevity, should be called only within the context of a transaction
@@ -153,7 +153,7 @@ class Transaction
      * requested, except in case of error.
      *
      * Note that this method will **always** return instances of
-     * {@see Google\Cloud\Firestore\DocumentSnapshot}, even if the documents
+     * {@see \Google\Cloud\Firestore\DocumentSnapshot}, even if the documents
      * requested do not exist. It is highly recommended that you check for
      * existence before accessing document data.
      *
@@ -234,7 +234,7 @@ class Transaction
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
      *        Note that unlike
-     *        {@see Google\Cloud\Firestore\DocumentReference::update()}, field
+     *        {@see \Google\Cloud\Firestore\DocumentReference::update()}, field
      *        paths are NOT supported by this method.
      * @return Transaction
      */
@@ -268,7 +268,7 @@ class Transaction
      * @param DocumentReference $document The document to modify or replace.
      * @param array $fields An array containing fields, where keys are the field
      *        names, and values are field values. Nested arrays are allowed.
-     *        Note that unlike {@see Google\Cloud\Firestore\Transaction::update()},
+     *        Note that unlike {@see \Google\Cloud\Firestore\Transaction::update()},
      *        field paths are NOT supported by this method.
      * @param array $options {
      *     Configuration options.
@@ -295,11 +295,11 @@ class Transaction
      *
      * This method supports various sentinel values, to perform special operations
      * on fields. Available sentinel values are provided as methods, found in
-     * {@see Google\Cloud\Firestore\FieldValue}.
+     * {@see \Google\Cloud\Firestore\FieldValue}.
      *
      * Note that field names must be provided using field paths, encoded either
      * as a dot-delimited string (i.e. `foo.bar`), or an instance of
-     * {@see Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
+     * {@see \Google\Cloud\Firestore\FieldPath}. Nested arrays are not allowed.
      *
      * Please note that conflicting paths will result in an exception. Paths
      * conflict when one path indicates a location nested within another path.
@@ -330,7 +330,7 @@ class Transaction
      *
      * ```
      * // If your field names contain special characters (such as `.`, or symbols),
-     * // using {@see Google\Cloud\Firestore\FieldPath} will properly escape each element.
+     * // using {@see \Google\Cloud\Firestore\FieldPath} will properly escape each element.
      *
      * use Google\Cloud\Firestore\FieldPath;
      *

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -23,8 +23,8 @@ if (false) {
  *
  * This class may be used directly for multiple non-transactional writes. To
  * run changes in a transaction (with automatic retry/rollback on failure),
- * use {@see Google\Cloud\Firestore\Transaction}. Single modifications can be
- * made using the various methods on {@see Google\Cloud\Firestore\DocumentReference}.
+ * use {@see \Google\Cloud\Firestore\Transaction}. Single modifications can be
+ * made using the various methods on {@see \Google\Cloud\Firestore\DocumentReference}.
  *
  * Example:
  * ```

--- a/Language/src/Annotation.php
+++ b/Language/src/Annotation.php
@@ -24,16 +24,16 @@ use Google\Cloud\Core\CallTrait;
  * [Google Cloud Natural Language API](https://cloud.google.com/natural-language/docs).
  *
  * This class is created internally by
- * {@see Google\Cloud\Language\LanguageClient} and is used to
+ * {@see \Google\Cloud\Language\LanguageClient} and is used to
  * represent various document analyzation results. It should not be instantiated
  * externally.
  *
  * Annotations are returned by
- * {@see Google\Cloud\Language\LanguageClient::analyzeEntities()},
- * {@see Google\Cloud\Language\LanguageClient::analyzeSentiment()},
- * {@see Google\Cloud\Language\LanguageClient::analyzeEntitySentiment()},
- * {@see Google\Cloud\Language\LanguageClient::analyzeSyntax()} and
- * {@see Google\Cloud\Language\LanguageClient::annotateText()}.
+ * {@see \Google\Cloud\Language\LanguageClient::analyzeEntities()},
+ * {@see \Google\Cloud\Language\LanguageClient::analyzeSentiment()},
+ * {@see \Google\Cloud\Language\LanguageClient::analyzeEntitySentiment()},
+ * {@see \Google\Cloud\Language\LanguageClient::analyzeSyntax()} and
+ * {@see \Google\Cloud\Language\LanguageClient::annotateText()}.
  *
  * Example:
  * ```

--- a/Language/src/LanguageClient.php
+++ b/Language/src/LanguageClient.php
@@ -136,7 +136,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -193,7 +193,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -252,7 +252,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -308,7 +308,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -365,7 +365,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -423,7 +423,7 @@ class LanguageClient
      *        either a string of UTF-8 encoded content, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *

--- a/Logging/src/Logger.php
+++ b/Logging/src/Logger.php
@@ -234,8 +234,8 @@ class Logger
 
     /**
      * Creates an entry which which can be written to a log. In order to write
-     * the entry to the log please use {@see Google\Cloud\Logging\Logger::write()}
-     * or {@see Google\Cloud\Logging\Logger::writeBatch()}.
+     * the entry to the log please use {@see \Google\Cloud\Logging\Logger::write()}
+     * or {@see \Google\Cloud\Logging\Logger::writeBatch()}.
      *
      * Example:
      * ```
@@ -369,7 +369,7 @@ class Logger
      *
      * @param array|string|Entry $entry The entry to write to the log.
      * @param array $options [optional] Please see
-     *        {@see Google\Cloud\Logging\Logger::entry()} to see the options
+     *        {@see \Google\Cloud\Logging\Logger::entry()} to see the options
      *        that can be applied to a log entry. Please note that if the
      *        provided entry is of type `Entry` these options will overwrite
      *        those that may already be set on the instance.

--- a/Logging/src/LoggingClient.php
+++ b/Logging/src/LoggingClient.php
@@ -131,7 +131,7 @@ class LoggingClient
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      * }
      * @return PsrLogger
@@ -244,7 +244,7 @@ class LoggingClient
     /**
      * Lazily instantiates a sink. There are no network requests made at this
      * point. To see the operations that can be performed on a sink please see
-     * {@see Google\Cloud\Logging\Sink}.
+     * {@see \Google\Cloud\Logging\Sink}.
      *
      * Example:
      * ```
@@ -345,7 +345,7 @@ class LoggingClient
     /**
      * Lazily instantiates a metric. There are no network requests made at this
      * point. To see the operations that can be performed on a metric please see
-     * {@see Google\Cloud\Logging\Metric}.
+     * {@see \Google\Cloud\Logging\Metric}.
      *
      * Example:
      * ```
@@ -548,7 +548,7 @@ class LoggingClient
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      * }
      * @return PsrLogger

--- a/Logging/src/PsrLogger.php
+++ b/Logging/src/PsrLogger.php
@@ -130,7 +130,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      * }
      */
@@ -164,7 +164,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -182,7 +182,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -200,7 +200,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -218,7 +218,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -236,7 +236,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -254,7 +254,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -272,7 +272,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */
@@ -290,7 +290,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * ```
      *
      * @param string $message The message to log.
-     * @param array $context [optional] Please see {@see Google\Cloud\Logging\PsrLogger::log()}
+     * @param array $context [optional] Please see {@see \Google\Cloud\Logging\PsrLogger::log()}
      *        for the available options.
      * @return void
      */

--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -597,7 +597,7 @@ class PubSubClient
      * Verify that a schema is valid.
      *
      * If the schema is valid, the response will be empty. If invalid, a
-     * {@see Google\Cloud\Core\Exception\BadRequestException} will be thrown.
+     * {@see \Google\Cloud\Core\Exception\BadRequestException} will be thrown.
      *
      * Example:
      * ```
@@ -637,7 +637,7 @@ class PubSubClient
      * Validate a given message against a schema.
      *
      * If the message is valid, the response will be empty. If invalid, a
-     * {@see Google\Cloud\Core\Exception\BadRequestException} will be thrown.
+     * {@see \Google\Cloud\Core\Exception\BadRequestException} will be thrown.
      *
      * Example:
      * ```

--- a/PubSub/src/Topic.php
+++ b/PubSub/src/Topic.php
@@ -580,7 +580,7 @@ class Topic
      *           responsible for serializing closures used in the
      *           `$clientConfig`. This is especially important when using the
      *           batch daemon. **Defaults to**
-     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           {@see \Google\Cloud\Core\Batch\OpisClosureSerializer} if the
      *           `opis/closure` library is installed.
      *     @type bool $enableCompression Flag to enable compression of messages
      *           before publishing. Set the flag to `true` to enable compression.

--- a/Spanner/src/ArrayType.php
+++ b/Spanner/src/ArrayType.php
@@ -74,7 +74,7 @@ class ArrayType
     /**
      * @param int|string|null|StructType $type A value type code or nested struct
      *        definition. Accepted integer and string values are defined as constants on
-     *        {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *        {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *        `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *        `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *        `Database::TYPE_DATE`, `Database::TYPE_STRING`,

--- a/Spanner/src/Backup.php
+++ b/Spanner/src/Backup.php
@@ -329,7 +329,7 @@ class Backup
      * When backups are created, they may take some time before
      * they are ready for use. This method allows for checking whether a
      * backup is ready. Note that this value is cached within the class instance,
-     * so if you are polling it, first call {@see Google\Cloud\Spanner\Backup::reload()}
+     * so if you are polling it, first call {@see \Google\Cloud\Spanner\Backup::reload()}
      * to refresh the cached value.
      *
      * Example:

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -205,7 +205,7 @@ class BatchClient
     }
 
     /**
-     * Create a {@see Google\Cloud\Spanner\Batch\BatchSnapshot} from a snapshot
+     * Create a {@see \Google\Cloud\Spanner\Batch\BatchSnapshot} from a snapshot
      * identifier.
      *
      * This method can be used to deserialize a snapshot which is
@@ -216,7 +216,7 @@ class BatchClient
      * $snapshot = $batch->snapshotFromString($snapshotString);
      * ```
      *
-     * @param string $identifier A stringified representation of {@see Google\Cloud\Spanner\Batch\BatchSnapshot}.
+     * @param string $identifier A stringified representation of {@see \Google\Cloud\Spanner\Batch\BatchSnapshot}.
      * @return BatchSnapshot
      */
     public function snapshotFromString($identifier)
@@ -241,7 +241,7 @@ class BatchClient
     }
 
     /**
-     * Create a {@see Google\Cloud\Spanner\Batch\PartitionInterface} instance.
+     * Create a {@see \Google\Cloud\Spanner\Batch\PartitionInterface} instance.
      *
      * This method can be used to deserialize a partition which is
      * shared across multiple servers or processes.

--- a/Spanner/src/Batch/BatchSnapshot.php
+++ b/Spanner/src/Batch/BatchSnapshot.php
@@ -29,11 +29,11 @@ use Google\Cloud\Spanner\TransactionalReadInterface;
  * Represents a Read-Only Batch Transaction in Cloud Spanner.
  *
  * Batch Snapshots can be shared with other servers or processes by casting the
- * object to a string, or by calling {@see Google\Cloud\Spanner\Batch\BatchSnapshot::serialize()}.
+ * object to a string, or by calling {@see \Google\Cloud\Spanner\Batch\BatchSnapshot::serialize()}.
  *
  * Please note that it is important that Snapshots are closed when they are no
  * longer needed. Closing a snapshot is accomplished by calling
- * {@see Google\Cloud\Spanner\Batch\BatchSnapshot::close()}. Snapshots should be
+ * {@see \Google\Cloud\Spanner\Batch\BatchSnapshot::close()}. Snapshots should be
  * closed only after all workers have finished processing. Closing a snapshot
  * before all workers have processed will result in call failures.
  *
@@ -179,7 +179,7 @@ class BatchSnapshot implements TransactionalReadInterface
      *           Generally, Google Cloud PHP can infer types. Explicit type
      *           definitions are only necessary for null parameter values.
      *           Accepted values are defined as constants on
-     *           {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\ValueMapper}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
@@ -207,8 +207,8 @@ class BatchSnapshot implements TransactionalReadInterface
     /**
      * Read rows from a partition.
      *
-     * Partitions are created by calling {@see Google\Cloud\Spanner\Batch\BatchSnapshot::partitionRead()}
-     * or {@see Google\Cloud\Spanner\Batch\BatchSnapshot::partitionQuery()}.
+     * Partitions are created by calling {@see \Google\Cloud\Spanner\Batch\BatchSnapshot::partitionRead()}
+     * or {@see \Google\Cloud\Spanner\Batch\BatchSnapshot::partitionQuery()}.
      * Generally, those partitions will be distributed to worker processes, each
      * of which will call this method with the partition it was given.
      *

--- a/Spanner/src/Batch/QueryPartition.php
+++ b/Spanner/src/Batch/QueryPartition.php
@@ -23,13 +23,13 @@ use Google\Cloud\Spanner\Session\Session;
  * Represents a Query Partition.
  *
  * Partitions can be shared with other servers or processes by casting the
- * object to a string, or by calling {@see Google\Cloud\Spanner\Batch\QueryPartition::serialize()}.
+ * object to a string, or by calling {@see \Google\Cloud\Spanner\Batch\QueryPartition::serialize()}.
  *
  * Note that when reading or querying against a partition, the request MUST be
  * made using the same Batch Snapshot with which the partition was initialized.
  * In practice, this means that a shared partition must be accompanied by its
  * corresponding snapshot. For more information, refer to usage notes on
- * {@see Google\Cloud\Spanner\Batch\BatchClient}.
+ * {@see \Google\Cloud\Spanner\Batch\BatchClient}.
  *
  * Example:
  * ```
@@ -91,7 +91,7 @@ class QueryPartition implements PartitionInterface
      *           Generally, Google Cloud PHP can infer types. Explicit type
      *           definitions are only necessary for null parameter values.
      *           Accepted values are defined as constants on
-     *           {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\ValueMapper}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,

--- a/Spanner/src/Batch/ReadPartition.php
+++ b/Spanner/src/Batch/ReadPartition.php
@@ -23,13 +23,13 @@ use Google\Cloud\Spanner\KeySet;
  * Represents a Read Partition.
  *
  * Partitions can be shared with other servers or processes by casting the
- * object to a string, or by calling {@see Google\Cloud\Spanner\Batch\ReadPartition::serialize()}.
+ * object to a string, or by calling {@see \Google\Cloud\Spanner\Batch\ReadPartition::serialize()}.
  *
  * Note that when reading or querying against a partition, the request MUST be
  * made using the same Batch Snapshot with which the partition was initialized.
  * In practice, this means that a shared partition must be accompanied by its
  * corresponding snapshot. For more information, refer to usage notes on
- * {@see Google\Cloud\Spanner\Batch\BatchClient}.
+ * {@see \Google\Cloud\Spanner\Batch\BatchClient}.
  *
  * Example:
  * ```

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -192,7 +192,7 @@ class Database
      * @param SessionPoolInterface $sessionPool [optional] The session pool
      *        implementation.
      * @param bool $returnInt64AsObject [optional If true, 64 bit integers will
-     *        be returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        be returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility. **Defaults to** false.
      * @param string $databaseRole The user created database role which creates the session.
      */
@@ -230,7 +230,7 @@ class Database
      * When databases are created or restored, they may take some time before
      * they are ready for use. This method allows for checking whether a
      * database is ready. Note that this value is cached within the class instance,
-     * so if you are polling it, first call {@see Google\Cloud\Spanner\Database::reload()}
+     * so if you are polling it, first call {@see \Google\Cloud\Spanner\Database::reload()}
      * to refresh the cached value.
      *
      * Example:
@@ -741,10 +741,10 @@ class Database
      *
      * When manually using a Transaction, it is advised that retry logic be
      * implemented to reapply all operations when an instance of
-     * {@see Google\Cloud\Core\Exception\AbortedException} is thrown.
+     * {@see \Google\Cloud\Core\Exception\AbortedException} is thrown.
      *
      * If you wish Google Cloud PHP to handle retry logic for you (recommended
-     * for most cases), use {@see Google\Cloud\Spanner\Database::runTransaction()}.
+     * for most cases), use {@see \Google\Cloud\Spanner\Database::runTransaction()}.
      *
      * Please note that once a transaction reads data, it will lock the read
      * data, preventing other users from modifying that data. For this reason,
@@ -807,7 +807,7 @@ class Database
      * new transaction.
      *
      * If a transaction exceeds the maximum number of retries,
-     * {@see Google\Cloud\Core\Exception\AbortedException} will be thrown. Any other
+     * {@see \Google\Cloud\Core\Exception\AbortedException} will be thrown. Any other
      * exception types will immediately bubble up and will interrupt the retry
      * operation.
      *
@@ -821,8 +821,8 @@ class Database
      * raise a `BadMethodCallException`.
      *
      * If a callable finishes executing without invoking
-     * {@see Google\Cloud\Spanner\Transaction::commit()} or
-     * {@see Google\Cloud\Spanner\Transaction::rollback()}, the transaction will
+     * {@see \Google\Cloud\Spanner\Transaction::commit()} or
+     * {@see \Google\Cloud\Spanner\Transaction::rollback()}, the transaction will
      * automatically be rolled back and `\RuntimeException` thrown.
      *
      * Example:
@@ -989,7 +989,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1038,7 +1038,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1084,7 +1084,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1130,7 +1130,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1177,7 +1177,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1225,7 +1225,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1272,7 +1272,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1320,7 +1320,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1370,7 +1370,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
      * }
@@ -1387,10 +1387,10 @@ class Database
      * Run a query.
      *
      * Google Cloud PHP will infer parameter types for all primitive types and
-     * all values implementing {@see Google\Cloud\Spanner\ValueInterface}, with
+     * all values implementing {@see \Google\Cloud\Spanner\ValueInterface}, with
      * the exception of `null`. Non-associative arrays will be interpreted as
      * a Spanner ARRAY type, and must contain only a single type of value.
-     * Associative arrays or values of type {@see Google\Cloud\Spanner\StructValue}
+     * Associative arrays or values of type {@see \Google\Cloud\Spanner\StructValue}
      * will be interpreted as Spanner STRUCT type. Structs MUST always explicitly
      * define their field types.
      *
@@ -1398,18 +1398,18 @@ class Database
      * explicitly define the parameter's type.
      *
      * With the exception of arrays and structs, types are defined using a type
-     * constant defined on {@see Google\Cloud\Spanner\Database}. Examples include
+     * constant defined on {@see \Google\Cloud\Spanner\Database}. Examples include
      * but are not limited to `Database::TYPE_STRING` and `Database::TYPE_INT64`.
      *
      * Arrays, when explicitly typing, should use an instance of
-     * {@see Google\Cloud\Spanner\ArrayType} to declare their type and the types
+     * {@see \Google\Cloud\Spanner\ArrayType} to declare their type and the types
      * of any values contained within the array elements.
      *
      * Structs must always declare their type using an instance of
-     * {@see Google\Cloud\Spanner\StructType}. Struct values may be expressed as
+     * {@see \Google\Cloud\Spanner\StructType}. Struct values may be expressed as
      * an associative array, however if the struct contains any unnamed fields,
      * or any fields with duplicate names, the struct must be expressed using an
-     * instance of {@see Google\Cloud\Spanner\StructValue}. Struct value types
+     * instance of {@see \Google\Cloud\Spanner\StructValue}. Struct value types
      * may be inferred with the same caveats as top-level parameters (in other
      * words, so long as they are not nullable and do not contain nested structs).
      *
@@ -1493,7 +1493,7 @@ class Database
      *
      * ```
      * // If a struct contains unnamed fields, or multiple fields with the same
-     * // name, it must be defined using {@see Google\Cloud\Spanner\StructValue}.
+     * // name, it must be defined using {@see \Google\Cloud\Spanner\StructValue}.
      * use Google\Cloud\Spanner\Database;
      * use Google\Cloud\Spanner\Result;
      * use Google\Cloud\Spanner\StructValue;
@@ -1575,14 +1575,14 @@ class Database
      *           declarations are required in the case of struct parameters,
      *           or when a null value exists as a parameter.
      *           Accepted values for primitive types are defined as constants on
-     *           {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *           `Database::TYPE_BYTES`. If the value is an array, use
-     *           {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *           {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *           parameter types. Likewise, for structs, use
-     *           {@see Google\Cloud\Spanner\StructType}.
+     *           {@see \Google\Cloud\Spanner\StructType}.
      *     @type bool $returnReadTimestamp If true, the Cloud Spanner-selected
      *           read timestamp is included in the Transaction message that
      *           describes the transaction.
@@ -1625,7 +1625,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for read-only
      *         transactions.
      * }
@@ -1659,7 +1659,7 @@ class Database
      * Returns the lower bound of rows modified by the DML statement.
      *
      * **PLEASE NOTE** Most use cases for DML are better served by using
-     * {@see Google\Cloud\Spanner\Transaction::executeUpdate()}. Please read and
+     * {@see \Google\Cloud\Spanner\Transaction::executeUpdate()}. Please read and
      * understand the documentation for partitioned DML before implementing it
      * in your application.
      *
@@ -1668,7 +1668,7 @@ class Database
      * rows).
      *
      * To execute a SELECT statement, use
-     * {@see Google\Cloud\Spanner\Database::execute()}.
+     * {@see \Google\Cloud\Spanner\Database::execute()}.
      *
      * The method will block until the update is complete. Running a DML
      * statement with this method does not offer exactly once semantics, and
@@ -1684,7 +1684,7 @@ class Database
      * into transaction size limits or accidentally locking the entire table in
      * one large transaction. Smaller scoped statements, such as an OLTP
      * workload, should prefer using
-     * {@see Google\Cloud\Spanner\Transaction::executeUpdate()}.
+     * {@see \Google\Cloud\Spanner\Transaction::executeUpdate()}.
      *
      * * The DML statement must be fully-partitionable. Specifically, the
      *   statement must be expressible as the union of many statements which
@@ -1753,19 +1753,19 @@ class Database
      *           declarations are required in the case of struct parameters,
      *           or when a null value exists as a parameter.
      *           Accepted values for primitive types are defined as constants on
-     *           {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *           `Database::TYPE_BYTES`. If the value is an array, use
-     *           {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *           {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *           parameter types. Likewise, for structs, use
-     *           {@see Google\Cloud\Spanner\StructType}.
+     *           {@see \Google\Cloud\Spanner\StructType}.
      *     @type array $requestOptions Request options.
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for partitioned DML.
      * }
      * @return int The number of rows modified.
@@ -1897,7 +1897,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for read-only transactions.
      * }
      * @codingStandardsIgnoreEnd
@@ -1943,7 +1943,7 @@ class Database
      * associated.
      *
      * It is highly important to ensure this is called as it is not always safe
-     * to rely soley on {@see Google\Cloud\Spanner\Database::__destruct()}.
+     * to rely soley on {@see \Google\Cloud\Spanner\Database::__destruct()}.
      *
      * Example:
      * ```
@@ -1995,7 +1995,7 @@ class Database
     /**
      * Lazily instantiates a session. There are no network requests made at this
      * point. To see the operations that can be performed on a session please
-     * see {@see Google\Cloud\Spanner\Session\Session}.
+     * see {@see \Google\Cloud\Spanner\Session\Session}.
      *
      * Sessions are handled behind the scenes and this method does not need to
      * be called directly.
@@ -2095,7 +2095,7 @@ class Database
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use transactions.
      * }
      * @return Timestamp The commit timestamp.

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -134,7 +134,7 @@ class Instance
      * @param string $projectId The project ID.
      * @param string $name The instance name or ID.
      * @param bool $returnInt64AsObject [optional] If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit platform
+     *        returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit platform
      *        compatibility. **Defaults to** false.
      * @param array $info [optional] A representation of the instance object.
      */
@@ -328,7 +328,7 @@ class Instance
      * When instances are created or updated, they may take some time before
      * they are ready for use. This method allows for checking whether an
      * instance is ready. Note that this value is cached within the class instance,
-     * so if you are polling it, first call {@see Google\Cloud\Spanner\Instance::reload()}
+     * so if you are polling it, first call {@see \Google\Cloud\Spanner\Instance::reload()}
      * to refresh the cached value
      *
      * Example:

--- a/Spanner/src/KeyRange.php
+++ b/Spanner/src/KeyRange.php
@@ -258,7 +258,7 @@ class KeyRange
     }
 
     /**
-     * Create a KeyRange from an array created by {@see Google\Cloud\Spanner\KeyRange::keyRangeObject()}.
+     * Create a KeyRange from an array created by {@see \Google\Cloud\Spanner\KeyRange::keyRangeObject()}.
      *
      * @param array $range An array of KeyRange data.
      * @return KeyRange

--- a/Spanner/src/KeySet.php
+++ b/Spanner/src/KeySet.php
@@ -256,7 +256,7 @@ class KeySet
     }
 
     /**
-     * Create a KeySet from an array created by {@see Google\Cloud\Spanner\KeySet::keySetObject()}.
+     * Create a KeySet from an array created by {@see \Google\Cloud\Spanner\KeySet::keySetObject()}.
      *
      * @param array $keySet An array of KeySet data.
      * @return KeySet

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -30,12 +30,12 @@ use Google\Rpc\Code;
 /**
  * Common interface for running operations against Cloud Spanner. This class is
  * intended for internal use by the client library only. Implementors should
- * access these operations via {@see Google\Cloud\Spanner\Database} or
- * {@see Google\Cloud\Spanner\Transaction}.
+ * access these operations via {@see \Google\Cloud\Spanner\Database} or
+ * {@see \Google\Cloud\Spanner\Transaction}.
  *
  * Usage examples may be found in classes making use of this class:
- * * {@see Google\Cloud\Spanner\Database}
- * * {@see Google\Cloud\Spanner\Transaction}
+ * * {@see \Google\Cloud\Spanner\Database}
+ * * {@see \Google\Cloud\Spanner\Transaction}
  */
 class Operation
 {
@@ -65,7 +65,7 @@ class Operation
      *        Spanner. This object is created by SpannerClient,
      *        and should not be instantiated outside of this client.
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *        platform compatibility.
      */
     public function __construct(ConnectionInterface $connection, $returnInt64AsObject)
@@ -127,7 +127,7 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -154,9 +154,9 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
-     * @return array An array containing {@see Google\Cloud\Spanner\Timestamp}
+     * @return array An array containing {@see \Google\Cloud\Spanner\Timestamp}
      *               at index 0 and the commit response as an array at index 1.
      */
     public function commitWithResponse(Session $session, array $mutations, array $options = [])
@@ -206,7 +206,7 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
      * @return Result
      */
@@ -252,7 +252,7 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
      * @return int
      * @throws \InvalidArgumentException If the SQL string isn't an update operation.
@@ -286,7 +286,7 @@ class Operation
      * Execute multiple DML statements.
      *
      * For detailed usage instructions, see
-     * {@see Google\Cloud\Spanner\Transaction::executeUpdateBatch()}.
+     * {@see \Google\Cloud\Spanner\Transaction::executeUpdateBatch()}.
      *
      * @param Session $session The session in which the update operation should
      *        be executed.
@@ -300,14 +300,14 @@ class Operation
      *        infer types. Explicit type declarations are required in the case
      *        of struct parameters, or when a null value exists as a parameter.
      *        Accepted values for primitive types are defined as constants on
-     *        {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *        {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *        `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *        `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *        `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *        `Database::TYPE_BYTES`. If the value is an array, use
-     *        {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *        {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *        parameter types. Likewise, for structs, use
-     *        {@see Google\Cloud\Spanner\StructType}.
+     *        {@see \Google\Cloud\Spanner\StructType}.
      * @param array $options [optional] {
      *     Configuration Options.
      *
@@ -315,7 +315,7 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
      * @return BatchDmlResult
      * @throws \InvalidArgumentException If any statement is missing the `sql` key.
@@ -372,7 +372,7 @@ class Operation
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      * }
      * @return Result
      */
@@ -571,7 +571,7 @@ class Operation
     /**
      * Lazily instantiates a session. There are no network requests made at this
      * point. To see the operations that can be performed on a session please
-     * see {@see Google\Cloud\Spanner\Session\Session}.
+     * see {@see \Google\Cloud\Spanner\Session\Session}.
      *
      * Sessions are handled behind the scenes and this method does not need to
      * be called directly.
@@ -616,7 +616,7 @@ class Operation
      *           Generally, Google Cloud PHP can infer types. Explicit type
      *           definitions are only necessary for null parameter values.
      *           Accepted values are defined as constants on
-     *           {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\ValueMapper}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,

--- a/Spanner/src/Result.php
+++ b/Spanner/src/Result.php
@@ -165,7 +165,7 @@ class Result implements \IteratorAggregate
      *        duplicate column names are present a `\RuntimeException` will be
      *        thrown. `Result::RETURN_ZERO_INDEXED` returns items as a 0 indexed
      *        array, with the key representing the column number as found by
-     *        executing {@see Google\Cloud\Spanner\Result::columns()}. Ex:
+     *        executing {@see \Google\Cloud\Spanner\Result::columns()}. Ex:
      *        `[0 => 'my_value']`. **Defaults to** `Result::RETURN_ASSOCIATIVE`.
      * @return \Generator
      * @throws \InvalidArgumentException When an invalid format is provided.

--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -44,11 +44,11 @@ use Psr\Cache\CacheItemPoolInterface;
  * for the pool to handle.
  *
  * Please note that when
- * {@see Google\Cloud\Spanner\Session\CacheSessionPool::acquire()} is called at
+ * {@see \Google\Cloud\Spanner\Session\CacheSessionPool::acquire()} is called at
  * most only a single session is created. Due to this, it is possible to sit
  * under the minimum session value declared when constructing this instance. In
  * order to have the pool match the minimum session value please use the
- * {@see Google\Cloud\Spanner\Session\CacheSessionPool::warmup()} method. This
+ * {@see \Google\Cloud\Spanner\Session\CacheSessionPool::warmup()} method. This
  * will create as many sessions as needed to match the minimum value, and is the
  * recommended way to bootstrap the session pool.
  *
@@ -57,7 +57,7 @@ use Psr\Cache\CacheItemPoolInterface;
  * required are managed by the pool, attempts will be made to automatically
  * downsize after every 10 minute window. This feature is configurable and one
  * may also downsize at their own choosing via
- * {@see Google\Cloud\Spanner\Session\CacheSessionPool::downsize()}. Downsizing
+ * {@see \Google\Cloud\Spanner\Session\CacheSessionPool::downsize()}. Downsizing
  * will help ensure you never run into issues where the Spanner backend is
  * locked up after having met the maximum number of sessions assigned per node.
  * For reference, the current maximum sessions per database per node is 10k. For
@@ -66,7 +66,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * When expecting a long period of inactivity (such as a
  * maintenance window), please make sure to call
- * {@see Google\Cloud\Spanner\Session\CacheSessionPool::clear()} in order to
+ * {@see \Google\Cloud\Spanner\Session\CacheSessionPool::clear()} in order to
  * delete any active sessions.
  *
  * If you're on Windows, or your PHP doesn't have `sysvshm` extension,

--- a/Spanner/src/Snapshot.php
+++ b/Spanner/src/Snapshot.php
@@ -24,7 +24,7 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
  * Read-only snapshot Transaction.
  *
  * For full usage details, please refer to
- * {@see Google\Cloud\Spanner\Database::snapshot()}.
+ * {@see \Google\Cloud\Spanner\Database::snapshot()}.
  *
  * Example:
  * ```

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -143,7 +143,7 @@ class SpannerClient
      *     @type string $quotaProject Specifies a user project to bill for
      *           access charges associated with the request.
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *           returned as a {@see \Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      *     @type array $queryOptions Query optimizer configuration.
      *     @type string $queryOptions.optimizerVersion An option to control the
@@ -397,7 +397,7 @@ class SpannerClient
      * NOTE: This method does not execute a service request and does not verify
      * the existence of the given configuration. Unless you know with certainty
      * that the configuration exists, it is advised that you use
-     * {@see Google\Cloud\Spanner\InstanceConfiguration::exists()} to verify
+     * {@see \Google\Cloud\Spanner\InstanceConfiguration::exists()} to verify
      * existence before attempting to use the configuration.
      *
      * Example:
@@ -821,7 +821,7 @@ class SpannerClient
      * Create a CommitTimestamp object.
      *
      * Commit Timestamps may be used to implement server-side commit timestamp
-     * tracking in tables. Refer to {@see Google\Cloud\Spanner\CommitTimestamp}
+     * tracking in tables. Refer to {@see \Google\Cloud\Spanner\CommitTimestamp}
      * for usage details.
      *
      * Example:

--- a/Spanner/src/StructType.php
+++ b/Spanner/src/StructType.php
@@ -98,7 +98,7 @@ class StructType
      *
      * Unnamed struct fields may be defined by providing `null` as the first
      * argument value, however you may find it more convenient to use the provided
-     * {@see Google\Cloud\Spanner\StructType::addUnnamed()} method.
+     * {@see \Google\Cloud\Spanner\StructType::addUnnamed()} method.
      *
      * Example:
      * ```
@@ -129,7 +129,7 @@ class StructType
      * @param string|null $name The field name.
      * @param int|ArrayType|StructType $type $type A value type code or nested
      *        struct or array definition. Accepted integer values are defined as
-     *        constants on {@see Google\Cloud\Spanner\Database}, and are as
+     *        constants on {@see \Google\Cloud\Spanner\Database}, and are as
      *        follows: `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *        `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *        `Database::TYPE_DATE`, `Database::TYPE_STRING` and
@@ -187,7 +187,7 @@ class StructType
      *
      * @param int|ArrayType|StructType $type $type A value type code or nested
      *        struct or array definition. Accepted integer values are defined as
-     *        constants on {@see Google\Cloud\Spanner\Database}, and are as
+     *        constants on {@see \Google\Cloud\Spanner\Database}, and are as
      *        follows: `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *        `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *        `Database::TYPE_DATE`, `Database::TYPE_STRING` and

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -25,21 +25,21 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
  * Manages interaction with Cloud Spanner inside a Transaction.
  *
  * Transactions can be started via
- * {@see Google\Cloud\Spanner\Database::runTransaction()} (recommended) or via
- * {@see Google\Cloud\Spanner\Database::transaction()}. Transactions should
- * always call {@see Google\Cloud\Spanner\Transaction::commit()} or
- * {@see Google\Cloud\Spanner\Transaction::rollback()} to ensure that locks are
+ * {@see \Google\Cloud\Spanner\Database::runTransaction()} (recommended) or via
+ * {@see \Google\Cloud\Spanner\Database::transaction()}. Transactions should
+ * always call {@see \Google\Cloud\Spanner\Transaction::commit()} or
+ * {@see \Google\Cloud\Spanner\Transaction::rollback()} to ensure that locks are
  * released in a timely manner.
  *
  * If you do not plan on performing any writes in your transaction, a
- * {@see Google\Cloud\Spanner\Snapshot} is a better solution which does not
+ * {@see \Google\Cloud\Spanner\Snapshot} is a better solution which does not
  * require a commit or rollback and does not lock any data.
  *
- * Transactions may raise {@see Google\Cloud\Core\Exception\AbortedException} errors
+ * Transactions may raise {@see \Google\Cloud\Core\Exception\AbortedException} errors
  * when the transaction cannot complete for any reason. In this case, the entire
  * operation (all reads and writes) should be reapplied atomically. Google Cloud
  * PHP handles this transparently when using
- * {@see Google\Cloud\Spanner\Database::runTransaction()}. In other cases, it is
+ * {@see \Google\Cloud\Spanner\Database::runTransaction()}. In other cases, it is
  * highly recommended that applications implement their own retry logic.
  *
  * Example:
@@ -352,7 +352,7 @@ class Transaction implements TransactionalReadInterface
      * [DML syntax guide](https://cloud.google.com/spanner/docs/dml-syntax).
      *
      * To execute a SQL query (such as a SELECT), use
-     * {@see Google\Cloud\Spanner\Transaction::execute()}.
+     * {@see \Google\Cloud\Spanner\Transaction::execute()}.
      *
      * Mutations performed via DML will be visible to subsequent operations
      * within the same transaction. In other words, unlike with other mutation
@@ -410,19 +410,19 @@ class Transaction implements TransactionalReadInterface
      *           declarations are required in the case of struct parameters,
      *           or when a null value exists as a parameter.
      *           Accepted values for primitive types are defined as constants on
-     *           {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *           `Database::TYPE_BYTES`. If the value is an array, use
-     *           {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *           {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *           parameter types. Likewise, for structs, use
-     *           {@see Google\Cloud\Spanner\StructType}.
+     *           {@see \Google\Cloud\Spanner\StructType}.
      *     @type array $requestOptions Request options.
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
      *         been set when creating the transaction.
      * }
@@ -449,7 +449,7 @@ class Transaction implements TransactionalReadInterface
      *
      * This method allows many statements to be run with lower latency than
      * submitting them sequentially with
-     * {@see Google\Cloud\Spanner\Transaction::executeUpdate()}.
+     * {@see \Google\Cloud\Spanner\Transaction::executeUpdate()}.
      *
      * Statements are executed in order, sequentially. Execution will stop at
      * the first failed statement; the remaining statements will not be run.
@@ -505,14 +505,14 @@ class Transaction implements TransactionalReadInterface
      *        infer types. Explicit type declarations are required in the case
      *        of struct parameters, or when a null value exists as a parameter.
      *        Accepted values for primitive types are defined as constants on
-     *        {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *        {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *        `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *        `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *        `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *        `Database::TYPE_BYTES`. If the value is an array, use
-     *        {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *        {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *        parameter types. Likewise, for structs, use
-     *        {@see Google\Cloud\Spanner\StructType}.
+     *        {@see \Google\Cloud\Spanner\StructType}.
      * @param array $options [optional] {
      *     Configuration Options.
      *
@@ -520,7 +520,7 @@ class Transaction implements TransactionalReadInterface
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
      *         been set when creating the transaction.
      * }
@@ -581,7 +581,7 @@ class Transaction implements TransactionalReadInterface
      * Commit and end the transaction.
      *
      * It is advised that transactions be run inside
-     * {@see Google\Cloud\Spanner\Database::runTransaction()} in order to take
+     * {@see \Google\Cloud\Spanner\Database::runTransaction()} in order to take
      * advantage of automated transaction retry in case of a transaction aborted
      * error.
      *
@@ -596,13 +596,13 @@ class Transaction implements TransactionalReadInterface
      *     @type array $mutations An array of mutations to commit. May be used
      *           instead of or in addition to enqueing mutations separately.
      *     @type bool $returnCommitStats If true, commit statistics will be
-     *           returned and accessible via {@see Google\Cloud\Spanner\Transaction::getCommitStats()}.
+     *           returned and accessible via {@see \Google\Cloud\Spanner\Transaction::getCommitStats()}.
      *           **Defaults to** `false`.
      *     @type array $requestOptions Request options.
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `requestTag` setting will be ignored as it is not supported for commit requests.
      * }
      * @return Timestamp The commit timestamp.
@@ -666,7 +666,7 @@ class Transaction implements TransactionalReadInterface
     /**
      * Check whether the current transaction is a retry transaction.
      *
-     * When using {@see Google\Cloud\Spanner\Database::runTransaction()},
+     * When using {@see \Google\Cloud\Spanner\Database::runTransaction()},
      * transactions are automatically retried when a conflict causes it to abort.
      * In such cases, subsequent invocations of the transaction callable will
      * provide a transaction where `$transaction->isRetry()` is true. This can

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -76,10 +76,10 @@ trait TransactionalReadTrait
      * Run a query.
      *
      * Google Cloud PHP will infer parameter types for all primitive types and
-     * all values implementing {@see Google\Cloud\Spanner\ValueInterface}, with
+     * all values implementing {@see \Google\Cloud\Spanner\ValueInterface}, with
      * the exception of `null`. Non-associative arrays will be interpreted as
      * a Spanner ARRAY type, and must contain only a single type of value.
-     * Associative arrays or values of type {@see Google\Cloud\Spanner\StructValue}
+     * Associative arrays or values of type {@see \Google\Cloud\Spanner\StructValue}
      * will be interpreted as Spanner STRUCT type. Structs MUST always explicitly
      * define their field types.
      *
@@ -87,18 +87,18 @@ trait TransactionalReadTrait
      * explicitly define the parameter's type.
      *
      * With the exception of arrays and structs, types are defined using a type
-     * constant defined on {@see Google\Cloud\Spanner\Database}. Examples include
+     * constant defined on {@see \Google\Cloud\Spanner\Database}. Examples include
      * but are not limited to `Database::TYPE_STRING` and `Database::TYPE_INT64`.
      *
      * Arrays, when explicitly typing, should use an instance of
-     * {@see Google\Cloud\Spanner\ArrayType} to declare their type and the types
+     * {@see \Google\Cloud\Spanner\ArrayType} to declare their type and the types
      * of any values contained within the array elements.
      *
      * Structs must always declare their type using an instance of
-     * {@see Google\Cloud\Spanner\StructType}. Struct values may be expressed as
+     * {@see \Google\Cloud\Spanner\StructType}. Struct values may be expressed as
      * an associative array, however if the struct contains any unnamed fields,
      * or any fields with duplicate names, the struct must be expressed using an
-     * instance of {@see Google\Cloud\Spanner\StructValue}. Struct value types
+     * instance of {@see \Google\Cloud\Spanner\StructValue}. Struct value types
      * may be inferred with the same caveats as top-level parameters (in other
      * words, so long as they are not nullable and do not contain nested structs).
      *
@@ -182,7 +182,7 @@ trait TransactionalReadTrait
      *
      * ```
      * // If a struct contains unnamed fields, or multiple fields with the same
-     * // name, it must be defined using {@see Google\Cloud\Spanner\StructValue}.
+     * // name, it must be defined using {@see \Google\Cloud\Spanner\StructValue}.
      * use Google\Cloud\Spanner\Database;
      * use Google\Cloud\Spanner\Result;
      * use Google\Cloud\Spanner\StructValue;
@@ -230,14 +230,14 @@ trait TransactionalReadTrait
      *           declarations are required in the case of struct parameters,
      *           or when a null value exists as a parameter.
      *           Accepted values for primitive types are defined as constants on
-     *           {@see Google\Cloud\Spanner\Database}, and are as follows:
+     *           {@see \Google\Cloud\Spanner\Database}, and are as follows:
      *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
      *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
      *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
      *           `Database::TYPE_BYTES`. If the value is an array, use
-     *           {@see Google\Cloud\Spanner\ArrayType} to declare the array
+     *           {@see \Google\Cloud\Spanner\ArrayType} to declare the array
      *           parameter types. Likewise, for structs, use
-     *           {@see Google\Cloud\Spanner\StructType}.
+     *           {@see \Google\Cloud\Spanner\StructType}.
      *     @type array $queryOptions Query optimizer configuration.
      *     @type string $queryOptions.optimizerVersion An option to control the
      *           selection of optimizer version. This parameter allows
@@ -255,7 +255,7 @@ trait TransactionalReadTrait
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
      *         been set when creating the transaction.
      * }
@@ -319,7 +319,7 @@ trait TransactionalReadTrait
      *         For more information on available options, please see
      *         [the upstream documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions).
      *         Please note, if using the `priority` setting you may utilize the constants available
-     *         on {@see Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
+     *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
      *         been set when creating the transaction.
      * }

--- a/Speech/src/SpeechClient.php
+++ b/Speech/src/SpeechClient.php
@@ -32,7 +32,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * Please note this client will be deprecated in our next release. In order
  * to receive the latest features and updates, please take
- * the time to familiarize yourself with {@see Google\Cloud\Speech\V1\SpeechClient}.
+ * the time to familiarize yourself with {@see \Google\Cloud\Speech\V1\SpeechClient}.
  *
  * Example:
  * ```
@@ -174,7 +174,7 @@ class SpeechClient
      *        be a resource, string of bytes, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -303,7 +303,7 @@ class SpeechClient
      *        be a resource, string of bytes, a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}` or a
-     *        {@see Google\Cloud\Storage\StorageObject}.
+     *        {@see \Google\Cloud\Storage\StorageObject}.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -364,7 +364,7 @@ class SpeechClient
     /**
      * Lazily instantiates an operation. There are no network requests made at
      * this point. To see the operations that can be performed on an operation
-     * please see {@see Google\Cloud\Speech\Operation}.
+     * please see {@see \Google\Cloud\Speech\Operation}.
      *
      * Example:
      * ```

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -761,7 +761,7 @@ class Bucket
      * }
      * @return Notification
      * @throws \InvalidArgumentException When providing a type other than string
-     *         or {@see Google\Cloud\PubSub\Topic} as $topic.
+     *         or {@see \Google\Cloud\PubSub\Topic} as $topic.
      * @throws GoogleException When a project ID has not been detected.
      * @experimental The experimental flag means that while we believe this
      *      method or class is ready for use, it may change before release in
@@ -1419,7 +1419,7 @@ class Bucket
      * @see https://cloud.google.com/storage/docs/access-control/signed-urls Signed URLs
      *
      * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
-     *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
+     *        will expire. May provide an instance of {@see \Google\Cloud\Core\Timestamp},
      *        [http://php.net/datetimeimmutable](`\DateTimeImmutable`), or a
      *        UNIX timestamp as an integer.
      * @param array $options {
@@ -1525,7 +1525,7 @@ class Bucket
      * @param string $objectName The path to the file in Google Cloud Storage,
      *        relative to the bucket.
      * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
-     *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
+     *        will expire. May provide an instance of {@see \Google\Cloud\Core\Timestamp},
      *        [http://php.net/datetimeimmutable](`\DateTimeImmutable`), or a
      *        UNIX timestamp as an integer.
      * @param array $options [optional] {

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -416,7 +416,7 @@ class StorageClient
      * @param string $uri The URI to accept an upload request.
      * @param string|resource|StreamInterface $data The data to be uploaded
      * @param array $options [optional] Configuration Options. Refer to
-     *        {@see Google\Cloud\Core\Upload\AbstractUploader::__construct()}.
+     *        {@see \Google\Cloud\Core\Upload\AbstractUploader::__construct()}.
      * @return SignedUrlUploader
      */
     public function signedUrlUploader($uri, $data, array $options = [])

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -813,7 +813,7 @@ class StorageObject
      * @see https://cloud.google.com/storage/docs/access-control/signed-urls Signed URLs
      *
      * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
-     *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
+     *        will expire. May provide an instance of {@see \Google\Cloud\Core\Timestamp},
      *        [http://php.net/datetimeimmutable](`\DateTimeImmutable`), or a
      *        UNIX timestamp as an integer.
      * @param array $options {
@@ -935,7 +935,7 @@ class StorageObject
      * ```
      *
      * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
-     *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
+     *        will expire. May provide an instance of {@see \Google\Cloud\Core\Timestamp},
      *        [http://php.net/datetimeimmutable](`\DateTimeImmutable`), or a
      *        UNIX timestamp as an integer.
      * @param array $options {

--- a/Trace/src/Attributes.php
+++ b/Trace/src/Attributes.php
@@ -25,9 +25,9 @@ namespace Google\Cloud\Trace;
  * allowing access via the array syntax (example below).
  *
  * Attributes are available to
- * {@see Google\Cloud\Trace\Annotation},
- * {@see Google\Cloud\Trace\Link}, and
- * {@see Google\Cloud\Trace\Span}.
+ * {@see \Google\Cloud\Trace\Annotation},
+ * {@see \Google\Cloud\Trace\Link}, and
+ * {@see \Google\Cloud\Trace\Span}.
  *
  * Example:
  * ```

--- a/Trace/src/Trace.php
+++ b/Trace/src/Trace.php
@@ -66,7 +66,7 @@ class Trace
      * @param string $traceId [optional] The id of the trace. If not provided, one will be generated
      *        automatically for you.
      * @param array $spans [optional] Array of Span constructor arguments. See
-     *        {@see Google\Cloud\Trace\Span::__construct()} for configuration details.
+     *        {@see \Google\Cloud\Trace\Span::__construct()} for configuration details.
      */
     public function __construct($projectId, $traceId = null, array $spans = [])
     {
@@ -125,14 +125,14 @@ class Trace
     }
 
     /**
-     * Create an instance of {@see Google\Cloud\Trace\Span}
+     * Create an instance of {@see \Google\Cloud\Trace\Span}
      *
      * Example:
      * ```
      * $span = $trace->span(['name' => 'newSpan']);
      * ```
      *
-     * @param array $options [optional] See {@see Google\Cloud\Trace\Span::__construct()}
+     * @param array $options [optional] See {@see \Google\Cloud\Trace\Span::__construct()}
      *        for configuration details.
      * @return Span
      */

--- a/Trace/src/TraceClient.php
+++ b/Trace/src/TraceClient.php
@@ -161,7 +161,7 @@ class TraceClient
     /**
      * Lazily find or instantiates a trace. There are no network requests made at this
      * point. To see the operations that can be performed on a trace please
-     * see {@see Google\Cloud\Trace\Trace}. If no traceId is provided, one will be
+     * see {@see \Google\Cloud\Trace\Trace}. If no traceId is provided, one will be
      * generated for you.
      *
      * Example:

--- a/Translate/src/TranslateClient.php
+++ b/Translate/src/TranslateClient.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Translate;
 
 if (false) {
     /**
-     * This class is deprecated. Use {@see Google\Cloud\Translate\V2\TranslateClient} instead.
+     * This class is deprecated. Use {@see \Google\Cloud\Translate\V2\TranslateClient} instead.
      * @deprecated
      */
     class TranslateClient {}

--- a/dev/src/GetComponentsTrait.php
+++ b/dev/src/GetComponentsTrait.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Dev;
 /**
  * Helper for managing components.
  *
- * @deprecated Use {@see Google\Cloud\Dev\ComponentManager} instead.
+ * @deprecated Use {@see \Google\Cloud\Dev\ComponentManager} instead.
  * @internal
  */
 trait GetComponentsTrait


### PR DESCRIPTION
A way to address https://github.com/googleapis/google-cloud-php/issues/6626, where `@see Google\**` is replaced with `@see \Google\**`. The extra `\` causes the references to be matched correctly.