### PR TITLE
build: remove .repo-metadata.json from export-ignore gitattributes config

### DIFF
--- a/AccessApproval/.gitattributes
+++ b/AccessApproval/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AccessContextManager/.gitattributes
+++ b/AccessContextManager/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AdvisoryNotifications/.gitattributes
+++ b/AdvisoryNotifications/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AiPlatform/.gitattributes
+++ b/AiPlatform/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AlloyDb/.gitattributes
+++ b/AlloyDb/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AnalyticsAdmin/.gitattributes
+++ b/AnalyticsAdmin/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AnalyticsData/.gitattributes
+++ b/AnalyticsData/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ApiGateway/.gitattributes
+++ b/ApiGateway/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ApiKeys/.gitattributes
+++ b/ApiKeys/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ApigeeConnect/.gitattributes
+++ b/ApigeeConnect/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ApigeeRegistry/.gitattributes
+++ b/ApigeeRegistry/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AppEngineAdmin/.gitattributes
+++ b/AppEngineAdmin/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AppHub/.gitattributes
+++ b/AppHub/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/AppsChat/.gitattributes
+++ b/AppsChat/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/AppsEventsSubscriptions/.gitattributes
+++ b/AppsEventsSubscriptions/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/AppsMeet/.gitattributes
+++ b/AppsMeet/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ArtifactRegistry/.gitattributes
+++ b/ArtifactRegistry/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Asset/.gitattributes
+++ b/Asset/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AssuredWorkloads/.gitattributes
+++ b/AssuredWorkloads/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/AutoMl/.gitattributes
+++ b/AutoMl/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BareMetalSolution/.gitattributes
+++ b/BareMetalSolution/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Batch/.gitattributes
+++ b/Batch/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BeyondCorpAppConnections/.gitattributes
+++ b/BeyondCorpAppConnections/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BeyondCorpAppConnectors/.gitattributes
+++ b/BeyondCorpAppConnectors/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BeyondCorpAppGateways/.gitattributes
+++ b/BeyondCorpAppGateways/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BeyondCorpClientConnectorServices/.gitattributes
+++ b/BeyondCorpClientConnectorServices/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BeyondCorpClientGateways/.gitattributes
+++ b/BeyondCorpClientGateways/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryAnalyticsHub/.gitattributes
+++ b/BigQueryAnalyticsHub/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryConnection/.gitattributes
+++ b/BigQueryConnection/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryDataExchange/.gitattributes
+++ b/BigQueryDataExchange/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryDataPolicies/.gitattributes
+++ b/BigQueryDataPolicies/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryDataTransfer/.gitattributes
+++ b/BigQueryDataTransfer/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryMigration/.gitattributes
+++ b/BigQueryMigration/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryReservation/.gitattributes
+++ b/BigQueryReservation/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BigQueryStorage/.gitattributes
+++ b/BigQueryStorage/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Bigtable/.gitattributes
+++ b/Bigtable/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Billing/.gitattributes
+++ b/Billing/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BillingBudgets/.gitattributes
+++ b/BillingBudgets/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/BinaryAuthorization/.gitattributes
+++ b/BinaryAuthorization/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Build/.gitattributes
+++ b/Build/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/CertificateManager/.gitattributes
+++ b/CertificateManager/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Channel/.gitattributes
+++ b/Channel/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/CommerceConsumerProcurement/.gitattributes
+++ b/CommerceConsumerProcurement/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Compute/.gitattributes
+++ b/Compute/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ConfidentialComputing/.gitattributes
+++ b/ConfidentialComputing/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Config/.gitattributes
+++ b/Config/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ContactCenterInsights/.gitattributes
+++ b/ContactCenterInsights/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Container/.gitattributes
+++ b/Container/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ContainerAnalysis/.gitattributes
+++ b/ContainerAnalysis/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ControlsPartner/.gitattributes
+++ b/ControlsPartner/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/DataCatalog/.gitattributes
+++ b/DataCatalog/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DataCatalogLineage/.gitattributes
+++ b/DataCatalogLineage/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DataFusion/.gitattributes
+++ b/DataFusion/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DataLabeling/.gitattributes
+++ b/DataLabeling/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dataflow/.gitattributes
+++ b/Dataflow/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dataform/.gitattributes
+++ b/Dataform/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dataplex/.gitattributes
+++ b/Dataplex/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dataproc/.gitattributes
+++ b/Dataproc/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DataprocMetastore/.gitattributes
+++ b/DataprocMetastore/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Datastore/.gitattributes
+++ b/Datastore/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DatastoreAdmin/.gitattributes
+++ b/DatastoreAdmin/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Datastream/.gitattributes
+++ b/Datastream/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Debugger/.gitattributes
+++ b/Debugger/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Deploy/.gitattributes
+++ b/Deploy/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dialogflow/.gitattributes
+++ b/Dialogflow/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DialogflowCx/.gitattributes
+++ b/DialogflowCx/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/DiscoveryEngine/.gitattributes
+++ b/DiscoveryEngine/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Dlp/.gitattributes
+++ b/Dlp/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Dms/.gitattributes
+++ b/Dms/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/DocumentAi/.gitattributes
+++ b/DocumentAi/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Domains/.gitattributes
+++ b/Domains/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/EdgeNetwork/.gitattributes
+++ b/EdgeNetwork/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ErrorReporting/.gitattributes
+++ b/ErrorReporting/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/EssentialContacts/.gitattributes
+++ b/EssentialContacts/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Eventarc/.gitattributes
+++ b/Eventarc/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/EventarcPublishing/.gitattributes
+++ b/EventarcPublishing/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Filestore/.gitattributes
+++ b/Filestore/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Firestore/.gitattributes
+++ b/Firestore/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Functions/.gitattributes
+++ b/Functions/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/GSuiteAddOns/.gitattributes
+++ b/GSuiteAddOns/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Gaming/.gitattributes
+++ b/Gaming/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/GkeBackup/.gitattributes
+++ b/GkeBackup/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/GkeConnectGateway/.gitattributes
+++ b/GkeConnectGateway/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/GkeHub/.gitattributes
+++ b/GkeHub/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/GkeMultiCloud/.gitattributes
+++ b/GkeMultiCloud/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Grafeas/.gitattributes
+++ b/Grafeas/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Iam/.gitattributes
+++ b/Iam/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/IamCredentials/.gitattributes
+++ b/IamCredentials/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Iap/.gitattributes
+++ b/Iap/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Ids/.gitattributes
+++ b/Ids/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Iot/.gitattributes
+++ b/Iot/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Kms/.gitattributes
+++ b/Kms/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/KmsInventory/.gitattributes
+++ b/KmsInventory/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Language/.gitattributes
+++ b/Language/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/LifeSciences/.gitattributes
+++ b/LifeSciences/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Logging/.gitattributes
+++ b/Logging/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/LongRunning/.gitattributes
+++ b/LongRunning/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /tests export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ManagedIdentities/.gitattributes
+++ b/ManagedIdentities/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/MediaTranslation/.gitattributes
+++ b/MediaTranslation/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Memcache/.gitattributes
+++ b/Memcache/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/MigrationCenter/.gitattributes
+++ b/MigrationCenter/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Monitoring/.gitattributes
+++ b/Monitoring/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/NetApp/.gitattributes
+++ b/NetApp/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/NetworkConnectivity/.gitattributes
+++ b/NetworkConnectivity/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/NetworkManagement/.gitattributes
+++ b/NetworkManagement/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/NetworkSecurity/.gitattributes
+++ b/NetworkSecurity/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Notebooks/.gitattributes
+++ b/Notebooks/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Optimization/.gitattributes
+++ b/Optimization/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/OrchestrationAirflow/.gitattributes
+++ b/OrchestrationAirflow/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/OrgPolicy/.gitattributes
+++ b/OrgPolicy/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/OsConfig/.gitattributes
+++ b/OsConfig/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Parallelstore/.gitattributes
+++ b/Parallelstore/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/PolicySimulator/.gitattributes
+++ b/PolicySimulator/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/PolicyTroubleshooter/.gitattributes
+++ b/PolicyTroubleshooter/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/PolicyTroubleshooterIam/.gitattributes
+++ b/PolicyTroubleshooterIam/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/PrivateCatalog/.gitattributes
+++ b/PrivateCatalog/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Profiler/.gitattributes
+++ b/Profiler/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/PubSub/.gitattributes
+++ b/PubSub/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Quotas/.gitattributes
+++ b/Quotas/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/RapidMigrationAssessment/.gitattributes
+++ b/RapidMigrationAssessment/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/RecommendationEngine/.gitattributes
+++ b/RecommendationEngine/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Recommender/.gitattributes
+++ b/Recommender/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Redis/.gitattributes
+++ b/Redis/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/RedisCluster/.gitattributes
+++ b/RedisCluster/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ResourceManager/.gitattributes
+++ b/ResourceManager/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ResourceSettings/.gitattributes
+++ b/ResourceSettings/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Retail/.gitattributes
+++ b/Retail/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Run/.gitattributes
+++ b/Run/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Scheduler/.gitattributes
+++ b/Scheduler/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/SecretManager/.gitattributes
+++ b/SecretManager/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/SecureSourceManager/.gitattributes
+++ b/SecureSourceManager/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/SecurityCenter/.gitattributes
+++ b/SecurityCenter/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/SecurityCenterManagement/.gitattributes
+++ b/SecurityCenterManagement/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/SecurityPrivateCa/.gitattributes
+++ b/SecurityPrivateCa/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/SecurityPublicCA/.gitattributes
+++ b/SecurityPublicCA/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ServiceControl/.gitattributes
+++ b/ServiceControl/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ServiceDirectory/.gitattributes
+++ b/ServiceDirectory/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ServiceHealth/.gitattributes
+++ b/ServiceHealth/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ServiceManagement/.gitattributes
+++ b/ServiceManagement/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ServiceUsage/.gitattributes
+++ b/ServiceUsage/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Shell/.gitattributes
+++ b/Shell/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/ShoppingCommonProtos/.gitattributes
+++ b/ShoppingCommonProtos/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ShoppingCss/.gitattributes
+++ b/ShoppingCss/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ShoppingMerchantConversions/.gitattributes
+++ b/ShoppingMerchantConversions/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ShoppingMerchantInventories/.gitattributes
+++ b/ShoppingMerchantInventories/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ShoppingMerchantQuota/.gitattributes
+++ b/ShoppingMerchantQuota/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/ShoppingMerchantReports/.gitattributes
+++ b/ShoppingMerchantReports/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Spanner/.gitattributes
+++ b/Spanner/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Speech/.gitattributes
+++ b/Speech/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/SqlAdmin/.gitattributes
+++ b/SqlAdmin/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/StorageControl/.gitattributes
+++ b/StorageControl/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/StorageInsights/.gitattributes
+++ b/StorageInsights/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/StorageTransfer/.gitattributes
+++ b/StorageTransfer/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Support/.gitattributes
+++ b/Support/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/Talent/.gitattributes
+++ b/Talent/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Tasks/.gitattributes
+++ b/Tasks/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/TelcoAutomation/.gitattributes
+++ b/TelcoAutomation/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/TextToSpeech/.gitattributes
+++ b/TextToSpeech/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Tpu/.gitattributes
+++ b/Tpu/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Trace/.gitattributes
+++ b/Trace/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Translate/.gitattributes
+++ b/Translate/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VideoIntelligence/.gitattributes
+++ b/VideoIntelligence/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VideoLiveStream/.gitattributes
+++ b/VideoLiveStream/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VideoStitcher/.gitattributes
+++ b/VideoStitcher/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VideoTranscoder/.gitattributes
+++ b/VideoTranscoder/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Vision/.gitattributes
+++ b/Vision/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /.owlbot export-ignore
 /owlbot.py export-ignore

