### PR TITLE
fix(Storage): ensure streams arent copied by default

### DIFF
--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -306,6 +306,7 @@ class Rest implements ConnectionInterface
                 $transcodedObj = true;
             }
         };
+        $attempt = null;
         $requestOptions['restRetryListener'] = function (
             \Exception $e,
             $retryAttempt,
@@ -313,7 +314,8 @@ class Rest implements ConnectionInterface
         ) use (
             $resultStream,
             $requestedBytes,
-            $invocationId
+            $invocationId,
+            &$attempt,
         ) {
             // if the exception has a response for us to use
             if ($e instanceof RequestException && $e->hasResponse()) {
@@ -331,6 +333,9 @@ class Rest implements ConnectionInterface
                 // modify the range headers to fetch the remaining data
                 $arguments[1]['headers']['Range'] = sprintf('bytes=%s-%s', $startByte, $endByte);
                 $arguments[0] = $this->modifyRequestForRetry($arguments[0], $retryAttempt, $invocationId);
+
+                // Copy the final result to the end of the stream
+                $attempt = $retryAttempt;
             }
         };
 
@@ -338,6 +343,13 @@ class Rest implements ConnectionInterface
             $request,
             $requestOptions
         )->getBody();
+
+        // If no retry attempt was made, then we can return the stream as is.
+        // This is important in the case where downloadObject is called to open
+        // the file but not to read from it yet.
+        if ($attempt === null) {
+            return $fetchedStream;
+        }
 
         // If our object is a transcoded object, then Range headers are not honoured.
         // That means even if we had a partial download available, the final obj


### PR DESCRIPTION
Attempts to address https://github.com/googleapis/google-cloud-php/issues/7473 by not copying streams by default. This was copying the full streams even when the stream was only supposed to be opened. 

The new code copies the stream only if retries took place. Admittedly this also isn't optimal behavior - it would be better to return a new stream which prepends any previous streams (without seeking through the new stream). We should investigate the Stream classes being used to see if it's possible to do something like this.