### PR TITLE
fix(PubSub): Credentials are not passed to the BatchPublisher

### DIFF
--- a/PubSub/src/Topic.php
+++ b/PubSub/src/Topic.php
@@ -658,10 +658,17 @@ class Topic
      */
     public function batchPublisher(array $options = [])
     {
+        $config = $this->clientConfig;
+
+        // We don't want to forward the credentials to the BatchPubslisher
+        if (isset($config['credentials'])) {
+            unset($config['credentials']);
+        }
+
         return new BatchPublisher(
             $this->name,
             $options + [
-                'clientConfig' => $this->clientConfig
+                'clientConfig' => $config
             ]
         );
     }


### PR DESCRIPTION
BatchPublisher [samples are failing](https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1967) with Pubsub v2 RC1.

This is because the `$config['credentials]` which is of the type `CredentialsWrapper` has a closure in it somewhere which is being passed to `shm_put_var` and we are getting a failure with the error: `Serialization of 'Closure' is not allowed`.

In v1 of Pubsub, we didn't pass any authentication data to the `BatchPublisher`, so this PR unsets the `$config['credentials]` before the `$config` is passed to the `BatchPublisher`.