### PR TITLE
feat: Add support for the ExplainOptions

### DIFF
--- a/Core/src/GrpcTrait.php
+++ b/Core/src/GrpcTrait.php
@@ -321,8 +321,8 @@ trait GrpcTrait
      */
     private function formatDurationFromApi($value): string
     {
-        $seconds = $metrics['seconds'];
-        $nanos = str_pad($metrics['nanos'], 9, 0, STR_PAD_LEFT);
+        $seconds = $value['seconds'];
+        $nanos = str_pad($value['nanos'], 9, 0, STR_PAD_LEFT);
 
         return "{$seconds}.{$nanos}s";
     }

--- a/Core/src/GrpcTrait.php
+++ b/Core/src/GrpcTrait.php
@@ -314,6 +314,20 @@ trait GrpcTrait
     }
 
     /**
+     * Format a duration from the API
+     *
+     * @param array $value
+     * @return string
+     */
+    private function formatDurationFromApi($value): string
+    {
+        $seconds = $metrics['seconds'];
+        $nanos = str_pad($metrics['nanos'], 9, 0, STR_PAD_LEFT);
+
+        return "{$seconds}.{$nanos}s";
+    }
+
+    /**
      * Construct a gapic client. Allows for tests to intercept.
      *
      * @param string $gapicName

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.58",
+        "google/cloud-core": "^1.62.4",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.62.4",
+        "google/cloud-core": "^1.63.0",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "google/cloud-core": "^1.57",
+        "google/cloud-core": "^1.58",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Datastore/src/Connection/Grpc.php
+++ b/Datastore/src/Connection/Grpc.php
@@ -76,6 +76,9 @@ class Grpc implements ConnectionInterface
             },
             'google.protobuf.Timestamp' => function ($v) {
                 return $this->formatTimestampFromApi($v);
+            },
+            'google.protobuf.Duration' => function ($v) {
+                return $this->formatDurationFromApi($v);
             }
         ], [], [
             'google.protobuf.Timestamp' => function ($v) {

--- a/Datastore/src/Connection/Rest.php
+++ b/Datastore/src/Connection/Rest.php
@@ -116,6 +116,13 @@ class Rest implements ConnectionInterface
      */
     public function runQuery(array $args)
     {
+        // There is a push to stop using generic arrays for options.
+        // We will transition into using structured options in the future
+        // hence we add this to handle options with the message type
+        if (isset($args['explainOptions'])) {
+            $args['explainOptions'] = json_decode($args['explainOptions']->serializeToJsonString());
+        }
+
         return $this->sendWithHeaders('projects', 'runQuery', $args);
     }
 
@@ -134,6 +141,12 @@ class Rest implements ConnectionInterface
                     $aggregation
                 );
             }
+        }
+        // There is a push to stop using generic arrays for options.
+        // We will transition into using structured options in the future
+        // hence we add this to handle options with the message type
+        if (isset($args['explainOptions'])) {
+            $args['explainOptions'] = json_decode($args['explainOptions']->serializeToJsonString());
         }
         return $this->sendWithHeaders('projects', 'runAggregationQuery', $args);
     }

--- a/Datastore/src/Connection/ServiceDefinition/datastore-v1.json
+++ b/Datastore/src/Connection/ServiceDefinition/datastore-v1.json
@@ -1,10 +1,85 @@
 {
-  "mtlsRootUrl": "https://datastore.mtls.googleapis.com/",
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  "basePath": "",
+  "title": "Cloud Datastore API",
+  "parameters": {
+    "access_token": {
+      "type": "string",
+      "description": "OAuth access token.",
+      "location": "query"
+    },
+    "alt": {
+      "type": "string",
+      "description": "Data format for response.",
+      "default": "json",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query"
+    },
+    "callback": {
+      "type": "string",
+      "description": "JSONP",
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query"
+    },
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "oauth_token": {
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "location": "query"
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "type": "string",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "location": "query"
+    },
+    "uploadType": {
+      "type": "string",
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "location": "query"
+    },
+    "$.xgafv": {
+      "type": "string",
+      "description": "V1 error format.",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query"
+    }
   },
   "servicePath": "",
+  "documentationLink": "https://cloud.google.com/datastore/",
   "schemas": {
     "GoogleLongrunningListOperationsResponse": {
       "id": "GoogleLongrunningListOperationsResponse",
@@ -280,6 +355,10 @@
           "items": {
             "$ref": "Key"
           }
+        },
+        "propertyMask": {
+          "description": "The properties to return. Defaults to returning all properties. If this field is set and an entity has a property not referenced in the mask, it will be absent from LookupResponse.found.entity.properties. The entity's key is always returned.",
+          "$ref": "PropertyMask"
         }
       }
     },
@@ -411,6 +490,20 @@
         "name": {
           "description": "The name of the entity. A name matching regex `__.*__` is reserved/read-only. A name must not be more than 1500 bytes when UTF-8 encoded. Cannot be `\"\"`. Must be valid UTF-8 bytes. Legacy values that are not valid UTF-8 are encoded as `__bytes__` where `` is the base-64 encoding of the bytes.",
           "type": "string"
+        }
+      }
+    },
+    "PropertyMask": {
+      "id": "PropertyMask",
+      "description": "The set of arbitrarily nested property paths used to restrict an operation to only a subset of properties in an entity.",
+      "type": "object",
+      "properties": {
+        "paths": {
+          "description": "The paths to the properties covered by this mask. A path is a list of property names separated by dots (`.`), for example `foo.bar` means the property `bar` inside the entity property `foo` inside the entity associated with this path. If a property name contains a dot `.` or a backslash `\\`, then that name must be escaped. A path must not be empty, and may not reference a value inside an array value.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -626,12 +719,20 @@
         "gqlQuery": {
           "description": "The GQL query to run. This query must be a non-aggregation query.",
           "$ref": "GqlQuery"
+        },
+        "propertyMask": {
+          "description": "The properties to return. This field must not be set for a projection query. See LookupRequest.property_mask.",
+          "$ref": "PropertyMask"
+        },
+        "explainOptions": {
+          "description": "Optional. Explain options for the query. If set, additional query statistics will be returned. If not, only query results will be returned.",
+          "$ref": "ExplainOptions"
         }
       }
     },
     "Query": {
       "id": "Query",
-      "description": "A query for entities.",
+      "description": "A query for entities. The query stages are executed in the following order: 1. kind 2. filter 3. projection 4. order + start_cursor + end_cursor 5. offset 6. limit 7. find_nearest",
       "type": "object",
       "properties": {
         "projection": {
@@ -685,6 +786,10 @@
           "description": "The maximum number of results to return. Applies after all other constraints. Optional. Unspecified is interpreted as no limit. Must be \u003e= 0 if specified.",
           "type": "integer",
           "format": "int32"
+        },
+        "findNearest": {
+          "description": "Optional. A potential Nearest Neighbors Search. Applies after all other filters and ordering. Finds the closest vector embeddings to the given query vector.",
+          "$ref": "FindNearest"
         }
       }
     },
@@ -832,6 +937,51 @@
         }
       }
     },
