### PR TITLE
chore: rename quotas repo

### DIFF
--- a/Quotas/README.md
+++ b/Quotas/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 
 ### Sample
 
-See the [samples directory](https://github.com/googleapis/php-cloud-quotas/tree/main/samples) for a canonical list of samples.
+See the [samples directory](https://github.com/googleapis/google-cloud-php-quotas/tree/main/samples) for a canonical list of samples.
 
 ### Version
 

--- a/Quotas/composer.json
+++ b/Quotas/composer.json
@@ -13,7 +13,7 @@
         "component": {
             "id": "cloud-quotas",
             "path": "Quotas",
-            "target": "googleapis/php-cloud-quotas"
+            "target": "googleapis/google-cloud-php-quotas"
         }
     },
     "require": {


### PR DESCRIPTION
I missed this, sorry - for `google/cloud-***` repos, we use the repo format `googleapis/google-cloud-php-***`