### PR TITLE
fix: Wrong key on array_merge on fetch logs entries

### DIFF
--- a/Logging/src/LoggingClient.php
+++ b/Logging/src/LoggingClient.php
@@ -469,7 +469,7 @@ class LoggingClient
             unset($options['projectIds']);
         }
         if (isset($options['resourceNames'])) {
-            $options['resourceNames'] = array_merge($resourceNames, $options['projectIds']);
+            $options['resourceNames'] = array_merge($resourceNames, $options['resourceNames']);
         } else {
             $options['resourceNames'] = $resourceNames;
         }


### PR DESCRIPTION
Array_merge with a wrong key, the used key was projectIds instead of resourceNames.