+    "FindNearest": {
+      "id": "FindNearest",
+      "description": "Nearest Neighbors search config. The ordering provided by FindNearest supersedes the order_by stage. If multiple documents have the same vector distance, the returned document order is not guaranteed to be stable between queries.",
+      "type": "object",
+      "properties": {
+        "vectorProperty": {
+          "description": "Required. An indexed vector property to search upon. Only documents which contain vectors whose dimensionality match the query_vector can be returned.",
+          "$ref": "PropertyReference"
+        },
+        "queryVector": {
+          "description": "Required. The query vector that we are searching on. Must be a vector of no more than 2048 dimensions.",
+          "$ref": "Value"
+        },
+        "distanceMeasure": {
+          "description": "Required. The Distance Measure to use, required.",
+          "type": "string",
+          "enumDescriptions": [
+            "Should not be set.",
+            "Measures the EUCLIDEAN distance between the vectors. See [Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance) to learn more. The resulting distance decreases the more similar two vectors are.",
+            "COSINE distance compares vectors based on the angle between them, which allows you to measure similarity that isn't based on the vectors magnitude. We recommend using DOT_PRODUCT with unit normalized vectors instead of COSINE distance, which is mathematically equivalent with better performance. See [Cosine Similarity](https://en.wikipedia.org/wiki/Cosine_similarity) to learn more about COSINE similarity and COSINE distance. The resulting COSINE distance decreases the more similar two vectors are.",
+            "Similar to cosine but is affected by the magnitude of the vectors. See [Dot Product](https://en.wikipedia.org/wiki/Dot_product) to learn more. The resulting distance increases the more similar two vectors are."
+          ],
+          "enum": [
+            "DISTANCE_MEASURE_UNSPECIFIED",
+            "EUCLIDEAN",
+            "COSINE",
+            "DOT_PRODUCT"
+          ]
+        },
+        "limit": {
+          "description": "Required. The number of nearest neighbors to return. Must be a positive integer of no more than 100.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "distanceResultProperty": {
+          "description": "Optional. Optional name of the field to output the result of the vector distance calculation. Must conform to entity property limitations.",
+          "type": "string"
+        },
+        "distanceThreshold": {
+          "description": "Optional. Option to specify a threshold for which no less similar documents will be returned. The behavior of the specified `distance_measure` will affect the meaning of the distance threshold. Since DOT_PRODUCT distances increase when the vectors are more similar, the comparison is inverted. * For EUCLIDEAN, COSINE: WHERE distance \u003c= distance_threshold * For DOT_PRODUCT: WHERE distance \u003e= distance_threshold",
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
     "GqlQuery": {
       "id": "GqlQuery",
       "description": "A [GQL query](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).",
@@ -877,13 +1027,24 @@
         }
       }
     },
+    "ExplainOptions": {
+      "id": "ExplainOptions",
+      "description": "Explain options for the query.",
+      "type": "object",
+      "properties": {
+        "analyze": {
+          "description": "Optional. Whether to execute this query. When false (the default), the query will be planned, returning only metrics from the planning stages. When true, the query will be planned and executed, returning the full query results along with both planning and execution stage metrics.",
+          "type": "boolean"
+        }
+      }
+    },
     "RunQueryResponse": {
       "id": "RunQueryResponse",
       "description": "The response for Datastore.RunQuery.",
       "type": "object",
       "properties": {
         "batch": {
-          "description": "A batch of query results (always present).",
+          "description": "A batch of query results. This is always present unless running a query under explain-only mode: RunQueryRequest.explain_options was provided and ExplainOptions.analyze was set to false.",
           "$ref": "QueryResultBatch"
         },
         "query": {
@@ -894,6 +1055,10 @@
           "description": "The identifier of the transaction that was started as part of this RunQuery request. Set only when ReadOptions.new_transaction was set in RunQueryRequest.read_options.",
           "type": "string",
           "format": "byte"
+        },
+        "explainMetrics": {
+          "description": "Query explain metrics. This is only present when the RunQueryRequest.explain_options is provided, and it is sent only once with the last response in the stream.",
+          "$ref": "ExplainMetrics"
         }
       }
     },
@@ -970,6 +1135,69 @@
         }
       }
     },
