### PR TITLE
chore: bump GAX to latest version

### DIFF
--- a/AccessApproval/composer.json
+++ b/AccessApproval/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AccessContextManager/composer.json
+++ b/AccessContextManager/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AdsAdManager/composer.json
+++ b/AdsAdManager/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AdsMarketingPlatformAdmin/composer.json
+++ b/AdsMarketingPlatformAdmin/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AdvisoryNotifications/composer.json
+++ b/AdvisoryNotifications/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AiPlatform/composer.json
+++ b/AiPlatform/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AlloyDb/composer.json
+++ b/AlloyDb/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/common-protos": "^4.4"
     },
     "require-dev": {

--- a/AnalyticsAdmin/composer.json
+++ b/AnalyticsAdmin/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AnalyticsData/composer.json
+++ b/AnalyticsData/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ApiGateway/composer.json
+++ b/ApiGateway/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ApiHub/composer.json
+++ b/ApiHub/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ApiKeys/composer.json
+++ b/ApiKeys/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ApigeeConnect/composer.json
+++ b/ApigeeConnect/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ApigeeRegistry/composer.json
+++ b/ApigeeRegistry/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AppEngineAdmin/composer.json
+++ b/AppEngineAdmin/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AppHub/composer.json
+++ b/AppHub/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AppsChat/composer.json
+++ b/AppsChat/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AppsEventsSubscriptions/composer.json
+++ b/AppsEventsSubscriptions/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AppsMeet/composer.json
+++ b/AppsMeet/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ArtifactRegistry/composer.json
+++ b/ArtifactRegistry/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Asset/composer.json
+++ b/Asset/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/access-context-manager": "^1.0",
         "google/cloud-osconfig": "^2.0"
     },

--- a/AssuredWorkloads/composer.json
+++ b/AssuredWorkloads/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/AutoMl/composer.json
+++ b/AutoMl/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/BackupDr/composer.json
+++ b/BackupDr/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BareMetalSolution/composer.json
+++ b/BareMetalSolution/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Batch/composer.json
+++ b/Batch/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BeyondCorpAppConnections/composer.json
+++ b/BeyondCorpAppConnections/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BeyondCorpAppConnectors/composer.json
+++ b/BeyondCorpAppConnectors/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BeyondCorpAppGateways/composer.json
+++ b/BeyondCorpAppGateways/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BeyondCorpClientConnectorServices/composer.json
+++ b/BeyondCorpClientConnectorServices/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BeyondCorpClientGateways/composer.json
+++ b/BeyondCorpClientGateways/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.55",
+        "google/cloud-core": "^1.57",
         "ramsey/uuid": "^3.0|^4.0"
     },
     "require-dev": {

--- a/BigQueryAnalyticsHub/composer.json
+++ b/BigQueryAnalyticsHub/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryConnection/composer.json
+++ b/BigQueryConnection/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryDataExchange/composer.json
+++ b/BigQueryDataExchange/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryDataPolicies/composer.json
+++ b/BigQueryDataPolicies/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryDataTransfer/composer.json
+++ b/BigQueryDataTransfer/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/BigQueryMigration/composer.json
+++ b/BigQueryMigration/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryReservation/composer.json
+++ b/BigQueryReservation/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BigQueryStorage/composer.json
+++ b/BigQueryStorage/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/gax": "^1.36.0",
-        "google/cloud-core": "^1.55"
+        "google/cloud-core": "^1.57"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34",
+        "google/gax": "^1.36.0",
         "google/cloud-core": "^1.55"
     },
     "require-dev": {

--- a/Billing/composer.json
+++ b/Billing/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BillingBudgets/composer.json
+++ b/BillingBudgets/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/BinaryAuthorization/composer.json
+++ b/BinaryAuthorization/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/grafeas": "^1.0.0"
     },
     "require-dev": {

--- a/Build/composer.json
+++ b/Build/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/CertificateManager/composer.json
+++ b/CertificateManager/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Channel/composer.json
+++ b/Channel/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/common-protos": "^3.2||^4.0"
     },
     "require-dev": {

--- a/CommerceConsumerProcurement/composer.json
+++ b/CommerceConsumerProcurement/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Compute/composer.json
+++ b/Compute/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/ConfidentialComputing/composer.json
+++ b/ConfidentialComputing/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Config/composer.json
+++ b/Config/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/common-protos": " ^4.4"
     },
     "require-dev": {

--- a/ContactCenterInsights/composer.json
+++ b/ContactCenterInsights/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Container/composer.json
+++ b/Container/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/ContainerAnalysis/composer.json
+++ b/ContainerAnalysis/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/grafeas": "^1.0.0"
     },
     "require-dev": {

--- a/ControlsPartner/composer.json
+++ b/ControlsPartner/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,7 @@
         "guzzlehttp/psr7": "^2.6",
         "monolog/monolog": "^2.9|^3.0",
         "psr/http-message": "^1.0|^2.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/DataCatalog/composer.json
+++ b/DataCatalog/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DataCatalogLineage/composer.json
+++ b/DataCatalogLineage/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DataFusion/composer.json
+++ b/DataFusion/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DataLabeling/composer.json
+++ b/DataLabeling/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dataflow/composer.json
+++ b/Dataflow/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dataform/composer.json
+++ b/Dataform/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dataplex/composer.json
+++ b/Dataplex/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dataproc/composer.json
+++ b/Dataproc/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/DataprocMetastore/composer.json
+++ b/DataprocMetastore/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DatastoreAdmin/composer.json
+++ b/DatastoreAdmin/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Datastream/composer.json
+++ b/Datastream/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.57",
-        "google/cloud-logging": "^1.16",
+        "google/cloud-logging": "^1.29.3",
         "google/gax": "^1.36.0",
         "google/cloud-common-protos": "~0.5",
         "psr/log": "^2.0||^3.0"

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/cloud-logging": "^1.16",
         "google/gax": "^1.36.0",
         "google/cloud-common-protos": "~0.5",

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
         "google/cloud-logging": "^1.16",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/cloud-common-protos": "~0.5",
         "psr/log": "^2.0||^3.0"
     },

