### PR TITLE
fix(Bigtable): always set rowsLimit to 1 for readRow requests

### DIFF
--- a/.github/workflows/conformance-tests-bigtable-proxy.yaml
+++ b/.github/workflows/conformance-tests-bigtable-proxy.yaml
@@ -19,13 +19,13 @@ on:
       - main
     paths:
       - 'Bigtable/**'
-      - '.github/workflows/conformance-tests-bigtable-emulator.yaml'
+      - '.github/workflows/conformance-tests-bigtable-proxy.yaml'
   pull_request:
     paths:
       - 'Bigtable/**'
-      - '.github/workflows/conformance-tests-bigtable-emulator.yaml'
+      - '.github/workflows/conformance-tests-bigtable-proxy.yaml'
   workflow_dispatch:
-name: Run Bigtable Conformance Tests With Emulator
+name: Run Bigtable Conformance Tests With Proxy
 jobs:
   conformance:
     runs-on: ubuntu-latest

--- a/Bigtable/src/Table.php
+++ b/Bigtable/src/Table.php
@@ -345,7 +345,10 @@ class Table
     public function readRow($rowKey, array $options = [])
     {
         return $this->readRows(
-            ['rowKeys' => [$rowKey]] + $options + $this->options
+            [
+                'rowKeys' => [$rowKey],
+                'rowsLimit' => 1,
+            ] + $options + $this->options
         )
             ->readAll()
             ->current();


### PR DESCRIPTION
 - [x] ensure tests pass
 - [x] verify that we want this behavior
 - [x] remove setting `rowsLimit` for `ReadRowRequest` in `ProxyService` 