### PR TITLE
Spanner: untangle options vars and traits

### DIFF
--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -187,7 +187,7 @@ class BatchClient
         $transactionOptions = $this->pluck('transactionOptions', $options);
         $transactionOptions['returnReadTimestamp'] = true;
 
-        $transactionOptions = $this->configureSnapshotOptions($transactionOptions);
+        $transactionOptions = $this->configureReadOnlyTransactionOptions($transactionOptions);
 
         if ($this->databaseRole !== null) {
             $sessionOptions['creator_role'] = $this->databaseRole;

--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -154,8 +154,8 @@ class Instance
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type} to set a value.
-     * @param int $isolationLevel The level of Isolation for the transactions executed by this Client's instance.
-     *           **Defaults to** IsolationLevel::ISOLATION_LEVEL_UNSPECIFIED
+     *     @type int $isolationLevel The level of Isolation for the transactions executed by this
+     *           Client's instance. **Defaults to** IsolationLevel::ISOLATION_LEVEL_UNSPECIFIED.
      * }
      */
     public function __construct(
@@ -524,6 +524,8 @@ class Instance
      *     @type SessionPoolInterface $sessionPool A pool used to manage
      *           sessions.
      *     @type string $databaseRole The user created database role which creates the session.
+     *     @type int $isolationLevel The level of Isolation for the transactions executed by this
+     *           Client's instance. **Defaults to** IsolationLevel::ISOLATION_LEVEL_UNSPECIFIED.
      * }
      * @return Database
      */

