### PR TITLE
feat!(Firestore): Upgrade Firestore V2

### DIFF
--- a/Core/src/Testing/FirestoreTestHelperTrait.php
+++ b/Core/src/Testing/FirestoreTestHelperTrait.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Testing;
+
+use Google\ApiCore\Serializer;
+use Google\Cloud\Core\ApiHelperTrait;
+
+/**
+ * Contains all the helper methods specific to testing in Firestore library.
+ *
+ * @internal
+ */
+trait FirestoreTestHelperTrait
+{
+    use ApiHelperTrait;
+
+    private static $_serializer;
+
+    private function getSerializer()
+    {
+        if (!self::$_serializer) {
+            self::$_serializer = new Serializer([], [
+                'google.protobuf.Value' => function ($v) {
+                    return $this->flattenValue($v);
+                },
+                'google.protobuf.ListValue' => function ($v) {
+                    return $this->flattenListValue($v);
+                },
+                'google.protobuf.Struct' => function ($v) {
+                    return $this->flattenStruct($v);
+                },
+                'google.protobuf.Timestamp' => function ($v) {
+                    return $this->formatTimestampFromApi($v);
+                },
+            ], [], [
+                'google.protobuf.Int32Value' => function ($v) {
+                    return ['value' => $v];
+                }
+            ]);
+        }
+
+        return self::$_serializer;
+    }
+}

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "ext-grpc": "*",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.60",
         "google/gax": "^1.30",
         "ramsey/uuid": "^3.0|^4.0"
     },

--- a/Firestore/src/AggregateQuery.php
+++ b/Firestore/src/AggregateQuery.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore;
 
+use Google\ApiCore\Serializer;
+use Google\Cloud\Core\RequestHandler;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\QueryTrait;
 
@@ -44,6 +46,16 @@ class AggregateQuery
     private $connection;
 
     /**
+     * @var RequestHandler
+     */
+    private $requestHandler;
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
      * @var array
      */
     private $query;
@@ -64,17 +76,24 @@ class AggregateQuery
      * @param ConnectionInterface $connection A Connection to Cloud Firestore.
      *        This object is created by FirestoreClient,
      *        and should not be instantiated outside of this client.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param string $parent The parent of the query.
      * @param array $query Represents the underlying structured query.
      * @param Aggregate $aggregate Aggregation over the provided query.
      */
     public function __construct(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         $parent,
         array $query,
         Aggregate $aggregate
     ) {
         $this->connection = $connection;
+        $this->requestHandler = $requestHandler;
+        $this->serializer = $serializer;
         $this->parentName = $parent;
         $this->query = $query;
         $this->aggregates[] = $aggregate;

--- a/Firestore/src/BulkWriter.php
+++ b/Firestore/src/BulkWriter.php
@@ -17,8 +17,10 @@
 
 namespace Google\Cloud\Firestore;
 
+use Google\ApiCore\Serializer;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\DebugInfoTrait;
+use Google\Cloud\Core\RequestHandler;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Core\ValidateTrait;
@@ -52,11 +54,11 @@ class BulkWriter
     use TimeTrait;
     use ValidateTrait;
 
-    const TYPE_UPDATE = 'update';
-    const TYPE_SET = 'set';
-    const TYPE_CREATE = 'create';
-    const TYPE_DELETE = 'delete';
-    const TYPE_TRANSFORM = 'transform';
+    public const TYPE_UPDATE = 'update';
+    public const TYPE_SET = 'set';
+    public const TYPE_CREATE = 'create';
+    public const TYPE_DELETE = 'delete';
+    public const TYPE_TRANSFORM = 'transform';
 
     /**
      * @var array Holds default configurations for Bulkwriter.
@@ -120,6 +122,16 @@ class BulkWriter
      * @internal
      */
     private $connection;
+
+    /**
+     * @var RequestHandler
+     */
+    private $requestHandler;
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
 
     /**
      * @var ValueMapper
@@ -210,6 +222,9 @@ class BulkWriter
      * @param ConnectionInterface $connection A connection to Cloud Firestore
      *        This object is created by FirestoreClient,
      *        and should not be instantiated outside of this client.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $valueMapper A Value Mapper instance
      * @param string $database The current database
      * @param array $options [optional] {
@@ -238,9 +253,17 @@ class BulkWriter
      *           true if retryable.
      * }
      */
-    public function __construct(ConnectionInterface $connection, $valueMapper, $database, $options = null)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
+        $valueMapper,
+        $database,
+        $options = null
+    ) {
         $this->connection = $connection;
+        $this->requestHandler = $requestHandler;
+        $this->serializer = $serializer;
         $this->valueMapper = $valueMapper;
         $this->database = $database;
         $this->closed = false;
@@ -1132,14 +1155,14 @@ class BulkWriter
                 ];
                 break;
 