+    "ExplainMetrics": {
+      "id": "ExplainMetrics",
+      "description": "Explain metrics for the query.",
+      "type": "object",
+      "properties": {
+        "planSummary": {
+          "description": "Planning phase information for the query.",
+          "$ref": "PlanSummary"
+        },
+        "executionStats": {
+          "description": "Aggregated stats from the execution of the query. Only present when ExplainOptions.analyze is set to true.",
+          "$ref": "ExecutionStats"
+        }
+      }
+    },
+    "PlanSummary": {
+      "id": "PlanSummary",
+      "description": "Planning phase information for the query.",
+      "type": "object",
+      "properties": {
+        "indexesUsed": {
+          "description": "The indexes selected for the query. For example: [ {\"query_scope\": \"Collection\", \"properties\": \"(foo ASC, __name__ ASC)\"}, {\"query_scope\": \"Collection\", \"properties\": \"(bar ASC, __name__ ASC)\"} ]",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object."
+            }
+          }
+        }
+      }
+    },
+    "ExecutionStats": {
+      "id": "ExecutionStats",
+      "description": "Execution statistics for the query.",
+      "type": "object",
+      "properties": {
+        "resultsReturned": {
+          "description": "Total number of results returned, including documents, projections, aggregation results, keys.",
+          "type": "string",
+          "format": "int64"
+        },
+        "executionDuration": {
+          "description": "Total time to execute the query in the backend.",
+          "type": "string",
+          "format": "google-duration"
+        },
+        "readOperations": {
+          "description": "Total billable read operations.",
+          "type": "string",
+          "format": "int64"
+        },
+        "debugStats": {
+          "description": "Debugging statistics from the execution of the query. Note that the debugging stats are subject to change as Firestore evolves. It could include: { \"indexes_entries_scanned\": \"1000\", \"documents_scanned\": \"20\", \"billing_details\" : { \"documents_billable\": \"20\", \"index_entries_billable\": \"1000\", \"min_query_cost\": \"0\" } }",
+          "type": "object",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object."
+          }
+        }
+      }
+    },
     "RunAggregationQueryRequest": {
       "id": "RunAggregationQueryRequest",
       "description": "The request for Datastore.RunAggregationQuery.",
@@ -994,6 +1222,10 @@
         "gqlQuery": {
           "description": "The GQL query to run. This query must be an aggregation query.",
           "$ref": "GqlQuery"
+        },
+        "explainOptions": {
+          "description": "Optional. Explain options for the query. If set, additional query statistics will be returned. If not, only query results will be returned.",
+          "$ref": "ExplainOptions"
         }
       }
     },
@@ -1089,6 +1321,10 @@
           "description": "The identifier of the transaction that was started as part of this RunAggregationQuery request. Set only when ReadOptions.new_transaction was set in RunAggregationQueryRequest.read_options.",
           "type": "string",
           "format": "byte"
+        },
+        "explainMetrics": {
+          "description": "Query explain metrics. This is only present when the RunAggregationQueryRequest.explain_options is provided, and it is sent only once with the last response in the stream.",
+          "$ref": "ExplainMetrics"
         }
       }
     },
@@ -1241,6 +1477,74 @@
           "description": "The update time of the entity that this mutation is being applied to. If this does not match the current update time on the server, the mutation conflicts.",
           "type": "string",
           "format": "google-datetime"
+        },
+        "conflictResolutionStrategy": {
+          "description": "The strategy to use when a conflict is detected. Defaults to `SERVER_VALUE`. If this is set, then `conflict_detection_strategy` must also be set.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unspecified. Defaults to `SERVER_VALUE`.",
+            "The server entity is kept.",
+            "The whole commit request fails."
+          ],
+          "enum": [
+            "STRATEGY_UNSPECIFIED",
+            "SERVER_VALUE",
+            "FAIL"
+          ]
+        },
+        "propertyMask": {
+          "description": "The properties to write in this mutation. None of the properties in the mask may have a reserved name, except for `__key__`. This field is ignored for `delete`. If the entity already exists, only properties referenced in the mask are updated, others are left untouched. Properties referenced in the mask but not in the entity are deleted.",
+          "$ref": "PropertyMask"
+        },
+        "propertyTransforms": {
+          "description": "Optional. The transforms to perform on the entity. This field can be set only when the operation is `insert`, `update`, or `upsert`. If present, the transforms are be applied to the entity regardless of the property mask, in order, after the operation.",
+          "type": "array",
+          "items": {
+            "$ref": "PropertyTransform"
+          }
+        }
+      }
+    },
+    "PropertyTransform": {
+      "id": "PropertyTransform",
+      "description": "A transformation of an entity property.",
+      "type": "object",
+      "properties": {
+        "property": {
+          "description": "Optional. The name of the property. Property paths (a list of property names separated by dots (`.`)) may be used to refer to properties inside entity values. For example `foo.bar` means the property `bar` inside the entity property `foo`. If a property name contains a dot `.` or a backlslash `\\`, then that name must be escaped.",
+          "type": "string"
+        },
+        "setToServerValue": {
+          "description": "Sets the property to the given server value.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unspecified. This value must not be used.",
+            "The time at which the server processed the request, with millisecond precision. If used on multiple properties (same or different entities) in a transaction, all the properties will get the same server timestamp."
+          ],
+          "enum": [
+            "SERVER_VALUE_UNSPECIFIED",
+            "REQUEST_TIME"
+          ]
+        },
+        "increment": {
+          "description": "Adds the given value to the property's current value. This must be an integer or a double value. If the property is not an integer or double, or if the property does not yet exist, the transformation will set the property to the given value. If either of the given value or the current property value are doubles, both values will be interpreted as doubles. Double arithmetic and representation of double values follows IEEE 754 semantics. If there is positive/negative integer overflow, the property is resolved to the largest magnitude positive/negative integer.",
+          "$ref": "Value"
+        },
+        "maximum": {
+          "description": "Sets the property to the maximum of its current value and the given value. This must be an integer or a double value. If the property is not an integer or double, or if the property does not yet exist, the transformation will set the property to the given value. If a maximum operation is applied where the property and the input value are of mixed types (that is - one is an integer and one is a double) the property takes on the type of the larger operand. If the operands are equivalent (e.g. 3 and 3.0), the property does not change. 0, 0.0, and -0.0 are all zero. The maximum of a zero stored value and zero input value is always the stored value. The maximum of any numeric value x and NaN is NaN.",
+          "$ref": "Value"
+        },
+        "minimum": {
+          "description": "Sets the property to the minimum of its current value and the given value. This must be an integer or a double value. If the property is not an integer or double, or if the property does not yet exist, the transformation will set the property to the input value. If a minimum operation is applied where the property and the input value are of mixed types (that is - one is an integer and one is a double) the property takes on the type of the smaller operand. If the operands are equivalent (e.g. 3 and 3.0), the property does not change. 0, 0.0, and -0.0 are all zero. The minimum of a zero stored value and zero input value is always the stored value. The minimum of any numeric value x and NaN is NaN.",
+          "$ref": "Value"
+        },
+        "appendMissingElements": {
+          "description": "Appends the given elements in order if they are not already present in the current property value. If the property is not an array, or if the property does not yet exist, it is first set to the empty array. Equivalent numbers of different types (e.g. 3L and 3.0) are considered equal when checking if a value is missing. NaN is equal to NaN, and the null value is equal to the null value. If the input contains multiple equivalent values, only the first will be considered. The corresponding transform result will be the null value.",
+          "$ref": "ArrayValue"
+        },
+        "removeAllFromArray": {
+          "description": "Removes all of the given elements from the array in the property. If the property is not an array, or if the property does not yet exist, it is set to the empty array. Equivalent numbers of different types (e.g. 3L and 3.0) are considered equal when deciding whether an element should be removed. NaN is equal to NaN, and the null value is equal to the null value. This will remove all equivalent values if there are duplicates. The corresponding transform result will be the null value.",
+          "$ref": "ArrayValue"
         }
       }
     },
