### PR TITLE
chore: do not export-ignore samples in umbrella package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /*.xml export-ignore
 /*.xml.dist export-ignore
 /*/tests export-ignore
-/*/samples export-ignore
 /.travis.yml export-ignore
 /appveyor.yml export-ignore
 /codecov.yml export-ignore


### PR DESCRIPTION
Similar to https://github.com/googleapis/google-cloud-php/pull/5837 - we can ship samples in umbrella package since this repo isn't recommended for production anyway

see b/262896693