### PR TITLE
fix: add php 8.4 to test matrix, remove implicit nullables

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        php: [ "8.0", "8.1", "8.2", "8.3" ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
         extensions: ["grpc-1.54.0"]
         type: ["Unit Test"]
         include:

--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.3"

--- a/BigQuery/tests/Unit/Connection/RestTest.php
+++ b/BigQuery/tests/Unit/Connection/RestTest.php
@@ -52,7 +52,7 @@ class RestTest extends TestCase
     public function testApiEndpointForUniverseDomain(
         array $config,
         string $expectedEndpoint,
-        string $envUniverse = null
+        ?string $envUniverse = null
     ) {
         if ($envUniverse) {
             putenv('GOOGLE_CLOUD_UNIVERSE_DOMAIN=' . $envUniverse);

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "erusev/parsedown": "^1.6",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "dg/bypass-finals": "^1.7"

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -18,7 +18,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "opis/closure": "^3",

--- a/Core/src/AnonymousCredentials.php
+++ b/Core/src/AnonymousCredentials.php
@@ -43,7 +43,7 @@ class AnonymousCredentials implements
      * @param callable $httpHandler
      * @return array
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return $this->token;
     }
@@ -81,7 +81,7 @@ class AnonymousCredentials implements
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         return $metadata;
     }

--- a/Core/src/Batch/BatchRunner.php
+++ b/Core/src/Batch/BatchRunner.php
@@ -57,8 +57,8 @@ class BatchRunner
      *        to use. **Defaults to** null. This is only for testing purpose.
      */
     public function __construct(
-        ConfigStorageInterface $configStorage = null,
-        ProcessItemInterface $processor = null
+        ?ConfigStorageInterface $configStorage = null,
+        ?ProcessItemInterface $processor = null
     ) {
         if ($configStorage === null || $processor === null) {
             if ($this->isSysvIPCLoaded() && $this->isDaemonRunning()) {

--- a/Core/src/Batch/Retry.php
+++ b/Core/src/Batch/Retry.php
@@ -37,7 +37,7 @@ class Retry
      *
      * @param BatchRunner $runner [optional] **Defaults to** a new BatchRunner.
      */
-    public function __construct(BatchRunner $runner = null)
+    public function __construct(?BatchRunner $runner = null)
     {
         $this->runner = $runner ?: new BatchRunner();
         $this->initFailureFile();

--- a/Core/src/Compute/Metadata.php
+++ b/Core/src/Compute/Metadata.php
@@ -59,7 +59,7 @@ class Metadata
     /**
      * @param ReaderInterface $reader [optional] A metadata reader implementation.
      */
-    public function __construct(ReaderInterface $reader = null)
+    public function __construct(?ReaderInterface $reader = null)
     {
         $this->reader = $reader ?: new HttpHandlerReader();
     }

--- a/Core/src/Compute/Metadata/Readers/HttpHandlerReader.php
+++ b/Core/src/Compute/Metadata/Readers/HttpHandlerReader.php
@@ -36,7 +36,7 @@ class HttpHandlerReader implements ReaderInterface
      * @param callable $httpHandler [optional] An HTTP Handler capable of
      *        accepting PSR7 requests and returning PSR7 responses.
      */
-    public function __construct(callable $httpHandler = null)
+    public function __construct(?callable $httpHandler = null)
     {
         $this->httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/Core/src/Exception/ServiceException.php
+++ b/Core/src/Exception/ServiceException.php
@@ -65,7 +65,7 @@ class ServiceException extends GoogleException
     public function __construct(
         $message = null,
         $code = 0,
-        Exception $serviceException = null,
+        ?Exception $serviceException = null,
         array $metadata = []
     ) {
         $this->serviceException = $serviceException;

--- a/Core/src/ExponentialBackoff.php
+++ b/Core/src/ExponentialBackoff.php
@@ -64,8 +64,8 @@ class ExponentialBackoff
      */
     public function __construct(
         $retries = null,
-        callable $retryFunction = null,
-        callable $retryListener = null
+        ?callable $retryFunction = null,
+        ?callable $retryListener = null
     ) {
         $this->retries = $retries !== null ? (int) $retries : 3;
         $this->retryFunction = $retryFunction;

--- a/Core/src/GrpcTrait.php
+++ b/Core/src/GrpcTrait.php
@@ -98,8 +98,8 @@ trait GrpcTrait
      */
     private function getGaxConfig(
         $version,
-        callable $authHttpHandler = null,
-        string $universeDomain = null
+        ?callable $authHttpHandler = null,
+        ?string $universeDomain = null
     ) {
         $config = [
             'libName' => 'gccl',

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -511,7 +511,7 @@ class RequestWrapper
     /**
      * Verify that the expected universe domain matches the universe domain from the credentials.
      */
-    private function checkUniverseDomain(FetchAuthTokenInterface $credentialsFetcher = null)
+    private function checkUniverseDomain(?FetchAuthTokenInterface $credentialsFetcher = null)
     {
         if (false === $this->hasCheckedUniverse) {
             if ($this->universeDomain === '') {

--- a/Core/src/RestTrait.php
+++ b/Core/src/RestTrait.php
@@ -122,7 +122,7 @@ trait RestTrait
      * @param string $apiEndpointTemplate
      * @return string
      */
-    private function getApiEndpoint($default, array $config, string $apiEndpointTemplate = null)
+    private function getApiEndpoint($default, array $config, ?string $apiEndpointTemplate = null)
     {
         // If the $default parameter is provided, or the user has set an "apiEndoint" config option,
         // fall back to the previous behavior.

--- a/Core/src/Retry.php
+++ b/Core/src/Retry.php
@@ -54,7 +54,7 @@ class Retry
     public function __construct(
         $retries,
         callable $delayFunction,
-        callable $retryFunction = null
+        ?callable $retryFunction = null
     ) {
         $this->retries = $retries !== null ? (int) $retries : 3;
         $this->delayFunction = $delayFunction;

--- a/Core/src/Testing/ArrayHasSameValuesToken.php
+++ b/Core/src/Testing/ArrayHasSameValuesToken.php
@@ -25,7 +25,7 @@ class ArrayHasSameValuesToken implements TokenInterface
      * @experimental
      * @internal
      */
-    public function __construct($value, StringUtil $util = null)
+    public function __construct($value, ?StringUtil $util = null)
     {
         $this->value = $value;
         $this->util = $util ?: new StringUtil();

--- a/Core/src/Testing/Reflection/ReflectionHandlerFactory.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerFactory.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Core\Testing\Reflection;
 
+use phpDocumentor\Reflection\Php\Factory\Argument;
+
 /**
  * Class for determining which verison of phpdocumentor/reflection is being used.
  * @internal
@@ -28,6 +30,8 @@ class ReflectionHandlerFactory
      */
     public static function create()
     {
-        return new ReflectionHandlerV5();
+        return class_exists(Argument::class)
+            ? new ReflectionHandlerV5()
+            : new ReflectionHandlerV6();
     }
 }

--- a/Core/src/Testing/Reflection/ReflectionHandlerV5.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV5.php
@@ -115,7 +115,9 @@ class ReflectionHandlerV5
      */
     protected function getAdditionalStrategies()
     {
-        return [new Factory\Argument(new PrettyPrinter())];
+        return [
+            new Factory\Argument(new PrettyPrinter()) // @phpstan-ignore-line
+        ];
     }
 
     /**

--- a/Core/src/Testing/Reflection/ReflectionHandlerV5.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV5.php
@@ -99,14 +99,31 @@ class ReflectionHandlerV5
     }
 
     /**
+     * Split this into a separate method because ReflectionHandler V6 looks
+     * different
+     */
+    protected function createParser()
+    {
+        return (new ParserFactory())->create(
+            ParserFactory::ONLY_PHP7,
+            new Lexer\Emulative(['phpVersion' => Lexer\Emulative::PHP_8_0])
+        );
+    }
+
+    /**
+     * Split this into a separate method because V6 does not support it
+     */
+    protected function getAdditionalStrategies()
+    {
+        return [new Factory\Argument(new PrettyPrinter())];
+    }
+
+    /**
      * @return ProjectFactory
      */
     public function createProjectFactory()
     {
-        $parser = (new ParserFactory())->create(
-            ParserFactory::ONLY_PHP7,
-            new Lexer\Emulative(['phpVersion' => Lexer\Emulative::PHP_8_0])
-        );
+        $parser = $this->createParser();
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new NameResolver());
         $nodeTraverser->addVisitor(new ElementNameResolver());
@@ -119,7 +136,6 @@ class ReflectionHandlerV5
         $strategies = new ProjectFactoryStrategies(
             [
                 new Factory\Namespace_(),
-                new Factory\Argument(new PrettyPrinter()),
                 new Factory\Class_($docblockFactory),
                 new Factory\Enum_($docblockFactory),
                 new Factory\EnumCase($docblockFactory, new PrettyPrinter()),
@@ -134,7 +150,7 @@ class ReflectionHandlerV5
                 new Factory\Trait_($docblockFactory),
                 new Factory\IfStatement(),
                 new TraitUse(),
-            ]
+            ] + $this->getAdditionalStrategies()
         );
 
         $strategies->addStrategy(

--- a/Core/src/Testing/Reflection/ReflectionHandlerV6.php
+++ b/Core/src/Testing/Reflection/ReflectionHandlerV6.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Testing\Reflection;
+
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+
+/**
+ * Class for running snippets using phpdocumentor/reflection:v6.
+ *
+ * @internal
+ */
+class ReflectionHandlerV6 extends ReflectionHandlerV5
+{
+    /**
+     * @see ReflectionHandlerV5
+     */
+    protected function createParser()
+    {
+        $phpVersion = PhpVersion::fromString('8.1');  // PHP 8.1.0
+        return (new ParserFactory())->createForVersion($phpVersion);
+    }
+
+    /**
+     * @see ReflectionHandlerV5
+     */
+    protected function getAdditionalStrategies()
+    {
+        return [];
+    }
+}

--- a/Core/src/Testing/System/DeletionQueue.php
+++ b/Core/src/Testing/System/DeletionQueue.php
@@ -90,7 +90,7 @@ class DeletionQueue
      * @experimental
      * @internal
      */
-    public function process(callable $action = null)
+    public function process(?callable $action = null)
     {
         if ($action) {
             $action($this->queue);

--- a/Core/src/ValidateTrait.php
+++ b/Core/src/ValidateTrait.php
@@ -37,7 +37,7 @@ trait ValidateTrait
     private function validateBatch(
         array $input,
         $type,
-        callable $additionalCheck = null
+        ?callable $additionalCheck = null
     ) {
         foreach ($input as $element) {
             if (!($element instanceof $type)) {

--- a/Core/tests/Unit/GrpcTraitTest.php
+++ b/Core/tests/Unit/GrpcTraitTest.php
@@ -203,7 +203,7 @@ class GrpcTraitTest extends TestCase
     public function testUniverseDomainFromGaxConfig(
         ?string $universeDomain,
         string $expectedUniverseDomain,
-        string $envUniverse = null
+        ?string $envUniverse = null
     ) {
         if ($envUniverse) {
             putenv('GOOGLE_CLOUD_UNIVERSE_DOMAIN=' . $envUniverse);

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -783,7 +783,7 @@ class RequestWrapperTest extends TestCase
     public function testCheckUniverseDomainFails(
         ?string $universeDomain,
         ?string $credentialsUniverse,
-        string $message = null
+        ?string $message = null
     ) {
         $this->expectException(GoogleException::class);
         $this->expectExceptionMessage($message ?: sprintf(

--- a/Core/tests/Unit/ServiceBuilderTest.php
+++ b/Core/tests/Unit/ServiceBuilderTest.php
@@ -46,7 +46,7 @@ class ServiceBuilderTest extends TestCase
     /**
      * @dataProvider serviceProvider
      */
-    public function testBuildsClients($serviceName, $expectedClient, array $args = [], callable $beforeCallable = null)
+    public function testBuildsClients($serviceName, $expectedClient, array $args = [], ?callable $beforeCallable = null)
     {
         $this->checkAndSkipTest([$expectedClient]);
 
@@ -86,7 +86,7 @@ class ServiceBuilderTest extends TestCase
         $serviceName,
         $expectedClient,
         array $args = [],
-        callable $beforeCallable = null
+        ?callable $beforeCallable = null
     ) {
         $this->checkAndSkipTest([$expectedClient]);
 
@@ -124,7 +124,7 @@ class ServiceBuilderTest extends TestCase
         $serviceName,
         $expectedClient,
         array $args = [],
-        callable $beforeCallable = null
+        ?callable $beforeCallable = null
     ) {
         $this->checkAndSkipTest([$expectedClient]);
 

--- a/Core/tests/Unit/ServicesNotFoundTest.php
+++ b/Core/tests/Unit/ServicesNotFoundTest.php
@@ -32,6 +32,11 @@ class ServicesNotFoundTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (version_compare(PHP_VERSION, '8.4', '>=')) {
+            // @TODO upgrade to using Laravel/closure instead
+            // @see https://github.com/opis/closure/pull/145
+            self::markTestSkipped('This test is not compatible with PHP 8.4');
+        }
         self::$cloud = new ServiceBuilder;
         foreach (spl_autoload_functions() as $function) {
             if ($function[0] instanceof ClassLoader) {

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6"
     },

--- a/Datastore/src/EntityInterface.php
+++ b/Datastore/src/EntityInterface.php
@@ -55,7 +55,7 @@ interface EntityInterface
      *           created as the result of a service request.
      * }
      */
-    public static function build(Key $key = null, array $entity = [], array $options = []);
+    public static function build(?Key $key = null, array $entity = [], array $options = []);
 
     /**
      * Defines embedded entity mappings.

--- a/Datastore/src/EntityTrait.php
+++ b/Datastore/src/EntityTrait.php
@@ -56,7 +56,7 @@ trait EntityTrait
      *           created as the result of a service request.
      * }
      */
-    public function __construct(Key $key = null, array $entity = [], array $options = [])
+    public function __construct(?Key $key = null, array $entity = [], array $options = [])
     {
         $this->key = $key;
         $this->entity = $entity;
@@ -92,7 +92,7 @@ trait EntityTrait
      * }
      * @throws \InvalidArgumentException
      */
-    public static function build(Key $key = null, array $entity = [], array $options = [])
+    public static function build(?Key $key = null, array $entity = [], array $options = [])
     {
         return new static($key, $entity, $options);
     }

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -15,7 +15,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-tools": "^0.14.0",

--- a/Debugger/src/Breakpoint.php
+++ b/Debugger/src/Breakpoint.php
@@ -649,7 +649,7 @@ class Breakpoint
      *     resolver that uses the current include path.
      * @return bool
      */
-    public function resolveLocation(SourceLocationResolver $resolver = null)
+    public function resolveLocation(?SourceLocationResolver $resolver = null)
     {
         $resolver = $resolver ?: new SourceLocationResolver();
         $this->resolvedLocation = $resolver->resolve($this->location);

--- a/Debugger/src/Daemon.php
+++ b/Debugger/src/Daemon.php
@@ -173,7 +173,7 @@ class Daemon
      * $daemon->run();
      * ```
      */
-    public function run(DebuggerClient $client = null, $asDaemon = true)
+    public function run(?DebuggerClient $client = null, $asDaemon = true)
     {
         $client = $client ?: $this->defaultClient();
         $extSourceContexts = $this->extSourceContext ? [$this->extSourceContext] : [];
@@ -274,7 +274,7 @@ class Daemon
         return new DebuggerClient($this->getUnwrappedClientConfig());
     }
 
-    private function defaultLabels(MetadataProviderInterface $metadataProvider = null)
+    private function defaultLabels(?MetadataProviderInterface $metadataProvider = null)
     {
         $metadataProvider = $metadataProvider ?: MetadataProviderUtils::autoSelect($_SERVER);
         $labels = [];

--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -33,7 +33,7 @@ class Bootstrap
      * @return void
      * @codeCoverageIgnore
      */
-    public static function init(PsrLogger $psrLogger = null)
+    public static function init(?PsrLogger $psrLogger = null)
     {
         self::$psrLogger = $psrLogger ?: (new LoggingClient())
             ->psrLogger(self::DEFAULT_LOGNAME, [
@@ -259,7 +259,7 @@ class Bootstrap
      *
      * @param array $trace The stack trace returned from Exception::getTrace()
      */
-    private static function getFunctionNameForReport(array $trace = null)
+    private static function getFunctionNameForReport(?array $trace = null)
     {
         if (null === $trace) {
             return '<unknown function>';

--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -79,9 +79,6 @@ class Bootstrap
             case E_USER_NOTICE:
                 $prefix = 'PHP Notice';
                 break;
-            case E_STRICT:
-                $prefix = 'PHP Debug';
-                break;
             default:
                 $prefix = 'PHP Notice';
         }
@@ -113,8 +110,6 @@ class Bootstrap
             case E_NOTICE:
             case E_USER_NOTICE:
                 return 'NOTICE';
-            case E_STRICT:
-                return 'DEBUG';
             default:
                 return 'NOTICE';
         }

--- a/ErrorReporting/tests/Unit/BootstrapTest.php
+++ b/ErrorReporting/tests/Unit/BootstrapTest.php
@@ -78,7 +78,6 @@ class BootstrapTest extends TestCase
             [E_USER_WARNING, 'PHP Warning'],
             [E_NOTICE, 'PHP Notice'],
             [E_USER_NOTICE, 'PHP Notice'],
-            [E_STRICT, 'PHP Debug'],
             [PHP_INT_MAX, 'PHP Notice'],
         ];
     }
@@ -107,7 +106,6 @@ class BootstrapTest extends TestCase
             [E_USER_WARNING, 'WARNING'],
             [E_NOTICE, 'NOTICE'],
             [E_USER_NOTICE, 'NOTICE'],
-            [E_STRICT, 'DEBUG'],
             [PHP_INT_MAX, 'NOTICE'],
         ];
     }

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6"
     },

--- a/Firestore/tests/System/ValueMapperTest.php
+++ b/Firestore/tests/System/ValueMapperTest.php
@@ -48,7 +48,7 @@ class ValueMapperTest extends FirestoreTestCase
     /**
      * @dataProvider values
      */
-    public function testValue($input, callable $expectation = null)
+    public function testValue($input, ?callable $expectation = null)
     {
         self::$document->update([
             ['path' => self::FIELD, 'value' => $input]

--- a/Firestore/tests/Unit/Connection/GrpcTest.php
+++ b/Firestore/tests/Unit/Connection/GrpcTest.php
@@ -410,7 +410,7 @@ class GrpcTest extends TestCase
         ];
     }
 
-    private function sendAndAssert($method, array $args, array $expectedArgs, Grpc $connection = null)
+    private function sendAndAssert($method, array $args, array $expectedArgs, ?Grpc $connection = null)
     {
         $connection = $connection ?: new Grpc([
             'projectId' => 'test',

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -1567,7 +1567,7 @@ class QueryTest extends TestCase
         ], $this->collectionGroupQuery);
     }
 
-    private function runAndAssert(callable $filters, $assertion, Query $query = null)
+    private function runAndAssert(callable $filters, $assertion, ?Query $query = null)
     {
         if (is_array($assertion)) {
             $this->connection->runQuery(

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.3"

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "fig/log-test": "^1.1",

--- a/Logging/src/Logger.php
+++ b/Logging/src/Logger.php
@@ -129,8 +129,8 @@ class Logger
         ConnectionInterface $connection,
         $name,
         $projectId,
-        array $resource = null,
-        array $labels = null
+        ?array $resource = null,
+        ?array $labels = null
     ) {
         $this->connection = $connection;
         $this->name = $name;
@@ -491,7 +491,7 @@ class Logger
      * @param \DateTimeInterface $dt [optional]
      * @return string
      */
-    private function createTimestamp(\DateTimeInterface $dt = null)
+    private function createTimestamp(?\DateTimeInterface $dt = null)
     {
         if (!$dt) {
             $dt = \DateTime::createFromFormat(

--- a/Logging/tests/Unit/LoggerTest.php
+++ b/Logging/tests/Unit/LoggerTest.php
@@ -323,7 +323,7 @@ class LoggerTest extends TestCase
         $this->assertNull($logger->writeBatch([$entry1, $entry2]));
     }
 
-    private function getLogger($connection, array $resource = null, array $labels = null)
+    private function getLogger($connection, ?array $resource = null, ?array $labels = null)
     {
         $logger = new LoggerStub($connection->reveal(), $this->logName, $this->projectId, $resource, $labels);
         $logger->setTime($this->microtime);

--- a/Logging/tests/Unit/PsrLoggerTest.php
+++ b/Logging/tests/Unit/PsrLoggerTest.php
@@ -46,7 +46,7 @@ class PsrLoggerTest extends TestCase
         $this->connection = $this->prophesize(ConnectionInterface::class);
     }
 
-    public function getPsrLogger($connection, array $resource = null, array $labels = null, $messageKey = 'message')
+    public function getPsrLogger($connection, ?array $resource = null, ?array $labels = null, $messageKey = 'message')
     {
         $logger = new Logger($connection->reveal(), $this->logName, $this->projectId, $resource, $labels);
         return new PsrLogger($logger, $messageKey, ['metadataProvider' => new EmptyMetadataProvider()]);

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "flix-tech/avro-php": "^5.0.0"

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-pubsub": "^2.0"

--- a/Spanner/src/BatchDmlResult.php
+++ b/Spanner/src/BatchDmlResult.php
@@ -67,7 +67,7 @@ class BatchDmlResult
      * @param array|null $errorStatement The statement (with params and types)
      *        which triggered an error.
      */
-    public function __construct(array $data, array $errorStatement = null)
+    public function __construct(array $data, ?array $errorStatement = null)
     {
         $this->data = $data;
         $this->errorStatement = $errorStatement;

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -218,7 +218,7 @@ class Database
         array $lroCallables,
         $projectId,
         $name,
-        SessionPoolInterface $sessionPool = null,
+        ?SessionPoolInterface $sessionPool = null,
         $returnInt64AsObject = false,
         array $info = [],
         $databaseRole = ''

--- a/Spanner/src/InstanceConfiguration.php
+++ b/Spanner/src/InstanceConfiguration.php
@@ -91,7 +91,7 @@ class InstanceConfiguration
         $projectId,
         $name,
         array $info = [],
-        LongRunningConnectionInterface $lroConnection = null
+        ?LongRunningConnectionInterface $lroConnection = null
     ) {
         $this->connection = $connection;
         $this->projectId = $projectId;

--- a/Spanner/tests/System/PgQueryTest.php
+++ b/Spanner/tests/System/PgQueryTest.php
@@ -681,7 +681,7 @@ class PgQueryTest extends SpannerPgTestCase
     /**
      * @dataProvider arrayTypesProvider
      */
-    public function testBindArrayOfType($value, $result = null, $resultType = null, callable $filter = null)
+    public function testBindArrayOfType($value, $result = null, $resultType = null, ?callable $filter = null)
     {
         if (!$filter) {
             $filter = function ($val) {

--- a/Spanner/tests/System/QueryTest.php
+++ b/Spanner/tests/System/QueryTest.php
@@ -379,7 +379,7 @@ class QueryTest extends SpannerTestCase
      * covers 55
      * @dataProvider arrayTypes
      */
-    public function testBindArrayOfType($value, $result = null, $resultType = null, callable $filter = null)
+    public function testBindArrayOfType($value, $result = null, $resultType = null, ?callable $filter = null)
     {
         if ($resultType == Numeric::class) {
             $this->skipEmulatorTests();

--- a/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
@@ -927,7 +927,7 @@ class CacheSessionPoolTest extends TestCase
         return $database->reveal();
     }
 
-    private function getCacheItemPool(array $cacheData = null)
+    private function getCacheItemPool(?array $cacheData = null)
     {
         $cacheItemPool = new MemoryCacheItemPool();
         $cacheItem = $cacheItemPool->getItem(

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.3"

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "phpseclib/phpseclib": "^2.0||^3.0",

--- a/Storage/src/WriteStream.php
+++ b/Storage/src/WriteStream.php
@@ -46,7 +46,7 @@ class WriteStream implements StreamInterface
      *            upload data
      * }
      */
-    public function __construct(AbstractUploader $uploader = null, $options = [])
+    public function __construct(?AbstractUploader $uploader = null, $options = [])
     {
         if ($uploader) {
             $this->setUploader($uploader);

--- a/Storage/tests/System/StreamWrapper/StreamWrapperTestCase.php
+++ b/Storage/tests/System/StreamWrapper/StreamWrapperTestCase.php
@@ -42,7 +42,7 @@ class StreamWrapperTestCase extends StorageTestCase
         self::$client->unregisterStreamWrapper();
     }
 
-    protected static function generateUrl($file, Bucket $bucket = null)
+    protected static function generateUrl($file, ?Bucket $bucket = null)
     {
         $bucket = $bucket ?: self::$bucket;
         $bucketName = $bucket->name();

--- a/Storage/tests/Unit/BucketTest.php
+++ b/Storage/tests/Unit/BucketTest.php
@@ -749,7 +749,7 @@ class BucketTest extends TestCase
     }
 
     private function getBucketForSigning(
-        SignBlobInterface $credentials = null,
+        ?SignBlobInterface $credentials = null,
         $scopes = ''
     ) {
         if ($credentials === null) {

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -67,7 +67,7 @@ class RestTest extends TestCase
     public function testApiEndpointForUniverseDomain(
         array $config,
         string $expectedEndpoint,
-        string $envUniverse = null
+        ?string $envUniverse = null
     ) {
         if ($envUniverse) {
             putenv('GOOGLE_CLOUD_UNIVERSE_DOMAIN=' . $envUniverse);

--- a/Storage/tests/Unit/SigningHelperTest.php
+++ b/Storage/tests/Unit/SigningHelperTest.php
@@ -496,7 +496,7 @@ class SigningHelperTest extends TestCase
     /**
      * @dataProvider options
      */
-    public function testNormalizeOptions(array $options, array $expected = null, $exception = null)
+    public function testNormalizeOptions(array $options, ?array $expected = null, $exception = null)
     {
         if ($exception) {
             $this->expectException($exception);

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -977,7 +977,7 @@ class StorageObjectTest extends TestCase
     }
 
     private function getStorageObjectForSigning(
-        SignBlobInterface $credentials = null,
+        ?SignBlobInterface $credentials = null,
         $scopes = '',
         $generation = null
     ) {

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6"
     },

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6"
     },

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.3.3",
+        "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.12"

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "phpdocumentor/reflection": "^5.0",
+        "phpdocumentor/reflection": "^5.0||^6.0",
         "erusev/parsedown": "^1.6",
         "phpseclib/phpseclib": "^3.0",
         "google/cloud-tools": "^0.14.0",

--- a/dev/src/Command/AddComponentCommand.php
+++ b/dev/src/Command/AddComponentCommand.php
@@ -73,7 +73,7 @@ class AddComponentCommand extends Command
      * @param Client $httpClient specify the HTTP client, useful for tests.
      * @param RunProcess $runProcess Instance to execute Symfony Process commands, useful for tests.
      */
-    public function __construct($rootPath, Client $httpClient = null, RunProcess $runProcess = null)
+    public function __construct($rootPath, ?Client $httpClient = null, ?RunProcess $runProcess = null)
     {
         $this->rootPath = realpath($rootPath);
         $this->httpClient = $httpClient ?: new Client();

--- a/dev/src/Command/ReleaseInfoCommand.php
+++ b/dev/src/Command/ReleaseInfoCommand.php
@@ -44,7 +44,7 @@ class ReleaseInfoCommand extends Command
     /**
      * @param Client $httpClient specify the HTTP client, useful for testing
      */
-    public function __construct(Client $httpClient = null)
+    public function __construct(?Client $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new Client();
         parent::__construct();

--- a/dev/src/Component.php
+++ b/dev/src/Component.php
@@ -40,7 +40,7 @@ class Component
     /** @var array<Component> */
     private array $componentDependencies;
 
-    public function __construct(private string $name, string $path = null)
+    public function __construct(private string $name, ?string $path = null)
     {
         $this->path = $path ?: $this->getComponentPath($name);
         $this->validateComponentFiles();

--- a/dev/src/DocFx/Node/XrefTrait.php
+++ b/dev/src/DocFx/Node/XrefTrait.php
@@ -156,7 +156,7 @@ trait XrefTrait
         );
     }
 
-    private function replaceUidWithLink(string $uid, string $name = null): string
+    private function replaceUidWithLink(string $uid, ?string $name = null): string
     {
         if (is_null($name)) {
             $name = ltrim($uid, '\\');

--- a/dev/src/GitHub.php
+++ b/dev/src/GitHub.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Dev;
 
+use DateTime;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
@@ -302,7 +303,7 @@ class GitHub
      *
      * @return array|null
      */
-    public function getReleases($target, \DateTime $fromDate = null): ?array
+    public function getReleases($target, ?DateTime $fromDate = null): ?array
     {
         try {
             $res = $this->client->get(sprintf(

--- a/dev/src/RunProcess.php
+++ b/dev/src/RunProcess.php
@@ -35,7 +35,7 @@ class RunProcess
      * @param string|null $cwd
      * @return string $shellOutput
      */
-    public function execute(array $command, string $cwd = null): string
+    public function execute(array $command, ?string $cwd = null): string
     {
         $process = new Process($command, $cwd);
         $process->mustRun();

--- a/dev/tests/fixtures/component/Vision/composer.json
+++ b/dev/tests/fixtures/component/Vision/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection": "^5.0",
+        "phpdocumentor/reflection": "^5.0||^6.0",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.12"
     },


### PR DESCRIPTION
 - Removes implicit nullables
 - Removes `E_STRICT`
 - Adds support for `phpdocumentor/reflection:V6` because this is required for PHP 8.4. This is only used to run the snippets tests.
 - Skips `ServiceBuilder` tests on 8.4. ServiceBuilder is deprecated, as is the library we are using to test it (`opis/closure`)