### PR TITLE
chore: mark google/cloud-game-servers abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "google/cloud",
     "type": "library",
     "description": "Google Cloud Client Library",
+    "abandoned": true,
     "keywords": [
         "google apis client",
         "google api client",


### PR DESCRIPTION
See Piper Rev-Id: 561043692

GameServer protos have been removed and are no longer being updated / maintained