### PR TITLE
fix: Escape the < character for generic types

### DIFF
--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -162,7 +162,7 @@ trait XrefTrait
         // Case for generic types
         if (preg_match('/(.*)<(.*)>/', $uid, $matches)) {
             return sprintf(
-                '%s<%s>',
+                '%s&lt;%s&gt;',
                 $this->replaceUidWithLink($matches[1]),
                 $this->replaceUidWithLink($matches[2])
             );

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -161,7 +161,7 @@ EOF;
         $uid = $guzzlePromiseClassName . '<' . $googleReference . '>';
 
         $expected = '<a href="https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-GuzzleHttp.Promise.Promise.html">GuzzleHttp\Promise\PromiseInterface</a>';
-        $expected .= '<<xref uid="' . $googleReference . '">Google\Cloud\AdvisoryNotifications\V1\Notification</xref>>';
+        $expected .= '&lt;<xref uid="' . $googleReference . '">Google\Cloud\AdvisoryNotifications\V1\Notification</xref>&gt;';
         $xref = new class {
             use XrefTrait;
 


### PR DESCRIPTION
Escapes the `<` and '>' character for the HTML generation in the docs.