### PR TITLE
fix(docs): avoid readme keyword in URL

### DIFF
--- a/dev/src/Command/DocFxCommand.php
+++ b/dev/src/Command/DocFxCommand.php
@@ -98,7 +98,8 @@ class DocFxCommand extends Command
                     $outDir . '/' . strtolower($file),
                     file_get_contents(Component::ROOT_DIR . '/' . $file)
                 );
-                $tocItems[] = ['name' => $name, 'href' => strtolower($file)];
+                $href = $file === 'README.md' ? 'getting-started' : strtolower($file);
+                $tocItems[] = ['name' => $name, 'href' => $href];
             }
             // Write the TOC to a file
             $guideToc = array_filter([

--- a/dev/tests/fixtures/docfx/ProductNeutralGuides/toc.yml
+++ b/dev/tests/fixtures/docfx/ProductNeutralGuides/toc.yml
@@ -4,7 +4,7 @@
   items:
     -
       name: 'Getting Started'
-      href: readme.md
+      href: getting-started
     -
       name: Authentication
       href: authentication.md


### PR DESCRIPTION
Cloud RAD does NOT like the name `readme` in the URL, apparently - this 404s in our help docs