### PR TITLE
feat: support excludeTxnFromChangeStreams option

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1103,6 +1103,11 @@ class Grpc implements ConnectionInterface
             $args = $this->addLarHeader($args, $this->larEnabled);
         }
 
+        // NOTE: if set for read-only actions, will throw exception
+        if (isset($transactionOptions['excludeTxnFromChangeStreams'])) {
+            $options->setExcludeTxnFromChangeStreams($args['excludeTxnFromChangeStreams']);
+        }
+
         $requestOptions = $this->pluck('requestOptions', $args, false) ?: [];
         if ($requestOptions) {
             $args['requestOptions'] = $this->serializer->decodeMessage(

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1105,7 +1105,9 @@ class Grpc implements ConnectionInterface
 
         // NOTE: if set for read-only actions, will throw exception
         if (isset($transactionOptions['excludeTxnFromChangeStreams'])) {
-            $options->setExcludeTxnFromChangeStreams($args['excludeTxnFromChangeStreams']);
+            $options->setExcludeTxnFromChangeStreams(
+                $transactionOptions['excludeTxnFromChangeStreams']
+            );
         }
 
         $requestOptions = $this->pluck('requestOptions', $args, false) ?: [];

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -917,7 +917,7 @@ class Database
         ];
 
         // There isn't anything configurable here.
-        $options['transactionOptions'] = $this->configureTransactionOptions();
+        $options['transactionOptions'] = $this->configureTransactionOptions($options['transactionOptions'] ?? []);
 
         $session = $this->selectSession(
             SessionPoolInterface::CONTEXT_READWRITE,

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -1593,7 +1593,7 @@ class Database
      * @param string $sql The query string to execute.
      * @param array $options [optional] {
      *     Configuration Options.
-     *     See {@see V1\TransactionOptions\ReadOnly} for detailed description of
+     *     See {@see V1\TransactionOptions\PBReadOnly} for detailed description of
      *     available transaction options. Please note that only one of
      *     `$strong`, `$minReadTimestamp`, `$maxStaleness`, `$readTimestamp` or
      *     `$exactStaleness` may be set in a request.

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -1556,7 +1556,7 @@ class Database
      * use Google\Cloud\Spanner\Session\SessionPoolInterface;
      *
      * $result = $database->execute('SELECT * FROM Posts WHERE ID = @postId', [
-     *      'parameters' => [
+     *     'parameters' => [
      *         'postId' => 1337
      *     ],
      *     'begin' => true,
@@ -1573,7 +1573,7 @@ class Database
      * use Google\Cloud\Spanner\Session\SessionPoolInterface;
      *
      * $result = $database->execute('SELECT * FROM Posts WHERE ID = @postId', [
-     *      'parameters' => [
+     *     'parameters' => [
      *         'postId' => 1337
      *     ],
      *     'begin' => true,
@@ -1593,11 +1593,10 @@ class Database
      * @param string $sql The query string to execute.
      * @param array $options [optional] {
      *     Configuration Options.
-     *     See [TransactionOptions](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions)
-     *     for detailed description of available transaction options. Please
-     *     note that only one of `$strong`, `$minReadTimestamp`,
-     *     `$maxStaleness`, `$readTimestamp` or `$exactStaleness` may be set in
-     *     a request.
+     *     See {@see V1\TransactionOptions\ReadOnly} for detailed description of
+     *     available transaction options. Please note that only one of
+     *     `$strong`, `$minReadTimestamp`, `$maxStaleness`, `$readTimestamp` or
+     *     `$exactStaleness` may be set in a request.
      *
      *     @type array $parameters A key/value array of Query Parameters, where
      *           the key is represented in the query string prefixed by a `@`
@@ -1899,11 +1898,16 @@ class Database
         unset($options['requestOptions']['transactionTag']);
         $session = $this->selectSession(SessionPoolInterface::CONTEXT_READWRITE);
 
-        $transaction = $this->operation->transaction($session, [
+        $beginTransactionOptions = [
             'transactionOptions' => [
-                'partitionedDml' => []
+                'partitionedDml' => [],
             ]
-        ]);
+        ];
+        if (isset($options['transactionOptions']['excludeTxnFromChangeStreams'])) {
+            $beginTransactionOptions['transactionOptions']['excludeTxnFromChangeStreams'] =
+                $options['transactionOptions']['excludeTxnFromChangeStreams'];
+        }
+        $transaction = $this->operation->transaction($session, $beginTransactionOptions);
 
         $options = $this->addLarHeader($options);
 

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -270,7 +270,6 @@ class Operation
         iterator_to_array($res->rows());
 
         $stats = $res->stats();
-
         if (!$stats) {
             throw new InvalidArgumentException(
                 'Partitioned DML response missing stats, possible due to non-DML statement as input.'

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -270,6 +270,7 @@ class Operation
         iterator_to_array($res->rows());
 
         $stats = $res->stats();
+
         if (!$stats) {
             throw new InvalidArgumentException(
                 'Partitioned DML response missing stats, possible due to non-DML statement as input.'

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Spanner;
 
+use Google\ApiCore\ValidationException;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Spanner\Session\Session;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
@@ -239,6 +240,12 @@ class Transaction implements TransactionalReadInterface
      */
     public function executeUpdate($sql, array $options = [])
     {
+        if (isset($options['transaction']['begin']['excludeTxnFromChangeStreams'])) {
+            throw new ValidationException(
+                'The excludeTxnFromChangeStreams option cannot be set for individual DML requests.'
+                . ' This option should be set at the transaction level.'
+            );
+        }
         $options = $this->buildUpdateOptions($options);
         return $this->operation
             ->executeUpdate($this->session, $this, $sql, $options);

--- a/Spanner/src/TransactionConfigurationTrait.php
+++ b/Spanner/src/TransactionConfigurationTrait.php
@@ -129,7 +129,9 @@ trait TransactionConfigurationTrait
         } elseif ($context === SessionPoolInterface::CONTEXT_READ) {
             $transactionOptions = $this->configureSnapshotOptions($options, $previous);
         } elseif ($context === SessionPoolInterface::CONTEXT_READWRITE) {
-            $transactionOptions = $this->configureTransactionOptions($type == 'begin' ? $begin : []);
+            $transactionOptions = $this->configureTransactionOptions(
+                $type == 'begin' && is_array($begin) ? $begin : []
+            );
         } else {
             throw new \BadMethodCallException(sprintf(
                 'Invalid transaction context %s',

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -2021,16 +2021,12 @@ class DatabaseTest extends TestCase
         $gapic = $this->prophesize(SpannerClient::class);
         $gapic->createSession(Argument::cetera())->shouldBeCalled()->willReturn($session);
         $gapic->deleteSession(Argument::cetera())->shouldBeCalled();
-        $gapic->executeStreamingSql(
-            $sessName,
-            $sql,
-            Argument::that(function (array $options) {
-                $this->assertArrayHasKey('transaction', $options);
-                $this->assertNotNull($transactionOptions = $options['transaction']->getBegin());
-                $this->assertTrue($transactionOptions->getExcludeTxnFromChangeStreams());
-                return true;
-            })
-        )
+        $gapic->executeStreamingSql($sessName, $sql, Argument::that(function (array $options) {
+            $this->assertArrayHasKey('transaction', $options);
+            $this->assertNotNull($transactionOptions = $options['transaction']->getBegin());
+            $this->assertTrue($transactionOptions->getExcludeTxnFromChangeStreams());
+            return true;
+        }))
             ->shouldBeCalledOnce()
             ->willReturn($stream->reveal());
 

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Spanner\Tests\Unit;
 
+use Google\ApiCore\ValidationException;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\TimeTrait;
@@ -250,6 +251,17 @@ class TransactionTest extends TestCase
         $res = $this->transaction->executeUpdate($sql, ['requestOptions' => ['requestTag' => self::REQUEST_TAG]]);
 
         $this->assertEquals(1, $res);
+    }
+
+    public function testExecuteUpdateWithExcludeTxnFromChangeStreamsThrowsException()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The excludeTxnFromChangeStreams option cannot be set for individual DML requests');
+
+        $sql = 'UPDATE foo SET bar = @bar';
+        $this->transaction->executeUpdate($sql, [
+           'transaction' => ['begin' => ['excludeTxnFromChangeStreams' => true]]
+        ]);
     }
 
     public function testDmlSeqno()

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -256,7 +256,9 @@ class TransactionTest extends TestCase
     public function testExecuteUpdateWithExcludeTxnFromChangeStreamsThrowsException()
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('The excludeTxnFromChangeStreams option cannot be set for individual DML requests');
+        $this->expectExceptionMessage(
+            'The excludeTxnFromChangeStreams option cannot be set for individual DML requests'
+        );
 
         $sql = 'UPDATE foo SET bar = @bar';
         $this->transaction->executeUpdate($sql, [


### PR DESCRIPTION
Ensures `excludeTxnFromChangeStreams` is configurable for the following methods, and adds tests:

 - Database::runTransaction
 - Database::executePartitionedUpdate
 - Operation::transaction
 - Operation::execute
 - Operation::executeUpdate
 - Database::batchUpdate

Additionally, ensures `excludeTxnFromChangeStreams` is NOT configurable for the following methods, and adds tests:

 - Transaction::executeUpdate

### Database::runTransaction

```php
$database->runTransaction(function (Transaction $t) use ($sql) {
        // Run a query
    }, [
        'transactionOptions' => ['excludeTxnFromChangeStreams' => true]
    ]);
```

### Database::executePartitionedUpdate

```php
$database->executePartitionedUpdate($sql, [
    'transactionOptions' => ['excludeTxnFromChangeStreams' => true]
]);
```

### Operation::transaction

```php
$transaction = $operation->transaction($this->session, [
    'transactionOptions' => ['excludeTxnFromChangeStreams' => true]
]);
```

### Operation::execute

```php
$operation->execute($this->session, $sql, [
   'transaction' => ['begin' => ['excludeTxnFromChangeStreams' => true]]
]);
```

### Operation::executeUpdate

```php
$operation->executeUpdate($this->session, $transaction, $sql, [
   'transaction' => ['begin' => ['excludeTxnFromChangeStreams' => true]]
]);
```

### Database::batchWrite

```php
$database->batchWrite($mutationGroups, [
    'excludeTxnFromChangeStreams' => true
]);
```

### Transaction::executeUpdate

Attempting to call `Transaction::executeUpdate` with the following options will **throw an exception**:

```php
// The following throws a `Google\ApiCore\ValidationException`:
$transaction->executeUpdate($sql, [
   'transaction' => ['begin' => ['excludeTxnFromChangeStreams' => true]]
]);
```