-            // @codeCoverageIgnoreStart
+                // @codeCoverageIgnoreStart
             default:
                 throw new \InvalidArgumentException(sprintf(
                     'Write operation type `%s is not valid. Allowed values are update, delete, verify, transform.',
                     $type
                 ));
                 break;
-            // @codeCoverageIgnoreEnd
+                // @codeCoverageIgnoreEnd
         }
     }
 

--- a/Firestore/src/FirestoreSessionHandler.php
+++ b/Firestore/src/FirestoreSessionHandler.php
@@ -16,7 +16,9 @@
  */
 namespace Google\Cloud\Firestore;
 
+use Google\ApiCore\Serializer;
 use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Core\RequestHandler;
 use SessionHandlerInterface;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 
@@ -120,6 +122,17 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      * @internal
      */
     private $connection;
+
+    /**
+     * @var RequestHandler
+     */
+    private $requestHandler;
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
     /**
      * @var ValueMapper
      */
@@ -159,6 +172,9 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      * @param ConnectionInterface $connection A Connection to Cloud Firestore.
      *        This object is created by FirestoreClient,
      *        and should not be instantiated outside of this client.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $valueMapper A Firestore Value Mapper.
      * @param string $projectId The current project id.
      * @param string $database The database id.
@@ -182,12 +198,16 @@ class FirestoreSessionHandler implements SessionHandlerInterface
      */
     public function __construct(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         ValueMapper $valueMapper,
         $projectId,
         $database,
         array $options = []
     ) {
         $this->connection = $connection;
+        $this->requestHandler = $requestHandler;
+        $this->serializer = $serializer;
         $this->valueMapper = $valueMapper;
         $this->projectId = $projectId;
         $this->database = $database;
@@ -234,6 +254,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
 
         $this->transaction = new Transaction(
             $this->connection,
+            $this->requestHandler,
+            $this->serializer,
             $this->valueMapper,
             $database,
             $beginTransaction['transaction']
@@ -276,6 +298,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
         try {
             $docRef = $this->getDocumentReference(
                 $this->connection,
+                $this->requestHandler,
+                $this->serializer,
                 $this->valueMapper,
                 $this->projectId,
                 $this->database,
@@ -309,6 +333,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
     {
         $docRef = $this->getDocumentReference(
             $this->connection,
+            $this->requestHandler,
+            $this->serializer,
             $this->valueMapper,
             $this->projectId,
             $this->database,
@@ -332,6 +358,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
     {
         $docRef = $this->getDocumentReference(
             $this->connection,
+            $this->requestHandler,
+            $this->serializer,
             $this->valueMapper,
             $this->projectId,
             $this->database,
@@ -363,6 +391,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
 
             $transaction = new Transaction(
                 $this->connection,
+                $this->requestHandler,
+                $this->serializer,
                 $this->valueMapper,
                 $database,
                 $beginTransaction['transaction']
@@ -370,6 +400,8 @@ class FirestoreSessionHandler implements SessionHandlerInterface
 
             $collectionRef = $this->getCollectionReference(
                 $this->connection,
+                $this->requestHandler,
+                $this->serializer,
                 $this->valueMapper,
                 $this->projectId,
                 $this->database,

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -17,8 +17,11 @@
 
 namespace Google\Cloud\Firestore;
 
+use Google\ApiCore\Serializer;
+use Google\Cloud\Core\ApiHelperTrait;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\RequestHandler;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Core\TimestampTrait;
@@ -30,7 +33,7 @@ use Google\Cloud\Firestore\DocumentReference;
  */
 trait SnapshotTrait
 {
-    use ArrayTrait;
+    use ApiHelperTrait;
     use PathTrait;
     use TimeTrait;
     use TimestampTrait;
@@ -41,6 +44,9 @@ trait SnapshotTrait
      * @param ConnectionInterface $connection A Connection to Cloud Firestore.
      *        This object is created by FirestoreClient,
      *        and should not be instantiated outside of this client.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $valueMapper A Firestore Value Mapper.
      * @param DocumentReference $reference The parent document.
      * @param array $options {
@@ -52,6 +58,8 @@ trait SnapshotTrait
      */
     private function createSnapshot(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         ValueMapper $valueMapper,
         DocumentReference $reference,
         array $options = []
@@ -61,7 +69,13 @@ trait SnapshotTrait
         $exists = true;
 
         try {
-            $document = $this->getSnapshot($connection, $reference->name(), $options);
+            $document = $this->getSnapshot(
+                $connection,
+                $requestHandler,
+                $serializer,
+                $reference->name(),
+                $options
+            );
         } catch (NotFoundException $e) {
             $exists = false;
         }
@@ -100,6 +114,9 @@ trait SnapshotTrait
      * Send a service request for a snapshot, and return the raw data
      *
      * @param ConnectionInterface $connection A Connection to Cloud Firestore
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param string $name The document name.
      * @param array $options Configuration options.
      * @return array
@@ -107,8 +124,13 @@ trait SnapshotTrait
      *     specified.
      * @throws NotFoundException If the document does not exist.
      */
-    private function getSnapshot(ConnectionInterface $connection, $name, array $options = [])
-    {
+    private function getSnapshot(
+        ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
+        $name,
+        array $options = []
+    ) {
         $options = $this->formatReadTimeOption($options);
 
         $snapshot = $connection->batchGetDocuments([
@@ -132,6 +154,9 @@ trait SnapshotTrait
      * not), and returns.
      *
      * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $mapper A Firestore value mapper.
      * @param string $projectId The current project id.
      * @param string $database The database id.
@@ -142,6 +167,8 @@ trait SnapshotTrait
      */
     private function getDocumentsByPaths(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         ValueMapper $mapper,
         $projectId,
         $database,
@@ -185,6 +212,8 @@ trait SnapshotTrait
 
             $ref = $this->getDocumentReference(
                 $connection,
+                $requestHandler,
+                $serializer,
                 $mapper,
                 $projectId,
                 $database,
@@ -211,6 +240,9 @@ trait SnapshotTrait
      * Creates a DocumentReference object.
      *
      * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $mapper A Firestore value mapper.
      * @param string $projectId The current project id.
      * @param string $database The database id.
@@ -220,6 +252,8 @@ trait SnapshotTrait
      */
     private function getDocumentReference(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         ValueMapper $mapper,
         $projectId,
         $database,
@@ -235,9 +269,13 @@ trait SnapshotTrait
 
         return new DocumentReference(
             $connection,
+            $requestHandler,
+            $serializer,
             $mapper,
             $this->getCollectionReference(
                 $connection,
+                $requestHandler,
+                $serializer,
                 $mapper,
                 $projectId,
                 $database,
@@ -251,6 +289,9 @@ trait SnapshotTrait
      * Creates a CollectionReference object.
      *
      * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param RequestHandler $requestHandler The request handler responsible for sending
+     *        requests and serializing responses into relevant classes.
+     * @param Serializer $serializer The serializer instance to encode/decode messages.
      * @param ValueMapper $mapper A Firestore value mapper.
      * @param string $projectId The current project id.
      * @param string $database The database id.
@@ -260,6 +301,8 @@ trait SnapshotTrait
      */
     private function getCollectionReference(
         ConnectionInterface $connection,
+        RequestHandler $requestHandler,
+        Serializer $serializer,
         ValueMapper $mapper,
         $projectId,
         $database,
@@ -276,7 +319,13 @@ trait SnapshotTrait
             ));
         }
 
-        return new CollectionReference($connection, $mapper, $name);
+        return new CollectionReference(
+            $connection,
+            $requestHandler,
+            $serializer,
+            $mapper,
+            $name
+        );
     }
 
     /**

--- a/Firestore/tests/Snippet/BulkWriterTest.php
+++ b/Firestore/tests/Snippet/BulkWriterTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\Parser\Snippet;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
@@ -35,21 +37,33 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class BulkWriterTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
-    const DATABASE = 'projects/example_project/databases/(default)';
-    const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
+    public const DATABASE = 'projects/example_project/databases/(default)';
+    public const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $batch;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->batch = TestHelpers::stub(BulkWriter::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::DATABASE,
             [],
         ]);

--- a/Firestore/tests/Snippet/DocumentSnapshotTest.php
+++ b/Firestore/tests/Snippet/DocumentSnapshotTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
@@ -35,10 +37,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class DocumentSnapshotTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
-    const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
+    public const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $snapshot;
 
@@ -52,7 +55,12 @@ class DocumentSnapshotTest extends SnippetTestCase
 
         $this->snapshot = TestHelpers::stub(DocumentSnapshot::class, [
             $ref->reveal(),
-            new ValueMapper($this->prophesize(ConnectionInterface::class)->reveal(), false),
+            new ValueMapper(
+                $this->prophesize(ConnectionInterface::class)->reveal(),
+                $this->prophesize(RequestHandler::class)->reveal(),
+                $this->getSerializer(),
+                false
+            ),
             [],
             [],
             true
@@ -130,7 +138,7 @@ class DocumentSnapshotTest extends SnippetTestCase
      */
     public function testTimestampMethods($method)
     {
-        $ts = new Timestamp(new \DateTime);
+        $ts = new Timestamp(new \DateTime());
         $info = [$method => $ts];
         $this->snapshot->___setProperty('info', $info);
 

--- a/Firestore/tests/Snippet/FieldValueTest.php
+++ b/Firestore/tests/Snippet/FieldValueTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
@@ -32,10 +34,13 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class FieldValueTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $firestore;
 
     public function setUp(): void
@@ -43,6 +48,8 @@ class FieldValueTest extends SnippetTestCase
         $this->checkAndSkipGrpcTests();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->firestore = TestHelpers::stub(FirestoreClient::class, [
             ['projectId' => 'my-awesome-project'],
         ]);

--- a/Firestore/tests/Snippet/FirestoreClientTest.php
+++ b/Firestore/tests/Snippet/FirestoreClientTest.php
@@ -20,6 +20,8 @@ namespace Google\Cloud\Firestore\Tests\Snippet;
 use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\GeoPoint;
 use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
@@ -40,6 +42,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class FirestoreClientTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
@@ -47,6 +50,8 @@ class FirestoreClientTest extends SnippetTestCase
     const DATABASE = '(default)';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $client;
 
     public function setUp(): void
@@ -54,6 +59,8 @@ class FirestoreClientTest extends SnippetTestCase
         $this->checkAndSkipGrpcTests();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->client = TestHelpers::stub(FirestoreClient::class, [
             ['projectId' => self::PROJECT]
         ]);

--- a/Firestore/tests/Snippet/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/Snippet/FirestoreSessionHandlerTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
@@ -33,12 +35,15 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class FirestoreSessionHandlerTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
     const TRANSACTION = 'transaction-id';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $client;
 
     public static function setUpBeforeClass(): void
@@ -59,6 +64,8 @@ class FirestoreSessionHandlerTest extends SnippetTestCase
         $this->checkAndSkipGrpcTests();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->client = TestHelpers::stub(FirestoreClient::class);
     }
 

--- a/Firestore/tests/Snippet/QuerySnapshotTest.php
+++ b/Firestore/tests/Snippet/QuerySnapshotTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
@@ -33,15 +35,20 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class QuerySnapshotTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $snapshot;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->snapshot = TestHelpers::stub(QuerySnapshot::class, [
             $this->prophesize(Query::class)->reveal(),
             []

--- a/Firestore/tests/Snippet/QueryTest.php
+++ b/Firestore/tests/Snippet/QueryTest.php
@@ -17,7 +17,9 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
 use Google\Cloud\Core\Testing\ArrayHasSameValuesToken;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\Parser\Snippet;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
@@ -38,18 +40,23 @@ use Google\Cloud\Firestore\V1\StructuredQuery\FieldFilter\Operator as FieldFilte
  */
 class QueryTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
-    const QUERY_PARENT = 'projects/example_project/databases/(default)/documents';
-    const COLLECTION = 'a';
-    const NAME = 'projects/example_project/databases/(default)/documents/a/b';
+    public const QUERY_PARENT = 'projects/example_project/databases/(default)/documents';
+    public const COLLECTION = 'a';
+    public const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
     }
 
     public function testClass()
@@ -65,7 +72,14 @@ class QueryTest extends SnippetTestCase
     {
         $query = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::QUERY_PARENT,
             [
                 'from' => [
@@ -92,7 +106,14 @@ class QueryTest extends SnippetTestCase
     {
         $query = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::QUERY_PARENT,
             [
                 'from' => [
@@ -127,7 +148,14 @@ class QueryTest extends SnippetTestCase
     {
         $query = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::QUERY_PARENT,
             [
                 'from' => [
@@ -353,7 +381,14 @@ class QueryTest extends SnippetTestCase
 
         $q = TestHelpers::stub(Query::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::QUERY_PARENT,
             [
                 'from' => $from

--- a/Firestore/tests/Snippet/WriteBatchTest.php
+++ b/Firestore/tests/Snippet/WriteBatchTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\Parser\Snippet;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
@@ -34,23 +36,35 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class WriteBatchTest extends SnippetTestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
-    const DATABASE = 'projects/example_project/databases/(default)';
-    const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
+    public const DATABASE = 'projects/example_project/databases/(default)';
+    public const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $batch;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->batch = TestHelpers::stub(WriteBatch::class, [
             $this->connection->reveal(),
-            new ValueMapper($this->connection->reveal(), false),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            new ValueMapper(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                false
+            ),
             self::DATABASE
-        ], ['connection', 'transaction']);
+        ], ['connection', 'requestHandler', 'transaction']);
     }
 
     public function testClass()

--- a/Firestore/tests/System/BulkWriterTest.php
+++ b/Firestore/tests/System/BulkWriterTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\System;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Firestore\BulkWriter;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
@@ -31,6 +33,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class BulkWriterTest extends FirestoreTestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
 
     private $document;
@@ -95,9 +98,17 @@ class BulkWriterTest extends FirestoreTestCase
     {
         $docs = $this->bulkDocuments();
         $connection = $this->prophesize(ConnectionInterface::class);
+        $requestHandler = $this->prophesize(RequestHandler::class);
         $this->batch = TestHelpers::stub(BulkWriter::class, [
             $connection->reveal(),
-            new ValueMapper($connection->reveal(), false),
+            $requestHandler->reveal(),
+            $this->getSerializer(),
+            new ValueMapper(
+                $connection->reveal(),
+                $requestHandler->reveal(),
+                $this->getSerializer(),
+                false
+            ),
             self::$collection->name(),
             [
                 'initialOpsPerSecond' => 5,

--- a/Firestore/tests/Unit/ConformanceTest.php
+++ b/Firestore/tests/Unit/ConformanceTest.php
@@ -17,7 +17,9 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\RequestHandler;
 use Google\Cloud\Core\Testing\ArrayHasSameValuesToken;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
@@ -47,6 +49,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class ConformanceTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use PathTrait;
     use ProphecyTrait;
@@ -60,6 +63,8 @@ class ConformanceTest extends TestCase
     private $testTypes = ['get', 'create', 'set', 'update', 'updatePaths', 'delete', 'query'];
     private $client;
     private $connection;
+    private $requestHandler;
+    private $serializer;
 
     private $excludes = [
         // need mergeFields support
@@ -88,6 +93,8 @@ class ConformanceTest extends TestCase
         ]);
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
     }
 
     /**
@@ -309,6 +316,8 @@ class ConformanceTest extends TestCase
 
                             $mapper = new ValueMapper(
                                 $this->prophesize(ConnectionInterface::class)->reveal(),
+                                $this->prophesize(RequestHandler::class)->reveal(),
+                                $this->serializer,
                                 false
                             );
 

--- a/Firestore/tests/Unit/DocumentReferenceTest.php
+++ b/Firestore/tests/Unit/DocumentReferenceTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
@@ -36,26 +38,44 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class DocumentReferenceTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
     use TimeTrait;
 
-    const PROJECT = 'example_project';
-    const DATABASE = '(default)';
-    const COLLECTION = 'projects/example_project/databases/(default)/documents/a';
-    const NAME = 'projects/example_project/databases/(default)/documents/a/b';
+    public const PROJECT = 'example_project';
+    public const DATABASE = '(default)';
+    public const COLLECTION = 'projects/example_project/databases/(default)/documents/a';
+    public const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $document;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
 
-        $valueMapper = new ValueMapper($this->connection->reveal(), false);
+        $valueMapper = new ValueMapper(
+            $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            false
+        );
         $this->document = TestHelpers::stub(DocumentReference::class, [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $valueMapper,
-            new CollectionReference($this->connection->reveal(), $valueMapper, self::COLLECTION),
+            new CollectionReference(
+                $this->connection->reveal(),
+                $this->requestHandler->reveal(),
+                $this->serializer,
+                $valueMapper,
+                self::COLLECTION
+            ),
             self::NAME
         ]);
     }

--- a/Firestore/tests/Unit/DocumentSnapshotTest.php
+++ b/Firestore/tests/Unit/DocumentSnapshotTest.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Firestore\Tests\Unit;
 
 use Exception;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
@@ -35,10 +37,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class DocumentSnapshotTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
 
-    const NAME = 'projects/example_project/databases/(default)/documents/a/b';
-    const ID = 'b';
+    public const NAME = 'projects/example_project/databases/(default)/documents/a/b';
+    public const ID = 'b';
 
     private $snapshot;
 
@@ -51,7 +54,12 @@ class DocumentSnapshotTest extends TestCase
 
         $this->snapshot = TestHelpers::stub(DocumentSnapshot::class, [
             $ref->reveal(),
-            new ValueMapper($this->prophesize(ConnectionInterface::class)->reveal(), false),
+            new ValueMapper(
+                $this->prophesize(ConnectionInterface::class)->reveal(),
+                $this->prophesize(RequestHandler::class)->reveal(),
+                $this->getSerializer(),
+                false
+            ),
             [], [], true
         ], ['info', 'data', 'exists']);
     }
@@ -81,7 +89,7 @@ class DocumentSnapshotTest extends TestCase
      */
     public function testTimestampMethods($method)
     {
-        $ts = new Timestamp(new \DateTime);
+        $ts = new Timestamp(new \DateTime());
         $info = [$method => $ts];
         $this->snapshot->___setProperty('info', $info);
 

--- a/Firestore/tests/Unit/FirestoreClientTest.php
+++ b/Firestore/tests/Unit/FirestoreClientTest.php
@@ -21,6 +21,8 @@ use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Core\GeoPoint;
 use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
@@ -43,6 +45,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class FirestoreClientTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use GrpcTestTrait;
     use ProphecyTrait;
 
@@ -50,6 +53,8 @@ class FirestoreClientTest extends TestCase
     const DATABASE = '(default)';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $client;
 
     public function setUp(): void
@@ -57,6 +62,8 @@ class FirestoreClientTest extends TestCase
         $this->checkAndSkipGrpcTests();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->client = TestHelpers::stub(
             FirestoreClient::class,
             [['projectId' => self::PROJECT]]

--- a/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
+++ b/Firestore/tests/Unit/FirestoreSessionHandlerTest.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Firestore\Tests\Unit;
 
 use Exception;
 use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\ValueMapper;
 use Google\Cloud\Firestore\FirestoreSessionHandler;
@@ -34,6 +36,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class FirestoreSessionHandlerTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
 
     const SESSION_SAVE_PATH = 'sessions';
@@ -42,12 +45,16 @@ class FirestoreSessionHandlerTest extends TestCase
     const DATABASE = '(default)';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $valueMapper;
     private $documents;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->valueMapper = $this->prophesize(ValueMapper::class);
         $this->documents = $this->prophesize(Iterator::class);
     }
@@ -59,6 +66,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willReturn(['transaction' => null]);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -76,6 +85,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willThrow(new ServiceException(''));
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -93,6 +104,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willReturn(['transaction' => null]);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -110,6 +123,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -136,6 +151,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willReturn($this->documents->reveal());
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -162,6 +179,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willThrow((new ServiceException('')));
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -199,6 +218,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willReturn($this->documents->reveal());
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -238,6 +259,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -273,6 +296,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willThrow((new ServiceException('')));
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -302,6 +327,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -330,6 +357,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -349,6 +378,8 @@ class FirestoreSessionHandlerTest extends TestCase
         $this->connection->commit()->shouldNotBeCalled();
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE
@@ -414,6 +445,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->shouldBeCalledTimes(1);
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE,
@@ -438,6 +471,8 @@ class FirestoreSessionHandlerTest extends TestCase
             ->willThrow(new ServiceException(''));
         $firestoreSessionHandler = new FirestoreSessionHandler(
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper->reveal(),
             self::PROJECT,
             self::DATABASE,

--- a/Firestore/tests/Unit/QuerySnapshotTest.php
+++ b/Firestore/tests/Unit/QuerySnapshotTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\Query;
@@ -32,12 +34,10 @@ class QuerySnapshotTest extends TestCase
 {
     use ProphecyTrait;
 
-    private $connection;
     private $snapshot;
 
     public function setUp(): void
     {
-        $this->connection = $this->prophesize(ConnectionInterface::class);
         $this->snapshot = TestHelpers::stub(QuerySnapshot::class, [
             $this->prophesize(Query::class)->reveal(),
             []

--- a/Firestore/tests/Unit/SnapshotTraitTest.php
+++ b/Firestore/tests/Unit/SnapshotTraitTest.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Firestore\Tests\Unit;
 
 use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
@@ -36,13 +38,16 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class SnapshotTraitTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
 
-    const PROJECT = 'example_project';
-    const DATABASE = '(default)';
-    const NAME = 'projects/example_project/databases/(default)/documents/a/b';
+    public const PROJECT = 'example_project';
+    public const DATABASE = '(default)';
+    public const NAME = 'projects/example_project/databases/(default)/documents/a/b';
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $mapper;
     private $impl;
     private $valueMapper;
@@ -50,9 +55,16 @@ class SnapshotTraitTest extends TestCase
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->impl = TestHelpers::impl(SnapshotTrait::class);
 
-        $this->valueMapper = new ValueMapper($this->connection->reveal(), false);
+        $this->valueMapper = new ValueMapper(
+            $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
+            false
+        );
     }
 
     public function testCreateSnapshot()
@@ -75,6 +87,8 @@ class SnapshotTraitTest extends TestCase
         $ref->name()->willReturn(self::NAME);
         $res = $this->impl->call('createSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper,
             $ref->reveal()
         ]);
@@ -98,6 +112,8 @@ class SnapshotTraitTest extends TestCase
         $ref->name()->willReturn(self::NAME);
         $res = $this->impl->call('createSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             $this->valueMapper,
             $ref->reveal()
         ]);
@@ -118,6 +134,8 @@ class SnapshotTraitTest extends TestCase
 
         $this->assertEquals('foo', $this->impl->call('getSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             self::NAME
         ]));
     }
@@ -137,6 +155,8 @@ class SnapshotTraitTest extends TestCase
 
         $this->impl->call('getSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             self::NAME,
             [
                 'readTime' => new Timestamp(
@@ -153,6 +173,8 @@ class SnapshotTraitTest extends TestCase
 
         $this->impl->call('getSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             self::NAME,
             ['readTime' => 'foo']
         ]);
@@ -171,6 +193,8 @@ class SnapshotTraitTest extends TestCase
 
         $this->impl->call('getSnapshot', [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             self::NAME
         ]);
     }

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -20,6 +20,8 @@ namespace Google\Cloud\Firestore\Tests\Unit;
 use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\GeoPoint;
 use Google\Cloud\Core\Int64;
+use Google\Cloud\Core\RequestHandler;
+use Google\Cloud\Core\Testing\FirestoreTestHelperTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
@@ -37,19 +39,26 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 class ValueMapperTest extends TestCase
 {
+    use FirestoreTestHelperTrait;
     use ProphecyTrait;
     use TimeTrait;
 
     private $connection;
+    private $requestHandler;
+    private $serializer;
     private $mapper;
 
     public function setUp(): void
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->requestHandler = $this->prophesize(RequestHandler::class);
+        $this->serializer = $this->getSerializer();
         $this->mapper = TestHelpers::stub(ValueMapper::class, [
             $this->connection->reveal(),
+            $this->requestHandler->reveal(),
+            $this->serializer,
             false
-        ], ['connection', 'returnInt64AsObject']);
+        ], ['connection', 'requestHandler', 'returnInt64AsObject']);
     }
 
     /**


### PR DESCRIPTION
### Firestore Library Upgrade

---

Main PR for all the Firestore v2 upgrade.

#### Part 1 [✅]

This PR contains all the additive changes to the library laying the ground work for the further work.

* Add gapic client configs.
* Add credentials wrapper support.
* Add root serializer and request handler.
* Update resource classes to add serializer and request handler to:
  * Constructors
  * Instantiations
* Add serializer and request handler support in all the snippet and unit tests.
* Update core's version to a future non existent version

PR: https://github.com/googleapis/google-cloud-php/pull/7298

#### Part 2 [ ]

Update the 9 RPCs exposed by `Grpc` connection class and correspondingly update their unit and system tests.

PR:

#### Part 3 [ ]

Do the rest of the work like:

- Update the system tests if something breaks
- Add MIGRATION.md file
- Update the documentation whereever required.
  - Snippets
  - Doc blocks
  - FirestoreClient constructor's documentation
- Remove old GAPIC files
  - Class aliases
  - Gapic client
- Update core's version to the next future version.
- Mark classes as `@internal` where ever required.

PR:

---

BREAKING_CHANGE_REASON=RC-1 for the version 2 of the Firestore Library