--- a/Spanner/src/SnapshotTrait.php
+++ b/Spanner/src/SnapshotTrait.php
@@ -45,6 +45,7 @@ trait SnapshotTrait
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type} to set a value.
+     *     @type array $transactionOptions The Transaction Options
      * }
      */
     private function initialize(
@@ -72,7 +73,11 @@ trait SnapshotTrait
 
         $this->context = SessionPoolInterface::CONTEXT_READ;
         $this->directedReadOptions = $options['directedReadOptions'] ?? [];
-        $this->options = $options;
+        $this->transactionSelector = array_intersect_key(
+            (array) $options,
+            array_flip(['singleUse', 'begin'])
+        );
+        $this->transactionOptions = $options['transactionOptions'] ?? [];
     }
 
     /**

--- a/Spanner/src/TransactionConfigurationTrait.php
+++ b/Spanner/src/TransactionConfigurationTrait.php
@@ -22,6 +22,8 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
 
 /**
  * Configure transaction selection for read, executeSql, rollback and commit.
+ *
+ * @internal
  */
 trait TransactionConfigurationTrait
 {
@@ -33,21 +35,23 @@ trait TransactionConfigurationTrait
      * Depending on given options, can be singleUse or begin, and can be read
      * or read/write.
      *
+     * @see V1\TransactionSelector
+     *
      * @param array $options call options.
-     * @param array $previous Previously given call options (for single-use snapshots).
+     * @param array $previousReadOnlyOptions Previously given call options (for single-use snapshots).
      * @return array [(array) transaction selector, (string) context]
      */
-    private function transactionSelector(array &$options, array $previous = [])
+    private function transactionSelector(array &$options, array $previousReadOnlyOptions = [])
     {
         $options += [
             'begin' => false,
             'transactionType' => SessionPoolInterface::CONTEXT_READ,
         ];
 
-        [$transactionOptions, $type, $context] = $this->transactionOptions($options, $previous);
+        [$transactionOptions, $type, $context] = $this->transactionOptions($options, $previousReadOnlyOptions);
 
         // TransactionSelector uses a different key name for singleUseTransaction
-        // and transactionId than transactionOptions, so we'll rewrite those here
+        // and transactionId than CommitRequest, so we'll rewrite those here
         // so transactionOptions works as expected for commitRequest.
 
         if ($type === 'singleUseTransaction') {
@@ -60,6 +64,169 @@ trait TransactionConfigurationTrait
             [$type => $transactionOptions],
             $context
         ];
+    }
+
+    /**
+     * Return transaction options based on given configuration options.
+     *
+     * @see V1\TransactionOptions
+     *
+     * @param array $options call options
+     *
+     * @param array $previousReadOnlyOptions Previously given call options (for single-use snapshots).
+     * @return array [(array) transaction options, (string) transaction type, (string) context]
+     */
+    private function transactionOptions(array &$options, array $previousReadOnlyOptions = [])
+    {
+        // @TODO: Remove $options being passed by reference
+
+        $type = null;
+        $begin = $options['begin'] ?? false;
+        $context = $options['transactionType'] ?? SessionPoolInterface::CONTEXT_READWRITE;
+        $id = $options['transactionId'] ?? null;
+
+        if ($id === null) {
+            if ($begin) {
+                $type = 'begin';
+            } else {
+                $type = 'singleUseTransaction';
+                $options['singleUse'] = true;
+            }
+        }
+
+        if ($id !== null) {
+            $type = 'transactionId';
+            $transactionOptions = $id;
+        } elseif ($context === SessionPoolInterface::CONTEXT_READ) {
+            $options += ['singleUse' => null];
+            $transactionOptions = $this->configureReadOnlyTransactionOptions($options, $previousReadOnlyOptions);
+        } elseif ($context === SessionPoolInterface::CONTEXT_READWRITE) {
+            $transactionOptions = $this->configureReadWriteTransactionOptions(
+                $type == 'begin' && is_array($begin) ? $begin : []
+            );
+        } else {
+            throw new \BadMethodCallException(sprintf(
+                'Invalid transaction context %s',
+                $context
+            ));
+        }
+
+        // @TODO: Remove this once $options is no longer passed by reference
+        unset(
+            $options['begin'],
+            $options['transactionType'],
+            $options['transactionId'],
+        );
+
+        // For backwards compatibility - remove all PBReadOnly fields
+        // This was previously being done in configureReadOnlyTransactionOptions
+        // @TODO: Remove this once $options is no longer passed by reference
+        unset(
+            $options['returnReadTimestamp'],
+            $options['strong'],
+            $options['readTimestamp'],
+            $options['exactStaleness'],
+            $options['minReadTimestamp'],
+            $options['maxStaleness'],
+        );
+
+        return [$transactionOptions, $type, $context];
+    }
+
+    private function configureReadWriteTransactionOptions(array $options = [])
+    {
+        return array_intersect_key($options, array_flip([
+            'excludeTxnFromChangeStreams',
+            'isolationLevel'
+        ])) + ['readWrite' => []];
+    }
+
+    /**
+     * Configure a Read-Only transaction.
+     *
+     * @param array $options [optional] {
+     *     Configuration Options
+     *
+     *     See [ReadOnly](https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions.ReadOnly)
+     *     for detailed description of available options.
+     *
+     *     Please note that only one of `$strong`, `$readTimestamp` or
+     *     `$exactStaleness` may be set in a request.
+     *
+     *     @type bool $returnReadTimestamp If true, the Cloud Spanner-selected
+     *           read timestamp is included in the Transaction message that
+     *           describes the transaction.
+     *     @type bool $strong Read at a timestamp where all previously committed
+     *           transactions are visible.
+     *     @type Timestamp $readTimestamp Executes all reads at the given
+     *           timestamp.
+     *     @type Duration $exactStaleness Represents a number of seconds. Executes
+     *           all reads at a timestamp that is $exactStaleness old.
+     *     @type Timestamp $minReadTimestamp Executes all reads at a
+     *           timestamp >= min_read_timestamp. Only available when
+     *           `$options.singleUse` is true.
+     *     @type Duration $maxStaleness Read data at a timestamp >= NOW - max_staleness
+     *           seconds. Guarantees that all writes that have committed more
+     *           than the specified number of seconds ago are visible. Only
+     *           available when `$options.singleUse` is true.
+     *     @type bool $singleUse If true, a Transaction ID will not be allocated
+     *           up front. Instead, the transaction will be considered
+     *           "single-use", and may be used for only a single operation.
+     *           **Defaults to** `false`.
+     * }
+     * @param array $previous Previously given call options (for single-use snapshots).
+     * @return array
+     */
+    private function configureReadOnlyTransactionOptions(array $options, array $previousReadOnlyOptions = [])
+    {
+        // select only the PBReadOnly fields from $options
+        $readOnly = array_intersect_key($options, array_flip([
+            'minReadTimestamp',
+            'readTimestamp',
+            'returnReadTimestamp',
+            'exactStaleness',
+            'maxStaleness',
+            'strong'
+        ]));
+
+        // Validate options types
+        if (isset($readOnly['minReadTimestamp'])) {
+            $this->validateOptionType($readOnly, 'minReadTimestamp', Timestamp::class);
+            $readOnly['minReadTimestamp'] = $readOnly['minReadTimestamp']->formatAsString();
+        }
+
+        if (isset($readOnly['readTimestamp'])) {
+            $this->validateOptionType($readOnly, 'readTimestamp', Timestamp::class);
+            $readOnly['readTimestamp'] = $readOnly['readTimestamp']->formatAsString();
+        }
+
+        if (isset($readOnly['exactStaleness'])) {
+            $this->validateOptionType($readOnly, 'exactStaleness', Duration::class);
+            $readOnly['exactStaleness'] = $readOnly['exactStaleness']->get();
+        }
+
+        if (isset($readOnly['maxStaleness'])) {
+            $this->validateOptionType($readOnly, 'maxStaleness', Duration::class);
+            $readOnly['maxStaleness'] = $readOnly['maxStaleness']->get();
+        }
+
+        // These are only available in single-use transactions.
+        if (
+            !($options['singleUse'] ?? false)
+            && (!empty($readOnly['maxStaleness']) || !empty($readOnly['minReadTimestamp']))
+        ) {
+            throw new \BadMethodCallException(
+                'maxStaleness and minReadTimestamp are only available in single-use transactions.'
+            );
+        }
+
+        $readOnly += $previousReadOnlyOptions;
+
+        if (empty($readOnly)) {
+            $readOnly['strong'] = true;
+        }
+
+        return ['readOnly' => $readOnly];
     }
 
     /**
@@ -79,8 +246,7 @@ trait TransactionConfigurationTrait
         }
 
         if (isset($requestOptions['transaction']['singleUse']) || (
-            isset($requestOptions['transactionContext']) &&
-            $requestOptions['transactionContext'] == SessionPoolInterface::CONTEXT_READ
+            ($requestOptions['transactionContext'] ?? null) == SessionPoolInterface::CONTEXT_READ
         ) || isset($requestOptions['transactionOptions']['readOnly'])
         ) {
             if (isset($clientOptions['includeReplicas'])) {
@@ -94,154 +260,16 @@ trait TransactionConfigurationTrait
     }
 
     /**
-     * Return transaction options based on given configuration options.
-     *
-     * @param array $options call options.
-     * @param array $previous Previously given call options (for single-use snapshots).
-     * @return array [(array) transaction options, (string) transaction type, (string) context]
+     * @throws \BadMethodCallException
      */
-    private function transactionOptions(array &$options, array $previous = [])
+    private function validateOptionType($options, $field, $type)
     {
-        $options += [
-            'begin' => false,
-            'transactionType' => SessionPoolInterface::CONTEXT_READWRITE,
-            'transactionId' => null,
-        ];
-
-        $type = null;
-
-        $context = $this->pluck('transactionType', $options);
-        $id = $this->pluck('transactionId', $options);
-
-        $begin = $this->pluck('begin', $options);
-        if ($id === null) {
-            if ($begin) {
-                $type = 'begin';
-            } else {
-                $type = 'singleUseTransaction';
-                $options['singleUse'] = true;
-            }
-        }
-
-        if ($id !== null) {
-            $type = 'transactionId';
-            $transactionOptions = $id;
-        } elseif ($context === SessionPoolInterface::CONTEXT_READ) {
-            $transactionOptions = $this->configureSnapshotOptions($options, $previous);
-        } elseif ($context === SessionPoolInterface::CONTEXT_READWRITE) {
-            $transactionOptions = $this->configureTransactionOptions(
-                $type == 'begin' && is_array($begin) ? $begin : []
-            );
-        } else {
+        if (!$options[$field] instanceof $type) {
             throw new \BadMethodCallException(sprintf(
-                'Invalid transaction context %s',
-                $context
+                'Read Only Transaction Configuration Field %s must be an instance of `%s`.',
+                $field,
+                $type
             ));
         }
-
-        return [$transactionOptions, $type, $context];
-    }
-
-    private function configureTransactionOptions(array $options = [])
-    {
-        $transactionOptions = [
-            'readWrite' => []
-        ];
-
-        if (isset($options['excludeTxnFromChangeStreams'])) {
-            $transactionOptions['excludeTxnFromChangeStreams'] = $options['excludeTxnFromChangeStreams'];
-        }
-
-        if (isset($options['isolationLevel'])) {
-            $transactionOptions['isolationLevel'] = $options['isolationLevel'];
-        }
-
-        return $transactionOptions;
-    }
-
-    /**
-     * Configure a Read-Only transaction.
-     *
-     * @param array $options Configuration Options.
-     * @param array $previous Previously given call options (for single-use snapshots).
-     * @return array
-     */
-    private function configureSnapshotOptions(array &$options, array $previous = [])
-    {
-        $options += [
-            'singleUse' => false,
-            'returnReadTimestamp' => null,
-            'strong' => null,
-            'readTimestamp' => null,
-            'exactStaleness' => null,
-            'minReadTimestamp' => null,
-            'maxStaleness' => null,
-        ];
-
-        $previousOptions = $previous['transactionOptions']['readOnly'] ?? [];
-
-        // These are only available in single-use transactions.
-        if (!$options['singleUse'] && ($options['maxStaleness'] || $options['minReadTimestamp'])) {
-            throw new \BadMethodCallException(
-                'maxStaleness and minReadTimestamp are only available in single-use transactions.'
-            );
-        }
-
-        $transactionOptions = [
-            'readOnly' => $this->arrayFilterRemoveNull([
-                'returnReadTimestamp' => $this->pluck('returnReadTimestamp', $options),
-                'strong' => $this->pluck('strong', $options),
-                'minReadTimestamp' => $this->pluck('minReadTimestamp', $options),
-                'maxStaleness' => $this->pluck('maxStaleness', $options),
-                'readTimestamp' => $this->pluck('readTimestamp', $options),
-                'exactStaleness' => $this->pluck('exactStaleness', $options),
-            ]) + $previousOptions
-        ];
-
-        if (empty($transactionOptions['readOnly'])) {
-            $transactionOptions['readOnly']['strong'] = true;
-        }
-
-        $timestampFields = [
-            'minReadTimestamp',
-            'readTimestamp'
-        ];
-
-        $durationFields = [
-            'exactStaleness',
-            'maxStaleness'
-        ];
-
-        foreach ($timestampFields as $tsf) {
-            if (isset($transactionOptions['readOnly'][$tsf]) && !isset($previousOptions[$tsf])) {
-                $field = $transactionOptions['readOnly'][$tsf];
-                if (!($field instanceof Timestamp)) {
-                    throw new \BadMethodCallException(sprintf(
-                        'Read Only Transaction Configuration Field %s must be an instance of `%s`.',
-                        $tsf,
-                        Timestamp::class
-                    ));
-                }
-
-                $transactionOptions['readOnly'][$tsf] = $field->formatAsString();
-            }
-        }
-
-        foreach ($durationFields as $df) {
-            if (isset($transactionOptions['readOnly'][$df]) && !isset($previousOptions[$df])) {
-                $field = $transactionOptions['readOnly'][$df];
-                if (!($field instanceof Duration)) {
-                    throw new \BadMethodCallException(sprintf(
-                        'Read Only Transaction Configuration Field %s must be an instance of `%s`.',
-                        $df,
-                        Duration::class
-                    ));
-                }
-
-                $transactionOptions['readOnly'][$df] = $field->get();
-            }
-        }
-
-        return $transactionOptions;
     }
 }

--- a/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
+++ b/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
@@ -61,7 +61,7 @@ class TransactionConfigurationTraitTest extends TestCase
     public function testTransactionSelectorBasicSnapshot()
     {
         $args = [];
-        $res = $this->impl->proxyTransactionSelector($args);
+        $res = $this->impl->transactionSelector($args);
         $this->assertEquals(SessionPoolInterface::CONTEXT_READ, $res[1]);
         $this->assertEquals($res[0]['singleUse']['readOnly'], ['strong' => true]);
     }
@@ -69,7 +69,7 @@ class TransactionConfigurationTraitTest extends TestCase
     public function testTransactionSelectorExistingId()
     {
         $args = ['transactionId' => self::TRANSACTION];
-        $res = $this->impl->proxyTransactionSelector($args);
+        $res = $this->impl->transactionSelector($args);
         $this->assertEquals(SessionPoolInterface::CONTEXT_READ, $res[1]);
         $this->assertEquals(self::TRANSACTION, $res[0]['id']);
     }
@@ -77,75 +77,75 @@ class TransactionConfigurationTraitTest extends TestCase
     public function testTransactionSelectorReadWrite()
     {
         $args = ['transactionType' => SessionPoolInterface::CONTEXT_READWRITE];
-        $res = $this->impl->proxyTransactionSelector($args);
+        $res = $this->impl->transactionSelector($args);
         $this->assertEquals(SessionPoolInterface::CONTEXT_READWRITE, $res[1]);
-        $this->assertEquals($this->impl->proxyConfigureTransactionOptions(), $res[0]['singleUse']);
+        $this->assertEquals($this->impl->configureReadWriteTransactionOptions(), $res[0]['singleUse']);
     }
 
     public function testTransactionSelectorReadOnly()
     {
         $args = ['transactionType' => SessionPoolInterface::CONTEXT_READ];
-        $res = $this->impl->proxyTransactionSelector($args);
+        $res = $this->impl->transactionSelector($args);
         $this->assertEquals(SessionPoolInterface::CONTEXT_READ, $res[1]);
     }
 
     public function testBegin()
     {
         $args = ['begin' => true];
-        $res = $this->impl->proxyTransactionSelector($args);
+        $res = $this->impl->transactionSelector($args);
         $this->assertEquals(SessionPoolInterface::CONTEXT_READ, $res[1]);
         $this->assertEquals($res[0]['begin']['readOnly'], ['strong' => true]);
     }
 
-    public function testConfigureSnapshotOptionsReturnReadTimestamp()
+    public function testConfigureReadOnlyTransactionOptionsReturnReadTimestamp()
     {
         $args = ['returnReadTimestamp' => true];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertTrue($res['readOnly']['returnReadTimestamp']);
     }
 
-    public function testConfigureSnapshotOptionsStrong()
+    public function testConfigureReadOnlyTransactionOptionsStrong()
     {
         $args = ['strong' => true];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertTrue($res['readOnly']['strong']);
     }
 
     /**
      * @dataProvider timestamps
      */
-    public function testConfigureSnapshotOptionsMinReadTimestamp($timestamp, $expected = null)
+    public function testConfigureReadOnlyTransactionOptionsMinReadTimestamp($timestamp, $expected = null)
     {
         $time = $this->parseTimeString($timestamp);
         $ts = new Timestamp($time[0], $time[1]);
         $args = ['minReadTimestamp' => $ts, 'singleUse' => true];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertEquals($expected ?: $timestamp, $res['readOnly']['minReadTimestamp']);
     }
 
     /**
      * @dataProvider timestamps
      */
-    public function testConfigureSnapshotOptionsReadTimestamp($timestamp)
+    public function testConfigureReadOnlyTransactionOptionsReadTimestamp($timestamp)
     {
         $time = $this->parseTimeString($timestamp);
         $ts = new Timestamp($time[0], $time[1]);
         $args = ['readTimestamp' => $ts];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertEquals($timestamp, $res['readOnly']['readTimestamp']);
     }
 
-    public function testConfigureSnapshotOptionsMaxStaleness()
+    public function testConfigureReadOnlyTransactionOptionsMaxStaleness()
     {
         $args = ['maxStaleness' => $this->duration, 'singleUse' => true];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertEquals($this->dur, $res['readOnly']['maxStaleness']);
     }
 
-    public function testConfigureSnapshotOptionsExactStaleness()
+    public function testConfigureReadOnlyTransactionOptionsExactStaleness()
     {
         $args = ['exactStaleness' => $this->duration];
-        $res = $this->impl->proxyConfigureSnapshotOptions($args);
+        $res = $this->impl->configureReadOnlyTransactionOptions($args);
         $this->assertEquals($this->dur, $res['readOnly']['exactStaleness']);
     }
 
@@ -154,39 +154,39 @@ class TransactionConfigurationTraitTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
 
         $args = ['transactionType' => 'foo'];
-        $this->impl->proxyTransactionSelector($args);
+        $this->impl->transactionSelector($args);
     }
 
