### PR TITLE
fix: adding unit tests for connection classes

### DIFF
--- a/BigQuery/tests/Unit/Connection/RestTest.php
+++ b/BigQuery/tests/Unit/Connection/RestTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
+use UnexpectedValueException;
 
 /**
  * @group bigquery
@@ -45,21 +46,33 @@ class RestTest extends TestCase
         $this->successBody = '{"canI":"kickIt"}';
     }
 
-    public function testApiEndpoint()
+    /**
+     * @dataProvider clientUniverseDomainConfigProvider
+     */
+    public function testApiEndpointForUniverseDomain($config, $expectedEndpoint, $expectException = false)
     {
-        $endpoint = 'https://foobar.com/';
-        $rest = TestHelpers::stub(Rest::class, [
-            [
-                'apiEndpoint' => $endpoint
-            ]
-        ], ['requestBuilder']);
+        if ($expectException) {
+            $this->expectException(UnexpectedValueException::class);
+        }
+        $rest = TestHelpers::stub(Rest::class, [$config], ['requestBuilder']);
 
         $rb = $rest->___getProperty('requestBuilder');
         $r = new \ReflectionObject($rb);
         $p = $r->getProperty('baseUri');
         $p->setAccessible(true);
 
-        $this->assertEquals($endpoint . 'bigquery/v2/', $p->getValue($rb));
+        $this->assertEquals($expectedEndpoint, $p->getValue($rb));
+    }
+
+    public function clientUniverseDomainConfigProvider()
+    {
+        return [
+            [[], 'https://bigquery.googleapis.com/bigquery/v2/'], // default
+            [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/bigquery/v2/'],
+            [['universeDomain' => 'googleapis.com'], 'https://bigquery.googleapis.com/bigquery/v2/'],
+            [['universeDomain' => 'abc.def.ghi'], 'https://bigquery.abc.def.ghi/bigquery/v2/'],
+            [['universeDomain' => ''], '', true],
+        ];
     }
 
     /**

--- a/BigQuery/tests/Unit/Connection/RestTest.php
+++ b/BigQuery/tests/Unit/Connection/RestTest.php
@@ -71,7 +71,7 @@ class RestTest extends TestCase
             [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/bigquery/v2/'],
             [['universeDomain' => 'googleapis.com'], 'https://bigquery.googleapis.com/bigquery/v2/'],
             [['universeDomain' => 'abc.def.ghi'], 'https://bigquery.abc.def.ghi/bigquery/v2/'],
-            [['universeDomain' => ''], '', true],
+            [['universeDomain' => null], '', true],
         ];
     }
 

--- a/Core/src/RestTrait.php
+++ b/Core/src/RestTrait.php
@@ -145,7 +145,7 @@ trait RestTrait
             );
         }
 
-        if (!isset($config['universeDomain'])) {
+        if (!isset($config['universeDomain']) || empty($config['universeDomain'])) {
             throw new UnexpectedValueException(
                 'The "universeDomain" config value must be set to use the default API endpoint template.'
             );

--- a/Core/src/RestTrait.php
+++ b/Core/src/RestTrait.php
@@ -145,7 +145,7 @@ trait RestTrait
             );
         }
 
-        if (!isset($config['universeDomain']) || empty($config['universeDomain'])) {
+        if (!isset($config['universeDomain'])) {
             throw new UnexpectedValueException(
                 'The "universeDomain" config value must be set to use the default API endpoint template.'
             );

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -817,7 +817,7 @@ class RequestWrapperTest extends TestCase
             ['googleapis.com', ''],
             ['', 'googleapis.com', 'The universe domain cannot be empty'],
             [null, 'foo.com'], // null in RequestWrapper will default to "googleapis.com"
-            ['foo.com', null], // Credentials not implementing GetUniverseDomainInterface will default to "googleapis.com"
+            ['foo.com', null], // Credentials not implementing `GetUniverseDomainInterface` will have default universe
         ];
     }
 

--- a/Core/tests/Unit/RestTraitTest.php
+++ b/Core/tests/Unit/RestTraitTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
+use UnexpectedValueException;
 
 /**
  * @group core
@@ -172,6 +173,21 @@ class RestTraitTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider universeDomains
+     */
+    public function testGetApiEndpointFromUniverseDomain($config, $template, $expected = null, $expectException = false)
+    {
+        if ($expectException) {
+            $this->expectException(UnexpectedValueException::class);
+        }
+
+        $this->assertEquals(
+            $expected,
+            TestHelpers::impl(RestTrait::class)->call('getApiEndpoint', [null, $config, $template])
+        );
+    }
+
     public function testAppendsPrettyPrintParameter()
     {
         $requestBuilder = $this->prophesize(RequestBuilder::class);
@@ -194,6 +210,18 @@ class RestTraitTest extends TestCase
         $this->implementation->setRequestBuilder($requestBuilder->reveal());
         $this->implementation->setRequestWrapper($this->requestWrapper->reveal());
         $this->assertEquals('prettyPrint=false', $this->implementation->send('foo', 'bar', []));
+    }
+
+    public function universeDomains()
+    {
+        return [
+            [[], '', null, true],
+            [[], null, null, true],
+            [['universeDomain' => null], 'ab.cd', null, true],
+            [['universeDomain' => ''], 'ab.cd', null, true],
+            [['universeDomain' => 'defg'], 'ab.cd', 'ab.cd/'],
+            [['universeDomain' => 'defg'], 'ab.UNIVERSE_DOMAIN.cd', 'ab.defg.cd/'],
+        ];
     }
 
     public function endpoints()

--- a/Core/tests/Unit/RestTraitTest.php
+++ b/Core/tests/Unit/RestTraitTest.php
@@ -218,8 +218,8 @@ class RestTraitTest extends TestCase
             [[], '', null, true],
             [[], null, null, true],
             [['universeDomain' => null], 'ab.cd', null, true],
-            [['universeDomain' => ''], 'ab.cd', null, true],
-            [['universeDomain' => 'defg'], 'ab.cd', 'ab.cd/'],
+            [['universeDomain' => ''], 'ab.cd/', 'ab.cd/'],
+            [['universeDomain' => 'defg'], '//ab.cd//', '//ab.cd//'],
             [['universeDomain' => 'defg'], 'ab.UNIVERSE_DOMAIN.cd', 'ab.defg.cd/'],
         ];
     }

