### PR TITLE
chore: fix System tests

### DIFF
--- a/Core/src/Testing/TestHelpers.php
+++ b/Core/src/Testing/TestHelpers.php
@@ -186,6 +186,8 @@ class TestHelpers
 
         SystemTestCase::setupQueue();
 
+        // also set up the generated system tests
+        self::generatedSystemTestBootstrap();
         $bootstraps = glob(self::projectRoot() .'/*tests/System/bootstrap.php');
         foreach ($bootstraps as $bootstrap) {
             require_once $bootstrap;
@@ -212,7 +214,7 @@ class TestHelpers
         putenv("GOOGLE_APPLICATION_CREDENTIALS=$keyFilePath");
         $keyFileData = json_decode(file_get_contents($keyFilePath), true);
         putenv('PROJECT_ID=' . $keyFileData['project_id']);
-
+        putenv('GOOGLE_PROJECT_ID=' . $keyFileData['project_id']);
     }
 
     /**


### PR DESCRIPTION
Fix system tests that seem to be broken, as per the [log](https://btx-internal.corp.google.com/invocations/a04346c8-d8a1-4a29-928a-5cc6ec23b504/targets/cloud-devrel%2Fclient-libraries%2Fphp%2Fgoogle-cloud-php%2Fcontinuous%2Fphp74;config=default/log)

Missing env var failures in the log:
```
20) Google\Cloud\Debugger\Tests\System\E2ETest::testWithFullPath
Set the GOOGLE_PROJECT_ID environment variable
```
