### PR TITLE
fix(Core): update minimum google/auth version

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.4",
         "rize/uri-template": "~0.3",
-        "google/auth": "^1.18",
+        "google/auth": "^1.25",
         "guzzlehttp/guzzle": "^6.5.8|^7.4.4",
         "guzzlehttp/promises": "^1.4||^2.0",
         "guzzlehttp/psr7": "^1.7|^2.0",


### PR DESCRIPTION
fixes https://github.com/googleapis/google-auth-library-php/issues/504

We are now using the `FetchAuthTokenCache::getFetcher` function in `google/auth:v1.25.0`, so we need to ensure the minimum version is set to `1.25.0`