### PR TITLE
feat(Storage): Enable hierarchical namespace

### DIFF
--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -292,6 +292,8 @@ class StorageClient
      *           set in conjunction. For more information, see
      *           [Bucket Locations](https://cloud.google.com/storage/docs/locations).
      *           **Defaults to** `"US"`.
+     *     @type array $hierarchicalNamespace The hierarchical namespace configuration
+     *           on this bucket.
      *     @type array $customPlacementConfig The bucket's dual regions. For more
      *           information, see
      *           [Bucket Locations](https://cloud.google.com/storage/docs/locations).

--- a/Storage/tests/System/ManageBucketsTest.php
+++ b/Storage/tests/System/ManageBucketsTest.php
@@ -104,6 +104,21 @@ class ManageBucketsTest extends StorageTestCase
         );
     }
 
+    /**
+     * @dataProvider hnsConfigs
+     */
+    public function testCreateBucketsWithHnsConfigs($hnsConfig, $expectedHnsEnabled)
+    {
+        $name = uniqid(self::TESTING_PREFIX);
+
+        $this->assertFalse(self::$client->bucket($name)->exists());
+        $bucket = self::createBucket(self::$client, $name, $hnsConfig);
+
+        $this->assertTrue(self::$client->bucket($name)->exists());
+        $this->assertEquals($name, $bucket->name());
+        $this->assertEquals($expectedHnsEnabled, $bucket->info()['hierarchicalNamespace']['enabled'] ?? false);
+    }
+
     public function testUpdateBucket()
     {
         $options = [
@@ -462,6 +477,20 @@ class ManageBucketsTest extends StorageTestCase
             [['enabled' => true]],
             [['enabled' => true, 'terminalStorageClass' => 'NEARLINE']],
             [['enabled' => true, 'terminalStorageClass' => 'ARCHIVE']],
+        ];
+    }
+
+    public function hnsConfigs()
+    {
+        return [
+            [[], false],
+            [['hierarchicalNamespace' => ['enabled' => false,]], false],
+            // TODO: Test cases fails because of no uniformBucketLevelAccess
+            // [['hierarchicalNamespace' => ['enabled' => true,]], false],
+            [[
+                'hierarchicalNamespace' => ['enabled' => true,],
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
+            ], true],
         ];
     }
 }

--- a/Storage/tests/System/ManageBucketsTest.php
+++ b/Storage/tests/System/ManageBucketsTest.php
@@ -485,8 +485,6 @@ class ManageBucketsTest extends StorageTestCase
         return [
             [[], false],
             [['hierarchicalNamespace' => ['enabled' => false,]], false],
-            // TODO: Test cases fails because of no uniformBucketLevelAccess
-            // [['hierarchicalNamespace' => ['enabled' => true,]], false],
             [[
                 'hierarchicalNamespace' => ['enabled' => true,],
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-php/issues/7277

```
➜  Storage git:(main) ✗ vendor/bin/phpunit -c phpunit-system.xml.dist --filter="::testCreateBucketsWithHnsConfigs"
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

...                                                                 3 / 3 (100%)

Time: 00:09.480, Memory: 14.00 MB

OK (3 tests, 12 assertions)
➜  Storage git:(feat_storage_hns1) ✗ 
```