### PR TITLE
chore: mark AccessContextManager stable

### DIFF
--- a/.repo-metadata-full.json
+++ b/.repo-metadata-full.json
@@ -10,7 +10,7 @@
     "AccessContextManager": {
         "language": "php",
         "distribution_name": "google/access-context-manager",
-        "release_level": "preview",
+        "release_level": "stable",
         "client_documentation": "https://cloud.google.com/php/docs/reference/access-context-manager/latest",
         "library_type": "GAPIC_AUTO",
         "api_shortname": "accesscontextmanager"


### PR DESCRIPTION
This API should have been marked stable already (and has been for some time)