@@ -1295,6 +1599,13 @@
         "conflictDetected": {
           "description": "Whether a conflict was detected for this mutation. Always false when a conflict detection strategy field is not set in the mutation.",
           "type": "boolean"
+        },
+        "transformResults": {
+          "description": "The results of applying each PropertyTransform, in the same order of the request.",
+          "type": "array",
+          "items": {
+            "$ref": "Value"
+          }
         }
       }
     },
@@ -1823,7 +2134,7 @@
       "type": "object",
       "properties": {
         "concurrencyMode": {
-          "description": "Ths concurrency mode for this database.",
+          "description": "The concurrency mode for this database.",
           "type": "string",
           "enumDescriptions": [
             "Unspecified.",
@@ -1864,15 +2175,6 @@
       }
     }
   },
-  "baseUrl": "https://datastore.googleapis.com/",
-  "version": "v1",
-  "fullyEncodeReservedExpansion": true,
-  "documentationLink": "https://cloud.google.com/datastore/",
-  "ownerDomain": "google.com",
-  "kind": "discovery#restDescription",
-  "batchPath": "batch",
-  "rootUrl": "https://datastore.googleapis.com/",
-  "discoveryVersion": "v1",
   "auth": {
     "oauth2": {
       "scopes": {
@@ -1885,89 +2187,14 @@
       }
     }
   },
-  "version_module": true,
-  "description": "Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application. ",
   "name": "datastore",
-  "revision": "20231103",
+  "kind": "discovery#restDescription",
   "ownerName": "Google",
-  "protocol": "rest",
-  "parameters": {
-    "access_token": {
-      "type": "string",
-      "description": "OAuth access token.",
-      "location": "query"
-    },
-    "alt": {
-      "type": "string",
-      "description": "Data format for response.",
-      "default": "json",
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query"
-    },
-    "callback": {
-      "type": "string",
-      "description": "JSONP",
-      "location": "query"
-    },
-    "fields": {
-      "type": "string",
-      "description": "Selector specifying which fields to include in a partial response.",
-      "location": "query"
-    },
-    "key": {
-      "type": "string",
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query"
-    },
-    "oauth_token": {
-      "type": "string",
-      "description": "OAuth 2.0 token for the current user.",
-      "location": "query"
-    },
-    "prettyPrint": {
-      "type": "boolean",
-      "description": "Returns response with indentations and line breaks.",
-      "default": "true",
-      "location": "query"
-    },
-    "quotaUser": {
-      "type": "string",
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "location": "query"
-    },
-    "upload_protocol": {
-      "type": "string",
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query"
-    },
-    "uploadType": {
-      "type": "string",
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "location": "query"
-    },
-    "$.xgafv": {
-      "type": "string",
-      "description": "V1 error format.",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query"
-    }
-  },
+  "mtlsRootUrl": "https://datastore.mtls.googleapis.com/",
+  "ownerDomain": "google.com",
+  "revision": "20250524",
+  "baseUrl": "https://datastore.googleapis.com/",
+  "discoveryVersion": "v1",
   "resources": {
     "projects": {
       "methods": {
@@ -2373,7 +2600,7 @@
                 "https://www.googleapis.com/auth/cloud-platform",
                 "https://www.googleapis.com/auth/datastore"
               ],
-              "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`."
+              "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`."
             }
           }
         },
@@ -2516,7 +2743,16 @@
       }
     }
   },
+  "version_module": true,
+  "batchPath": "batch",
+  "description": "Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application. ",
+  "fullyEncodeReservedExpansion": true,
+  "protocol": "rest",
+  "rootUrl": "https://datastore.googleapis.com/",
+  "version": "v1",
   "id": "datastore:v1",
-  "basePath": "",
-  "title": "Cloud Datastore API"
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  }
 }

--- a/Datastore/src/DatastoreClient.php
+++ b/Datastore/src/DatastoreClient.php
@@ -1222,7 +1222,8 @@ class DatastoreClient
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
-     *     @type ExplainOptions $explainOptions An ExplainOptions instance. {@see \Google\Cloud\Datastore\V1\ExplainOptions}
+     *     @type ExplainOptions $explainOptions An ExplainOptions instance.
+     *           {@see \Google\Cloud\Datastore\V1\ExplainOptions}
      * }
      * @return AggregationQueryResult
      */

--- a/Datastore/src/DatastoreClient.php
+++ b/Datastore/src/DatastoreClient.php
@@ -1222,6 +1222,7 @@ class DatastoreClient
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
+     *     @type ExplainOptions $explainOptions An ExplainOptions instance. {@see \Google\Cloud\Datastore\V1\ExplainOptions}
      * }
      * @return AggregationQueryResult
      */

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -135,32 +135,9 @@ class EntityIterator implements \Iterator
         }
 
         $explainMetrics = new ExplainMetrics();
-        $jsonString = json_encode($this->fixDurationFormat($metrics));
+        $jsonString = json_encode($metrics);
         $explainMetrics->mergeFromJsonString($jsonString);
 
         return $explainMetrics;
