### PR TITLE
chore: Upgrade GAX version for v2 release of Pubsub

### DIFF
--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.55",
-        "google/gax": "^1.29.1"
+        "google/gax": "^1.30.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Upgraded the GAX version to `1.30.0`
Samples verified in [this PR](https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1967).
Release-As:2.0.0