### PR TITLE
chore: set gcs-sdk-team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,6 @@
 /Bigtable       @googleapis/api-bigtable @googleapis/yoshi-php @googleapis/cicd
 /Datastore/     @googleapis/api-datastore-sdk @googleapis/yoshi-php @googleapis/cicd
 /Firestore/     @googleapis/api-firestore @googleapis/yoshi-php @googleapis/cicd
-/Storage/       @googleapis/cloud-storage-dpe @googleapis/yoshi-php @googleapis/cicd
+/Storage/       @googleapis/gcs-sdk-team @googleapis/yoshi-php @googleapis/cicd
 /BigQuery*/.    @googleapis/api-bigquery @googleapis/yoshi-php @googleapis/cicd
 /PubSub/        @googleapis/api-pubsub @googleapis/yoshi-php @googleapis/cicd


### PR DESCRIPTION
Clean up old references to cloud-storage-dpe