### PR TITLE
feat(storage): support IncludeFoldersAsPrefixes

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -645,6 +645,9 @@ class Bucket
      *           from the prefix, contain delimiter will have their name,
      *           truncated after the delimiter, returned in prefixes. Duplicate
      *           prefixes are omitted.
+     *     @type bool $includeFoldersAsPrefixes If true, will also include folders
+     *           and managed folders (besides objects) in the returned prefixes.
+     *           Only applicable if delimiter is set to '/'.
      *     @type int $maxResults Maximum number of results to return per
      *           request. **Defaults to** `1000`.
      *     @type int $resultLimit Limit the number of results returned in total.

--- a/Storage/tests/Unit/BucketTest.php
+++ b/Storage/tests/Unit/BucketTest.php
@@ -246,6 +246,28 @@ class BucketTest extends TestCase
         $this->assertEquals('file2.txt', $objects[1]->name());
     }
 
+    public function testGetsObjectsWithManagedFolders()
+    {
+        $this->connection->listObjects(Argument::any())
+            ->willReturn([
+                'kind' => 'storage#objects',
+                'prefixes' => ['managedFolders/', 'mf/'],
+                'items' => [[
+                    'name' => 'mf/file.txt',
+                    'generation' => 'abc',
+                    'kind' => 'storage#object'
+                ]]
+            ]);
+
+        $bucket = $this->getBucket();
+        $objects = iterator_to_array($bucket->objects([
+            'delimiter' => '/',
+            'includeFoldersAsPrefixes' => true
+        ]));
+
+        $this->assertEquals('mf/file.txt', $objects[0]->name());
+    }
+
     public function testDelete()
     {
         $bucket = $this->getBucket([], false);


### PR DESCRIPTION
Adds support for IncludeFoldersAsPrefixes to object listing, which allows managed folders to be included in the results.
Create / List / Delete / Get calls to be handled separately.

Fixes: https://github.com/googleapis/google-cloud-php/issues/7039