### PR TITLE
feat: Add support for external links for the Guzzle's Promise Interface

### DIFF
--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -159,7 +159,7 @@ trait XrefTrait
         // Remove preceeding "\" from namespace
         $name = $name ?: ltrim($uid, '\\');
 
-        // Case for nested types
+        // Case for generic types
         if (preg_match('/(.*)<(.*)>/', $uid, $matches)) {
             return sprintf(
                 '%s<%s>',

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -170,22 +170,22 @@ trait XrefTrait
 
         // Check for external package namespaces
         switch (true) {
-            case 0 === strpos($uid, '\Google\ApiCore\\'):
+            case str_starts_with($uid, '\Google\ApiCore\\'):
                 $extLinkRoot = 'https://googleapis.github.io/gax-php#';
                 break;
-            case 0 === strpos($uid, '\Google\Auth\\'):
+            case str_starts_with($uid, '\Google\Auth\\'):
                 $extLinkRoot = 'https://googleapis.github.io/google-auth-library-php/main/';
                 break;
-            case 0 === strpos($uid, '\Google\Protobuf\\'):
+            case str_starts_with($uid, '\Google\Protobuf\\'):
                 $extLinkRoot = 'https://protobuf.dev/reference/php/api-docs/';
                 break;
-            case 0 === strpos($uid, '\Google\Api\\'):
-            case 0 === strpos($uid, '\Google\Cloud\Iam\V1\\'):
-            case 0 === strpos($uid, '\Google\Cloud\Location\\'):
-            case 0 === strpos($uid, '\Google\Cloud\Logging\Type\\'):
-            case 0 === strpos($uid, '\Google\Iam\\'):
-            case 0 === strpos($uid, '\Google\Rpc\\'):
-            case 0 === strpos($uid, '\Google\Type\\'):
+            case str_starts_with($uid, '\Google\Api\\'):
+            case str_starts_with($uid, '\Google\Cloud\Iam\V1\\'):
+            case str_starts_with($uid, '\Google\Cloud\Location\\'):
+            case str_starts_with($uid, '\Google\Cloud\Logging\Type\\'):
+            case str_starts_with($uid, '\Google\Iam\\'):
+            case str_starts_with($uid, '\Google\Rpc\\'):
+            case str_starts_with($uid, '\Google\Type\\'):
                 $extLinkRoot = 'https://googleapis.github.io/common-protos-php#';
                 break;
             case 0 === strpos($uid, '\GuzzleHttp\Promise\PromiseInterface'):
@@ -197,7 +197,7 @@ trait XrefTrait
 
         // Create external link
         if ($extLinkRoot) {
-            if (str_starts_with('\Google', $uid)) {
+            if (str_starts_with($uid, '\Google')) {
                 $extLinkRoot .= str_replace(['::', '\\', '()'], ['#method_', '/'], $name);
             }
             return sprintf('<a href="%s">%s</a>', $extLinkRoot, $name);

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -198,7 +198,7 @@ trait XrefTrait
         // Create external link
         if ($extLinkRoot) {
             if (str_starts_with('\Google', $uid)) {
-                $extLinkRoot = str_replace(['::', '\\', '()'], ['#method_', '/'], $name);
+                $extLinkRoot .= str_replace(['::', '\\', '()'], ['#method_', '/'], $name);
             }
             return sprintf('<a href="%s">%s</a>', $extLinkRoot, $name);
         }

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -159,6 +159,15 @@ trait XrefTrait
         // Remove preceeding "\" from namespace
         $name = $name ?: ltrim($uid, '\\');
 
+        // Case for nested types
+        if (preg_match('/(.*)<(.*)>/', $uid, $matches)) {
+            return sprintf(
+                '%s<%s>',
+                $this->replaceUidWithLink($matches[1]),
+                $this->replaceUidWithLink($matches[2])
+            );
+        }
+
         // Check for external package namespaces
         switch (true) {
             case 0 === strpos($uid, '\Google\ApiCore\\'):
@@ -179,14 +188,19 @@ trait XrefTrait
             case 0 === strpos($uid, '\Google\Type\\'):
                 $extLinkRoot = 'https://googleapis.github.io/common-protos-php#';
                 break;
+            case 0 === strpos($uid, '\GuzzleHttp\Promise\PromiseInterface'):
+                $extLinkRoot = 'https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html';
+                break;
             default:
                 $extLinkRoot = '';
         }
 
         // Create external link
         if ($extLinkRoot) {
-            $path = str_replace(['::', '\\', '()'], ['#method_', '/'], $name);
-            return sprintf('<a href="%s">%s</a>', $extLinkRoot . $path, $name);
+            if (str_starts_with('\Google', $uid)) {
+                $extLinkRoot = str_replace(['::', '\\', '()'], ['#method_', '/'], $name);
+            }
+            return sprintf('<a href="%s">%s</a>', $extLinkRoot, $name);
         }
 
         return sprintf('<xref uid="%s">%s</xref>', $uid, $name);

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -154,7 +154,7 @@ EOF;
         $this->assertEquals($expected, $result);
     }
 
-    public function testReplaceNestedPromiseClass()
+    public function testReplaceGenericPromiseClass()
     {
         $guzzlePromiseClassName = '\GuzzleHttp\Promise\PromiseInterface';
         $googleReference = '\Google\Cloud\AdvisoryNotifications\V1\Notification';

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -138,6 +138,42 @@ EOF;
         );
     }
 
+    public function testReplaceGuzzleExternalLink()
+    {
+        $guzzlePromiseClassName = '\GuzzleHttp\Promise\PromiseInterface';
+        $expected = '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>';
+        $xref = new class {
+            use XrefTrait;
+
+            public function replace(string $uid) {
+                return $this->replaceUidWithLink($uid);
+            }
+        };
+
+        $result = $xref->replace($guzzlePromiseClassName);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testReplaceNestedPromiseClass()
+    {
+        $guzzlePromiseClassName = '\GuzzleHttp\Promise\PromiseInterface';
+        $googleReference = '\Google\Cloud\AdvisoryNotifications\V1\Notification';
+        $uid = $guzzlePromiseClassName . '<' . $googleReference . '>';
+
+        $expected = '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>';
+        $expected .= '<<xref uid="' . $googleReference . '">Google\Cloud\AdvisoryNotifications\V1\Notification</xref>>';
+        $xref = new class {
+            use XrefTrait;
+
+            public function replace(string $uid) {
+                return $this->replaceUidWithLink($uid);
+            }
+        };
+
+        $result = $xref->replace($uid);
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * @dataProvider provideReplaceProtoRefWithXref
      */

--- a/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
+++ b/dev/tests/fixtures/docfx/NewClient/V1.Client.SecretManagerServiceClient.yml
@@ -604,7 +604,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::addSecretVersionAsync()'
     name: addSecretVersionAsync
@@ -625,7 +625,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::createSecretAsync()'
     name: createSecretAsync
@@ -646,7 +646,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::deleteSecretAsync()'
     name: deleteSecretAsync
@@ -667,7 +667,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::destroySecretVersionAsync()'
     name: destroySecretVersionAsync
@@ -688,7 +688,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::disableSecretVersionAsync()'
     name: disableSecretVersionAsync
@@ -709,7 +709,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::enableSecretVersionAsync()'
     name: enableSecretVersionAsync
@@ -730,7 +730,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getIamPolicyAsync()'
     name: getIamPolicyAsync
@@ -751,7 +751,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretAsync()'
     name: getSecretAsync
@@ -772,7 +772,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::getSecretVersionAsync()'
     name: getSecretVersionAsync
@@ -793,7 +793,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretVersionsAsync()'
     name: listSecretVersionsAsync
@@ -814,7 +814,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::listSecretsAsync()'
     name: listSecretsAsync
@@ -835,7 +835,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::setIamPolicyAsync()'
     name: setIamPolicyAsync
@@ -856,7 +856,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::testIamPermissionsAsync()'
     name: testIamPermissionsAsync
@@ -877,7 +877,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::updateSecretAsync()'
     name: updateSecretAsync
@@ -898,7 +898,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient::projectName()'
     name: 'static::projectName'

--- a/dev/tests/fixtures/docfx/Vision/V1.Client.ImageAnnotatorClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Client.ImageAnnotatorClient.yml
@@ -244,7 +244,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::asyncBatchAnnotateImagesAsync()'
     name: asyncBatchAnnotateImagesAsync
@@ -265,7 +265,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::batchAnnotateFilesAsync()'
     name: batchAnnotateFilesAsync
@@ -286,7 +286,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::batchAnnotateImagesAsync()'
     name: batchAnnotateImagesAsync
@@ -307,7 +307,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ImageAnnotatorClient::getOperationsClient()'
     name: getOperationsClient

--- a/dev/tests/fixtures/docfx/Vision/V1.Client.ProductSearchClient.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.Client.ProductSearchClient.yml
@@ -826,7 +826,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::createProductAsync()'
     name: createProductAsync
@@ -847,7 +847,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::createProductSetAsync()'
     name: createProductSetAsync
@@ -868,7 +868,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::createReferenceImageAsync()'
     name: createReferenceImageAsync
@@ -889,7 +889,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::deleteProductAsync()'
     name: deleteProductAsync
@@ -910,7 +910,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::deleteProductSetAsync()'
     name: deleteProductSetAsync
@@ -931,7 +931,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::deleteReferenceImageAsync()'
     name: deleteReferenceImageAsync
@@ -952,7 +952,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::getProductAsync()'
     name: getProductAsync
@@ -973,7 +973,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::getProductSetAsync()'
     name: getProductSetAsync
@@ -994,7 +994,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::getReferenceImageAsync()'
     name: getReferenceImageAsync
@@ -1015,7 +1015,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::importProductSetsAsync()'
     name: importProductSetsAsync
@@ -1036,7 +1036,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::listProductSetsAsync()'
     name: listProductSetsAsync
@@ -1057,7 +1057,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::listProductsAsync()'
     name: listProductsAsync
@@ -1078,7 +1078,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::listProductsInProductSetAsync()'
     name: listProductsInProductSetAsync
@@ -1099,7 +1099,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::listReferenceImagesAsync()'
     name: listReferenceImagesAsync
@@ -1120,7 +1120,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::purgeProductsAsync()'
     name: purgeProductsAsync
@@ -1141,7 +1141,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::removeProductFromProductSetAsync()'
     name: removeProductFromProductSetAsync
@@ -1162,7 +1162,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::updateProductAsync()'
     name: updateProductAsync
@@ -1183,7 +1183,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::updateProductSetAsync()'
     name: updateProductSetAsync
@@ -1204,7 +1204,7 @@ items:
           description: ''
       returns:
         -
-          var_type: '<xref uid="\GuzzleHttp\Promise\PromiseInterface">GuzzleHttp\Promise\PromiseInterface</xref>'
+          var_type: '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>'
   -
     uid: '\Google\Cloud\Vision\V1\Client\ProductSearchClient::getOperationsClient()'
     name: getOperationsClient


### PR DESCRIPTION
Add external links for Guzzle's `PromiseInterface` for a more descriptive documentation on the `async` magic methods.

related:
https://github.com/googleapis/gapic-generator-php/pull/732

Bug:
b/372535203