### PR TITLE
feat(dev): latest version query

### DIFF
--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableCellStyle;
 
 /**
  * List release details
@@ -52,9 +54,15 @@ class ReleaseInfoCommand extends Command
     {
         $this->setName('release-info')
             ->setDescription('list information for a google-cloud-php release')
-            ->addArgument('tag', InputArgument::REQUIRED, 'The git tag of the release (e.g. v0.200.0)')
+            ->addArgument('tag', InputArgument::OPTIONAL, 'The git tag of the release (e.g. v0.200.0)')
             ->addOption('token', 't', InputOption::VALUE_REQUIRED, 'Github token to use for authentication', '')
-            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'output format, can be "json" or "shell"', 'shell')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'output format, can be "json", "shell", or "sql"', 'shell')
+            ->addOption(
+                'from',
+                '',
+                InputOption::VALUE_REQUIRED,
+                'Date string representing how far back to get release data (e.g. "-6 months")'
+            )
         ;
     }
 
@@ -63,13 +71,95 @@ class ReleaseInfoCommand extends Command
         $github = new Github(
             new RunShell(),
             $this->httpClient,
-            $input->getOption('token')
+            $input->getOption('token'),
+            $output
         );
 
-        $changelog = $github->getChangelog(
-            self::REPO_ID,
-            $tag = $input->getArgument('tag')
-        );
+        if ($from = $input->getOption('from')) {
+            if ($input->getArgument('tag')) {
+                throw new \InvalidArgumentException('cannot specify both a tag and a from date');
+            }
+            $releases = [];
+            $tags = [];
+            foreach ($github->getReleases(self::REPO_ID, new \DateTime($from)) as $release) {
+                $releases = array_merge($releases, $this->getReleaseDataFromTag($release['name'], $github));
+                $tags[] = $release['name'];
+            }
+            $tag = implode(', ', $tags);
+        } else {
+            if (!$tag = $input->getArgument('tag')) {
+                // if no tag is supplied, get the most recent tag
+                $releases = $github->getReleases(self::REPO_ID);
+                $tag = $releases[0]['name'] ?? '';
+            }
+            $releases = $this->getReleaseDataFromTag($tag, $github);
+        }
+
+        switch ($input->getOption('format')) {
+            case 'shell':
+                (new Table($output))
+                    ->setHeaders([
+                        [
+                            new TableCell($tag, [
+                                'rowspan' => 1,
+                                'colspan' => 3,
+                                'style' => new TableCellStyle(['align' => 'center', 'cellFormat' => '<info>%s</info>'])
+                            ])
+                        ],
+                        ['component', 'id', 'version']
+                    ])
+                    ->setRows($releases)
+                    ->render();
+                break;
+            case 'json':
+                $releases = ['version' => $tag, 'releases' => $releases];
+                $output->writeln(json_encode($releases, JSON_PRETTY_PRINT));
+                break;
+            case 'sql':
+                $output->writeln('FALSE');
+                foreach ($releases as $release) {
+                    $component = new Component($release['component']);
+                    // Some components make calls to multiple services, so we can add a query line for each one.
+                    foreach (array_filter($component->getApiShortnames()) as $shortname) {
+                        // The following service names are used by more than one package, so we exclude them to be more accurate
+                        if (in_array($shortname, [
+                            'beyondcorp', // used by cloud-beyondcorp-[appconnections|appconnectors|appgateways|clientconnectorservices|clientgateways]
+                            'analyticshub', // used by cloud-bigquery-analyticshub and cloud-bigquery-data-exchange
+                            'datastore', // used by cloud-datastore and cloud-datastore-admin
+                            'dialogflow', // used by cloud-dialogflow and cloud-dialogflow-cx
+                            'containeranalysis', // used by cloud-container-analysis and grafeas
+                            'policytroubleshooter', // used by cloud-policy-troubleshooter and cloud-policytroubleshooter-iam
+                            'redis', // used by cloud-redis and cloud-redis-cluster
+                            'merchantapi', // used by shopping-merchant-inventories and shopping-merchant-reports
+                        ])) {
+                            // corresponds to multiple packages, so skip
+                            continue;
+                        }
+                        $output->writeln(sprintf(
+                            'OR (service_name = "%s" and client_library_version = "%s")',
+                            $shortname,
+                            $release['version']
+                        ));
+                    }
+                }
+                break;
+            default:
+                throw new \InvalidArgumentException('invalid format');
+        }
+
+        return 0;
+    }
+
+    private function getReleaseDataFromTag(string $tag, Github $github)
+    {
+        if (false === $github->doesTagExist(self::REPO_ID, $tag)) {
+            throw new \InvalidArgumentException(sprintf('tag "%s" not found', $tag));
+        }
+
+        $changelog = $github->getChangelog(self::REPO_ID, $tag);
+        if (null === $changelog) {
+            throw new \RuntimeException('Unable to retrieve tag');
+        }
 
         $releaseNotes = new ReleaseNotes($changelog);
 
@@ -84,21 +174,6 @@ class ReleaseInfoCommand extends Command
             }
         }
 
-        switch ($input->getOption('format')) {
-            case 'shell':
-                (new Table($output))
-                    ->setHeaders(['component', 'id', 'version'])
-                    ->setRows($releases)
-                    ->render();
-                break;
-            case 'json':
-                $releases = ['version' => $tag, 'releases' => $releases];
-                $output->writeln(json_encode($releases, JSON_PRETTY_PRINT));
-                break;
-            default:
-                throw new \InvalidArgumentException('invalid format');
-        }
-
-        return 0;
+        return $releases;
     }
 }

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -154,11 +154,10 @@ class ReleaseInfoCommand extends Command
 
     private function getReleaseDataFromTag(string $tag, Github $github)
     {
-        if (false === $github->doesTagExist(self::REPO_ID, $tag)) {
-            throw new \InvalidArgumentException(sprintf('tag "%s" not found', $tag));
-        }
-
         $changelog = $github->getChangelog(self::REPO_ID, $tag);
+        if (false === $changelog) {
+            throw new \InvalidArgumentException(sprintf('Tag "%s" not found', $tag));
+        }
         if (null === $changelog) {
             throw new \RuntimeException('Unable to retrieve tag');
         }

--- a/dev/src/Command/RepoInfoCommand.php
+++ b/dev/src/Command/RepoInfoCommand.php
@@ -53,7 +53,7 @@ class RepoInfoCommand extends Command
             ->addArgument('component', InputArgument::OPTIONAL, 'If specified, display repo info for this component only', '')
             ->addOption('token', 't', InputOption::VALUE_REQUIRED, 'Github token to use for authentication', '')
             ->addOption('page', 'p', InputOption::VALUE_REQUIRED, 'page to start from', '1')
-            ->addOption('results-per-page', 'r', InputOption::VALUE_REQUIRED, 'results to display per page', '10')
+            ->addOption('results-per-page', 'r', InputOption::VALUE_REQUIRED, 'results to display per page (0 for all)', '10')
             ->addOption('fix', 'f', InputOption::VALUE_NONE, 'whether to prompt to fix non-compliant repos')
         ;
     }
@@ -75,7 +75,7 @@ class RepoInfoCommand extends Command
             if ($i < (($page-1) * $resultsPerPage)) {
                 continue;
             }
-            if ($i >= ($page * $resultsPerPage)) {
+            if (0 !== $resultsPerPage && $i >= ($page * $resultsPerPage)) {
                 $table->render();
                 if (!$this->getHelper('question')->ask($input, $output, $nextPageQuestion)) {
                     return 0;
@@ -159,7 +159,7 @@ class RepoInfoCommand extends Command
         $fields = array_map(
             fn ($field) => is_bool($field) ? var_export($field, true) : $field,
             array_intersect_key(
-                $this->github->getRepoDetails($component->getRepoName()),
+                (array) $this->github->getRepoDetails($component->getRepoName()),
                 self::$allFields
             )
         );

--- a/dev/src/Component.php
+++ b/dev/src/Component.php
@@ -268,6 +268,9 @@ class Component
         $paths = array_map(fn ($file) => $file->getRelativePathname(), iterator_to_array($result));
         $paths = array_reverse(array_values($paths));
         usort($paths, [$this, 'versionCompare']);
+        if (empty($paths)) {
+            $paths = [''];
+        }
         return $paths;
     }
 

--- a/dev/src/GitHub.php
+++ b/dev/src/GitHub.php
@@ -30,8 +30,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class GitHub
 {
     const GITHUB_REPO_ENDPOINT = 'https://api.github.com/repos/%s';
-    const GITHUB_RELEASE_TAG_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/tags/%s';
-    const GITHUB_RELEASE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases';
+    const GITHUB_RELEASE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/tags/%s';
+    const GITHUB_RELEASE_CREATE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases';
     const GITHUB_RELEASE_UPDATE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/%s';
     const GITHUB_RELEASE_GET_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/releases/tags/%s';
     const GITHUB_WEBHOOK_CREATE_ENDPOINT = self::GITHUB_REPO_ENDPOINT . '/hooks';
@@ -92,7 +92,7 @@ class GitHub
     {
         try {
             $res = $this->client->get(sprintf(
-                self::GITHUB_RELEASE_TAG_ENDPOINT,
+                self::GITHUB_RELEASE_ENDPOINT,
                 $this->cleanTarget($target), $tagName
             ), [
                 'auth' => [null, $this->token]
@@ -128,7 +128,7 @@ class GitHub
 
         try {
             $res = $this->client->post(sprintf(
-                self::GITHUB_RELEASE_ENDPOINT,
+                self::GITHUB_RELEASE_CREATE_ENDPOINT,
                 $this->cleanTarget($target)
             ), [
                 'json' => $requestBody,
@@ -200,7 +200,7 @@ class GitHub
     {
         try {
             $res = $this->client->get(sprintf(
-                self::GITHUB_RELEASE_TAG_ENDPOINT,
+                self::GITHUB_RELEASE_ENDPOINT,
                 $target,
                 $tagName
             ), [
@@ -306,7 +306,7 @@ class GitHub
     {
         try {
             $res = $this->client->get(sprintf(
-                self::GITHUB_RELEASE_ENDPOINT,
+                self::GITHUB_RELEASE_CREATE_ENDPOINT,
                 $this->cleanTarget($target)
             ), [
                 'auth' => [null, $this->token]

--- a/dev/src/GitHub.php
+++ b/dev/src/GitHub.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\Dev;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -189,14 +189,14 @@ class GitHub
     }
 
     /**
-     * Get the changelog from a release.
+     * Get the changelog from a release. False if the release doesn't exist.
      *
      * @param string $target The GitHub organization and repository ID separated
      *        by a forward slash, i.e. `organization/repository'.
      * @param string $tagName The name of the tag to fetch from.
-     * @return string|null
+     * @return string|null|false
      */