-    }
-
-    private function fixDurationFormat(array $metrics): array
-    {
-        // The current protobuf library does not support the current json representation
-        // of the well-known type Duration.
-        // Hence we have to convert the object format into a string format for the merging from json to work.
-        // If the protobuf library gets updated, this should be removed.
-        if (!isset($metrics['executionStats']) && !isset($metrics['executionStats']['executionDuration'])) {
-            return $metrics;
-        }
-
-        // The REST version returns the executionDuration in a String format. If is a string should be ready to go
-        if (isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
-            return $metrics;
-        }
-
-        $seconds = $metrics['executionStats']['executionDuration']['seconds'];
-        $nanos = str_pad($metrics['executionStats']['executionDuration']['nanos'], 9, 0, STR_PAD_LEFT);
-
-        $metrics['executionStats']['executionDuration'] = "{$seconds}.{$nanos}s";
-
-        return $metrics;
     }
 }

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -58,6 +58,9 @@ class EntityIterator implements \Iterator
      * the request then also gets executed, including the ExecutionStates on the ExplainMetrics
      * object
      *
+     * Contrary to looping through the result of run query, this method caches the first metrics
+     * to avoid variations when analyzing said metrics.
+     *
      * Example:
      * ```
      * use Google\Cloud\Datastore\DatastoreClient;

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -150,6 +150,11 @@ class EntityIterator implements \Iterator
             return $metrics;
         }
 
+        // The REST version returns the executionDuration in a String format. If is a string should be ready to go
+        if(isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
+            return $metrics;
+        }
+
         $seconds = $metrics['executionStats']['executionDuration']['seconds'];
         $nanos = str_pad($metrics['executionStats']['executionDuration']['nanos'], 9, 0, STR_PAD_LEFT);
 

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -55,7 +55,7 @@ class EntityIterator implements \Iterator
      * contains only the planning statistics {@see \Google\Cloud\Datastore\V1\ExplainMetrics}.
      *
      * If the request was configured with the ExplainOptions object `Analyze` attribute to true
-     * the request then also gets executed, including the ExecutionStates on the ExplainMetrics
+     * the request then also gets executed, including the ExecutionStats on the ExplainMetrics
      * object
      *
      * Contrary to looping through the result of run query, this method caches the first metrics
@@ -98,10 +98,10 @@ class EntityIterator implements \Iterator
      * $explainMetrics = $res->getExplainMetrics();
      *
      * // This is populated
-     * $explainMetrics->planningSummary
+     * $explainMetrics->getPlanSummary()
      *
      * // This is also populated
-     * $explainMetrics->executionStats
+     * $explainMetrics->getExecutionStats()
      * ```
      *
      * @return null|ExplainMetrics
@@ -129,6 +129,8 @@ class EntityIterator implements \Iterator
 
             $this->pageIterator->next();
         }
+
+        $this->rewind();
 
         if (is_null($metrics)) {
             return null;

--- a/Datastore/src/EntityIterator.php
+++ b/Datastore/src/EntityIterator.php
@@ -52,7 +52,7 @@ class EntityIterator implements \Iterator
      * Returns a ExplainMetrics object from the query.
      *
      * By default, the query does not get executed and the explain metrics object
-     * contains only the planning statistics {@see Google\Cloud\Datastore\V1\ExplainMetrics}.
+     * contains only the planning statistics {@see \Google\Cloud\Datastore\V1\ExplainMetrics}.
      *
      * If the request was configured with the ExplainOptions object `Analyze` attribute to true
      * the request then also gets executed, including the ExecutionStates on the ExplainMetrics
@@ -106,7 +106,7 @@ class EntityIterator implements \Iterator
      *
      * @return null|ExplainMetrics
      */
-    public function getExplainMetrics() : null|ExplainMetrics
+    public function getExplainMetrics(): null|ExplainMetrics
     {
         if (is_null($this->explainMetrics)) {
             $this->explainMetrics = $this->gatherExplainMetrics();
@@ -115,7 +115,7 @@ class EntityIterator implements \Iterator
         return $this->explainMetrics;
     }
 
-    private function gatherExplainMetrics() : null|explainMetrics
+    private function gatherExplainMetrics(): null|explainMetrics
     {
         $metrics = null;
         $this->pageIterator->current();
@@ -141,9 +141,10 @@ class EntityIterator implements \Iterator
         return $explainMetrics;
     }
 
-    private function fixDurationFormat(array $metrics) : array
+    private function fixDurationFormat(array $metrics): array
     {
-        // The current protobuf library does not support the current json representation of the well-known type Duration.
+        // The current protobuf library does not support the current json representation
+        // of the well-known type Duration.
         // Hence we have to convert the object format into a string format for the merging from json to work.
         // If the protobuf library gets updated, this should be removed.
         if (!isset($metrics['executionStats']) && !isset($metrics['executionStats']['executionDuration'])) {
@@ -151,7 +152,7 @@ class EntityIterator implements \Iterator
         }
 
         // The REST version returns the executionDuration in a String format. If is a string should be ready to go
-        if(isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
+        if (isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
             return $metrics;
         }
 

--- a/Datastore/src/EntityPageIterator.php
+++ b/Datastore/src/EntityPageIterator.php
@@ -65,11 +65,11 @@ class EntityPageIterator implements \Iterator
     }
 
     /**
-     * Get the ExplainMetrics object if included on the request options
+     * Get the ExplainMetrics object if included on the request options.
      *
      * @return null|array
      */
-    public function getExplainMetrics() : null|array
+    public function getExplainMetrics(): null|array
     {
         if (is_null($this->page)) {
             return null;

--- a/Datastore/src/EntityPageIterator.php
+++ b/Datastore/src/EntityPageIterator.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Datastore;
 
 use Google\Cloud\Core\Iterator\PageIteratorTrait;
+use Google\Cloud\Datastore\V1\ExplainMetrics;
 
 /**
  * Iterates over a set of pages containing {@see \Google\Cloud\Datastore\Entity}
@@ -61,5 +62,23 @@ class EntityPageIterator implements \Iterator
         $this->moreResultsType = $this->page['batch']['moreResults'] ?? null;
 
         return $this->get($this->itemsPath, $this->page);
+    }
+
+    /**
+     * Get the ExplainMetrics object if included on the request options
+     *
+     * @return null|array
+     */
+    public function getExplainMetrics() : null|array
+    {
+        if (is_null($this->page)) {
+            return null;
+        }
+
+        if (!isset($this->page['explainMetrics'])) {
+            return null;
+        }
+
+        return $this->page['explainMetrics'];
     }
 }

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -515,7 +515,6 @@ class Operation
                     $options['namespaceId'],
                     $options['databaseId']
                 ),
-                'explainOptions' => $options['explainOptions'],
                 $runQueryObj->queryKey() => $requestQueryArr,
             ] + $this->readOptions($options) + $options;
 
@@ -580,6 +579,10 @@ class Operation
             'namespaceId' => $this->namespaceId,
             'databaseId' => $this->databaseId,
         ];
+
+        if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
+            throw new InvalidArgumentException('The explainOptions parameter needs to be an instance of the ExplainOptions class');
+        }
 
         $args = [
             'query' => [],

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -458,7 +458,8 @@ class Operation
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type string $databaseId ID of the database to which the entities belong.
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
-     *     @type ExplainMetrics $explainMetrics The ExplainMetrics object for query stats. {@see \Google\Cloud\Datastore\V1\ExplainOptions}
+     *     @type ExplainMetrics $explainMetrics The ExplainMetrics object for query stats.
+     *           {@see \Google\Cloud\Datastore\V1\ExplainOptions}
      * }
      * @return EntityIterator<EntityInterface>
      * @throws InvalidArgumentException
