### PR TITLE
chore: fix spanner concurrent transaction tests

### DIFF
--- a/.github/workflows/spanner-emulator-system-tests.yaml
+++ b/.github/workflows/spanner-emulator-system-tests.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          ini-values: grpc.enable_fork_support=1
           tools: pecl
           extensions: bcmath, grpc
 

--- a/Spanner/tests/System/SpannerTestCase.php
+++ b/Spanner/tests/System/SpannerTestCase.php
@@ -132,7 +132,7 @@ class SpannerTestCase extends SystemTestCase
 
     public static function getDatabaseInstance($dbName, $options = [])
     {
-        return self::$client->connect(self::INSTANCE_NAME, $dbName, $options);
+        return self::getClient()->connect(self::INSTANCE_NAME, $dbName, $options);
     }
 
     public static function getDatabaseFromInstance($instance, $dbName, $options = [])

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -117,7 +117,7 @@ class TransactionTest extends SpannerTestCase
 
         $this->assertEquals(2, $row['number']);
         // Emulator aborts a parallel transaction therefore
-        // iterations might be greator than 2
+        // iterations might be greater than 2
         $this->assertGreaterThanOrEqual(2, $iterations);
     }
 
@@ -173,7 +173,7 @@ class TransactionTest extends SpannerTestCase
 
         $this->assertEquals(2, $row['number']);
         // Emulator aborts a parallel transaction therefore
-        // iterations might be greator than 2
+        // iterations might be greater than 2
         $this->assertGreaterThanOrEqual(2, $iterations);
     }
 
@@ -208,7 +208,7 @@ class TransactionTest extends SpannerTestCase
 
         $this->assertEquals(2, $row['number']);
         // Emulator aborts a parallel transaction therefore
