### PR TITLE
fix: [PubSub] Prevent fatal error when using emulator without grpc

### DIFF
--- a/.github/emulator/start-emulator.sh
+++ b/.github/emulator/start-emulator.sh
@@ -18,3 +18,4 @@ CONTAINER=`docker run \
   $IMAGE gcloud beta emulators $1 start --host-port=0.0.0.0:8085 --project=emulator-project`
 sleep 10
 docker logs $CONTAINER
+

--- a/Core/src/EmulatorTrait.php
+++ b/Core/src/EmulatorTrait.php
@@ -36,17 +36,21 @@ trait EmulatorTrait
             $emulatorHost = str_replace($search, '', $emulatorHost);
         }
 
-        return [
+        $config = [
             'apiEndpoint' => $emulatorHost,
-            'transportConfig' => [
+            'credentials' => new InsecureCredentialsWrapper(),
+        ];
+        if (class_exists('Grpc\ChannelCredentials')) {
+            $config['transportConfig'] = [
                 'grpc' => [
                     'stubOpts' => [
                         'credentials' => \Grpc\ChannelCredentials::createInsecure()
                     ]
                 ]
-            ],
-            'credentials' => new InsecureCredentialsWrapper(),
-        ];
+            ];
+        }
+
+        return $config;
     }
     /**
      * Retrieve a valid base uri for a service emulator.

--- a/Core/tests/Unit/EmulatorTraitTest.php
+++ b/Core/tests/Unit/EmulatorTraitTest.php
@@ -22,6 +22,8 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
+use function extension_loaded;
+
 /**
  * @group core
  */
@@ -48,6 +50,23 @@ class EmulatorTraitTest extends TestCase
         $res = $this->impl->call('emulatorGapicConfig', [$hostname]);
         $this->assertEquals($expected, $res['apiEndpoint']);
         $this->assertNull($res['transportConfig']['grpc']['stubOpts']['credentials']);
+    }
+
+
+    /**
+     * @dataProvider hostnames
+     */
+    public function testEmulatorGapicConfigWithNoGrpc($hostname, $expected = null)
+    {
+        if (extension_loaded('grpc')) {
+            $this->markTestSkipped("Cannot run test with grpc extension loaded");
+        }
+
+        $expected = $expected ?: $hostname;
+
+        $res = $this->impl->call('emulatorGapicConfig', [$hostname]);
+        $this->assertEquals($expected, $res['apiEndpoint']);
+        $this->assertArrayNotHasKey('transportConfig', $res);
     }
 
     public function hostnames()

--- a/Core/tests/Unit/EmulatorTraitTest.php
+++ b/Core/tests/Unit/EmulatorTraitTest.php
@@ -22,8 +22,6 @@ use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
-use function extension_loaded;
-
 /**
  * @group core
  */
@@ -58,7 +56,7 @@ class EmulatorTraitTest extends TestCase
      */
     public function testEmulatorGapicConfigWithNoGrpc($hostname, $expected = null)
     {
-        if (extension_loaded('grpc')) {
+        if (\extension_loaded('grpc')) {
             $this->markTestSkipped("Cannot run test with grpc extension loaded");
         }
 


### PR DESCRIPTION
This fixes https://github.com/googleapis/google-cloud-php/issues/7187

Unfortunately using the PubSub emulator is still not entirely straightforward with REST: the `https` schema is hardcoded in `Google\ApiCore\RequestBuilder::buildUri()`, probably for very good reason!

I have managed to get it to work by supplying a modified `httpHandler`:

```php
// double the # of characters before truncation by default
        $bodySummarizer = new BodySummarizer(240);
        $stack = HandlerStack::create();
        $stack->remove('http_errors');
        $stack->unshift(Middleware::httpErrors($bodySummarizer), 'http_errors');
        $stack->push(Middleware::mapRequest(static function (RequestInterface $request) {
            $uri = $request->getUri();
            return $request->withUri($uri->withScheme('http')); // convert https -> http for emulator
        }));
        $client = new Client(['handler' => $stack]);

        $pubSubClient = new PubSubClient([
            'projectId'         => 'emulator-project',
            'credentialsConfig' => [
                'keyFile' => [
                    "client_id"     => "fake-fake-fake.apps.googleusercontent.com",
                    "client_secret" => "fake-fake-fake",
                    "refresh_token" => "fake-fake-fake",
                    "type"          => "authorized_user",
                ],
            ],
            'transportConfig' => [
                'rest' => [
                    'httpHandler' => [HttpHandlerFactory::build($client), 'async'],
                ],
            ],
        ]);
```