--- a/Deploy/composer.json
+++ b/Deploy/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DeveloperConnect/composer.json
+++ b/DeveloperConnect/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dialogflow/composer.json
+++ b/Dialogflow/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/DialogflowCx/composer.json
+++ b/DialogflowCx/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DiscoveryEngine/composer.json
+++ b/DiscoveryEngine/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Dlp/composer.json
+++ b/Dlp/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Dms/composer.json
+++ b/Dms/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/DocumentAi/composer.json
+++ b/DocumentAi/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Domains/composer.json
+++ b/Domains/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/EdgeNetwork/composer.json
+++ b/EdgeNetwork/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ErrorReporting/composer.json
+++ b/ErrorReporting/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-logging": "^1.29",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/EssentialContacts/composer.json
+++ b/EssentialContacts/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Eventarc/composer.json
+++ b/Eventarc/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/EventarcPublishing/composer.json
+++ b/EventarcPublishing/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Filestore/composer.json
+++ b/Filestore/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/cloud-common-protos": "~0.5"
     },
     "require-dev": {

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "ext-grpc": "*",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0",
         "ramsey/uuid": "^3.0|^4.0"
     },

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.0",
         "ext-grpc": "*",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "ramsey/uuid": "^3.0|^4.0"
     },
     "require-dev": {

--- a/Functions/composer.json
+++ b/Functions/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/GSuiteAddOns/composer.json
+++ b/GSuiteAddOns/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/GkeBackup/composer.json
+++ b/GkeBackup/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/GkeConnectGateway/composer.json
+++ b/GkeConnectGateway/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/GkeHub/composer.json
+++ b/GkeHub/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/GkeMultiCloud/composer.json
+++ b/GkeMultiCloud/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Grafeas/composer.json
+++ b/Grafeas/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Iam/composer.json
+++ b/Iam/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/IamCredentials/composer.json
+++ b/IamCredentials/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Iap/composer.json
+++ b/Iap/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Ids/composer.json
+++ b/Ids/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Kms/composer.json
+++ b/Kms/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/KmsInventory/composer.json
+++ b/KmsInventory/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/cloud-kms": "^2.0"
     },
     "require-dev": {

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/LifeSciences/composer.json
+++ b/LifeSciences/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.58",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -5,11 +5,11 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.57",
+        "google/cloud-core": "^1.58",
         "google/gax": "^1.36.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.6",
         "phpspec/prophecy-phpunit": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.58",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/LongRunning/composer.json
+++ b/LongRunning/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require-dev": {
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "phpunit/phpunit": "^9.0"
     }
 }

