### PR TITLE
(Fix) When a resourceNames was passed as an option, the array_merge w…

### DIFF
--- a/Logging/src/LoggingClient.php
+++ b/Logging/src/LoggingClient.php
@@ -469,7 +469,7 @@ class LoggingClient
             unset($options['projectIds']);
         }
         if (isset($options['resourceNames'])) {
-            $options['resourceNames'] = array_merge($resourceNames, $options['projectIds']);
+            $options['resourceNames'] = array_merge($resourceNames, $options['resourceNames']);
         } else {
             $options['resourceNames'] = $resourceNames;
         }


### PR DESCRIPTION
When a resourceNames was passed as an option, the array_merge was merging with the wrong key (project_ids),