### PR TITLE
chore: export-ignore changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@
 /*/.owlbot export-ignore
 /*/owlbot.py export-ignore
 /*/src/**/gapic_metadata.json export-ignore
+/CHANGELOG.md export-ignore


### PR DESCRIPTION
The `CHANGELOG.md` is getting big (1.4M), so we should `export-ignore` it so that it doesn't get installed by composer.