-    public function getChangelog($target, $tagName)
+    public function getChangelog($target, $tagName): string|null|false
     {
         try {
             $res = $this->client->get(sprintf(
@@ -208,9 +208,9 @@ class GitHub
             ]);
 
             return json_decode((string) $res->getBody(), true)['body'];
-        } catch (\Exception $e) {
+        } catch (RequestException $e) {
             $this->logException($e);
-            return null;
+            return $e->getResponse()?->getStatusCode() === 404 ? false : null;
         }
     }
 

--- a/dev/tests/Unit/GitHubTest.php
+++ b/dev/tests/Unit/GitHubTest.php
@@ -21,7 +21,7 @@ use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Dev\GitHub;
 use Google\Cloud\Dev\RunShell;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -58,7 +58,7 @@ class GitHubTest extends TestCase
             $this->guzzle->reveal(),
             self::TOKEN
         ], ['shell', 'client']);
-        $this->exception = $this->prophesize(BadResponseException::class);
+        $this->exception = $this->prophesize(RequestException::class);
     }
 
     public function testGetDefaultBranch()


### PR DESCRIPTION
**Primary changes**
- adds `from` option to the `release-info` command (previously, the "tag" parameter was required). This returns info for all releases since that date.
- adds `sql` to the `format` option, which outputs the WHERE clause in SQL for the given releases

```sh
dev/google-cloud release-info --from="-6 months" --format sql 
```

**Other misc changes**
- added logic to determine "API Shortname" for non-GAPICs
- if neither "tag" nor "from" is supplied , defaults to latest release
- allows `0` to `results-per-page` in `repo-info` command, which means no pagination
- the `GitHub::getChangelog` method now returns `false` if the tag doesn't exist