### PR TITLE
fix: add SERVICE_NAME constant to bigtable client

### DIFF
--- a/Bigtable/src/BigtableClient.php
+++ b/Bigtable/src/BigtableClient.php
@@ -45,6 +45,9 @@ class BigtableClient
     use DetectProjectIdTrait;
     use ClientOptionsTrait;
 
+    // The name of the service. Used in debug logging.
+    private const SERVICE_NAME = 'google.bigtable.v2.Bigtable';
+
     /**
      * @var GapicClient
      */


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/8018