### PR TITLE
chore: deprecate ServiceBuilder

### DIFF
--- a/Core/src/ServiceBuilder.php
+++ b/Core/src/ServiceBuilder.php
@@ -49,6 +49,8 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * Please note that unless otherwise noted the examples below take advantage of
  * [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+ *
+ * @deprecated
  */
 class ServiceBuilder
 {


### PR DESCRIPTION
With the coming V2 changes, many of these clients are getting removed or renamed. Best to encourage users to remove use of this class altogether by marking it as deprecated.