### PR TITLE
fix: pubsub version constant

### DIFF
--- a/PubSub/src/PubSubClient.php
+++ b/PubSub/src/PubSubClient.php
@@ -99,7 +99,7 @@ class PubSubClient
     use ApiHelperTrait;
     use ClientOptionsTrait;
 
-    const VERSION = '2.0.0-RC1';
+    const VERSION = '2.2.0';
 
     const FULL_CONTROL_SCOPE = 'https://www.googleapis.com/auth/pubsub';
 


### PR DESCRIPTION
BREAKING_CHANGE_REASON=changing the VERSION constant is not considered breaking in this library