-    public function testConfigureSnapshotOptionsInvalidExactStaleness()
+    public function testConfigureReadOnlyTransactionOptionsInvalidExactStaleness()
     {
         $this->expectException(\BadMethodCallException::class);
 
         $args = ['exactStaleness' => 'foo'];
-        $this->impl->proxyConfigureSnapshotOptions($args);
+        $this->impl->configureReadOnlyTransactionOptions($args);
     }
 
-    public function testConfigureSnapshotOptionsInvalidMaxStaleness()
+    public function testConfigureReadOnlyTransactionOptionsInvalidMaxStaleness()
     {
         $this->expectException(\BadMethodCallException::class);
 
         $args = ['maxStaleness' => 'foo'];
-        $this->impl->proxyConfigureSnapshotOptions($args);
+        $this->impl->configureReadOnlyTransactionOptions($args);
     }
 
-    public function testConfigureSnapshotOptionsInvalidMinReadTimestamp()
+    public function testConfigureReadOnlyTransactionOptionsInvalidMinReadTimestamp()
     {
         $this->expectException(\BadMethodCallException::class);
 
         $args = ['minReadTimestamp' => 'foo'];
-        $this->impl->proxyConfigureSnapshotOptions($args);
+        $this->impl->configureReadOnlyTransactionOptions($args);
     }
 