@@ -581,7 +582,9 @@ class Operation
         ];
 
         if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
-            throw new InvalidArgumentException('The explainOptions parameter needs to be an instance of the ExplainOptions class');
+            throw new InvalidArgumentException(
+                'The explainOptions parameter needs to be an instance of the ExplainOptions class'
+            );
         }
 
         $args = [

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -25,7 +25,9 @@ use Google\Cloud\Datastore\Query\AggregationQuery;
 use Google\Cloud\Datastore\Query\AggregationQueryResult;
 use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
+use Google\Cloud\Datastore\V1\ExplainOptions;
 use Google\Cloud\Datastore\V1\QueryResultBatch\MoreResultsType;
+use InvalidArgumentException;
 
 /**
  * Run lookups and queries and commit changes.
@@ -456,8 +458,10 @@ class Operation
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      *     @type string $databaseId ID of the database to which the entities belong.
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
+     *     @type ExplainMetrics $explainMetrics The ExplainMetrics object for query stats. {@see \Google\Cloud\Datastore\V1\ExplainOptions}
      * }
      * @return EntityIterator<EntityInterface>
+     * @throws InvalidArgumentException
      */
     public function runQuery(QueryInterface $query, array $options = [])
     {
@@ -466,6 +470,10 @@ class Operation
             'namespaceId' => $this->namespaceId,
             'databaseId' => $this->databaseId,
         ];
+
+        if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
+            throw new InvalidArgumentException('The explainOptions option should be an instance of ExplainOptions.');
+        }
 
         $iteratorConfig = [
             'itemsKey' => 'batch.entityResults',
@@ -507,6 +515,7 @@ class Operation
                     $options['namespaceId'],
                     $options['databaseId']
                 ),
+                'explainOptions' => $options['explainOptions'],
                 $runQueryObj->queryKey() => $requestQueryArr,
             ] + $this->readOptions($options) + $options;
 

--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -583,7 +583,7 @@ class Operation
 
         if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
             throw new InvalidArgumentException(
-                'The explainOptions parameter needs to be an instance of the ExplainOptions class'
+                'The explainOptions option needs to be an instance of the ExplainOptions class'
             );
         }
 

--- a/Datastore/src/Query/AggregationQueryResult.php
+++ b/Datastore/src/Query/AggregationQueryResult.php
@@ -108,7 +108,7 @@ class AggregationQueryResult
             $this->readTime = $result['batch']['readTime'];
         }
         if (isset($result['explainMetrics'])) {
-            $metricsJson = json_encode($this->fixDurationFormat($result['explainMetrics']));
+            $metricsJson = json_encode($result['explainMetrics']);
             $metrics = new ExplainMetrics();
             $metrics->mergeFromJsonString($metricsJson);
             $this->explainMetrics = $metrics;
@@ -192,28 +192,5 @@ class AggregationQueryResult
     public function getExplainMetrics(): null|ExplainMetrics
     {
         return $this->explainMetrics;
-    }
-
-    private function fixDurationFormat(array $metrics): array
-    {
-        // The current protobuf library does not support the current json representation
-        // of the well-known type Duration.
-        // Hence we have to convert the object format into a string format for the merging from json to work.
-        // If the protobuf library gets updated, this should be removed.
-        if (!isset($metrics['executionStats']) && !isset($metrics['executionStats']['executionDuration'])) {
-            return $metrics;
-        }
-
-        // The REST version returns the executionDuration in a String format. If is a string should be ready to go
-        if (isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
-            return $metrics;
-        }
-
-        $seconds = $metrics['executionStats']['executionDuration']['seconds'];
-        $nanos = str_pad($metrics['executionStats']['executionDuration']['nanos'], 9, 0, STR_PAD_LEFT);
-
-        $metrics['executionStats']['executionDuration'] = "{$seconds}.{$nanos}s";
-
-        return $metrics;
     }
 }

--- a/Datastore/src/Query/AggregationQueryResult.php
+++ b/Datastore/src/Query/AggregationQueryResult.php
@@ -203,6 +203,11 @@ class AggregationQueryResult
             return $metrics;
         }
 
+        // The REST version returns the executionDuration in a String format. If is a string should be ready to go
+        if(isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
+            return $metrics;
+        }
+
         $seconds = $metrics['executionStats']['executionDuration']['seconds'];
         $nanos = str_pad($metrics['executionStats']['executionDuration']['nanos'], 9, 0, STR_PAD_LEFT);
 

