### PR TITLE
chore(tests): Fix AddComponentCommandTest

### DIFF
--- a/dev/tests/Unit/Command/AddComponentCommandTest.php
+++ b/dev/tests/Unit/Command/AddComponentCommandTest.php
@@ -63,9 +63,7 @@ class AddComponentCommandTest extends TestCase
     public function testAddComponent()
     {
         self::$commandTester->setInputs([
-            'Y',                                                            // Does this information look correct? [Y/n]
-            'https://cloud.google.com/secret-manager/docs/reference/rest/', // What is the product documentation URL?
-            'https://cloud.google.com/secret-manager',                     // What is the product homepage?
+            'Y'    // Does this information look correct? [Y/n]
         ]);
 
         self::$commandTester->execute([
@@ -189,9 +187,7 @@ class AddComponentCommandTest extends TestCase
 
         $commandTester = new CommandTester($application->get('add-component'));
         $commandTester->setInputs([
-            'Y',                                                            // Does this information look correct? [Y/n]
-            'https://cloud.google.com/secret-manager/docs/reference/rest/', // What is the product documentation URL?
-            'https://cloud.google.com/secret-manager',                     // What is the product homepage?
+            'Y'    // Does this information look correct? [Y/n]
         ]);
 
         $commandTester->execute([

--- a/dev/tests/fixtures/component/SecretManager/README.md
+++ b/dev/tests/fixtures/component/SecretManager/README.md
@@ -42,4 +42,4 @@ This component is considered alpha. As such, it is still a work-in-progress and 
 
 ### Next Steps
 
-1. Understand the [official documentation](https://cloud.google.com/secret-manager/docs/reference/rest/).
+1. Understand the [official documentation](https://cloud.google.com/secret-manager/docs/overview).


### PR DESCRIPTION
The inclusion of a Documentation URI in the `google/cloud/secretmanager/v1/secretmanager_v1.yaml` file for the `secretmanager` component now breaks tests in the `dev`. Previously, during the AddComponent command, the absence of a Documentation URI would trigger a prompt, allowing the test to provide it.  This PR updates tests to accommodate the change, as the command now automatically obtains the Documentation URI from the YAML file.

Refer: https://github.com/googleapis/googleapis/commit/034570432b14b429c5f597701132b6d9ceb553a2#diff-4dfeb801ec53963f0695de0ee5856641691c50d1b2aa7f8a6159ab26978e4fb3R46