### PR TITLE
feat(dev): add library_type component field

### DIFF
--- a/dev/src/Command/ComponentInfoCommand.php
+++ b/dev/src/Command/ComponentInfoCommand.php
@@ -49,6 +49,7 @@ class ComponentInfoCommand extends Command
         'service_address' => 'Service Address',
         'api_shortname' => 'API Shortname',
         'description' => 'Description',
+        'library_type' => 'Library Type',
         'created_at' => 'Created At',
         'available_api_versions' => 'Availble API Versions',
         'downloads' => 'Downloads',
@@ -60,6 +61,11 @@ class ComponentInfoCommand extends Command
         'api_version',
         'release_level',
         'api_shortname',
+    ];
+    private static $slowFields = [
+        'available_api_versions',
+        'created_at',
+        'downloads',
     ];
 
     private string $token;
@@ -96,7 +102,7 @@ class ComponentInfoCommand extends Command
             null => self::$defaultFields,
             'all' => array_keys(array_diff_key(
                 self::$allFields,
-                ['available_api_versions' => '', 'created_at' => '', 'downloads' => '']
+                array_flip(self::$slowFields)
             )),
             default => explode(',', $input->getOption('fields')),
         };
@@ -222,6 +228,7 @@ class ComponentInfoCommand extends Command
             'service_address' => $package ? $package->getServiceAddress() : implode(",", $component->getServiceAddresses()),
             'api_shortname' => $package ? $package->getApiShortname() : implode(",", array_filter($component->getApiShortnames())),
             'description' => $component->getDescription(),
+            'library_type' => $component->getLibraryType(),
             'available_api_versions' => null,
             'created_at' => null,
             'downloads' => null,

--- a/dev/src/Component.php
+++ b/dev/src/Component.php
@@ -35,6 +35,7 @@ class Component
     private string $repoName;
     private string $productDocumentation;
     private string $clientDocumentation;
+    private string $libraryType;
     private string $description;
     private array $namespaces;
     /** @var array<Component> */
@@ -111,6 +112,11 @@ class Component
     public function getProductDocumentation(): string
     {
         return $this->productDocumentation;
+    }
+
+    public function getLibraryType(): string
+    {
+        return $this->libraryType;
     }
 
     public function getDescription(): string
@@ -219,6 +225,7 @@ class Component
         $this->releaseLevel = $repoMetadataJson['release_level'];
         $this->clientDocumentation = $repoMetadataJson['client_documentation'];
         $this->productDocumentation = $repoMetadataJson['product_documentation'] ?? '';
+        $this->libraryType = $repoMetadataJson['library_type'];
 
         $namespaces = [];
         foreach ($composerJson['autoload']['psr-4'] as $namespace => $dir) {


### PR DESCRIPTION
Small change to the `./dev/google-cloud component-info` command: Adds field `library_type` to list of possible output fields.  Possible options are `GAPIC_AUTO`, `GAPIC_COMBO`, `GAPIC_MANUAL` and `CORE`

```
$ $ ./dev/google-cloud component-info --filter 'component_name~=Storage' --fields '+library_type'
+-----------------+-------------------------------+-----------------+-------------+---------------+-----------------+--------------+
| Component Name  | Package Name                  | Package Version | API Version | Release Level | API Shortname   | Library Type |
+-----------------+-------------------------------+-----------------+-------------+---------------+-----------------+--------------+
| BigQueryStorage | google/cloud-bigquery-storage | 2.1.1           | V1          | stable        | bigquerystorage | GAPIC_AUTO   |
| Storage         | google/cloud-storage          | 1.44.0          |             | stable        | storage         | GAPIC_MANUAL |
| StorageControl  | google/cloud-storage-control  | 1.0.1           | V2          | stable        | storage         | GAPIC_AUTO   |
| StorageInsights | google/cloud-storageinsights  | 1.0.1           | V1          | stable        | storageinsights | GAPIC_AUTO   |
| StorageTransfer | google/cloud-storage-transfer | 2.0.1           | V1          | stable        | storagetransfer | GAPIC_AUTO   |
+-----------------+-------------------------------+-----------------+-------------+---------------+-----------------+--------------+