### PR TITLE
fix(Bigtable): ensure appProfileId is sent in requests when set in options

### DIFF
--- a/Bigtable/tests/Unit/TableTest.php
+++ b/Bigtable/tests/Unit/TableTest.php
@@ -158,6 +158,50 @@ class TableTest extends TestCase
         $this->table->mutateRows($this->rowMutations, $options);
     }
 
+    public function testAppProfileIdInTableConstructor()
+    {
+        $this->serverStream->readAll()
+            ->shouldBeCalled()
+            ->willReturn(
+                $this->arrayAsGenerator([])
+            );
+        $this->bigtableClient->mutateRows(
+            Argument::that(function (MutateRowsRequest $request) {
+                return $request->getAppProfileId() === self::APP_PROFILE;
+            }),
+            Argument::type('array')
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn(
+                $this->serverStream->reveal()
+            );
+
+        $this->table->mutateRows($this->rowMutations);
+    }
+
+    public function testAppProfileIdInMethodOptions()
+    {
+        $this->serverStream->readAll()
+            ->shouldBeCalled()
+            ->willReturn(
+                $this->arrayAsGenerator([])
+            );
+
+        $this->bigtableClient->mutateRows(
+            Argument::that(function (MutateRowsRequest $request) {
+                return $request->getAppProfileId() === 'app-profile-id-2';
+            }),
+            Argument::type('array')
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn(
+                $this->serverStream->reveal()
+            );
+        $this->table->mutateRows($this->rowMutations, [
+            'appProfileId' => 'app-profile-id-2'
+        ]);
+    }
+
     public function testMutateRowsFailure()
     {
         $statuses = [];


### PR DESCRIPTION
fixes issue found when implementing #7959 

if a user sets `appProfileId` in `Table` class constructor, this option is not passed to the requests as expected. Instead, the user has to pass `appProfileId` in for each call.

This change fixed the issue and ensures that any `appProfileId` passed into the `Table` constructor will be propagated to each RPC call. This still allows a call-time `appProfileId` to be passed in as well, which takes precedence. 