### PR TITLE
feat: Add the ExplainOptions class support

### DIFF
--- a/Firestore/src/AggregateQuery.php
+++ b/Firestore/src/AggregateQuery.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Firestore;
 
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
+use Google\Cloud\Firestore\V1\ExplainOptions;
+use InvalidArgumentException;
 
 /**
  * A Cloud Firestore Aggregate Query.
@@ -98,12 +100,19 @@ class AggregateQuery
      *     Configuration options is an array.
      *
      *     @type Timestamp $readTime Reads entities as they were at the given timestamp.
+     *     @type ExplainOptions $explainOptions An instance of the ExplainOptions class.
+     *           {@see \Google\Cloud\Firestore\ExplainOptions}
      * }
      * @return AggregateQuerySnapshot
      */
     public function getSnapshot($options = [])
     {
         $parsedAggregates = [];
+
+        if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
+            throw new InvalidArgumentException('The explainOptions option must be an instance of the ExplainOptions class.');
+        }
+
         foreach ($this->aggregates as $aggregate) {
             $parsedAggregates[] = $aggregate->getProps();
         }

--- a/Firestore/src/AggregateQuery.php
+++ b/Firestore/src/AggregateQuery.php
@@ -110,7 +110,9 @@ class AggregateQuery
         $parsedAggregates = [];
 
         if (isset($options['explainOptions']) && !$options['explainOptions'] instanceof ExplainOptions) {
-            throw new InvalidArgumentException('The explainOptions option must be an instance of the ExplainOptions class.');
+            throw new InvalidArgumentException(
+                'The explainOptions option must be an instance of the ExplainOptions class.'
+            );
         }
 
         foreach ($this->aggregates as $aggregate) {

--- a/Firestore/src/AggregateQuerySnapshot.php
+++ b/Firestore/src/AggregateQuerySnapshot.php
@@ -102,7 +102,8 @@ class AggregateQuerySnapshot
     }
 
     /**
-     * Get the ExplainMetrics object (TODO)
+     * Get the ExplainMetrics if the explainOptions was supplied
+     * {@see \Google\Cloud\Firestore\ExplainOptions}
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/src/AggregateQuerySnapshot.php
+++ b/Firestore/src/AggregateQuerySnapshot.php
@@ -106,7 +106,7 @@ class AggregateQuerySnapshot
      * If the explainOptions analyze was set to false, the query gets
      * planned and not executed returning only the planSummary and not
      * the executionStats nor the result.
-     * {@see \Google\Cloud\Firestore\ExplainOptions}
+     * {@see \Google\Cloud\Firestore\V1\ExplainMetrics}
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/src/AggregateQuerySnapshot.php
+++ b/Firestore/src/AggregateQuerySnapshot.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Firestore;
 
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
+use Google\Cloud\Firestore\V1\ExplainMetrics;
 
 /**
  * Represents the result set of an AggregateQuery.
@@ -54,6 +55,11 @@ class AggregateQuerySnapshot
     private $transaction;
 
     /**
+     * @var null|ExplainMetrics
+     */
+    private null|ExplainMetrics $explainMetrics;
+
+    /**
      * An immutable snapshot of aggregate query results.
      *
      * @param array $snapshot Result of an AggregateQuery.
@@ -69,6 +75,9 @@ class AggregateQuerySnapshot
         }
         if (isset($snapshot['result']['aggregateFields'])) {
             $this->aggregateFields = $snapshot['result']['aggregateFields'];
+        }
+        if (isset($snapshot['explainMetrics'])) {
+            $this->explainMetrics = $this->parseMetrics($snapshot['explainMetrics']);
         }
     }
 
@@ -90,6 +99,16 @@ class AggregateQuerySnapshot
     public function getReadTime()
     {
         return $this->readTime;
+    }
+
+    /**
+     * Get the ExplainMetrics object (TODO)
+     *
+     * @return null|ExplainMetrics
+     */
+    public function getExplainMetrics()
+    {
+        return $this->explainMetrics;
     }
 
     /**
@@ -115,5 +134,14 @@ class AggregateQuerySnapshot
             return $result[$key];
         }
         return $result;
+    }
+
+    private function parseMetrics(array $metrics): ExplainMetrics
+    {
+        $explainMetrics = new ExplainMetrics();
+        $json = json_encode($metrics, true);
+        $explainMetrics->mergeFromJsonString($json);
+
+        return $explainMetrics;
     }
 }

--- a/Firestore/src/AggregateQuerySnapshot.php
+++ b/Firestore/src/AggregateQuerySnapshot.php
@@ -102,11 +102,10 @@ class AggregateQuerySnapshot
     }
 
     /**
-     * Get the ExplainMetrics if the explainOptions was supplied.
-     * If the explainOptions analyze was set to false, the query gets
-     * planned and not executed returning only the planSummary and not
-     * the executionStats nor the result.
-     * {@see \Google\Cloud\Firestore\V1\ExplainMetrics}
+     * Gets `ExplainMetrics` when the `explainOptions` option is supplied.
+     * If `ExplainOptions::setAnalyze` is set to `false`, the query is
+     * planned and not executed, returning only the {@see V1\PlanSummary}
+     * instead of the {@see V1\ExecutionStats} and result.
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/src/AggregateQuerySnapshot.php
+++ b/Firestore/src/AggregateQuerySnapshot.php
@@ -102,7 +102,10 @@ class AggregateQuerySnapshot
     }
 
     /**
-     * Get the ExplainMetrics if the explainOptions was supplied
+     * Get the ExplainMetrics if the explainOptions was supplied.
+     * If the explainOptions analyze was set to false, the query gets
+     * planned and not executed returning only the planSummary and not
+     * the executionStats nor the result.
      * {@see \Google\Cloud\Firestore\ExplainOptions}
      *
      * @return null|ExplainMetrics

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -85,7 +85,7 @@ class Grpc implements ConnectionInterface
             'google.protobuf.Timestamp' => function ($v) {
                 return $this->formatTimestampFromApi($v);
             },
-            'google.protobuf.Duration' => function($v) {
+            'google.protobuf.Duration' => function ($v) {
                 return $this->formatDurationFromApi($v);
             }
         ], [], [

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -85,6 +85,9 @@ class Grpc implements ConnectionInterface
             'google.protobuf.Timestamp' => function ($v) {
                 return $this->formatTimestampFromApi($v);
             },
+            'google.protobuf.Duration' => function($v) {
+                return $this->formatDurationFromApi($v);
+            }
         ], [], [
             'google.protobuf.Int32Value' => function ($v) {
                 return ['value' => $v];

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -21,10 +21,12 @@ use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\FieldValue\FieldValueInterface;
+use Google\Cloud\Firestore\V1\ExplainMetrics;
 use Google\Cloud\Firestore\V1\StructuredQuery\CompositeFilter\Operator;
 use Google\Cloud\Firestore\V1\StructuredQuery\Direction;
 use Google\Cloud\Firestore\V1\StructuredQuery\FieldFilter\Operator as FieldFilterOperator;
 use Google\Cloud\Firestore\V1\StructuredQuery\UnaryFilter\Operator as UnaryFilterOperator;
+use InvalidArgumentException;
 
 /**
  * A Cloud Firestore Query.
@@ -186,6 +188,9 @@ class Query
      */
     public function count(array $options = [])
     {
+        if (isset($options['explainOptions'])) {
+            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+        }
         $aggregateQuery = $this->addAggregation(Aggregate::count()->alias('count'));
 
         $aggregationResult = $aggregateQuery->getSnapshot($options);
@@ -215,6 +220,9 @@ class Query
      */
     public function sum(string $field, array $options = [])
     {
+        if (isset($options['explainOptions'])) {
+            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+        }
         $aggregateQuery = $this->addAggregation(Aggregate::sum($field)->alias('sum'));
 
         $aggregationResult = $aggregateQuery->getSnapshot($options);
@@ -244,6 +252,9 @@ class Query
      */
     public function avg(string $field, array $options = [])
     {
+        if (isset($options['explainOptions'])) {
+            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+        }
         $aggregateQuery = $this->addAggregation(Aggregate::avg($field)->alias('avg'));
 
         $aggregationResult = $aggregateQuery->getSnapshot($options);
@@ -317,7 +328,10 @@ class Query
             'query' => $this->query,
             'limitToLast' => $this->limitToLast
         ]);
-        $rows = (new ExponentialBackoff($maxRetries))->execute(function () use ($query, $options) {
+
+        $explainMetrics = null;
+
+        $rows = (new ExponentialBackoff($maxRetries))->execute(function () use ($query, $options, &$explainMetrics) {
 
             $generator = $this->connection->runQuery($this->arrayFilterRemoveNull([
                 'parent' => $this->parentName,
@@ -355,6 +369,10 @@ class Query
                     $out[] = $this->createSnapshotWithData($this->valueMapper, $ref, $document);
                 }
 
+                if (isset($result['explainMetrics'])) {
+                    $explainMetrics = $this->parseMetrics($result['explainMetrics']);
+                }
+
                 $generator->next();
             }
 
@@ -365,7 +383,7 @@ class Query
                 : $out;
         });
 
-        return new QuerySnapshot($this, $rows);
+        return new QuerySnapshot($this, $rows, $explainMetrics);
     }
 
     /**
@@ -1180,5 +1198,14 @@ class Query
         }
 
         return $filters;
+    }
+
+    private function parseMetrics(array $metrics): ExplainMetrics
+    {
+        $explainMetrics = new ExplainMetrics();
+        $json = json_encode($metrics, true);
+        $explainMetrics->mergeFromJsonString($json);
+
+        return $explainMetrics;
     }
 }

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -189,7 +189,9 @@ class Query
     public function count(array $options = [])
     {
         if (isset($options['explainOptions'])) {
-            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+            throw new InvalidArgumentException(
+                'The explainOptions option is not supported in the ' . __FUNCTION__ . ' method'
+            );
         }
         $aggregateQuery = $this->addAggregation(Aggregate::count()->alias('count'));
 
@@ -221,7 +223,9 @@ class Query
     public function sum(string $field, array $options = [])
     {
         if (isset($options['explainOptions'])) {
-            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+            throw new InvalidArgumentException(
+                'The explainOptions option is not supported in the ' . __FUNCTION__ . ' method'
+            );
         }
         $aggregateQuery = $this->addAggregation(Aggregate::sum($field)->alias('sum'));
 
@@ -253,7 +257,9 @@ class Query
     public function avg(string $field, array $options = [])
     {
         if (isset($options['explainOptions'])) {
-            throw new InvalidArgumentException('The explainOptions option is not supported in the ' . __FUNCTION__ . ' method');
+            throw new InvalidArgumentException(
+                'The explainOptions option is not supported in the ' . __FUNCTION__ . ' method'
+            );
         }
         $aggregateQuery = $this->addAggregation(Aggregate::avg($field)->alias('avg'));
 

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -118,11 +118,10 @@ class QuerySnapshot implements \IteratorAggregate
     }
 
     /**
-     * Get the ExplainMetrics if the explainOptions was supplied.
-     * If the explainOptions analyze was set to false, the query gets
-     * planned and not executed returning only the planSummary and not
-     * the executionStats nor the result.
-     * {@see \Google\Cloud\Firestore\V1\ExplainMetrics}
+     * Gets `ExplainMetrics` when the `explainOptions` option is supplied.
+     * If `ExplainOptions::setAnalyze` is set to `false`, the query is
+     * planned and not executed, returning only the {@see V1\PlanSummary}
+     * instead of the {@see V1\ExecutionStats} and result.
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -118,8 +118,10 @@ class QuerySnapshot implements \IteratorAggregate
     }
 
     /**
-     * Return the explainMetrics option if the explainOptions was supplied
-     * {@see \Google\Cloud\Firestore\ExplainOptions}
+     * Get the ExplainMetrics if the explainOptions was supplied.
+     * If the explainOptions analyze was set to false, the query gets
+     * planned and not executed returning only the planSummary and not
+     * the executionStats nor the result.
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Firestore;
 
+use Google\Cloud\Firestore\V1\ExplainMetrics;
+
 /**
  * Represents the result set of a Cloud Firestore Query.
  *
@@ -51,15 +53,22 @@ class QuerySnapshot implements \IteratorAggregate
     private $rows;
 
     /**
+     * @var null|ExplainMetrics
+     */
+    private null|ExplainMetrics $explainMetrics;
+
+    /**
      * @param Query $query The Query which generated this snapshot.
      * @param DocumentSnapshot[] $rows The query result rows.
      */
     public function __construct(
         Query $query,
-        array $rows
+        array $rows,
+        null|ExplainMetrics $explainMetrics = null
     ) {
         $this->query = $query;
         $this->rows = $rows;
+        $this->explainMetrics = $explainMetrics;
     }
 
     /**
@@ -106,6 +115,11 @@ class QuerySnapshot implements \IteratorAggregate
     public function rows()
     {
         return $this->rows;
+    }
+
+    public function getExplainMetrics()
+    {
+        return $this->explainMetrics;
     }
 
     /**

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -117,6 +117,12 @@ class QuerySnapshot implements \IteratorAggregate
         return $this->rows;
     }
 
+    /**
+     * Return the explainMetrics option if the explainOptions was supplied
+     * {@see \Google\Cloud\Firestore\ExplainOptions}
+     *
+     * @return null|ExplainMetrics
+     */
     public function getExplainMetrics()
     {
         return $this->explainMetrics;

--- a/Firestore/src/QuerySnapshot.php
+++ b/Firestore/src/QuerySnapshot.php
@@ -122,6 +122,7 @@ class QuerySnapshot implements \IteratorAggregate
      * If the explainOptions analyze was set to false, the query gets
      * planned and not executed returning only the planSummary and not
      * the executionStats nor the result.
+     * {@see \Google\Cloud\Firestore\V1\ExplainMetrics}
      *
      * @return null|ExplainMetrics
      */

--- a/Firestore/tests/System/AggregateQueryTest.php
+++ b/Firestore/tests/System/AggregateQueryTest.php
@@ -190,7 +190,7 @@ class AggregateQueryTest extends FirestoreTestCase
         );
     }
 
-    public function testExplainOptionsAnalyzeFalseReturnsPlan()
+    public function testAggregationExplainOptionsWithAnalyzeFalseReturnsPlanSummaryOnly()
     {
         $docsToAdd = [['foo' => 'bar', 'hello' => 'world', 'good' => 'night']];
 
@@ -218,7 +218,7 @@ class AggregateQueryTest extends FirestoreTestCase
         $result->get('total');
     }
 
-    public function testExplainOptionsAnalyzeTrue()
+    public function testAggregationExplainOptionsWithAnalyzeTrueReturnsAll()
     {
         $docsToAdd = [['foo' => 'bar', 'hello' => 'world', 'good' => 'night']];
 

--- a/Firestore/tests/System/AggregateQueryTest.php
+++ b/Firestore/tests/System/AggregateQueryTest.php
@@ -212,7 +212,8 @@ class AggregateQueryTest extends FirestoreTestCase
         $this->assertNull($explainMetrics->getExecutionStats());
 
         // When setting the ExplainOptions::analyze to false, the 'total' alias
-        // should be empty. Get throws an error when the alias is not found
+        // should be empty. The AggregateQuerySnapshot::get() method
+        // throws an error when the alias is not found
         $this->expectException(InvalidArgumentException::class);
         $result->get('total');
     }

--- a/Firestore/tests/System/AggregateQueryTest.php
+++ b/Firestore/tests/System/AggregateQueryTest.php
@@ -210,8 +210,10 @@ class AggregateQueryTest extends FirestoreTestCase
         $this->assertNotNull($explainMetrics);
         $this->assertNotNull($explainMetrics->getPlanSummary());
         $this->assertNull($explainMetrics->getExecutionStats());
-        $this->expectException(InvalidArgumentException::class);
 
+        // When setting the ExplainOptions::analyze to false, the 'total' alias
+        // should be empty. Get throws an error when the alias is not found
+        $this->expectException(InvalidArgumentException::class);
         $result->get('total');
     }
 

--- a/Firestore/tests/System/GetAllDocumentsTest.php
+++ b/Firestore/tests/System/GetAllDocumentsTest.php
@@ -18,7 +18,6 @@
 namespace Google\Cloud\Firestore\Tests\System;
 
 use Google\Cloud\Firestore\DocumentSnapshot;
-use Google\Cloud\Firestore\V1\ExplainOptions;
 
 /**
  * @group firestore
@@ -62,50 +61,6 @@ class GetAllDocumentsTest extends FirestoreTestCase
         $res = $f->documents($paths);
 
         $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
-        foreach ($res as $i => $document) {
-            $name = $document->name();
-
-            // check order
-            $this->assertEquals($paths[$i]->name(), $name);
-
-            $exist = array_key_exists($name, self::$refsExist);
-
-            $this->assertEquals($exist, $document->exists());
-        }
-    }
-
-    public function textExplainOptionsWithAnalyzeFalseReturnsPlanSummaryOnly()
-    {
-        $f = self::$client;
-
-        $explainOptions = new ExplainOptions();
-        $explainOptions->setAnalyze(false);
-
-        $paths = $this->interleave();
-        $res = $f->documents($paths);
-        $explainMetrics = $res->getExplainMetrics();
-
-        $this->assertNotNull($explainMetrics->getPlanSummary());
-        $this->assertNull($explainMetrics->getExecutionStats());
-
-        $this->assertEmpty($res->rows());
-    }
-
-    public function textExplainOptionsWithAnalyzeReturnsAllData()
-    {
-        $f = self::$client;
-
-        $explainOptions = new ExplainOptions();
-        $explainOptions->setAnalyze(false);
-
-        $paths = $this->interleave();
-        $res = $f->documents($paths);
-        $explainMetrics = $res->getExplainMetrics();
-
-        $this->assertNotNull($explainMetrics->getPlanSummary());
-        $this->assertNotNull($explainMetrics->getExecutionStats());
-
-         $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
         foreach ($res as $i => $document) {
             $name = $document->name();
 

--- a/Firestore/tests/System/GetAllDocumentsTest.php
+++ b/Firestore/tests/System/GetAllDocumentsTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Firestore\Tests\System;
 
 use Google\Cloud\Firestore\DocumentSnapshot;
+use Google\Cloud\Firestore\V1\ExplainOptions;
 
 /**
  * @group firestore
@@ -61,6 +62,50 @@ class GetAllDocumentsTest extends FirestoreTestCase
         $res = $f->documents($paths);
 
         $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
+        foreach ($res as $i => $document) {
+            $name = $document->name();
+
+            // check order
+            $this->assertEquals($paths[$i]->name(), $name);
+
+            $exist = array_key_exists($name, self::$refsExist);
+
+            $this->assertEquals($exist, $document->exists());
+        }
+    }
+
+    public function textExplainOptionsWithAnalyzeFalseReturnsPlanSummaryOnly()
+    {
+        $f = self::$client;
+
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(false);
+
+        $paths = $this->interleave();
+        $res = $f->documents($paths);
+        $explainMetrics = $res->getExplainMetrics();
+
+        $this->assertNotNull($explainMetrics->getPlanSummary());
+        $this->assertNull($explainMetrics->getExecutionStats());
+
+        $this->assertEmpty($res->rows());
+    }
+
+    public function textExplainOptionsWithAnalyzeReturnsAllData()
+    {
+        $f = self::$client;
+
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(false);
+
+        $paths = $this->interleave();
+        $res = $f->documents($paths);
+        $explainMetrics = $res->getExplainMetrics();
+
+        $this->assertNotNull($explainMetrics->getPlanSummary());
+        $this->assertNotNull($explainMetrics->getExecutionStats());
+
+         $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
         foreach ($res as $i => $document) {
             $name = $document->name();
 

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore\Tests\System;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\FieldPath;
 use Google\Cloud\Firestore\Filter;
+use Google\Cloud\Firestore\V1\ExplainOptions;
 
 /**
  * @group firestore
@@ -77,6 +78,53 @@ class QueryTest extends FirestoreTestCase
             Filter::field('foo', '=', $randomVal)
         ));
         $this->assertEquals($res->name(), $doc->name());
+    }
+
+    public function testExplainOptionsFalseReturnsPlanSummaryOnly()
+    {
+        $randomVal = base64_encode(random_bytes(10));
+        $doc = $this->insertDoc([
+            'foo' => $randomVal
+        ]);
+
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(false);
+
+        $res = $this->query->where('foo', '=', $randomVal)
+            ->documents([
+                'explainOptions' => $explainOptions
+            ]);
+
+        $explainMetrics = $res->getExplainMetrics();
+
+        $this->assertNotNull($explainMetrics);
+        $this->assertNotNull($explainMetrics->getPlanSummary());
+        $this->assertNull($explainMetrics->getExecutionStats());
+        $this->assertEmpty(iterator_to_array($res));
+    }
+
+    public function testExplainOptionsTrueReturnsAll()
+    {
+        $randomVal = base64_encode(random_bytes(10));
+        $doc = $this->insertDoc([
+            'foo' => $randomVal
+        ]);
+
+        $explainOptions = new ExplainOptions();
+        $explainOptions->setAnalyze(true);
+
+        $res = $this->query->where('foo', '=', $randomVal)
+            ->documents([
+                'explainOptions' => $explainOptions
+            ]);
+
+        $explainMetrics = $res->getExplainMetrics();
+
+        $this->assertNotNull($explainMetrics);
+        $this->assertNotNull($explainMetrics->getPlanSummary());
+        $this->assertNotNull($explainMetrics->getExecutionStats());
+
+        $this->assertEquals(current(iterator_to_array($res))->name(), $doc->name());
     }
 
     public function testWhereNull()

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -80,7 +80,7 @@ class QueryTest extends FirestoreTestCase
         $this->assertEquals($res->name(), $doc->name());
     }
 
-    public function testExplainOptionsFalseReturnsPlanSummaryOnly()
+    public function testExplainOptionsWithAnalyzeFalseReturnsPlanSummaryOnly()
     {
         $randomVal = base64_encode(random_bytes(10));
         $doc = $this->insertDoc([
@@ -103,7 +103,7 @@ class QueryTest extends FirestoreTestCase
         $this->assertEmpty(iterator_to_array($res));
     }
 
-    public function testExplainOptionsTrueReturnsAll()
+    public function testExplainOptionsWithAnalyzeTrueReturnsAll()
     {
         $randomVal = base64_encode(random_bytes(10));
         $doc = $this->insertDoc([


### PR DESCRIPTION
This adds support for the `explainOptions` class providing some profiling tools.

Example:
```
$snapshot = $firestoreClient->collection('pokemon')
    ->documents([
        'explainOptions' => $explainOptions
    ]);

foreach ($snapshot as $pokemon) {
    printf("Name: " . $pokemon['name'] . "\n");
}

var_dump($snapshot->getExplainMetrics());
```

b/2F364935279