### PR TITLE
Fix incorrect namespace in README for RecaptchaEnterpriseServiceClien…

### DIFF
--- a/RecaptchaEnterprise/README.md
+++ b/RecaptchaEnterprise/README.md
@@ -34,7 +34,7 @@ on authenticating your client. Once authenticated, you'll be ready to start maki
 require 'vendor/autoload.php';
 
 use Google\Cloud\RecaptchaEnterprise\V1\Key;
-use Google\Cloud\RecaptchaEnterprise\V1\RecaptchaEnterpriseServiceClient;
+use Google\Cloud\RecaptchaEnterprise\V1\Client\RecaptchaEnterpriseServiceClient;
 use Google\Cloud\RecaptchaEnterprise\V1\WebKeySettings;
 use Google\Cloud\RecaptchaEnterprise\V1\WebKeySettings\IntegrationType;
 


### PR DESCRIPTION
## Summary

This pull request fixes an incorrect `use` statement in the README documentation of the `google/cloud-recaptcha-enterprise` library.

Currently, the README suggests importing the client like this:

```php
use Google\Cloud\RecaptchaEnterprise\V1\RecaptchaEnterpriseServiceClient;
```

However, this results in a "Class not found" error because the correct path includes the Client subnamespace:

```php
use Google\Cloud\RecaptchaEnterprise\V1\Client\RecaptchaEnterpriseServiceClient;
```

# Why this matters
The PHP client library for recaptcha-enterprise nests the actual gRPC client under a Client subnamespace. However, this is omitted in the current README, which leads to runtime errors and confusion during implementation.

This issue is not limited to this README — it appears transversally across multiple tutorials and official documentation, including:

- Google Cloud’s official PHP guide for creating assessments
- Third-party blog posts and tutorials on Laravel/PHP integration with reCAPTCHA Enterprise

As a result, many developers (especially those working with Laravel or unfamiliar with the internals of this client library) may face avoidable errors and friction when implementing this service.

