### PR TITLE
chore: fix ci tests

### DIFF
--- a/phpunit-system.xml.dist
+++ b/phpunit-system.xml.dist
@@ -16,7 +16,6 @@
   <testsuites>
     <testsuite name="System Test Suite">
       <directory>*/tests/System</directory>
-      <directory>tests/System</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
Currently CI tests are broken and only a message is produced by phpunit command, `Test directory "./tests/System" not found`. [ref](https://source.cloud.google.com/results/invocations/ae0f498a-7d40-4af5-995d-7c974acf2614/log)
This PR will atleast get the phpunit to execute the tests.