-    public function testConfigureSnapshotOptionsInvalidReadTimestamp()
+    public function testConfigureReadOnlyTransactionOptionsInvalidReadTimestamp()
     {
         $this->expectException(\BadMethodCallException::class);
 
         $args = ['readTimestamp' => 'foo'];
-        $this->impl->proxyConfigureSnapshotOptions($args);
+        $this->impl->configureReadOnlyTransactionOptions($args);
     }
 
     public function testRequestLevelConfigureDirectedReadOptions()
@@ -196,7 +196,7 @@ class TransactionConfigurationTraitTest extends TestCase
             'directedReadOptions' => $this->directedReadOptionsIncludeReplicas
         ];
         $clientOptions = [];
-        $res = $this->impl->proxyConfigureDirectedReadOptions($requestOptions, $clientOptions);
+        $res = $this->impl->configureDirectedReadOptions($requestOptions, $clientOptions);
         $this->assertEquals($res, $requestOptions['directedReadOptions']);
     }
 
@@ -204,7 +204,7 @@ class TransactionConfigurationTraitTest extends TestCase
     {
         $requestOptions = ['transaction' => ['singleUse' => true]];
         $clientOptions = $this->directedReadOptionsIncludeReplicas;
-        $res = $this->impl->proxyConfigureDirectedReadOptions($requestOptions, $clientOptions);
+        $res = $this->impl->configureDirectedReadOptions($requestOptions, $clientOptions);
         $this->assertEquals($res, $clientOptions);
     }
 
