### PR TITLE
chore: Deprecate Google\Cloud\Core\InsecureCredentialsWrapper

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,7 @@
         "guzzlehttp/psr7": "^2.6",
         "monolog/monolog": "^2.9|^3.0",
         "psr/http-message": "^1.0|^2.0",
-        "google/gax": "dev-main as 1.29"
+        "google/gax": "^1.29"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,7 @@
         "guzzlehttp/psr7": "^2.6",
         "monolog/monolog": "^2.9|^3.0",
         "psr/http-message": "^1.0|^2.0",
-        "google/gax": "^1.28.2"
+        "google/gax": "dev-main as 1.29"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,7 @@
         "guzzlehttp/psr7": "^2.6",
         "monolog/monolog": "^2.9|^3.0",
         "psr/http-message": "^1.0|^2.0",
-        "google/gax": "^1.27.0"
+        "google/gax": "^1.28.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -22,6 +22,9 @@ use Google\ApiCore\CredentialsWrapper;
 
 /**
  * For connect to emulator.
+ *
+ * This class is deprecated. Use Google\ApiCore\InsecureCredentialsWrapper instead.
+ * @deprecated
  */
 class InsecureCredentialsWrapper extends CredentialsWrapper
 {

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -18,7 +18,7 @@
 
 namespace Google\Cloud\Core;
 
-use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\InsecureCredentialsWrapper;
 
 /**
  * For connect to emulator.
@@ -26,18 +26,9 @@ use Google\ApiCore\CredentialsWrapper;
  * This class is deprecated. Use Google\ApiCore\InsecureCredentialsWrapper instead.
  * @deprecated
  */
-class InsecureCredentialsWrapper extends CredentialsWrapper
+class InsecureCredentialsWrapper extends InsecureCredentialsWrapper
 {
     public function __construct()
-    {
-    }
-
-    public function getAuthorizationHeaderCallback($audience = null)
-    {
-        return null;
-    }
-
-    public function checkUniverseDomain()
     {
     }
 }

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -18,7 +18,7 @@
 
 namespace Google\Cloud\Core;
 
-use Google\ApiCore\InsecureCredentialsWrapper;
+use Google\ApiCore\InsecureCredentialsWrapper as ApiCoreInsecureCredentialsWrapper;
 
 /**
  * For connect to emulator.
@@ -26,7 +26,7 @@ use Google\ApiCore\InsecureCredentialsWrapper;
  * This class is deprecated. Use Google\ApiCore\InsecureCredentialsWrapper instead.
  * @deprecated
  */
-class InsecureCredentialsWrapper extends InsecureCredentialsWrapper
+class InsecureCredentialsWrapper extends ApiCoreInsecureCredentialsWrapper
 {
     public function __construct()
     {

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "monolog/monolog": "^2.9||^3.0",
         "psr/http-message": "^1.0|^2.0",
         "ramsey/uuid": "^4.0",
-        "google/gax": "dev-main as 1.29",
+        "google/gax": "^1.29",
         "google/common-protos": "^4.4",
         "google/auth": "^1.34"
     },

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "monolog/monolog": "^2.9||^3.0",
         "psr/http-message": "^1.0|^2.0",
         "ramsey/uuid": "^4.0",
-        "google/gax": "^1.27.0",
+        "google/gax": "dev-main as 1.29",
         "google/common-protos": "^4.4",
         "google/auth": "^1.34"
     },


### PR DESCRIPTION
BREAKING_CHANGE_REASON=The actual return type of `InsecureCredentialsWrapper:getAuthorizationHeaderCallback()` is `callable` in `ApiCore/CredentialsWrapper`. This PR fixes this by setting the return type of `InsecureCredentialsWrapper:getAuthorizationHeaderCallback()` as callable. So, this PR acknowledge the breaking changes, and they shouldn't have any adverse affects on the users.