### PR TITLE
feat: Ordering and lock options

### DIFF
--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -2037,6 +2037,12 @@ class Database
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type} to set a value.
+     *     @type int $orderBy Set the OrderBy option for the ReadRequest.
+     *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\OrderBy}
+     *           for more information and available options.
+     *     @type int $lockHint Set the LockHint option for the ReadRequest.
+     *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\LockHint}
+     *           for more information and available options.
      * }
      * @codingStandardsIgnoreEnd
      * @return Result

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -218,7 +218,7 @@ class ReadTest extends SpannerTestCase
         $this->assertNotContains(self::$dataset[10], $rows);
     }
 
-     public function testOrderByReturnsRowsOrderedById()
+    public function testOrderByReturnsRowsOrderedById()
     {
         $db = self::$database;
 

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -233,7 +233,11 @@ class ReadTest extends SpannerTestCase
 
         // Assert that the returned rows are sorted by the 'id' property.
         for ($i = 0; $i < count($rows) - 1; $i++) {
-            $this->assertLessThanOrEqual($rows[$i + 1]['id'], $rows[$i]['id'], 'The array is not sorted by id in ascending order.');
+            $this->assertLessThanOrEqual(
+                $rows[$i + 1]['id'],
+                $rows[$i]['id'],
+                'The array is not sorted by id in ascending order.'
+            );
         }
     }
 

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -218,6 +218,27 @@ class ReadTest extends SpannerTestCase
         $this->assertNotContains(self::$dataset[10], $rows);
     }
 
+     public function testOrderByReturnsRowsOrderedById()
+    {
+        $db = self::$database;
+
+        $range = new KeyRange([
+            'start' => self::$dataset[0],
+            'end' => self::$dataset[10],
+            'startType' => KeyRange::TYPE_CLOSED,
+            'endType' => KeyRange::TYPE_CLOSED,
+        ]);
+
+        $keyset = new KeySet(['ranges' => [$range]]);
+
+        $res = $db->read(self::$rangeTableName, $keyset, array_keys(self::$dataset[0]), [
+            'index' => $this->getIndexName(self::$rangeTableName, 'complex')
+        ]);
+        $rows = iterator_to_array($res->rows());
+        $this->assertEquals(self::$dataset[0]['id'], $rows[0]['id']);
+        $this->assertEquals(self::$dataset[10]['id'], $rows[10]['id']);
+    }
+
     /**
      * covers 9
      */

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -17,10 +17,12 @@
 
 namespace Google\Cloud\Spanner\Tests\System;
 
+use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Core\Exception\DeadlineExceededException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
+use Google\Cloud\Spanner\V1\ReadRequest\OrderBy;
 
 /**
  * @group spanner
@@ -222,21 +224,17 @@ class ReadTest extends SpannerTestCase
     {
         $db = self::$database;
 
-        $range = new KeyRange([
-            'start' => self::$dataset[0],
-            'end' => self::$dataset[10],
-            'startType' => KeyRange::TYPE_CLOSED,
-            'endType' => KeyRange::TYPE_CLOSED,
-        ]);
+        $this->insertUnorderedBatch();
 
-        $keyset = new KeySet(['ranges' => [$range]]);
-
-        $res = $db->read(self::$rangeTableName, $keyset, array_keys(self::$dataset[0]), [
-            'index' => $this->getIndexName(self::$rangeTableName, 'complex')
+        $res = $db->read(self::$rangeTableName, new KeySet(['all' => true]), array_keys(self::$dataset[0]), [
+            'orderBy' => OrderBy::ORDER_BY_PRIMARY_KEY
         ]);
         $rows = iterator_to_array($res->rows());
-        $this->assertEquals(self::$dataset[0]['id'], $rows[0]['id']);
-        $this->assertEquals(self::$dataset[10]['id'], $rows[10]['id']);
+
+        // Assert that the returned rows are sorted by the 'id' property.
+        for ($i = 0; $i < count($rows) - 1; $i++) {
+            $this->assertLessThanOrEqual($rows[$i + 1]['id'], $rows[$i]['id'], 'The array is not sorted by id in ascending order.');
+        }
     }
 
     /**
@@ -536,5 +534,24 @@ class ReadTest extends SpannerTestCase
         }
 
         return current($res)['name'];
+    }
+
+    private function insertUnorderedBatch()
+    {
+        // Because we are generating IDs at random there is a non zero chance
+        // that we create an ID that already exists on the DB.
+        // If that happens, we recursively call this function to generate another set.
+        try {
+            $unorderedDataset = self::generateDataset(10, false);
+            self::$database->insertBatch(self::$rangeTableName, $unorderedDataset);
+        } catch (ConflictException $e) {
+            $json = json_decode($e->getMessage(), true);
+
+            if ($json['status'] == 'ALREADY_EXISTS') {
+                $this->insertUnorderedBatch($data);
+            } else {
+                throw $e;
+            }
+        }
     }
 }

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -57,6 +57,8 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Spanner\V1\ReadRequest\LockHint;
+use Google\Cloud\Spanner\V1\ReadRequest\OrderBy;
 
 /**
  * @group spanner
@@ -1364,6 +1366,58 @@ class DatabaseTest extends TestCase
             new KeySet(['all' => true]),
             ['ID'],
             ['transactionType' => SessionPoolInterface::CONTEXT_READWRITE]
+        );
+        $this->assertInstanceOf(Result::class, $res);
+        $rows = iterator_to_array($res->rows());
+        $this->assertEquals(10, $rows[0]['ID']);
+    }
+
+    public function testSetOrderByReachesTheConnection()
+    {
+        $table = 'Table';
+        $opts = ['foo' => 'bar'];
+
+        $this->connection->streamingRead(Argument::withEntry('orderBy', OrderBy::ORDER_BY_PRIMARY_KEY))
+            ->shouldBeCalled()
+            ->willReturn($this->resultGenerator());
+
+        $this->refreshOperation($this->database, $this->connection->reveal());
+
+        $options = [
+            'orderBy' => OrderBy::ORDER_BY_PRIMARY_KEY
+        ];
+
+        $res = $this->database->read(
+            $table,
+            new KeySet(['all' => true]),
+            ['ID'],
+            $options
+        );
+        $this->assertInstanceOf(Result::class, $res);
+        $rows = iterator_to_array($res->rows());
+        $this->assertEquals(10, $rows[0]['ID']);
+    }
+
+    public function testSetLockHintReachesTheConnection()
+    {
+        $table = 'Table';
+        $opts = ['foo' => 'bar'];
+
+        $this->connection->streamingRead(Argument::withEntry('lockHint', LockHint::LOCK_HINT_SHARED))
+            ->shouldBeCalled()
+            ->willReturn($this->resultGenerator());
+
+        $this->refreshOperation($this->database, $this->connection->reveal());
+
+        $options = [
+            'lockHint' => LockHint::LOCK_HINT_SHARED
+        ];
+
+        $res = $this->database->read(
+            $table,
+            new KeySet(['all' => true]),
+            ['ID'],
+            $options
         );
         $this->assertInstanceOf(Result::class, $res);
         $rows = iterator_to_array($res->rows());


### PR DESCRIPTION
Add documentation and support for the `orderBy` and `lockHint` options.

This consists mostly on adding documentation as the options are already being passed to the GAPIC client and the server validates the type.