### PR TITLE
Chore: Rework the compile splitsh command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,17 @@ jobs:
             mkdir libgit2/build && cd libgit2/build
             cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
             sudo cmake --build . --target install
-        - name: Install splitsh-lite
+        - name: Clone splitsh/lite
+          uses: actions/checkout@master
+          with:
+            repository: splitsh/lite
+            ref: v2.0.0
+            path: lite
+        - name: Build splitsh-lite
           run: |
-            go install github.com/splitsh/lite
+            cd lite
+            go build -o splitsh-lite github.com/splitsh/lite
+            mv splitsh-lite /usr/local/bin/splitsh-lite
         - name: Checkout google/cloud
           uses: actions/checkout@v4
           with:
@@ -56,7 +64,7 @@ jobs:
             RELEASE_TAG: ${{ inputs.tag != '' && inputs.tag || steps.getTag.outputs.tag }}
           run: |
             ./dev/google-cloud split $GITHUB_REPOSITORY $RELEASE_TAG \
-              --splitsh=$HOME/go/bin/lite \
+              --splitsh=/usr/local/bin/splitsh-lite \
               -t ${{ secrets.SPLIT_TOKEN }} \
               --packagist-username=${{ vars.PACKAGIST_USERNAME }} \
               --packagist-token=${{ secrets.PACKAGIST_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,9 @@ jobs:
             mkdir libgit2/build && cd libgit2/build
             cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
             sudo cmake --build . --target install
-        - name: Compile splitsh
+        - name: Install splitsh-lite
           run: |
-            go env -w GO111MODULE=off
-            go get github.com/splitsh/lite
-            go build -o /usr/local/bin/splitsh-lite github.com/splitsh/lite
+            go install github.com/splitsh/lite
         - name: Checkout google/cloud
           uses: actions/checkout@v4
           with:
@@ -58,7 +56,7 @@ jobs:
             RELEASE_TAG: ${{ inputs.tag != '' && inputs.tag || steps.getTag.outputs.tag }}
           run: |
             ./dev/google-cloud split $GITHUB_REPOSITORY $RELEASE_TAG \
-              --splitsh=/usr/local/bin/splitsh-lite \
+              --splitsh=$HOME/go/bin/lite \
               -t ${{ secrets.SPLIT_TOKEN }} \
               --packagist-username=${{ vars.PACKAGIST_USERNAME }} \
               --packagist-token=${{ secrets.PACKAGIST_TOKEN }}


### PR DESCRIPTION
Reworks the compile splitsh step on the release action to clone the lite version, build it and have it ready to pass to the final step of the splitting.