### PR TITLE
fix: mark Debugger deprecated

### DIFF
--- a/Debugger/README.md
+++ b/Debugger/README.md
@@ -6,6 +6,10 @@
 
 * [API documentation](https://cloud.google.com/php/docs/reference/cloud-debugger/latest)
 
+**IMPORTANT**: This library has been deprecated. See [Cloud Debugger Deprecation][debugger-deprecation]
+
+[debugger-deprecation]: https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
+
 **NOTE:** This repository is part of [Google Cloud PHP](https://github.com/googleapis/google-cloud-php). Any
 support requests, bug reports, or development contributions should be directed to
 that project.

--- a/Debugger/src/Agent.php
+++ b/Debugger/src/Agent.php
@@ -40,6 +40,7 @@ use Psr\Log\LoggerInterface;
  *
  * $agent = new Agent();
  * ```
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Agent
 {

--- a/Debugger/src/AliasContext.php
+++ b/Debugger/src/AliasContext.php
@@ -32,6 +32,7 @@ use Google\Cloud\DevTools\Source\V1\AliasContext\Kind;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#aliascontext AliasContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class AliasContext
 {

--- a/Debugger/src/Breakpoint.php
+++ b/Debugger/src/Breakpoint.php
@@ -41,6 +41,7 @@ use Google\Cloud\Debugger\V2\Breakpoint\LogLevel;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#Breakpoint Breakpoint model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Breakpoint
 {

--- a/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
+++ b/Debugger/src/BreakpointStorage/FileBreakpointStorage.php
@@ -23,6 +23,7 @@ use Google\Cloud\Debugger\Debuggee;
 
 /**
  * This implementation of BreakpointStorageInterface using a local file.
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class FileBreakpointStorage implements BreakpointStorageInterface
 {

--- a/Debugger/src/BreakpointStorage/SysvBreakpointStorage.php
+++ b/Debugger/src/BreakpointStorage/SysvBreakpointStorage.php
@@ -23,6 +23,7 @@ use Google\Cloud\Debugger\Debuggee;
 /**
  * This implementation of BreakpointStorageInterface using PHP's shared memory
  * provided by the [Semaphore Functions](http://php.net/manual/en/ref.sem.php).
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class SysvBreakpointStorage implements BreakpointStorageInterface
 {

--- a/Debugger/src/BufferFullException.php
+++ b/Debugger/src/BufferFullException.php
@@ -21,6 +21,7 @@ use Exception;
 
 /**
  * Exception thrown when a Breakpoint has exhausted its allotted evaluation size.
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class BufferFullException extends Exception
 {

--- a/Debugger/src/CliDaemon.php
+++ b/Debugger/src/CliDaemon.php
@@ -23,6 +23,7 @@ use Google\Cloud\Core\SysvTrait;
 /**
  * This class handles command line options and starts a configured Debugger
  * Daemon.
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class CliDaemon
 {

--- a/Debugger/src/CloudRepoSourceContext.php
+++ b/Debugger/src/CloudRepoSourceContext.php
@@ -41,6 +41,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#cloudreposourcecontext CloudRepoSourceContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class CloudRepoSourceContext implements SourceContext
 {

--- a/Debugger/src/CloudWorkspaceId.php
+++ b/Debugger/src/CloudWorkspaceId.php
@@ -40,6 +40,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#cloudworkspaceid CloudWorkspaceId model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class CloudWorkspaceId
 {

--- a/Debugger/src/CloudWorkspaceSourceContext.php
+++ b/Debugger/src/CloudWorkspaceSourceContext.php
@@ -40,6 +40,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#cloudworkspacesourcecontext CloudWorkspaceSourceContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class CloudWorkspaceSourceContext implements SourceContext
 {

--- a/Debugger/src/Connection/Firebase.php
+++ b/Debugger/src/Connection/Firebase.php
@@ -25,6 +25,7 @@ use Kreait\Firebase\Factory;
  * Implementation of the Firebase connection
  *
  * @internal
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Firebase implements ConnectionInterface
 {

--- a/Debugger/src/Connection/Grpc.php
+++ b/Debugger/src/Connection/Grpc.php
@@ -31,6 +31,7 @@ use Google\Cloud\Debugger\V2\Debugger2Client;
  * [Google Debugger gRPC API](https://cloud.google.com/debugger/docs/).
  *
  * @internal
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Grpc implements ConnectionInterface
 {

--- a/Debugger/src/Connection/Rest.php
+++ b/Debugger/src/Connection/Rest.php
@@ -27,6 +27,7 @@ use Google\Cloud\Debugger\DebuggerClient;
  * [Google Debugger REST API](https://cloud.google.com/debugger/docs/reference/rest/).
  *
  * @internal
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Rest implements ConnectionInterface
 {

--- a/Debugger/src/Daemon.php
+++ b/Debugger/src/Daemon.php
@@ -41,6 +41,7 @@ use Google\Cloud\Debugger\BreakpointStorage\SysvBreakpointStorage;
  * $daemon = new Daemon();
  * $daemon->run();
  * ```
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Daemon
 {

--- a/Debugger/src/Debuggee.php
+++ b/Debugger/src/Debuggee.php
@@ -32,6 +32,7 @@ use Google\Cloud\Debugger\Connection\ConnectionInterface;
  * ```
  *
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee Debuggee API Documentation
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Debuggee
 {

--- a/Debugger/src/DebuggerClient.php
+++ b/Debugger/src/DebuggerClient.php
@@ -35,6 +35,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * $debugger = new DebuggerClient();
  * ```
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class DebuggerClient
 {

--- a/Debugger/src/ExtendedSourceContext.php
+++ b/Debugger/src/ExtendedSourceContext.php
@@ -33,6 +33,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#extendedsourcecontext ExtendedSourceContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class ExtendedSourceContext implements SourceContext
 {

--- a/Debugger/src/FormatMessage.php
+++ b/Debugger/src/FormatMessage.php
@@ -30,6 +30,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#formatmessage FormatMessage model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class FormatMessage
 {

--- a/Debugger/src/GerritSourceContext.php
+++ b/Debugger/src/GerritSourceContext.php
@@ -36,6 +36,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#gerritsourcecontext GerritSourceContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class GerritSourceContext implements SourceContext
 {

--- a/Debugger/src/GitSourceContext.php
+++ b/Debugger/src/GitSourceContext.php
@@ -34,6 +34,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#gitsourcecontext GitSourceContext model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class GitSourceContext implements SourceContext
 {

--- a/Debugger/src/MatchingFileIterator.php
+++ b/Debugger/src/MatchingFileIterator.php
@@ -28,6 +28,7 @@ namespace Google\Cloud\Debugger;
  * ```
  *
  * @access private
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class MatchingFileIterator extends \FilterIterator
 {

--- a/Debugger/src/ProjectRepoId.php
+++ b/Debugger/src/ProjectRepoId.php
@@ -34,6 +34,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#projectrepoid ProjectRepoId model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class ProjectRepoId
 {

--- a/Debugger/src/RepoId.php
+++ b/Debugger/src/RepoId.php
@@ -34,6 +34,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#repoid RepoId model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class RepoId
 {

--- a/Debugger/src/SourceLocation.php
+++ b/Debugger/src/SourceLocation.php
@@ -30,6 +30,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#sourcelocation SourceLocation model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class SourceLocation
 {

--- a/Debugger/src/SourceLocationResolver.php
+++ b/Debugger/src/SourceLocationResolver.php
@@ -28,6 +28,7 @@ namespace Google\Cloud\Debugger;
  * $resolver = new SourceLocationResolver();
  * $resolvedLocation = $resolver->resolve($location);
  * ```
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class SourceLocationResolver
 {

--- a/Debugger/src/StackFrame.php
+++ b/Debugger/src/StackFrame.php
@@ -32,6 +32,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#stackframe StackFrame model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class StackFrame
 {

--- a/Debugger/src/StatusMessage.php
+++ b/Debugger/src/StatusMessage.php
@@ -37,6 +37,7 @@ use Google\Cloud\Debugger\V2\StatusMessage\Reference;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#statusmessage StatusMessage model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class StatusMessage
 {

--- a/Debugger/src/Variable.php
+++ b/Debugger/src/Variable.php
@@ -30,6 +30,7 @@ namespace Google\Cloud\Debugger;
  * @codingStandardsIgnoreStart
  * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints#variable Variable model documentation
  * @codingStandardsIgnoreEnd
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class Variable
 {

--- a/Debugger/src/VariableTable.php
+++ b/Debugger/src/VariableTable.php
@@ -13,6 +13,7 @@ namespace Google\Cloud\Debugger;
  *
  * $variableTable = new VariableTable();
  * ```
+ * @deprecated see https://cloud.google.com/stackdriver/docs/deprecations/debugger-deprecation
  */
 class VariableTable
 {


### PR DESCRIPTION
Addresses https://github.com/googleapis/google-cloud-php/issues/6153 almost two years too late

 - [ ] After this is merged and released, we should mark the package as abandoned in Composer