--- a/PubSub/tests/Unit/Connection/GrpcTest.php
+++ b/PubSub/tests/Unit/Connection/GrpcTest.php
@@ -77,6 +77,30 @@ class GrpcTest extends TestCase
         $this->assertEquals($expected, $grpc->config['apiEndpoint']);
     }
 
+
+    /**
+     * @dataProvider clientUniverseDomainConfigProvider
+     */
+    public function testUniverseDomain($config, $expectedUniverseDomain, $domainConfigExists = true)
+    {
+        $grpc = new GrpcStub($config);
+
+        if ($domainConfigExists) {
+            $this->assertEquals($expectedUniverseDomain, $grpc->config['universeDomain']);
+        } else {
+            $this->assertArrayNotHasKey('universeDomain', $grpc->config);
+        }
+    }
+
+    public function clientUniverseDomainConfigProvider()
+    {
+        return [
+            [[], 'googleapis.com', false],
+            [['universeDomain' => 'googleapis.com'], 'googleapis.com'],
+            [['universeDomain' => 'abc.def.ghi'], 'abc.def.ghi'],
+        ];
+    }
+
     public function testUpdateTopic()
     {
         $topic = new Topic();

--- a/PubSub/tests/Unit/Connection/RestTest.php
+++ b/PubSub/tests/Unit/Connection/RestTest.php
@@ -72,7 +72,7 @@ class RestTest extends TestCase
             [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/'],
             [['universeDomain' => 'googleapis.com'], 'https://pubsub.googleapis.com/'],
             [['universeDomain' => 'abc.def.ghi'], 'https://pubsub.abc.def.ghi/'],
-            [['universeDomain' => ''], '', true],
+            [['universeDomain' => null], '', true],
         ];
     }
 

