### PR TITLE
feat(Storage): support object retention lock

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -267,7 +267,8 @@ class Bucket
      *           Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
-     *     @type array $retention Object retention configuration.
+     *     @type array $retention The full list of available options are outlined
+     *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $retention.retainUntilTime The earliest time in RFC 3339
      *           UTC "Zulu" format that the object can be deleted or replaced.
      *           This is the retention configuration set for this object.

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -268,15 +268,15 @@ class Bucket
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
      *     @type array $retention Object retention configuration.
-     *     @type string $retention.retainUntilTime The earliest time in RFC3339
+     *     @type string $retention.retainUntilTime The earliest time in RFC 3339
      *           UTC "Zulu" format that the object can be deleted or replaced.
      *           This is the retention configuration set for this object.
      *     @type string $retention.mode The mode of the retention configuration,
      *           which can be either `"Unlocked"` or `"Locked"`.
      *     @type string $retentionExpirationTime The earliest time in
-     *           RFC3339 UTC "Zulu" format that the object can be deleted or
+     *           RFC 3339 UTC "Zulu" format that the object can be deleted or
      *           replaced. This depends on any retention configuration set for
-     *           the object and any retention policy set for the bucket that
+     *           the object as well as retention policy set for the bucket that
      *           contains the object. This value should normally only be set by
      *           the back-end API.
      *     @type array $metadata The full list of available options are outlined

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -267,6 +267,18 @@ class Bucket
      *           Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
+     *     @type array $retention Object retention configuration.
+     *     @type string $retention.retainUntilTime The earliest time in RFC3339
+     *           UTC "Zulu" format that the object can be deleted or replaced.
+     *           This is the retention configuration set for this object.
+     *     @type string $retention.mode The mode of the retention configuration,
+     *           which can be either `"Unlocked"` or `"Locked"`.
+     *     @type string $retentionExpirationTime The earliest time in
+     *           RFC3339 UTC "Zulu" format that the object can be deleted or
+     *           replaced. This depends on any retention configuration set for
+     *           the object and any retention policy set for the bucket that
+     *           contains the object. This value should normally only be set by
+     *           the back-end API.
      *     @type array $metadata The full list of available options are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type array $metadata.metadata User-provided metadata, in key/value pairs.

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -432,6 +432,8 @@ class Rest implements ConnectionInterface
 
         $args['metadata']['name'] = $args['name'];
         if (isset($args['retention'])) {
+            // during object creation retention properties go into metadata
+            // but not into request body
             $args['metadata']['retention'] = $args['retention'];
             unset($args['retention']);
         }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -431,7 +431,9 @@ class Rest implements ConnectionInterface
         }
 
         $args['metadata']['name'] = $args['name'];
-        $args['metadata']['retention'] = $args['retention'] ?? [];
+        if (isset($args['retention'])) {
+            $args['metadata']['retention'] = $args['retention'];
+        }
         unset($args['name']);
         unset($args['retention']);
         $args['contentType'] = $args['metadata']['contentType']

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -433,9 +433,9 @@ class Rest implements ConnectionInterface
         $args['metadata']['name'] = $args['name'];
         if (isset($args['retention'])) {
             $args['metadata']['retention'] = $args['retention'];
+            unset($args['retention']);
         }
         unset($args['name']);
-        unset($args['retention']);
         $args['contentType'] = $args['metadata']['contentType']
             ?? MimeType::fromFilename($args['metadata']['name']);
 

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -431,7 +431,9 @@ class Rest implements ConnectionInterface
         }
 
         $args['metadata']['name'] = $args['name'];
+        $args['metadata']['retention'] = $args['retention'] ?? [];
         unset($args['name']);
+        unset($args['retention']);
         $args['contentType'] = $args['metadata']['contentType']
             ?? MimeType::fromFilename($args['metadata']['name']);
 

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -271,6 +271,10 @@ class StorageClient
      *           `"projectPrivate"`, and `"publicRead"`.
      *     @type string $predefinedDefaultObjectAcl Apply a predefined set of
      *           default object access controls to this bucket.
