### PR TITLE
fix: removed abandoned package from composer

### DIFF
--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -14,7 +14,7 @@
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^5.0",
         "erusev/parsedown": "^1.6",
-        "rg/avro-php": "^3.0.0"
+        "flix-tech/avro-php": "^5.0.0"
     },
     "suggest": {
         "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",

--- a/PubSub/tests/System/SchemaTest.php
+++ b/PubSub/tests/System/SchemaTest.php
@@ -116,9 +116,6 @@ class SchemaTest extends PubSubTestCase
      */
     public function testPublishWithAvroSchemaBinary(PubSubClient $client)
     {
-        if (version_compare(phpversion(), '7.3.0') === -1) {
-            $this->markTestSkipped('This test can only be run on php 7.3+');
-        }
         $definition = file_get_contents(__DIR__ . '/testdata/schema.avsc');
         $schema = $client->createSchema(
             uniqid(self::TESTING_PREFIX),
@@ -147,9 +144,10 @@ class SchemaTest extends PubSubTestCase
         $encoder = new \AvroIOBinaryEncoder($io);
         $writer->write($data, $encoder);
 
-        $topic->publish(new Message([
+        $messageIds = $topic->publish(new Message([
             'data' => $io->string(),
         ]));
+        $this->assertNotEmpty($messageIds);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "phpseclib/phpseclib": "^3.0",
         "google/cloud-tools": "^0.13.0",
         "opis/closure": "^3.0",
-        "rg/avro-php": "^3.0.0",
+        "flix-tech/avro-php": "^5.0.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "kreait/firebase-php": "^5.26.5"
     },


### PR DESCRIPTION
In https://packagist.org/packages/rg/avro-php, we are seeing deprecation warnings. Fixing them:
<img width="860" alt="Screenshot 2023-12-15 at 16 02 29" src="https://github.com/googleapis/google-cloud-php/assets/7369612/2900ed90-0626-4592-b6e3-5d1799f9dad8">


```
➜  PubSub git:(chore_spanner_concurrent_tests) ✗ vendor/bin/phpunit  -c phpunit-syst
em.xml.dist --filter="SchemaTest::testPublishWithAvroSchemaBinary" 
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

..                                                                  2 / 2 (100%)

Time: 00:27.959, Memory: 12.00 MB

OK (2 tests, 2 assertions)
➜  PubSub git:(chore_spanner_concurrent_tests) ✗
```