### PR TITLE
chore(dev): remove unneeded copy_excludes

### DIFF
--- a/dev/templates/owlbot.py.twig
+++ b/dev/templates/owlbot.py.twig
@@ -30,13 +30,7 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(
-    src=src,
-    dest=dest,
-    copy_excludes=[
-        src / "**/[A-Z]*_*.php",
-    ]
-)
+php.owlbot_main(src=src, dest=dest)
 
 # remove class_alias code
 s.replace(

--- a/dev/tests/fixtures/component/CustomInput/owlbot.py
+++ b/dev/tests/fixtures/component/CustomInput/owlbot.py
@@ -30,13 +30,7 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(
-    src=src,
-    dest=dest,
-    copy_excludes=[
-        src / "**/[A-Z]*_*.php",
-    ]
-)
+php.owlbot_main(src=src, dest=dest)
 
 # remove class_alias code
 s.replace(

--- a/dev/tests/fixtures/component/SecretManager/owlbot.py
+++ b/dev/tests/fixtures/component/SecretManager/owlbot.py
@@ -30,13 +30,7 @@ dest = Path().resolve()
 # Added so that we can pass copy_excludes in the owlbot_main() call
 _tracked_paths.add(src)
 
-php.owlbot_main(
-    src=src,
-    dest=dest,
-    copy_excludes=[
-        src / "**/[A-Z]*_*.php",
-    ]
-)
+php.owlbot_main(src=src, dest=dest)
 
 # remove class_alias code
 s.replace(


### PR DESCRIPTION
We no longer need to exclude the underscored protobuf files, as these have been removed from generation.