### PR TITLE
fix: ensure attempts increment without exception

### DIFF
--- a/Bigtable/src/ResumableStream.php
+++ b/Bigtable/src/ResumableStream.php
@@ -163,7 +163,6 @@ class ResumableStream implements \IteratorAggregate
                     $headers['bigtable-attempt'] = [(string) $totalAttempt];
                     ($this->delayFunction)($currentAttempt);
                 }
-
                 $stream = call_user_func_array(
                     [$this->gapicClient, $this->method],
                     [$this->request, ['headers' => $headers] + $this->callOptions]
@@ -176,6 +175,9 @@ class ResumableStream implements \IteratorAggregate
                     }
                 } catch (\Exception $ex) {
                 }
+                // It's possible for the retry function to retry even when `$ex` is null
+                // (see Table::mutateRowsWithEntries). For this reason, we increment the attemts
+                // outside the try/catch block.
                 $totalAttempt++;
                 $currentAttempt++;
             }

--- a/Bigtable/src/ResumableStream.php
+++ b/Bigtable/src/ResumableStream.php
@@ -175,11 +175,11 @@ class ResumableStream implements \IteratorAggregate
                         $currentAttempt = 0; // reset delay and attempt on successful read.
                     }
                 } catch (\Exception $ex) {
-                    $totalAttempt++;
-                    $currentAttempt++;
                 }
+                $totalAttempt++;
+                $currentAttempt++;
             }
-        } while ((!$this->retryFunction || ($this->retryFunction)($ex)) && $currentAttempt <= $this->retries);
+        } while (($this->retryFunction)($ex) && $currentAttempt <= $this->retries);
         if ($ex !== null) {
             throw $ex;
         }

--- a/Bigtable/tests/Unit/SmartRetriesTest.php
+++ b/Bigtable/tests/Unit/SmartRetriesTest.php
@@ -681,20 +681,13 @@ class SmartRetriesTest extends TestCase
             ->willReturn($this->serverStream->reveal());
 
         $entries = $this->generateEntries(2, 3);
-        $this->bigtableClient->mutateRows(
-            Argument::that(function ($request) use ($entries) {
-                return iterator_to_array($request->getEntries()) == $entries;
-            }),
-            Argument::withEntry('headers', ['my-header' => 'my-header-value'])
-        )
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->serverStream->reveal());
 
+        // ensure the bigtable-attempt header is sent in for the next retry.
         $this->bigtableClient->mutateRows(
             Argument::that(function ($request) use ($entries) {
                 return iterator_to_array($request->getEntries()) == $entries;
             }),
-            Argument::withEntry('headers', ['my-header' => 'my-header-value', 'bigtable-attempt' => ['1']])
+            Argument::withEntry('headers', ['bigtable-attempt' => ['1']] + $this->options['headers'])
         )
             ->shouldBeCalledTimes(1)
             ->willReturn($this->serverStream->reveal());

--- a/Bigtable/tests/Unit/SmartRetriesTest.php
+++ b/Bigtable/tests/Unit/SmartRetriesTest.php
@@ -676,20 +676,29 @@ class SmartRetriesTest extends TestCase
                 return iterator_to_array($request->getEntries()) == $entries;
             }),
             Argument::type('array')
-        )->shouldBeCalledTimes(1)
-        ->willReturn(
-            $this->serverStream->reveal()
-        );
+        )
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->serverStream->reveal());
+
         $entries = $this->generateEntries(2, 3);
         $this->bigtableClient->mutateRows(
             Argument::that(function ($request) use ($entries) {
                 return iterator_to_array($request->getEntries()) == $entries;
             }),
-            Argument::type('array')
-        )->shouldBeCalled()
-        ->willReturn(
-            $this->serverStream->reveal()
-        );
+            Argument::withEntry('headers', ['my-header' => 'my-header-value'])
+        )
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->serverStream->reveal());
+
+        $this->bigtableClient->mutateRows(
+            Argument::that(function ($request) use ($entries) {
+                return iterator_to_array($request->getEntries()) == $entries;
+            }),
+            Argument::withEntry('headers', ['my-header' => 'my-header-value', 'bigtable-attempt' => ['1']])
+        )
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->serverStream->reveal());
+
         $mutations = $this->generateMutations(0, 5);
         $this->table->mutateRows($mutations);
     }


### PR DESCRIPTION
In `Table`, the `retryFunction` can retry even when an exception is not thrown (if one of the responses has a non-OK status code, see [here](https://github.com/googleapis/google-cloud-php/blob/21a154bc73ea8f04b12250f1f48b2b17c4329c43/Bigtable/src/Table.php#L549)). Because of this, we need to ensure attempts are incremented even when there is no exception.

Also removes unnecessary check for `$this->retryFunction`