### PR TITLE
feat(Bigtable): add attempts headers on retry and exception logging

### DIFF
--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -23,6 +23,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Bigtable\V2\BigtableClient as GapicClient;
 use Google\Cloud\Core\ArrayTrait;
+use Psr\Log\LoggerInterface;
 
 /**
  * Google Cloud Bigtable is Google's NoSQL Big Data database service.
@@ -144,6 +145,7 @@ class BigtableClient
      *     @type string $appProfileId This value specifies routing for
      *           replication. **Defaults to** the "default" application profile.
      *     @type array $headers Headers to be passed with each request.
+     *     @type LoggerInterface $logger
      * }
      * @return Table
      */

--- a/Bigtable/src/ChunkFormatter.php
+++ b/Bigtable/src/ChunkFormatter.php
@@ -140,7 +140,8 @@ class ChunkFormatter implements \IteratorAggregate
                 }
                 return false;
             },
-            $this->pluck('retries', $this->options, false)
+            $this->pluck('retries', $this->options, false),
+            $this->pluck('logger', $this->options, false)
         );
     }
 

--- a/Bigtable/src/Table.php
+++ b/Bigtable/src/Table.php
@@ -30,6 +30,7 @@ use Google\Cloud\Bigtable\V2\RowRange;
 use Google\Cloud\Bigtable\V2\RowSet;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Rpc\Code;
+use Psr\Log\LoggerInterface;
 
 /**
  * A table instance can be used to read rows and to perform insert, update, and
@@ -83,6 +84,7 @@ class Table
      *           This settings only applies to {@see \Google\Cloud\Bigtable\Table::mutateRows()},
      *           {@see \Google\Cloud\Bigtable\Table::upsert()} and
      *           {@see \Google\Cloud\Bigtable\Table::readRows()}.
+     *     @type LoggerInterface $logger
      * }
      */
     public function __construct(
@@ -519,7 +521,8 @@ class Table
             [$this->gapicClient, 'mutateRows'],
             $argumentFunction,
             $retryFunction,
-            $this->pluck('retries', $options, false)
+            $this->pluck('retries', $options, false),
+            $this->pluck('logger', $options, false)
         );
         $message = 'partial failure';
         try {

--- a/Core/src/InsecureCredentialsWrapper.php
+++ b/Core/src/InsecureCredentialsWrapper.php
@@ -33,4 +33,8 @@ class InsecureCredentialsWrapper extends CredentialsWrapper
     {
         return null;
     }
+
+    public function checkUniverseDomain()
+    {
+    }
 }


### PR DESCRIPTION
This PR adds two visibility features to the Bigtable client in `v0.221.0` (which will apply to `google/cloud-bigtable: 1.28.3`)

### 1. The `bigtable-attempt` header for retry attempts

If a retryable exception is thrown, and the Bigtable client retries the call, all additional attempts will contain the header/metadata `bigtable-attempt`, which will start with "1" for the first retry and increment from there

### 2. The `logger` option for `BigtableClient`

By setting a [PSR3-compatible](https://www.php-fig.org/psr/psr-3/) logging client, the `BigtableClient` class will log retryable or non-retryable exceptions which occur during the `readRows` stream

```php
// create any PSR3-compatible logging client
$logger = new Monolog\Logger();

// pass it in when creating the bigtable client
$bigtable = new Google\Cloud\Bigtable\BigtableClient(['logger' => $logger]);

// Or pass it in when calling Table::ReadRows
$table = $bigtable->table($instanceId, $tableId);
$rows = $table->readRows(['logger' => $logger]);
```

**Note**: In the case of an exception, the exception message (e.g. `$e->getMessage()`) will be logged using `LoggerInterface::error`.