### PR TITLE
chore(Spanner): Make createTransactionSelector faster

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1387,9 +1387,10 @@ class Grpc implements ConnectionInterface
                 $transaction['begin'] = $this->formatTransactionOptions($transaction['begin']);
             }
 
-            $selector = $this->serializer->decodeMessage($selector, $transaction);
+            $str = json_encode($transaction);
+            $selector->mergeFromJsonString($str);
         } elseif (isset($args['transactionId'])) {
-            $selector = $this->serializer->decodeMessage($selector, ['id' => $this->pluck('transactionId', $args)]);
+            $selector->setId($this->pluck('transactionId', $args));
         }
 
         return $selector;

--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -1381,26 +1381,28 @@ class GrpcTest extends TestCase
                 [
                     'transaction' => [
                         'singleUse' => [
-                            'readWrite' => []
+                            'readWrite' => [
+                                'readLockMode' => 0
+                            ]
                         ]
                     ]
                 ],
                 new TransactionSelector([
                     'single_use' => new TransactionOptions([
-                        'read_write' => new ReadWrite
+                        'read_write' => new ReadWrite()
                     ])
                 ])
             ], [
                 [
                     'transaction' => [
                         'begin' => [
-                            'readWrite' => []
+                            'readWrite' => ['readLockMode' => 1]
                         ]
                     ]
                 ],
                 new TransactionSelector([
                     'begin' => new TransactionOptions([
-                        'read_write' => new ReadWrite
+                        'read_write' => new ReadWrite(['read_lock_mode' => 1])
                     ])
                 ])
             ]


### PR DESCRIPTION
This PR simply replaces the use of `decodeMessage` from the Serializer and uses the `mergeFromJsonString` and the protobuf class's setter method.

The metrics on average are:

### Using decodeMessage
When `createTransactionSelector` is called the first time: 900 us(micros)
When `createTransactionSelector` is called the second time: 300 us (This is low because the Serializer caches a lot of things like proto descriptors etc).

### Using mergeFromJsonString
When `createTransactionSelector` is called the first time: 200 us(micros)
When `createTransactionSelector` is called the second time: 150 us