+     *     @type bool $enableObjectRetention Whether object retention should
+     *          be enabled on this bucket. For more information, refer to the
+     *          [Object Retention Lock](https://cloud.google.com/storage/docs/object-lock)
+     *          documentation.
      *     @type string $projection Determines which properties to return. May
      *           be either `"full"` or `"noAcl"`. **Defaults to** `"noAcl"`,
      *           unless the bucket resource specifies acl or defaultObjectAcl

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -224,6 +224,23 @@ class StorageObject
      *           Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
+     *     @type array $retention Object retention configuration.
+     *     @type string $retention.retainUntilTime The earliest time in RFC3339
+     *           UTC "Zulu" format that the object can be deleted or replaced.
+     *           This is the retention configuration set for this object.
+     *     @type string $retention.mode The mode of the retention configuration,
+     *           which can be either `"Unlocked"` or `"Locked"`.
+     *     @type string $retentionExpirationTime The earliest time in
+     *           RFC3339 UTC "Zulu" format that the object can be deleted or
+     *           replaced. This depends on any retention configuration set for
+     *           the object and any retention policy set for the bucket that
+     *           contains the object. This value should normally only be set by
+     *           the back-end API.
+     *     @type bool $overrideUnlockedRetention Applicable for objects that
+     *           have an unlocked retention configuration. Required to be set to
+     *           `true` if the operation includes a retention property that
+     *           changes the mode to `Locked`, reduces the `retainUntilTime`, or
+     *           removes the retention configuration from the object.
      *     @type string $projection Determines which properties to return. May
      *           be either 'full' or 'noAcl'.
      *     @type string $fields Selector which will cause the response to only

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -225,7 +225,7 @@ class StorageObject
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
      *     @type array $retention Object retention configuration.
-     *     @type string $retention.retainUntilTime The earliest time in RFC3339
+     *     @type string $retention.retainUntilTime The earliest time in RFC 3339
      *           UTC "Zulu" format that the object can be deleted or replaced.
      *           This is the retention configuration set for this object.
      *     @type string $retention.mode The mode of the retention configuration,
@@ -233,7 +233,7 @@ class StorageObject
      *     @type string $retentionExpirationTime The earliest time in
      *           RFC3339 UTC "Zulu" format that the object can be deleted or
      *           replaced. This depends on any retention configuration set for
-     *           the object and any retention policy set for the bucket that
+     *           the object as well as retention policy set for the bucket that
      *           contains the object. This value should normally only be set by
      *           the back-end API.
      *     @type bool $overrideUnlockedRetention Applicable for objects that

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -231,7 +231,7 @@ class StorageObject
      *     @type string $retention.mode The mode of the retention configuration,
      *           which can be either `"Unlocked"` or `"Locked"`.
      *     @type string $retentionExpirationTime The earliest time in
-     *           RFC3339 UTC "Zulu" format that the object can be deleted or
+     *           RFC 3339 UTC "Zulu" format that the object can be deleted or
      *           replaced. This depends on any retention configuration set for
      *           the object as well as retention policy set for the bucket that
      *           contains the object. This value should normally only be set by

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -224,7 +224,8 @@ class StorageObject
      *           Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`.
-     *     @type array $retention Object retention configuration.
+     *     @type array $retention The full list of available options are outlined
+     *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/update#request-body).
      *     @type string $retention.retainUntilTime The earliest time in RFC 3339
      *           UTC "Zulu" format that the object can be deleted or replaced.
      *           This is the retention configuration set for this object.

--- a/Storage/tests/System/ManageObjectsTest.php
+++ b/Storage/tests/System/ManageObjectsTest.php
@@ -84,13 +84,94 @@ class ManageObjectsTest extends StorageTestCase
         }
     }
 
-    public function testObjectRetentionLock()
+    public function testObjectRetentionLockedMode()
     {
-        // Test bucket created with object retention enabled
-        $bucket = self::createBucket(self::$client, uniqid('object_retention-'), [
+        // Bucket with object retention locked mode is not cleaned up immediately
+        $bucket = self::$client->createBucket(uniqid('object-retention-locked-'), [
             'enableObjectRetention' => true
         ]);
-        $this->assertEquals($bucket->info()['objectRetention']['mode'], 'Enabled');
+
+        // Test create object with object retention enabled
+        $objectName = "object-retention-lock";
+        $time = (new \DateTime)->add(
+            \DateInterval::createFromDateString('+2 hours')
+        );
+        $object = $bucket->upload(self::DATA, [
+            'name' => $objectName,
+            'retention' => [
+                'mode' => 'Locked',
+                'retainUntilTime' => $time->format(\DateTime::RFC3339)
+            ]
+        ]);
+        $this->assertEquals('Locked', $object->info()['retention']['mode']);
+
+        $laterTime = (new \DateTime)->add(
+            \DateInterval::createFromDateString('+4 hours')
+        );
+
+        // retainUntilTime of a locked mode object can be increased
+        $object->update([
+            'retention' => [
+                'mode' => 'Locked',
+                'retainUntilTime' => $laterTime->format(\DateTime::RFC3339)
+            ]
+        ]);
+        $this->assertEqualsWithDelta(
+            $laterTime,
+            new \DateTime($object->info()['retention']['retainUntilTime']),
+            1
+        );
+
+        // retainUntilTime of a locked mode object can not be decreased
+        $exception = null;
+        try {
+            $object->update([
+                'retention' => [
+                    'mode' => 'Locked',
+                    'retainUntilTime' => $time->format(\DateTime::RFC3339)
+                ]
+            ]);
+        } catch (ServiceException $e) {
+            $exception = $e;
+        }
+        $this->assertInstanceOf(ServiceException::class, $exception);
+        $this->assertStringContainsString(
+            'retention period cannot be shortened',
+            $exception->getMessage()
+        );
+        $this->assertEqualsWithDelta(
+            $laterTime,
+            new \DateTime($object->info()['retention']['retainUntilTime']),
+            1
+        );
+
+        // Retention mode of a locked mode object can not be changed
+        $exception = null;
+        try {
+            $object->update([
+                'retention' => [
+                    'mode' => 'Unlocked',
+                    'retainUntilTime' => $laterTime->format(\DateTime::RFC3339)
+                ],
+                'overrideUnlockedRetention' => true
+            ]);
+        } catch (ServiceException $e) {
+            $exception = $e;
+        }
+        $this->assertInstanceOf(ServiceException::class, $exception);
+        $this->assertStringContainsString(
+            'retention mode cannot be changed',
+            $exception->getMessage()
+        );
+    }
+
+    public function testObjectRetentionUnlockedMode()
+    {
+        // Test bucket created with object retention enabled
+        $bucket = self::createBucket(self::$client, uniqid('object-retention-'), [
+            'enableObjectRetention' => true
+        ]);
+        $this->assertEquals('Enabled', $bucket->info()['objectRetention']['mode']);
 
         // Test create object with object retention enabled
         $objectName = "object-retention-lock";
@@ -104,14 +185,32 @@ class ManageObjectsTest extends StorageTestCase
                 'retainUntilTime' => $expires->format(\DateTime::RFC3339)
             ]
         ]);
-        $this->assertEquals($object->info()['retention']['mode'], 'Unlocked');
+        $this->assertEquals('Unlocked', $object->info()['retention']['mode']);
 
-        // Test patch object to disable object retention
+        // Object delete throws when object has a valid retention policy
+        $exception = null;
+        try {
+            $object->delete();
+        } catch (ServiceException $e) {
+            $exception = $e;
+        }
+        $this->assertInstanceOf(ServiceException::class, $exception);
+        $this->assertStringContainsString(
+            'cannot be deleted or overwritten',
+            $exception->getMessage()
+        );
+        $this->assertTrue($object->exists());
+
+        // Disable object retention
         $object->update([
             'retention' => [],
             'overrideUnlockedRetention' => true
         ]);
         $this->assertNotContains('retention', $object->info());
+
+        // Object delete succeeds when object retention is disabled
+        $object->delete();
+        $this->assertFalse($object->exists());
     }
 
     public function testObjectExists()

--- a/Storage/tests/System/ManageObjectsTest.php
+++ b/Storage/tests/System/ManageObjectsTest.php
@@ -178,13 +178,15 @@ class ManageObjectsTest extends StorageTestCase
         $expires = (new \DateTime)->add(
             \DateInterval::createFromDateString('+2 hours')
         );
-        $object = $bucket->upload(self::DATA, [
-            'name' => $objectName,
-            'retention' => [
-                'mode' => 'Unlocked',
-                'retainUntilTime' => $expires->format(\DateTime::RFC3339)
-            ]
-        ]);
+        $uploader = $bucket->getStreamableUploader('initial contents', [
+                'name' => $objectName,
+                'retention' => [
+                    'mode' => 'Unlocked',
+                    'retainUntilTime' => $expires->format(\DateTime::RFC3339)
+                ]
+            ]);
+        $uploader->upload();
+        $object = $bucket->object($objectName);
         $this->assertEquals('Unlocked', $object->info()['retention']['mode']);
 
         // Object delete throws when object has a valid retention policy


### PR DESCRIPTION
This adds support for [object retention lock](https://cloud.google.com/storage/docs/object-lock)


Fixes https://github.com/googleapis/google-cloud-php/issues/6741
PRD: [go/gcs-object-retention-client-request](https://goto.google.com/gcs-object-retention-client-request)

## Tests
System tests pass in my local which were run on an allowlisted project:

```
➜  Storage git:(main) ✗ vendor/bin/phpunit  -c phpunit-system.xml.dist --filter="ManageObjectsTest::testObjectRetentionLock"
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:04.678, Memory: 14.00 MB

OK (1 test, 3 assertions)
➜  Storage git:(main) ✗
```