### PR TITLE
fix: php-grpc extension is optional when PUBSUB_EMULATOR_HOST is set

### DIFF
--- a/PubSub/src/V1/Client/PublisherClient.php
+++ b/PubSub/src/V1/Client/PublisherClient.php
@@ -685,7 +685,9 @@ final class PublisherClient
         }
 
         $options['apiEndpoint'] ??= $emulatorHost;
-        $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        if (class_exists(ChannelCredentials::class)) {
+            $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        }
         $options['credentials'] ??= new InsecureCredentialsWrapper();
         return $options;
     }

--- a/PubSub/src/V1/Client/SchemaServiceClient.php
+++ b/PubSub/src/V1/Client/SchemaServiceClient.php
@@ -633,7 +633,9 @@ final class SchemaServiceClient
         }
 
         $options['apiEndpoint'] ??= $emulatorHost;
-        $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        if (class_exists(ChannelCredentials::class)) {
+            $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        }
         $options['credentials'] ??= new InsecureCredentialsWrapper();
         return $options;
     }

--- a/PubSub/src/V1/Client/SubscriberClient.php
+++ b/PubSub/src/V1/Client/SubscriberClient.php
@@ -934,7 +934,9 @@ final class SubscriberClient
         }
 
         $options['apiEndpoint'] ??= $emulatorHost;
-        $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        if (class_exists(ChannelCredentials::class)) {
+            $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        }
         $options['credentials'] ??= new InsecureCredentialsWrapper();
         return $options;
     }


### PR DESCRIPTION
Fix for https://github.com/googleapis/google-cloud-php/issues/8052