### PR TITLE
chore: add required vars to Spanner system test

### DIFF
--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -56,3 +56,5 @@ jobs:
           Spanner/vendor/bin/phpunit -c Spanner/phpunit-system.xml.dist
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
+          GOOGLE_CLOUD_PHP_TESTS_KEY_PATH: '.github/emulator/example-key.json'
+          GOOGLE_CLOUD_PHP_WHITELIST_TESTS_KEY_PATH: '.github/emulator/example-key.json'


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-php/pull/6726 uncovers lack of required env vars in Spanner system tests.

This is causing failures [in other PRs](https://github.com/googleapis/google-cloud-php/actions/runs/6707182781/job/18225126264?pr=6708)