### PR TITLE
feat(dev): add "all" keyword and multiple components to component-info command

### DIFF
--- a/dev/src/Command/ComponentInfoCommand.php
+++ b/dev/src/Command/ComponentInfoCommand.php
@@ -102,13 +102,17 @@ class ComponentInfoCommand extends Command
         }
         $this->token = $input->getOption('token');
 
+        // Parse filters
+        $filters = $this->parseFilters($input->getOption('filter') ?: '');
+
         // Filter out invalid fields
-        $requestedFields = array_intersect_key(array_flip($fields), self::$allFields);
+        $requestedFields = array_intersect_key(
+            array_flip($fields) + array_flip(array_column($filters, 0)),
+            self::$allFields
+        );
 
         // Compile all the component data into rows
         $components = Component::getComponents($input->getOption('component'));
-
-        $filters = $this->parseFilters($input->getOption('filter') ?: '');
 
         $rows = [];
         foreach ($components as $component) {
@@ -118,9 +122,9 @@ class ComponentInfoCommand extends Command
                 $input->getOption('expanded')
             );
 
-            foreach ($filters as $filter) {
-                list($field, $value, $operator) = $filter;
-                foreach ($componentRows as $row) {
+            foreach ($componentRows as $row) {
+                foreach ($filters as $filter) {
+                    list($field, $value, $operator) = $filter;
                     if (!match ($operator) {
                         '=' => ($row[$field] === $value),
                         '!=' => ($row[$field] !== $value),

--- a/dev/src/Command/ComponentInfoCommand.php
+++ b/dev/src/Command/ComponentInfoCommand.php
@@ -117,6 +117,7 @@ class ComponentInfoCommand extends Command
                 $requestedFields,
                 $input->getOption('expanded')
             );
+
             foreach ($filters as $filter) {
                 list($field, $value, $operator) = $filter;
                 foreach ($componentRows as $row) {
@@ -216,7 +217,7 @@ class ComponentInfoCommand extends Command
                 'github_repo' => $component->getRepoName(),
                 'proto_path' => implode("\n", $component->getProtoPackages()),
                 'service_address' => implode("\n", $component->getServiceAddresses()),
-                'api_shortname' => implode("\n", $component->getApiShortnames()),
+                'api_shortname' => implode("\n", array_filter($component->getApiShortnames())),
                 'description' => $component->getDescription(),
             ], $requestedFields));
 

--- a/dev/src/Command/ComponentInfoCommand.php
+++ b/dev/src/Command/ComponentInfoCommand.php
@@ -64,7 +64,7 @@ class ComponentInfoCommand extends Command
         $this->setName('component-info')
             ->setDescription('list info of a component or the whole library')
             ->addOption('component', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'get info for a single component', [])
-            ->addOption('csv', '', InputOption::VALUE_REQUIRED, 'export findings to csv.')
+            ->addOption('csv', '', InputOption::VALUE_OPTIONAL, 'export findings to csv.', false)
             ->addOption('fields', 'f', InputOption::VALUE_REQUIRED, sprintf(
                 "Comma-separated list of fields, \"all\" for all fields. The following fields are available: \n - %s\n" .
                 "NOTE: \"available_api_versions\" are omited by default because they take a long time to load.\n" .
@@ -153,14 +153,20 @@ class ComponentInfoCommand extends Command
             array_intersect_key(self::$allFields, $requestedFields)
         ));
 
-        if ($csv = $input->getOption('csv')) {
-            $fp = fopen($csv, 'wa+');
-            fputcsv($fp, $headers);
-            foreach ($rows as $row) {
-                fputcsv($fp, $row);
+        if (false !== $csv = $input->getOption('csv')) {
+            if (null === $csv) {
+                foreach ($rows as $row) {
+                    $output->writeln(implode(',', $row));
+                }
+            } else {
+                $fp = fopen($csv, 'wa+');
+                fputcsv($fp, $headers);
+                foreach ($rows as $row) {
+                    fputcsv($fp, $row);
+                }
+                fclose($fp);
+                $output->writeln('Output written to ' . $csv);
             }
-            fclose($fp);
-            $output->writeln('Output written to ' . $csv);
         } else {
             $table = new Table($output);
             $table

--- a/dev/src/Command/SplitCommand.php
+++ b/dev/src/Command/SplitCommand.php
@@ -341,6 +341,24 @@ class SplitCommand extends Command
 
         // This is the first release!
         if ($tagName === 'v0.1.0') {
+            // Ensure issues/projects/wiki/pages/discussion are disabled and the repo is public
+            $ret = $github->updateRepoDetails($repoName, [
+                'has_issues' => false,
+                'has_projects' => false,
+                'has_wiki' => false,
+                'has_pages' => false,
+                'has_discussions' => false,
+                'visibility' => 'public',
+            ]);
+
+            if ($ret) {
+                $output->writeln(sprintf('<comment>%s</comment>: Disabled repo issues/projects/etc for first release.', $componentId));
+            } else {
+                $output->writeln(sprintf('<error>%s</error>: Unable to update repo details.', $componentId));
+
+                return false;
+            }
+
             // Submit the new package to Packagist and add a webhook to update it
             if ($packagist) {
                 $output->writeln('<comment>[info]</comment> Creating Packagist package.');
@@ -362,23 +380,6 @@ class SplitCommand extends Command
 
                     return false;
                 }
-            }
-
-            // Ensure issues/projects/wiki/pages/discussion are disabled
-            $ret = $github->updateRepoDetails($repoName, [
-                'has_issues' => false,
-                'has_projects' => false,
-                'has_wiki' => false,
-                'has_pages' => false,
-                'has_discussions' => false,
-            ]);
-
-            if ($ret) {
-                $output->writeln(sprintf('<comment>%s</comment>: Disabled repo issues/projects/etc for first release.', $componentId));
-            } else {
-                $output->writeln(sprintf('<error>%s</error>: Unable to update repo details.', $componentId));
-
-                return false;
             }
 
             // Ensure "yoshi-php" is an admin

--- a/dev/src/Component.php
+++ b/dev/src/Component.php
@@ -55,10 +55,10 @@ class Component
         return $components;
     }
 
-    public static function getComponents(): array
+    public static function getComponents(array $componentNames = []): array
     {
         $components = [];
-        foreach (self::getComponentNames() as $name) {
+        foreach ($componentNames ?: self::getComponentNames() as $name) {
             $components[] = new Component($name);
         }
 

--- a/dev/tests/Unit/Command/ComponentInfoCommandTest.php
+++ b/dev/tests/Unit/Command/ComponentInfoCommandTest.php
@@ -55,7 +55,7 @@ class ComponentInfoCommandTest extends TestCase
 
     public function testComponentDetails()
     {
-        self::$commandTester->execute(['-c' => 'AccessContextManager']);
+        self::$commandTester->execute(['-c' => ['AccessContextManager']]);
 
         // confirm a few fields we expect to see in the output
         $display = self::$commandTester->getDisplay();
@@ -69,7 +69,7 @@ class ComponentInfoCommandTest extends TestCase
     public function testFieldsOption()
     {
         self::$commandTester->execute([
-            '-c' => 'AccessContextManager',
+            '-c' => ['AccessContextManager'],
             '--fields' => 'component_name,package_name,doesnt_exist',
         ]);
         $this->assertEquals(<<<EOL
@@ -84,7 +84,7 @@ EOL, self::$commandTester->getDisplay());
     public function testFieldsOptionOrder()
     {
         self::$commandTester->execute([
-            '-c' => 'AccessContextManager',
+            '-c' => ['AccessContextManager'],
             '--fields' => 'package_name,component_name',
         ]);
         $this->assertEquals(<<<EOL
@@ -101,7 +101,7 @@ EOL, self::$commandTester->getDisplay());
         mkdir($tmpDir = sys_get_temp_dir() . '/component-info-test-' . time());
         $csv = $tmpDir . '/test.csv';
         self::$commandTester->execute([
-            '-c' => 'AccessContextManager',
+            '-c' => ['AccessContextManager'],
             '--fields' => 'package_name,component_name,github_repo',
             '--csv' => $csv,
         ]);


### PR DESCRIPTION
Adds the following features to the dev commands:

1. Allows "all" keyword to `--fields` option to show all fields (the default is to only show a few, for readability)
2. Allows multiple "component" values supplied, e.g. `-c Storage -c BigQuery` so that multiple specific components can be easily viewed
3. Ensures new repos are `public` when modifying their settings.
4. Allow CSV output to stdout

Potential TODO: allow multiple `--filter` options which are a logical OR between them (similar to components)