### PR TITLE
fix(Core): pass total_bytes in ResumableUploader

### DIFF
--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -264,7 +264,7 @@ class ResumableUploader extends AbstractUploader
         $request = new Request(
             'PUT',
             $this->resumeUri,
-            ['Content-Range' => 'bytes */*']
+            ['Content-Range' => 'bytes */' . $this->data->getSize()]
         );
 
         return $this->requestWrapper->send($request, $this->requestOptions);

--- a/Core/tests/Unit/Upload/ResumableUploaderTest.php
+++ b/Core/tests/Unit/Upload/ResumableUploaderTest.php
@@ -124,22 +124,43 @@ class ResumableUploaderTest extends TestCase
         $this->assertEquals($resumeUri, $uploader->getResumeUri());
     }
 
-    public function testResumesUpload()
+    public function testResumeUploadReturnsIfAlreadySuccessful()
     {
         $response = new Response(200, [], $this->successBody);
-        $statusResponse = new Response(200, ['Range' => 'bytes 0-2']);
 
         $this->requestWrapper->send(
             Argument::type(RequestInterface::class),
             Argument::type('array')
         )->willReturn($response);
 
+        $uploader = new ResumableUploader(
+            $this->requestWrapper->reveal(),
+            $this->stream,
+            'http://www.example.com'
+        );
+
+        $this->assertEquals(
+            json_decode($this->successBody, true),
+            $uploader->resume('http://some-resume-uri.example.com')
+        );
+    }
+
+    public function testResumesFailedUpload()
+    {
+        $response = new Response(200, [], $this->successBody);
+        $statusResponse = new Response(200, ['Range' => 'bytes 0-2']);
+
         $this->requestWrapper->send(
             Argument::that(function ($request) {
-                return $request->getHeaderLine('Content-Range') === 'bytes */*';
+                return $request->getHeaderLine('Content-Range') === 'bytes */4';
             }),
             Argument::type('array')
         )->willReturn($statusResponse);
+
+        $this->requestWrapper->send(
+            Argument::type(RequestInterface::class),
+            Argument::type('array')
+        )->willReturn($response);
 
         $uploader = new ResumableUploader(
             $this->requestWrapper->reveal(),


### PR DESCRIPTION
When querying the last uploaded bytes, `ResumableUploader` should pass the `total_bytes` to be uploaded in HTTP PUT call. [Guidance here in point # 4](http://go/scotty-http-protocols#common-base-protocol-resumable-http-puts)

Also, fixes tests which were not exactly testing that uploads do happen on resume.

Addresses (but not exactly fixes #https://github.com/googleapis/google-cloud-php/issues/7088
