### PR TITLE
feat: Support for Spanner ReadLockMode

### DIFF
--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Spanner\Connection;
 use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Serializer;
+use Google\ApiCore\ValidationException;
 use Google\Auth\GetUniverseDomainInterface;
 use Google\Cloud\Core\EmulatorTrait;
 use Google\Cloud\Core\GrpcRequestWrapper;

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -1104,6 +1104,12 @@ class Grpc implements ConnectionInterface
             $readWrite = new ReadWrite();
             $options->setReadWrite($readWrite);
             $args = $this->addLarHeader($args, $this->larEnabled);
+
+            if (isset($transactionOptions['readWrite']['readLockMode'])) {
+                // Nested option `readLockMode` inside `readWrite` transactions
+                $readLockModeOption = $transactionOptions['readWrite']['readLockMode'];
+                $options->getReadWrite()->setReadLockMode($readLockModeOption);
+            }
         } elseif (isset($transactionOptions['partitionedDml'])) {
             $pdml = new PartitionedDml();
             $options->setPartitionedDml($pdml);
@@ -1573,6 +1579,32 @@ class Grpc implements ConnectionInterface
             $transactionOptions['readOnly'] = $ro;
         }
 
+        if (isset($transactionOptions['readLockMode'])) {
+            if (isset($transactionOptions['readOnly'])) {
+                throw new ValidationException(
+                    'The readLockMode option is only valid for readWrite transactions.'
+                );
+            }
+
+            if (!isset($transactionOptions['readWrite'])) {
+                $transactionOptions['readWrite'] = [];
+            }
+        }
+
+        if (isset($transactionOptions['readWrite'])) {
+            $rw = $transactionOptions['readWrite'];
+
+            // Format nested options inside readWrite transaction
+            if (isset($transactionOptions['readLockMode'])) {
+                $rw['readLockMode'] = $transactionOptions['readLockMode'];
+
+                // Unset the readLockMode key on the base options array.
+                // If we don't do this it causes issues in the serializer for TransactionOptions
+                unset($transactionOptions['readLockMode']);
+            }
+
+            $transactionOptions['readWrite'] = $rw;
+        }
         return $transactionOptions;
     }
 

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -775,10 +775,8 @@ class Database
      * If you wish Google Cloud PHP to handle retry logic for you (recommended
      * for most cases), use {@see \Google\Cloud\Spanner\Database::runTransaction()}.
      *
-     * Please note that once a transaction reads data, it will lock the read
-     * data, preventing other users from modifying that data. For this reason,
-     * it is important that every transaction commits or rolls back as early as
-     * possible. Do not hold transactions open longer than necessary.
+     * Please note for locking semantics and defaults for the transactions
+     * use {@see \Google\Cloud\Spanner\V1\TransactionOptions\ReadWrite\ReadLockMode}
      *
      * Example:
      * ```
@@ -812,8 +810,8 @@ class Database
             throw new \BadMethodCallException('Nested transactions are not supported by this client.');
         }
 
-        // There isn't anything configurable here.
-        $options['transactionOptions'] = $this->configureTransactionOptions();
+        // Configure readWrite options here. Any nested options for readWrite should be added to this call
+        $options['transactionOptions'] = $this->configureTransactionOptions($options['transactionOptions'] ?? []);
 
         $session = $this->selectSession(
             SessionPoolInterface::CONTEXT_READWRITE,
@@ -840,10 +838,8 @@ class Database
      * exception types will immediately bubble up and will interrupt the retry
      * operation.
      *
-     * Please note that once a transaction reads data, it will lock the read
-     * data, preventing other users from modifying that data. For this reason,
-     * it is important that every transaction commits or rolls back as early as
-     * possible. Do not hold transactions open longer than necessary.
+     * Please note for locking semantics and defaults for the transactions
+     * use {@see \Google\Cloud\Spanner\V1\TransactionOptions\ReadWrite\ReadLockMode}
      *
      * Please also note that nested transactions are NOT supported by this client.
      * Attempting to call `runTransaction` inside a transaction callable will
@@ -920,7 +916,6 @@ class Database
             'maxRetries' => self::MAX_RETRIES,
         ];
 
-        // There isn't anything configurable here.
         $options['transactionOptions'] = $this->configureTransactionOptions($options['transactionOptions'] ?? []);
 
         $session = $this->selectSession(

--- a/Spanner/src/TransactionConfigurationTrait.php
+++ b/Spanner/src/TransactionConfigurationTrait.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner;
 
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
+use Google\Cloud\Spanner\V1\TransactionOptions\ReadWrite\ReadLockMode as ReadLockMode;
 
 /**
  * Configure transaction selection for read, executeSql, rollback and commit.
@@ -150,6 +151,15 @@ trait TransactionConfigurationTrait
 
         if (isset($options['excludeTxnFromChangeStreams'])) {
             $transactionOptions['excludeTxnFromChangeStreams'] = $options['excludeTxnFromChangeStreams'];
+        }
+
+        // Allow for proper configuring of the `readLockMode` if it's set as a base or nested option
+        if (isset($options['readLockMode'])) {
+            $transactionOptions['readWrite']['readLockMode'] = $options['readLockMode'];
+        }
+
+        if (isset($options['readWrite']['readLockMode'])) {
+            $transactionOptions['readWrite']['readLockMode'] = $options['readWrite']['readLockMode'];
         }
 
         return $transactionOptions;


### PR DESCRIPTION
Feature to add `ReadLockMode` option for `ReadWrite` transactions only. Two ways users can set the option -
1) Set it on the base `transactionOption` array like any other txn option. This provides consistency with how our other option configurations work 
2) Set it directly on the `readWrite` options inside the `transactionOption` array. This provides flexibility for the user since the readLockMode is a special nested option inside of the readWrite.

Some comment changes to be in accordance with this new feature and unit tests have been added.