### PR TITLE
fix(Spanner): Cast some fields in the ResultStats object to int

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -253,6 +253,14 @@ class Grpc implements ConnectionInterface
                 $fields = $msg->getMetadata()?->getRowType()?->getFields();
                 $data['metadata']['rowType']['fields'] = $this->getFieldDataFromRepeatedFields($fields);
 
+                // These fields in stats should be an int
+                if (isset($data['stats']['rowCountLowerBound'])) {
+                    $data['stats']['rowCountLowerBound'] = (int) $data['stats']['rowCountLowerBound'];
+                }
+                if (isset($data['stats']['rowCountExact'])) {
+                    $data['stats']['rowCountExact'] = (int) $data['stats']['rowCountExact'];
+                }
+
                 return $data;
             }
         ]);


### PR DESCRIPTION
This was changed to strings in the `1.76.0` release of Spanner. The other fields in the stats object like inside `queryPlan` were already returned as a string so we don't need to cast them.

But these 2 properties, `rowCountLowerBound` and `rowCountExact` are now casted to int so that we preserve the speed boost we get and maintain data integrity within the `ResultStats` object.

Fixes #7279 