### PR TITLE
chore: fix docs url for google/apps-chat

### DIFF
--- a/AppsChat/.repo-metadata.json
+++ b/AppsChat/.repo-metadata.json
@@ -1,8 +1,8 @@
 {
     "language": "php",
-    "distribution_name": "google/chat",
+    "distribution_name": "google/apps-chat",
     "release_level": "preview",
-    "client_documentation": "https://cloud.google.com/php/docs/reference/chat/latest",
+    "client_documentation": "https://cloud.google.com/php/docs/reference/apps-chat/latest",
     "library_type": "GAPIC_AUTO",
     "api_shortname": "chat"
 }


### PR DESCRIPTION
The docs URL for `google/apps-chat` is incorrect here: https://cloud.google.com/php/docs/reference