### PR TITLE
chore(Storage): fixing risky tests via adding assertions

### DIFF
--- a/Storage/tests/Snippet/HmacKeyTest.php
+++ b/Storage/tests/Snippet/HmacKeyTest.php
@@ -94,7 +94,8 @@ class HmacKeyTest extends SnippetTestCase
     public function testUpdate()
     {
         $this->connection->updateHmacKey(Argument::withEntry('state', 'INACTIVE'))
-            ->willReturn($this->metadata);
+            ->willReturn($this->metadata)
+            ->shouldBeCalled();
 
         $this->key->___setProperty('connection', $this->connection->reveal());
 
@@ -107,7 +108,8 @@ class HmacKeyTest extends SnippetTestCase
     public function testDelete()
     {
         $this->connection->deleteHmacKey(Argument::any())
-            ->willReturn(null);
+            ->willReturn(null)
+            ->shouldBeCalled();
 
         $this->key->___setProperty('connection', $this->connection->reveal());
 


### PR DESCRIPTION
Fixes warnings in snippet tests, [here](https://github.com/googleapis/google-cloud-php/actions/runs/8279003211/job/22652518332?pr=7144#step:4:1942).


<img width="811" alt="Screenshot 2024-03-15 at 11 43 59 PM" src="https://github.com/googleapis/google-cloud-php/assets/7369612/e44e2703-5a68-4b74-8a72-e6f13354e1e6">