--- a/PubSub/tests/Unit/Connection/RestTest.php
+++ b/PubSub/tests/Unit/Connection/RestTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
+use UnexpectedValueException;
 
 /**
  * @group pubsub
@@ -46,21 +47,33 @@ class RestTest extends TestCase
         $this->successBody = '{"canI":"kickIt"}';
     }
 
-    public function testApiEndpoint()
+    /**
+     * @dataProvider clientUniverseDomainConfigProvider
+     */
+    public function testApiEndpointForUniverseDomain($config, $expectedEndpoint, $expectException = false)
     {
-        $endpoint = 'https://foobar.com/';
-        $rest = TestHelpers::stub(Rest::class, [
-            [
-                'apiEndpoint' => $endpoint
-            ]
-        ], ['requestBuilder']);
+        if ($expectException) {
+            $this->expectException(UnexpectedValueException::class);
+        }
+        $rest = TestHelpers::stub(Rest::class, [$config], ['requestBuilder']);
 
         $rb = $rest->___getProperty('requestBuilder');
         $r = new \ReflectionObject($rb);
         $p = $r->getProperty('baseUri');
         $p->setAccessible(true);
 
-        $this->assertEquals($endpoint, $p->getValue($rb));
+        $this->assertEquals($expectedEndpoint, $p->getValue($rb));
+    }
+
+    public function clientUniverseDomainConfigProvider()
+    {
+        return [
+            [[], 'https://pubsub.googleapis.com/'], // default
+            [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/'],
+            [['universeDomain' => 'googleapis.com'], 'https://pubsub.googleapis.com/'],
+            [['universeDomain' => 'abc.def.ghi'], 'https://pubsub.abc.def.ghi/'],
+            [['universeDomain' => ''], '', true],
+        ];
     }
 
     /**

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -86,7 +86,7 @@ class RestTest extends TestCase
             [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/storage/v1/'],
             [['universeDomain' => 'googleapis.com'], 'https://storage.googleapis.com/storage/v1/'],
             [['universeDomain' => 'abc.def.ghi'], 'https://storage.abc.def.ghi/storage/v1/'],
-            [['universeDomain' => ''], '', true],
+            [['universeDomain' => null], '', true],
         ];
     }
 

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -35,6 +35,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use UnexpectedValueException;
 
 /**
  * @group storage
@@ -60,21 +61,33 @@ class RestTest extends TestCase
         $this->successBody = '{"canI":"kickIt"}';
     }
 
-    public function testApiEndpoint()
+    /**
+     * @dataProvider clientUniverseDomainConfigProvider
+     */
+    public function testApiEndpointForUniverseDomain($config, $expectedEndpoint, $expectException = false)
     {
-        $endpoint = 'https://foobar.com/';
-        $rest = TestHelpers::stub(Rest::class, [
-            [
-                'apiEndpoint' => $endpoint
-            ]
-        ], ['requestBuilder']);
+        if ($expectException) {
+            $this->expectException(UnexpectedValueException::class);
+        }
+        $rest = TestHelpers::stub(Rest::class, [$config], ['requestBuilder']);
 
         $rb = $rest->___getProperty('requestBuilder');
         $r = new \ReflectionObject($rb);
         $p = $r->getProperty('baseUri');
         $p->setAccessible(true);
 
-        $this->assertEquals($endpoint . 'storage/v1/', $p->getValue($rb));
+        $this->assertEquals($expectedEndpoint, $p->getValue($rb));
+    }
+
+    public function clientUniverseDomainConfigProvider()
+    {
+        return [
+            [[], 'https://storage.googleapis.com/storage/v1/'], // default
+            [['apiEndpoint' => 'https://foobar.com'], 'https://foobar.com/storage/v1/'],
+            [['universeDomain' => 'googleapis.com'], 'https://storage.googleapis.com/storage/v1/'],
+            [['universeDomain' => 'abc.def.ghi'], 'https://storage.abc.def.ghi/storage/v1/'],
+            [['universeDomain' => ''], '', true],
+        ];
     }
 
     /**


### PR DESCRIPTION
Added tests for handwritten classes in BQ / Storage / PubSub for TPC.

I have manually tested that the TPC works for environment when I used `PubSubClient`, `StorageClient` and `BigQueryClient`. I initialized their clients (provided `universeDomain` config in addition to the `universe_domain` present in service account json key) and called methods to `topics`, `buckets` and `datasets` respectively.