-        // iterations might be greator than 2
+        // iterations might be greater than 2
         $this->assertGreaterThanOrEqual(2, $iterations);
     }
 

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -92,7 +92,6 @@ class TransactionTest extends SpannerTestCase
      */
     public function testConcurrentTransactionsIncrementValueWithRead()
     {
-        $this->markTestSkipped('fixme');
         $db = self::$database;
 
         $id = $this->randId();
@@ -117,7 +116,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertGreaterThan(2, $iterations);
+        $this->assertEquals(2, $iterations);
     }
 
     /**
@@ -147,7 +146,6 @@ class TransactionTest extends SpannerTestCase
      */
     public function testAbortedErrorCausesRetry()
     {
-        $this->markTestSkipped('fixme');
         $db = self::$database;
         $db2 = self::$database2;
 
@@ -182,7 +180,6 @@ class TransactionTest extends SpannerTestCase
      */
     public function testConcurrentTransactionsIncrementValueWithExecute()
     {
-        $this->markTestSkipped('fixme');
         $db = self::$database;
 
         $id = $this->randId();
@@ -206,7 +203,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertGreaterThan(2, $iterations);
+        $this->assertEquals(2, $iterations);
     }
 
     public function testStrongRead()

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -170,6 +170,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
+        // Emulator doesn't support parallel transaction therefore we are
         $this->assertGreaterThan(2, $iterations);
     }
 

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -116,7 +116,9 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertGreaterThan(2, $iterations);
+        // Emulator aborts a parallel transaction therefore
+        // iterations might be greator than 2
+        $this->assertGreaterThanOrEqual(2, $iterations);
     }
 
     /**
@@ -170,8 +172,9 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        // Emulator doesn't support parallel transaction therefore we are
-        $this->assertGreaterThan(2, $iterations);
+        // Emulator aborts a parallel transaction therefore
+        // iterations might be greator than 2
+        $this->assertGreaterThanOrEqual(2, $iterations);
     }
 
     /**
@@ -204,7 +207,9 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertGreaterThan(2, $iterations);
+        // Emulator aborts a parallel transaction therefore
+        // iterations might be greator than 2
+        $this->assertGreaterThanOrEqual(2, $iterations);
     }
 
     public function testStrongRead()

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -116,7 +116,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertEquals(2, $iterations);
+        $this->assertGreaterThan(2, $iterations);
     }
 
     /**
@@ -170,7 +170,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertEquals(2, $iterations);
+        $this->assertGreaterThan(2, $iterations);
     }
 
     /**
@@ -203,7 +203,7 @@ class TransactionTest extends SpannerTestCase
         ])->rows()->current();
 
         $this->assertEquals(2, $row['number']);
-        $this->assertEquals(2, $iterations);
+        $this->assertGreaterThan(2, $iterations);
     }
 
     public function testStrongRead()

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -22,7 +22,7 @@ if ($childPID1 = pcntl_fork()) {
             'parameters' => ['id' => (int) $id]
         ])->rows()->current();
 
-        if ($iteration < 2) {
+        if ($iteration <= 2) {
             throw new AbortedException('foo', 409, null, [
                 [
                     'retryDelay' => [

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -42,8 +42,6 @@ if ($childPID1 = pcntl_fork()) {
     echo $iteration;
     pcntl_waitpid($childPID1, $status1);
 } else {
-    TestHelpers::SystemBootstrap();
-    SpannerTestCase::setUpBeforeClass();
     $db2 = SpannerTestCase::getDatabaseInstance($dbName);
     $db2->runTransaction(function ($t) use ($id, $tableName) {
         $row = $t->execute('SELECT id, number FROM ' . $tableName . ' WHERE ID = @id', [

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -3,18 +3,20 @@
 include __DIR__ . '/../../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
-use Google\Cloud\Spanner\Database;
-use Google\Cloud\Spanner\Spanner\Tests\SystemTestCase;
+use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
 list ($dbName, $tableName, $id) = getInputArgs();
 
+TestHelpers::SystemBootstrap();
+SpannerTestCase::setUpBeforeClass();
 $db1 = SpannerTestCase::getDatabaseInstance($dbName);
 $db2 = SpannerTestCase::getDatabaseInstance($dbName);
 
-$delay = 50000;
+$delay = 10000;
 
 if ($childPID1 = pcntl_fork()) {
-    usleep(1 * $delay);
+    usleep($delay);
 
     $iteration = 0;
     $db1->runTransaction(function ($t) use ($id, $tableName, $delay, &$iteration) {
@@ -35,7 +37,7 @@ if ($childPID1 = pcntl_fork()) {
     echo $iteration;
     pcntl_waitpid($childPID1, $status1);
 } else {
-    usleep(1 * $delay);
+    usleep($delay);
 
     $db2->runTransaction(function ($t) use ($id, $tableName) {
         $row = $t->execute('SELECT id, number FROM ' . $tableName . ' WHERE ID = @id', [

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -3,30 +3,34 @@
 include __DIR__ . '/../../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
+use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
 list ($dbName, $tableName, $id) = getInputArgs();
-
-TestHelpers::SystemBootstrap();
-SpannerTestCase::setUpBeforeClass();
-$db1 = SpannerTestCase::getDatabaseInstance($dbName);
-$db2 = SpannerTestCase::getDatabaseInstance($dbName);
-
-$delay = 10000;
+$delay = 2000;
 
 if ($childPID1 = pcntl_fork()) {
     usleep($delay);
-
     $iteration = 0;
+    TestHelpers::SystemBootstrap();
+    SpannerTestCase::setUpBeforeClass();
+    $db1 = SpannerTestCase::getDatabaseInstance($dbName);
     $db1->runTransaction(function ($t) use ($id, $tableName, $delay, &$iteration) {
         $iteration++;
         $row = $t->execute('SELECT id, number FROM ' . $tableName . ' WHERE ID = @id', [
             'parameters' => ['id' => (int) $id]
         ])->rows()->current();
 
-        if ($iteration === 0) {
-            usleep(3 * $delay);
+        if ($iteration < 2) {
+            throw new AbortedException('foo', 409, null, [
+                [
+                    'retryDelay' => [
+                        'seconds' => 1,
+                        'nanos' => 0
+                    ]
+                ]
+            ]);
         }
 
         $row['number'] += 1;
@@ -38,7 +42,9 @@ if ($childPID1 = pcntl_fork()) {
     pcntl_waitpid($childPID1, $status1);
 } else {
     usleep($delay);
-
+    TestHelpers::SystemBootstrap();
+    SpannerTestCase::setUpBeforeClass();
+    $db2 = SpannerTestCase::getDatabaseInstance($dbName);
     $db2->runTransaction(function ($t) use ($id, $tableName) {
         $row = $t->execute('SELECT id, number FROM ' . $tableName . ' WHERE ID = @id', [
             'parameters' => ['id' => (int) $id]

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -1,6 +1,6 @@
 <?php
 
-include __DIR__ . '/../../../../vendor/autoload.php';
+include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
 use Google\Cloud\Core\Exception\AbortedException;

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -13,8 +13,6 @@ $delay = 5000;
 if ($childPID1 = pcntl_fork()) {
     usleep($delay);
     $iteration = 0;
-    TestHelpers::SystemBootstrap();
-    SpannerTestCase::setUpBeforeClass();
     $db1 = SpannerTestCase::getDatabaseInstance($dbName);
     $db1->runTransaction(function ($t) use ($id, $tableName, $delay, &$iteration) {
         $iteration++;

--- a/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
+++ b/Spanner/tests/System/pcntl/AbortedErrorCausesRetry.php
@@ -4,7 +4,6 @@ include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
 use Google\Cloud\Core\Exception\AbortedException;
-use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
 list ($dbName, $tableName, $id) = getInputArgs();

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithExecute.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithExecute.php
@@ -3,7 +3,6 @@
 include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
-use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
 list ($dbName, $tableName, $id) = getInputArgs();
@@ -13,8 +12,6 @@ setupIterationTracker($tmpFile);
 
 $callable = function ($dbName, $tableName, $id) use ($tmpFile) {
     $iterations = 0;
-    TestHelpers::SystemBootstrap();
-    SpannerTestCase::setUpBeforeClass();
     $db = SpannerTestCase::getDatabaseInstance($dbName);
     $db->runTransaction(function ($transaction) use ($id, $tableName, &$iterations) {
         $iterations++;

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithExecute.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithExecute.php
@@ -1,6 +1,6 @@
 <?php
 
-include __DIR__ . '/../../../../vendor/autoload.php';
+include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
 use Google\Cloud\Core\Testing\TestHelpers;

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
@@ -3,15 +3,18 @@
 include __DIR__ . '/../../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
+use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeySet;
-use Google\Cloud\Spanner\Spanner\Tests\SystemTestCase;
+use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
 list ($dbName, $tableName, $id) = getInputArgs();
 
 $tmpFile = sys_get_temp_dir() . '/ConcurrentTransactionsIncremementValueWithRead.txt';
 setupIterationTracker($tmpFile);
 
+TestHelpers::SystemBootstrap();
+SpannerTestCase::setUpBeforeClass();
 $db1 = SpannerTestCase::getDatabaseInstance($dbName);
 $db2 = SpannerTestCase::getDatabaseInstance($dbName);
 
@@ -33,15 +36,19 @@ $callable = function (Database $db, KeySet $keyset, array $columns, $tableName) 
     updateIterationTracker($tmpFile, $iterations);
 };
 
-$delay = 50000;
+$delay = 5000;
+$retryLimit = 3;
 if ($childPID1 = pcntl_fork()) {
-    usleep(2 * $delay);
+    usleep($delay);
 
     $callable($db1, $keyset, $columns, $tableName);
 
-    pcntl_waitpid($childPID1, $status1);
+    while (pcntl_waitpid($childPID1, $status1, WNOHANG) == 0 && $retryLimit) {
+        usleep(2 * $delay);
+        $retryLimit--;
+    }
 } else {
-    usleep(2 * $delay);
+    usleep($delay);
 
     $callable($db2, $keyset, $columns, $tableName);
 

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
@@ -3,7 +3,6 @@
 include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
-use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
@@ -17,8 +16,6 @@ $columns = ['id','number'];
 
 $callable = function ($dbName, KeySet $keyset, array $columns, $tableName) use ($tmpFile) {
     $iterations = 0;
-    TestHelpers::SystemBootstrap();
-    SpannerTestCase::setUpBeforeClass();
     $db = SpannerTestCase::getDatabaseInstance($dbName);
     $db->runTransaction(function ($transaction) use ($keyset, $columns, $tableName, &$iterations) {
         $iterations++;

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
@@ -1,6 +1,6 @@
 <?php
 
-include __DIR__ . '/../../../../vendor/autoload.php';
+include __DIR__ . '/../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
 use Google\Cloud\Core\Testing\TestHelpers;

--- a/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
+++ b/Spanner/tests/System/pcntl/ConcurrentTransactionsIncrementValueWithRead.php
@@ -4,7 +4,6 @@ include __DIR__ . '/../../../../vendor/autoload.php';
 include __DIR__ . '/forked-process-test.php';
 
 use Google\Cloud\Core\Testing\TestHelpers;
-use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Tests\System\SpannerTestCase;
 
@@ -13,16 +12,14 @@ list ($dbName, $tableName, $id) = getInputArgs();
 $tmpFile = sys_get_temp_dir() . '/ConcurrentTransactionsIncremementValueWithRead.txt';
 setupIterationTracker($tmpFile);
 
-TestHelpers::SystemBootstrap();
-SpannerTestCase::setUpBeforeClass();
-$db1 = SpannerTestCase::getDatabaseInstance($dbName);
-$db2 = SpannerTestCase::getDatabaseInstance($dbName);
-
 $keyset = new KeySet(['keys' => [$id]]);
 $columns = ['id','number'];
 
-$callable = function (Database $db, KeySet $keyset, array $columns, $tableName) use ($tmpFile) {
+$callable = function ($dbName, KeySet $keyset, array $columns, $tableName) use ($tmpFile) {
     $iterations = 0;
+    TestHelpers::SystemBootstrap();
+    SpannerTestCase::setUpBeforeClass();
+    $db = SpannerTestCase::getDatabaseInstance($dbName);
     $db->runTransaction(function ($transaction) use ($keyset, $columns, $tableName, &$iterations) {
         $iterations++;
         $row = $transaction->read($tableName, $keyset, $columns)->rows()->current();
@@ -36,21 +33,21 @@ $callable = function (Database $db, KeySet $keyset, array $columns, $tableName) 
     updateIterationTracker($tmpFile, $iterations);
 };
 
-$delay = 5000;
+$delay = 2000;
 $retryLimit = 3;
 if ($childPID1 = pcntl_fork()) {
     usleep($delay);
 
-    $callable($db1, $keyset, $columns, $tableName);
+    $callable($dbName, $keyset, $columns, $tableName);
 
     while (pcntl_waitpid($childPID1, $status1, WNOHANG) == 0 && $retryLimit) {
         usleep(2 * $delay);
         $retryLimit--;
     }
 } else {
-    usleep($delay);
+    usleep(2 * $delay);
 
-    $callable($db2, $keyset, $columns, $tableName);
+    $callable($dbName, $keyset, $columns, $tableName);
 
     exit(0);
 }

--- a/Spanner/tests/System/pcntl/forked-process-test.php
+++ b/Spanner/tests/System/pcntl/forked-process-test.php
@@ -30,8 +30,6 @@ function setupIterationTracker($tmpFile)
 
         $h = fopen($tmpFile, 'r+');
         flock($h, LOCK_UN);
-
-        unlink($tmpFile);
     });
 
     file_put_contents($tmpFile, '0');
@@ -50,4 +48,5 @@ function updateIterationTracker($tmpFile, $iterations)
 
         flock($fp, LOCK_UN);
     }
+    fclose($fp);
 }


### PR DESCRIPTION
This is an attempt to fix the concurrent tests for Spanner.

There are 3 tests dependent on `pcntl` and they assert records values after transaction is committed in concurrent processes.

We need to add `grpc.enable_fork_support=1` in order to enable `pcntl_waitpid` function to exit, else it keeps on waiting forever. The waiting logic is also changed, instead of using a blocking waiting, we also check status of child process and then wait for a max number of retries.

Also, Spanner emulator currently doesn't support parallel transactions, and it randomly kills a transaction if attempted in parallel, leading to more number of transaction iterations than expected in the test. Hence, the tests assert for iterations has been changed to `assertGreaterThan` from previously `assertEquals`.