--- a/VmMigration/.gitattributes
+++ b/VmMigration/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VmwareEngine/.gitattributes
+++ b/VmwareEngine/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/VpcAccess/.gitattributes
+++ b/VpcAccess/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/WebRisk/.gitattributes
+++ b/WebRisk/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/WebSecurityScanner/.gitattributes
+++ b/WebSecurityScanner/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/Workflows/.gitattributes
+++ b/Workflows/.gitattributes
@@ -2,7 +2,6 @@
 /tests export-ignore
 /.github export-ignore
 /samples export-ignore
-/.repo-metadata.json export-ignore
 /.OwlBot.yaml export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore

--- a/dev/templates/.gitattributes
+++ b/dev/templates/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/dev/tests/fixtures/component/CustomInput/.gitattributes
+++ b/dev/tests/fixtures/component/CustomInput/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore

--- a/dev/tests/fixtures/component/SecretManager/.gitattributes
+++ b/dev/tests/fixtures/component/SecretManager/.gitattributes
@@ -1,7 +1,6 @@
 /*.xml.dist export-ignore
 /.OwlBot.yaml export-ignore
 /.github export-ignore
-/.repo-metadata.json export-ignore
 /owlbot.py export-ignore
 /src/**/gapic_metadata.json export-ignore
 /samples export-ignore


### PR DESCRIPTION
This is blocking the scanning of client libraries as the files are not exported for the data pipelines to process in bulk.

For any 1 client library, this file is ~300 bytes and not significant to the installed package size.

An alternative could be to use the single manifest-style `.repo-metadata-full.json` file (like [go does here](https://github.com/googleapis/google-cloud-go/blob/main/internal/.repo-metadata-full.json)), which would still need be included in the meta `google/cloud` package.
