### PR TITLE
chore: Extract compareResult test helper method to Core

### DIFF
--- a/Core/src/Testing/TestHelpers.php
+++ b/Core/src/Testing/TestHelpers.php
@@ -24,6 +24,7 @@ use Google\Cloud\Core\Testing\Snippet\Coverage\Coverage;
 use Google\Cloud\Core\Testing\Snippet\Coverage\Scanner;
 use Google\Cloud\Core\Testing\Snippet\Parser\Parser;
 use Google\Cloud\Core\Testing\System\SystemTestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class TestHelpers is used to hold static functions required for testing
@@ -254,6 +255,26 @@ class TestHelpers
         }, null, $className);
 
         return $c($class);
+    }
+
+    /**
+     * Compare actual and expected results when the requirement for comparision
+     * is `===` including outlier cases like:
+     *  - Comparing NAN
+     *  - Comparing floating point values with some delta
+     */
+    public static function compareResult($expected, $actual)
+    {
+        if (is_float($expected)) {
+            if (is_nan($expected)) {
+                Assert::assertNan($actual);
+            } else {
+                Assert::assertEqualsWithDelta($expected, $actual, 0.01);
+            }
+        } else {
+            // Used because assertEquals(null, '') doesn't fails
+            Assert::assertSame($expected, $actual);
+        }
     }
 
     /**

--- a/Firestore/tests/System/AggregateQueryTest.php
+++ b/Firestore/tests/System/AggregateQueryTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Firestore\Tests\System;
 
 use Exception;
 use Google\Cloud\Core\Exception\BadRequestException;
+use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Aggregate;
 use Google\Cloud\Firestore\Filter;
@@ -111,7 +112,7 @@ class AggregateQueryTest extends FirestoreTestCase
 
         $querySnapshot = $query->getSnapshot();
         foreach ($expectedResults as $key => $value) {
-            $this->compareResult($value, $querySnapshot->get($key));
+            TestHelpers::compareResult($value, $querySnapshot->get($key));
         }
     }
 
@@ -144,7 +145,7 @@ class AggregateQueryTest extends FirestoreTestCase
 
         $actual = $arg ? $query->$type($arg) : $query->$type();
 
-        $this->compareResult($expected, $actual);
+        TestHelpers::compareResult($expected, $actual);
         $this->assertQueryWithMultipleAggregations($query, $type, $arg, $expected);
     }
 
@@ -174,7 +175,7 @@ class AggregateQueryTest extends FirestoreTestCase
 
         foreach ($expectedResults as $key => $expectedResult) {
             $actualResult = $snapshot->get($key);
-            $this->compareResult($expected, $actualResult);
+            TestHelpers::compareResult($expected, $actualResult);
         }
 
         $this->assertEquals(0, strlen($snapshot->getTransaction()));
@@ -288,7 +289,7 @@ class AggregateQueryTest extends FirestoreTestCase
             // For testing where: equality for random value
             ['count', null, '=', $randomVal, 1, [['value' => $randomVal]]],
             ['sum', 'value', '=', $randomInt, $randomInt, [['value' => $randomInt]]],
-            ['avg', 'value', '=', $randomInt, $randomInt, [['value' => $randomInt]]],
+            ['avg', 'value', '=', $randomInt, (float)$randomInt, [['value' => $randomInt]]],
 
             // For testing where: equality for null
             ['count', null, '=', null, 1, [['value' => null]]],
@@ -341,7 +342,7 @@ class AggregateQueryTest extends FirestoreTestCase
         return [
             ['count', null, [4, 3, 3, 4], $docsToAdd],
             ['sum', 'value', [10, 9, 6, 10], $docsToAdd],
-            ['avg', 'value', [2.5, 3, 2, 2.5], $docsToAdd]
+            ['avg', 'value', [2.5, 3.0, 2.0, 2.5], $docsToAdd]
         ];
     }
 


### PR DESCRIPTION
With the refactoring of tests cleanly use dataproviders with multiple cases in the single testing method, we expect the test method to receive multitude of data types requiring same assertEqualts. Few edge cases arising in those situations are:

* Asserting NANs
* Asserting null is equal to ''
* Asserting floats with some delta

This requirement is both is Firestore and Datastore (actually "will be" until https://github.com/googleapis/google-cloud-php/pull/6817) merges. Therefore it's better to extract this functionality to Core/src/Testing.