### PR TITLE
feat(ci): check for major versions and use MAJOR_VERSION_ALLOWED= to release them

### DIFF
--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -46,7 +46,8 @@ jobs:
               --from=${{ steps.latest-release.outputs.release }} \
               --to=origin/main --format=github-actions
 
-  # Ensure the release PR does not contain an unexpected (2.0.0) major version release
+  # Ensure the release PR does not contain an unexpected (e.g. 2.0.0) major version release
+  # add "MAJOR_VERSION_ALLOWED=component1,component2" to the PR description to allow major version releases for those components
   unexpected-major-version-check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'release-please[bot]'
@@ -54,9 +55,32 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Parse allowed major versions
+        uses: actions-ecosystem/action-regex-match@v2
+        id: allowed-major-versions
+        with:
+          text: ${{ github.event.pull_request.body }}
+          regex: '^MAJOR_VERSION_ALLOWED=(.*)$'
+          flags: gm
       - name: "Check for unexpected major version"
         run: |
-          if [[ "true" == "${{ contains(github.event.pull_request.body, '2.0.0') }}" ]]; then
-            echo "Unexpected 2.0.0 major version release found"
+          # get all changed components
+          IFS=', ' read -r -a ALLOWED_MAJOR_VERSIONS <<< "${{ steps.allowed-major-versions.outputs.group1 }}"
+          COMPONENTS=$(git diff origin/main --name-only | grep VERSION | xargs dirname)
+          FAIL=""
+          for COMPONENT in ${COMPONENTS}; do {
+            # A new version is being released
+            if [[ "$(cat $COMPONENT/VERSION)" == [123456789].0.0 ]]; then
+              if [[ ${ALLOWED_MAJOR_VERSIONS[@]} =~ $COMPONENT ]]; then
+                echo "Major version release allowed: $COMPONENT"
+              else
+                echo "Unexpected major version release found: $COMPONENT"
+                FAIL="true"
+              fi
+            fi
+          }; done
+          if [[ "$FAIL" == "true" ]]; then
+            echo "Add \"MAJOR_VERSION_ALLOWED=component1,component2\" to the PR description to allow "
+            echo "major version releases for those components"
             exit 1
           fi

--- a/.github/workflows/backwards-compatibility-check.yaml
+++ b/.github/workflows/backwards-compatibility-check.yaml
@@ -47,7 +47,8 @@ jobs:
               --to=origin/main --format=github-actions
 
   # Ensure the release PR does not contain an unexpected (e.g. 2.0.0) major version release
-  # add "MAJOR_VERSION_ALLOWED=component1,component2" to the PR description to allow major version releases for those components
+  # Add "MAJOR_VERSION_ALLOWED=component1,component2" to the PR description to allow major version
+  # releases for those components
   unexpected-major-version-check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'release-please[bot]'
@@ -64,13 +65,14 @@ jobs:
           flags: gm
       - name: "Check for unexpected major version"
         run: |
-          # get all changed components
+          # parse allowed major versions into an array
           IFS=', ' read -r -a ALLOWED_MAJOR_VERSIONS <<< "${{ steps.allowed-major-versions.outputs.group1 }}"
+          # get all changed components
           COMPONENTS=$(git diff origin/main --name-only | grep VERSION | xargs dirname)
           FAIL=""
           for COMPONENT in ${COMPONENTS}; do {
-            # A new version is being released
             if [[ "$(cat $COMPONENT/VERSION)" == [123456789].0.0 ]]; then
+              # A new version is being released - make sure it's allowed
               if [[ ${ALLOWED_MAJOR_VERSIONS[@]} =~ $COMPONENT ]]; then
                 echo "Major version release allowed: $COMPONENT"
               else


### PR DESCRIPTION
See [this failing workflow run](https://github.com/googleapis/google-cloud-php/actions/runs/7643586486/job/20825970498) and [this passing workflow run](https://github.com/googleapis/google-cloud-php/actions/runs/7643817664/job/20826730963) for an example of how these work:

**Failing Workflow Run**
<img width="469" alt="Screenshot 2024-01-24 at 9 19 39 AM" src="https://github.com/googleapis/google-cloud-php/assets/103941/7697fb71-c4da-4b59-95d4-6d896469b1f4">

**Passing Workflow Run**
<img width="400" alt="Screenshot 2024-01-24 at 9 19 52 AM" src="https://github.com/googleapis/google-cloud-php/assets/103941/c82e1ff2-3040-45cd-ba48-40a76cd49ec8">

The workflow checks the changed `VERSION` file for a major release, and if it detects one, fails if the component is not contained in a `MAJOR_VERSION_ALLOWED=` tag in the PR body, e.g:

```
MAJOR_VERSION_ALLOWED=Workflows,AnalyticsData
```