### PR TITLE
chore: revert pin grpc to fix failing tests, add version to CommonProtos

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
       uses: shivammathur/setup-php@verbose
       with:
         php-version: '8.1'
-        extensions: grpc-1.63.0
+        extensions: grpc
     - name: Run Package Test Suites
       run: bash .github/run-package-tests.sh
 
@@ -89,7 +89,7 @@ jobs:
       uses: shivammathur/setup-php@verbose
       with:
         php-version: '8.1'
-        extensions: grpc-1.63.0
+        extensions: grpc
     - name: Run Package Test Suites
       env:
         PREFER_LOWEST: ${{ github.event.pull_request.user.login == 'release-please[bot]' && '--prefer-lowest-strict' || '--prefer-lowest' }}

--- a/CommonProtos/composer.json
+++ b/CommonProtos/composer.json
@@ -2,6 +2,7 @@
   "name": "google/common-protos",
   "type": "library",
   "description": "Google API Common Protos for PHP",
+  "version": "4.8.1",
   "keywords": [
     "google"
   ],


### PR DESCRIPTION
Reverts googleapis/google-cloud-php#7532, as https://github.com/grpc/grpc/issues/37222 is now fixed. This will make our individual package tests run about 20 minutes faster

Additionally, add "version" to `CommonProtos`, as this is required for the same reason that it's required in `LongRunning` (it ends up being a dependency of a dependency in testing)