### PR TITLE
fix: fatal error in InsecureCredentialsWrapper with gax >= 1.28.1

### DIFF
--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -33,4 +33,11 @@ class InsecureCredentialsWrapper extends CredentialsWrapper
     {
         return null;
     }
+
+    public function checkUniverseDomain()
+    {
+        // no-op: universe domain is not validated for an insecure credential. This is only implemented
+        // to prevent an exception due to the parent class not being initialised.
+    }
+
 }


### PR DESCRIPTION
Since gax 1.28.1, any attempt to use the InsecureCredentialsWrapper (e.g. to connect to an emulator) throws a fatal error caused by:

`Typed property Google\ApiCore\CredentialsWrapper::$universeDomain must not be accessed before initialization`

The issue was reported in googleapis/gax-php#537 related to use of cloud-php-spanner, but in fact all usages of the class are broken.

This was caused by googleapis/gax-php#534, which added runtime calls to the `checkUniverseDomain()` method that was previously private. Unfortunately, that method assumes that the universeDomain property has been initialised in the constructor. However InsecureCredentialsWrapper does not call the parent constructor, leaving all the internals of the class in an inconsistent / undefined state.

Patching this method to a no-op fixes the immediate issue.

Ideally this would be covered by tests, but I can't see an obvious place to add them and in any case they would not necessarily catch issues caused by new gax releases. The better solution would probably be for CredentialsWrapper to be an interface, so that InsecureCredentialsWrapper could implement it without either class making assumptions about the internals of the other. However, that would obviously be a breaking change and a substantial refactoring.