### PR TITLE
fix(cs): remove bleeding edge from phpstan, cleanup config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,6 @@ parameters:
         # Problems with legacy namespaces (I'm not sure why these are throwing errors)
         - message: '#^Class Google\\[A-Za-z1-9\\]+_[A-Za-z1-9_]+ not found\.$#'
         # Protobuf constant classes sometimes contain multiple values for one array key
-        - { identifier: array.duplicateKey }
+        - identifier: array.duplicateKey
         # Ignore this error because I don't consider it to be level 0
-        - { identifier: new.static }
+        - identifier: new.static

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,24 +1,21 @@
 parameters:
     level: 0
     excludePaths:
-    # Ignore classes not compatible with Monolog2
-    - Core/src/Logger/*.php
-    # Ignore deprecated classes
-    - Core/src/Lock/SymfonyLockAdapter.php
-    - Core/src/PhpArray.php
-    # Ignore classes using the deprecated stackriver_debugger extension
-    - Debugger/src/Agent.php
-    - Debugger/src/Breakpoint.php
-    # Ignore Monolog3 for now, as these tests run using Monolog2
-    - Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
-    - Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
+        # Ignore classes not compatible with Monolog2
+        - Core/src/Logger/*.php
+        # Ignore deprecated classes
+        - Core/src/Lock/SymfonyLockAdapter.php
+        - Core/src/PhpArray.php
+        # Ignore classes using the deprecated stackriver_debugger extension
+        - Debugger/src/Agent.php
+        - Debugger/src/Breakpoint.php
+        # Ignore Monolog3 for now, as these tests run using Monolog2
+        - Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
+        - Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
     ignoreErrors:
-    # Problems with legacy namespaces (I'm not sure why these are throwing errors)
-    - '#^Class Google\\[A-Za-z1-9\\]+_[A-Za-z1-9_]+ not found\.$#'
-    # Protobuf constant classes sometimes contain multiple values for one array key
-    - '#Array has \d duplicate keys with value #'
-    # Ignore this error because I don't consider it to be level 0
-    - '#Unsafe usage of new static#'
-includes:
-    - dev/vendor/phpstan/phpstan/conf/bleedingEdge.neon
-
+        # Problems with legacy namespaces (I'm not sure why these are throwing errors)
+        - message: '#^Class Google\\[A-Za-z1-9\\]+_[A-Za-z1-9_]+ not found\.$#'
+        # Protobuf constant classes sometimes contain multiple values for one array key
+        - { identifier: array.duplicateKey }
+        # Ignore this error because I don't consider it to be level 0
+        - { identifier: new.static }


### PR DESCRIPTION
The [latest version of PHPStan](https://github.com/phpstan/phpstan/releases/tag/2.1.13) breaks our static analysis tests for the "bleeding edge" configuration.  To fix this, remove the "bleeding edge" from our configuration.

Additionally, uses the `identifer` instead of message matching for `array.duplicateKey` and `new.static`, and clean up the formatting/whitespace to be more readable. 