### PR TITLE
fix(ci): ref in backwards-compatibility-checks

### DIFF
--- a/.github/workflows/backwards-compatibility-checks.yaml
+++ b/.github/workflows/backwards-compatibility-checks.yaml
@@ -69,7 +69,7 @@ jobs:
         # OwlBot PRs which are not labelled feat should not add new files or methods
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \
-            --from=${{ github.ref_name }} \
+            --from=${{ github.head_ref || github.ref_name }} \
             --to=origin/main --format=github-actions
       - name: "Print the action item"
         run: |


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/actions/runs/11251717947/job/31283357805#step:5:39

Will fix the argument to the backwards compatibility checker from a value such as `merge/7728` to `bshaffer-patch-1`