@@ -221,7 +221,7 @@ class TransactionConfigurationTraitTest extends TestCase
                 ]
             ]
         ];
-        $res = $this->impl->proxyConfigureDirectedReadOptions($requestOptions, $clientOptions);
+        $res = $this->impl->configureDirectedReadOptions($requestOptions, $clientOptions);
         $this->assertEquals($res, $requestOptions['directedReadOptions']);
     }
 
@@ -237,26 +237,11 @@ class TransactionConfigurationTraitTest extends TestCase
 //@codingStandardsIgnoreStart
 class TransactionConfigurationTraitImplementation
 {
-    use TransactionConfigurationTrait;
-
-    public function proxyTransactionSelector(array &$options)
-    {
-        return $this->transactionSelector($options);
-    }
-
-    public function proxyConfigureTransactionOptions()
-    {
-        return $this->configureTransactionOptions();
-    }
-
-    public function proxyConfigureSnapshotOptions(array &$options)
-    {
-        return $this->configureSnapshotOptions($options);
-    }
-
-    public function proxyConfigureDirectedReadOptions(array $args1, array $args2)
-    {
-        return $this->configureDirectedReadOptions($args1, $args2);
+    use TransactionConfigurationTrait {
+        transactionSelector as public;
+        configureReadWriteTransactionOptions as public;
+        configureReadOnlyTransactionOptions as public;
+        configureDirectedReadOptions as public;
     }
 }
 //@codingStandardsIgnoreEnd


### PR DESCRIPTION
  - explicitly selecting valid fields
  - better names for variables
  - documenting missing options in phpdoc
  - removing pass-by-reference