--- a/Datastore/src/Query/AggregationQueryResult.php
+++ b/Datastore/src/Query/AggregationQueryResult.php
@@ -189,14 +189,15 @@ class AggregationQueryResult
      *
      * @return null|ExplainMetrics
      */
-    public function getExplainMetrics()
+    public function getExplainMetrics(): null|ExplainMetrics
     {
         return $this->explainMetrics;
     }
 
-    private function fixDurationFormat(array $metrics) : array
+    private function fixDurationFormat(array $metrics): array
     {
-        // The current protobuf library does not support the current json representation of the well-known type Duration.
+        // The current protobuf library does not support the current json representation
+        // of the well-known type Duration.
         // Hence we have to convert the object format into a string format for the merging from json to work.
         // If the protobuf library gets updated, this should be removed.
         if (!isset($metrics['executionStats']) && !isset($metrics['executionStats']['executionDuration'])) {
@@ -204,7 +205,7 @@ class AggregationQueryResult
         }
 
         // The REST version returns the executionDuration in a String format. If is a string should be ready to go
-        if(isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
+        if (isset($metrics['executionStats']) && is_string($metrics['executionStats']['executionDuration'])) {
             return $metrics;
         }
 

--- a/Datastore/tests/System/AggregationQueryTest.php
+++ b/Datastore/tests/System/AggregationQueryTest.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Datastore\Tests\System;
 
 use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Datastore\Query\Aggregation;
+use Google\Cloud\Datastore\V1\ExplainOptions;
+use InvalidArgumentException;
 
 /**
  * @group datastore
@@ -109,6 +111,63 @@ class AggregationQueryTest extends DatastoreMultipleDbTestCase
         $results = $client->runAggregationQuery($aggregationQuery);
 
         $this->compareResult($expected, $results->get('result'));
+    }
+
+     /**
+     * @dataProvider filterCases
+     * @dataProvider cornerCases
+     */
+    public function testAggregationQueryExplainOptions(DatastoreClient $client, $type, $property, $expected)
+    {
+        $this->skipEmulatorTests();
+        $aggregation = (is_null($property) ? Aggregation::$type() : Aggregation::$type($property));
+        $aggregationQuery = $client->query()
+            ->kind(self::$kind)
+            ->aggregation($aggregation->alias('result'));
+
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(true);
+
+        $queryOptions = [
+            'explainOptions' => $explainOptions
+        ];
+
+        $results = $client->runAggregationQuery($aggregationQuery, $queryOptions);
+        $explainMetrics = $results->getExplainMetrics();
+
+        $this->compareResult($expected, $results->get('result'));
+        $this->assertNotEmpty($explainMetrics);
+        $this->assertNotEmpty($explainMetrics->getPlanSummary());
+        $this->assertNotEmpty($explainMetrics->getExecutionStats());
+    }
+
+    /**
+     * @dataProvider filterCases
+     * @dataProvider cornerCases
+     */
+    public function testAggregationExplainFalseDoesNotContainExecution(DatastoreClient $client, $type, $property, $expected)
+    {
+        $this->skipEmulatorTests();
+        $aggregation = (is_null($property) ? Aggregation::$type() : Aggregation::$type($property));
+        $aggregationQuery = $client->query()
+            ->kind(self::$kind)
+            ->aggregation($aggregation->alias('result'));
+
+        $explainOptions = new ExplainOptions();
+
+        $queryOptions = [
+            'explainOptions' => $explainOptions
+        ];
+
+        $results = $client->runAggregationQuery($aggregationQuery, $queryOptions);
+        $explainMetrics = $results->getExplainMetrics();
+
+        $this->assertNotEmpty($explainMetrics);
+        $this->assertNotEmpty($explainMetrics->getPlanSummary());
+        $this->assertNull($explainMetrics->getExecutionStats());
+
+        $this->expectException(InvalidArgumentException::class);
+        $results->get('result');
     }
 
     /**

--- a/Datastore/tests/System/AggregationQueryTest.php
+++ b/Datastore/tests/System/AggregationQueryTest.php
@@ -145,7 +145,7 @@ class AggregationQueryTest extends DatastoreMultipleDbTestCase
      * @dataProvider filterCases
      * @dataProvider cornerCases
      */
-    public function testAggregationExplainFalseDoesNotContainExecution(DatastoreClient $client, $type, $property, $expected)
+    public function testExplainFalseDoesNotContainExecution(DatastoreClient $client, $type, $property, $expected)
     {
         $this->skipEmulatorTests();
         $aggregation = (is_null($property) ? Aggregation::$type() : Aggregation::$type($property));

--- a/Datastore/tests/System/RunQueryTest.php
+++ b/Datastore/tests/System/RunQueryTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Datastore\Tests\System;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Datastore\Query\Aggregation;
+use Google\Cloud\Datastore\V1\ExplainOptions;
 
 /**
  * @group datastore
@@ -102,6 +103,65 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
         $results = iterator_to_array($client->runQuery($query));
 
         $this->assertCount(0, $results);
+    }
+
+    /**
+     * @dataProvider defaultDbClientProvider
+     */
+    public function testExplainMetricsReturnsResultsAndInformation(DatastoreClient $client)
+    {
+        $explainOptions = new ExplainOptions();
+        $queryOptions = [
+            'explainOptions' => $explainOptions
+        ];
+
+        $query = $client->query()
+            ->kind(self::$kind)
+            ->order('knownDances');
+
+        $response = $client->runQuery($query, $queryOptions);
+
+        $this->assertNotEmpty($response->getExplainMetrics());
+        $this->assertNotEmpty($response->getExplainMetrics()->getPlanSummary());
+        $this->assertNull($response->getExplainMetrics()->getExecutionStats());
+
+        $results = iterator_to_array($response);
+
+        // $this->assertEquals(self::$data[0], $results[0]->get());
+        // $this->assertEquals(self::$data[1], $results[1]->get());
+        // $this->assertEquals(self::$data[2], $results[2]->get());
+        // $this->assertEquals(self::$data[3], $results[3]->get());
+        $this->assertCount(0, $results);
+    }
+
+    /**
+     * @dataProvider defaultDbClientProvider
+     */
+    public function testExplainMetricsReturnsAllData(DatastoreClient $client)
+    {
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(true);
+        $queryOptions = [
+            'explainOptions' => $explainOptions
+        ];
+
+        $query = $client->query()
+            ->kind(self::$kind)
+            ->order('knownDances');
+
+        $response = $client->runQuery($query, $queryOptions);
+
+        $this->assertNotEmpty($response->getExplainMetrics());
+        $this->assertNotEmpty($response->getExplainMetrics()->getPlanSummary());
+        $this->assertNotEmpty($response->getExplainMetrics()->getExecutionStats());
+
+        $results = iterator_to_array($response);
+
+        $this->assertEquals(self::$data[0], $results[0]->get());
+        $this->assertEquals(self::$data[1], $results[1]->get());
+        $this->assertEquals(self::$data[2], $results[2]->get());
+        $this->assertEquals(self::$data[3], $results[3]->get());
+        $this->assertCount(4, $results);
     }
 
     /**

--- a/Datastore/tests/System/RunQueryTest.php
+++ b/Datastore/tests/System/RunQueryTest.php
@@ -108,8 +108,9 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
     /**
      * @dataProvider defaultDbClientProvider
      */
-    public function testExplainMetricsReturnsResultsAndInformation(DatastoreClient $client)
+    public function testExplainMetricsReturnsPlanSummary(DatastoreClient $client)
     {
+        // This is equivalent to $explainOptions->setAnalyze(false);
         $explainOptions = new ExplainOptions();
         $queryOptions = [
             'explainOptions' => $explainOptions
@@ -127,10 +128,6 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
 
         $results = iterator_to_array($response);
 
-        // $this->assertEquals(self::$data[0], $results[0]->get());
-        // $this->assertEquals(self::$data[1], $results[1]->get());
-        // $this->assertEquals(self::$data[2], $results[2]->get());
-        // $this->assertEquals(self::$data[3], $results[3]->get());
         $this->assertCount(0, $results);
     }
 

--- a/Datastore/tests/System/RunQueryTest.php
+++ b/Datastore/tests/System/RunQueryTest.php
@@ -110,6 +110,7 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
      */
     public function testExplainMetricsReturnsPlanSummary(DatastoreClient $client)
     {
+        $this->skipEmulatorTests();
         // This is equivalent to $explainOptions->setAnalyze(false);
         $explainOptions = new ExplainOptions();
         $queryOptions = [
@@ -136,6 +137,7 @@ class RunQueryTest extends DatastoreMultipleDbTestCase
      */
     public function testExplainMetricsReturnsAllData(DatastoreClient $client)
     {
+        $this->skipEmulatorTests();
         $explainOptions = new ExplainOptions();
         $explainOptions->setAnalyze(true);
         $queryOptions = [

--- a/Datastore/tests/Unit/DatastoreClientTest.php
+++ b/Datastore/tests/Unit/DatastoreClientTest.php
@@ -775,8 +775,6 @@ class DatastoreClientTest extends TestCase
         $query->queryKey()->willReturn('gqlQuery');
         $query->queryObject()->willReturn(['queryString' => 'SELECT 1=1']);
 
-
-
         iterator_to_array($this->client->runQuery($query->reveal(), ['explainOptions' => $explainOptions]));
     }
 

--- a/Datastore/tests/Unit/DatastoreClientTest.php
+++ b/Datastore/tests/Unit/DatastoreClientTest.php
@@ -775,7 +775,9 @@ class DatastoreClientTest extends TestCase
         $query->queryKey()->willReturn('gqlQuery');
         $query->queryObject()->willReturn(['queryString' => 'SELECT 1=1']);
 
-        iterator_to_array($this->client->runQuery($query->reveal(), ['explainOptions' => $explainOptions]));
+        $result = $this->client->runQuery($query->reveal(), ['explainOptions' => $explainOptions]);
+
+        iterator_to_array($result);
     }
 
     public function aggregationReturnTypesCases()

--- a/Datastore/tests/Unit/EntityIteratorTest.php
+++ b/Datastore/tests/Unit/EntityIteratorTest.php
@@ -67,6 +67,8 @@ class EntityIteratorTest extends TestCase
         $pageIterator->nextResultToken()
             ->willReturn(null)
             ->shouldBeCalled(1);
+        $pageIterator->rewind()
+            ->shouldBeCalledTimes(1);
 
         $response = new EntityIterator($pageIterator->reveal());
 

--- a/Datastore/tests/Unit/EntityIteratorTest.php
+++ b/Datastore/tests/Unit/EntityIteratorTest.php
@@ -46,12 +46,12 @@ class EntityIteratorTest extends TestCase
     public function testGetExplainMetrics()
     {
         $explainMetrics = [
-            "planSummary" => [
-                "indexesUsed" => [
+            'planSummary' => [
+                'indexesUsed' => [
                     [
-                        "fields" => [
-                            "query_scope" => "Collection group",
-                            "properties" => "(done ASC, __name__ ASC)"
+                        'fields' => [
+                            'query_scope' => 'Collection group',
+                            'properties' => '(done ASC, __name__ ASC)'
                         ]
                     ]
                 ]


### PR DESCRIPTION
This PR adds support for the `ExplainOptions` message type being passed to the `runQuery` and `runAggregationQuery` methods:

```php
use Google\Cloud\Datastore\DatastoreClient;
use Google\Cloud\Datastore\V1\ExplainOptions;

$datastore = new DatastoreClient([
    'projectId' => <project id>,
    'databaseId' => <database id>
]);

$query = $datastore->query();
$query->kind('Task');
$query->filter('done', '=', false);

$explainOptions = new ExplainOptions();
$explainOptions->setAnalyze(true);

$response = $datastore->runQuery($query, [
    'explainOptions' => $explainOptions
])

var_dump ($response->getExplainMetrics()) //This contains all the explain metrics, se the ExplainMetrics proto.
```

b/364933728