--- a/ManagedIdentities/composer.json
+++ b/ManagedIdentities/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ManagedKafka/composer.json
+++ b/ManagedKafka/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.33.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/MapsFleetEngine/composer.json
+++ b/MapsFleetEngine/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/geo-common-protos": "^0.2"
     },
     "require-dev": {

--- a/MapsFleetEngineDelivery/composer.json
+++ b/MapsFleetEngineDelivery/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/geo-common-protos": "^0.2"
     },
     "require-dev": {

--- a/MapsRouteOptimization/composer.json
+++ b/MapsRouteOptimization/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/MediaTranslation/composer.json
+++ b/MediaTranslation/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Memcache/composer.json
+++ b/Memcache/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/MigrationCenter/composer.json
+++ b/MigrationCenter/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Monitoring/composer.json
+++ b/Monitoring/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/NetApp/composer.json
+++ b/NetApp/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/NetworkConnectivity/composer.json
+++ b/NetworkConnectivity/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/NetworkManagement/composer.json
+++ b/NetworkManagement/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/NetworkSecurity/composer.json
+++ b/NetworkSecurity/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/NetworkServices/composer.json
+++ b/NetworkServices/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Notebooks/composer.json
+++ b/Notebooks/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Optimization/composer.json
+++ b/Optimization/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/OracleDatabase/composer.json
+++ b/OracleDatabase/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/OrchestrationAirflow/composer.json
+++ b/OrchestrationAirflow/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/OrgPolicy/composer.json
+++ b/OrgPolicy/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/OsConfig/composer.json
+++ b/OsConfig/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/OsLogin/composer.json
+++ b/OsLogin/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Parallelstore/composer.json
+++ b/Parallelstore/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/PolicySimulator/composer.json
+++ b/PolicySimulator/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/PolicyTroubleshooter/composer.json
+++ b/PolicyTroubleshooter/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/PolicyTroubleshooterIam/composer.json
+++ b/PolicyTroubleshooterIam/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/cloud-iam": "^1.0.0"
     },
     "require-dev": {

--- a/PrivateCatalog/composer.json
+++ b/PrivateCatalog/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/PrivilegedAccessManager/composer.json
+++ b/PrivilegedAccessManager/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Profiler/composer.json
+++ b/Profiler/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.55",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.55",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Quotas/composer.json
+++ b/Quotas/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/RapidMigrationAssessment/composer.json
+++ b/RapidMigrationAssessment/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/RecaptchaEnterprise/composer.json
+++ b/RecaptchaEnterprise/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/RecommendationEngine/composer.json
+++ b/RecommendationEngine/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Recommender/composer.json
+++ b/Recommender/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Redis/composer.json
+++ b/Redis/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.0",
         "ext-grpc": "*",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/RedisCluster/composer.json
+++ b/RedisCluster/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ResourceManager/composer.json
+++ b/ResourceManager/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ResourceSettings/composer.json
+++ b/ResourceSettings/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Retail/composer.json
+++ b/Retail/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Run/composer.json
+++ b/Run/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Scheduler/composer.json
+++ b/Scheduler/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/SecretManager/composer.json
+++ b/SecretManager/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/SecureSourceManager/composer.json
+++ b/SecureSourceManager/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/SecurityCenter/composer.json
+++ b/SecurityCenter/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/SecurityCenterManagement/composer.json
+++ b/SecurityCenterManagement/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/SecurityPrivateCa/composer.json
+++ b/SecurityPrivateCa/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/SecurityPublicCA/composer.json
+++ b/SecurityPublicCA/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ServiceControl/composer.json
+++ b/ServiceControl/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ServiceDirectory/composer.json
+++ b/ServiceDirectory/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ServiceHealth/composer.json
+++ b/ServiceHealth/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ServiceManagement/composer.json
+++ b/ServiceManagement/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ServiceUsage/composer.json
+++ b/ServiceUsage/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Shell/composer.json
+++ b/Shell/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingCss/composer.json
+++ b/ShoppingCss/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantAccounts/composer.json
+++ b/ShoppingMerchantAccounts/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantConversions/composer.json
+++ b/ShoppingMerchantConversions/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantDataSources/composer.json
+++ b/ShoppingMerchantDataSources/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantInventories/composer.json
+++ b/ShoppingMerchantInventories/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantLfp/composer.json
+++ b/ShoppingMerchantLfp/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantNotifications/composer.json
+++ b/ShoppingMerchantNotifications/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantProducts/composer.json
+++ b/ShoppingMerchantProducts/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantPromotions/composer.json
+++ b/ShoppingMerchantPromotions/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/ShoppingMerchantQuota/composer.json
+++ b/ShoppingMerchantQuota/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantReports/composer.json
+++ b/ShoppingMerchantReports/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },
     "require-dev": {

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.0",
         "ext-grpc": "*",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "ext-grpc": "*",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SqlAdmin/composer.json
+++ b/SqlAdmin/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.55",
+        "google/cloud-core": "^1.57",
         "ramsey/uuid": "^4.2.3"
     },
     "require-dev": {

--- a/StorageControl/composer.json
+++ b/StorageControl/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "ext-grpc": "*",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/StorageInsights/composer.json
+++ b/StorageInsights/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/StorageTransfer/composer.json
+++ b/StorageTransfer/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Support/composer.json
+++ b/Support/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Talent/composer.json
+++ b/Talent/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Tasks/composer.json
+++ b/Tasks/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/TelcoAutomation/composer.json
+++ b/TelcoAutomation/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/TextToSpeech/composer.json
+++ b/TextToSpeech/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Tpu/composer.json
+++ b/Tpu/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
         "ramsey/uuid": "^3.0|^4.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.36.0"
     },

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VideoIntelligence/composer.json
+++ b/VideoIntelligence/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/VideoLiveStream/composer.json
+++ b/VideoLiveStream/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/VideoStitcher/composer.json
+++ b/VideoStitcher/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/VideoTranscoder/composer.json
+++ b/VideoTranscoder/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "google/cloud-core": "^1.52.7",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.52.7",
+        "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VmMigration/composer.json
+++ b/VmMigration/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/VmwareEngine/composer.json
+++ b/VmwareEngine/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/common-protos": "^4.4"
     },
     "require-dev": {

--- a/VpcAccess/composer.json
+++ b/VpcAccess/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/WebRisk/composer.json
+++ b/WebRisk/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/WebSecurityScanner/composer.json
+++ b/WebSecurityScanner/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/Workflows/composer.json
+++ b/Workflows/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.0",
-        "google/gax": "^1.34.0"
+        "google/gax": "^1.36.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "monolog/monolog": "^2.9||^3.0",
         "psr/http-message": "^1.0|^2.0",
         "ramsey/uuid": "^4.0",
-        "google/gax": "^1.34.0",
+        "google/gax": "^1.36.0",
         "google/auth": "^1.42"
     },
     "require-dev": {

--- a/dev/src/Command/UpdateDepsCommand.php
+++ b/dev/src/Command/UpdateDepsCommand.php
@@ -41,6 +41,7 @@ class UpdateDepsCommand extends Command
             ->addOption('component', 'c', InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'bumps deps for the specified component/file')
             ->addOption('bump', '', InputOption::VALUE_NONE, 'Bump to latest version of the package')
             ->addOption('add', '', InputOption::VALUE_OPTIONAL, 'Adds the dep if it doesn\'t exist (--add=dev for require-dev)', false)
+            ->addOption('no-dev', '', InputOption::VALUE_NONE, 'Only updates the dep if its in "require" (deps in "require-dev" are left alone)')
             ->addOption('local', '', InputOption::VALUE_NONE, 'Add a link to the local component')
         ;
     }
@@ -73,7 +74,7 @@ class UpdateDepsCommand extends Command
             $composerJson = json_decode(file_get_contents($jsonFile), true);
             $require = 'require';
             if (!isset($composerJson['require'][$package])) {
-                if (isset($composerJson['require-dev'][$package])) {
+                if (isset($composerJson['require-dev'][$package]) && !$input->getOption('no-dev')) {
                     $require = 'require-dev';
                 } elseif (false === $input->getOption('add')) {
                     continue;


### PR DESCRIPTION
Ensure we have the latest version of GAX, which guarantees `logger` support.