### PR TITLE
chore: drop support for PHP 8.0

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        php: [ "8.1", "8.2", "8.3", "8.4" ]
         extensions: ["grpc-1.54.0"]
         type: ["Unit Test"]
         include:
           - platform: "ubuntu-latest"
-            php: "8.0"
+            php: "8.1"
             extensions: "protobuf,grpc-1.54.0"
             type: "Unit Test + protobuf extension"
     name: PHP ${{ matrix.php }} ${{ matrix.type }} (${{ matrix.platform }})

--- a/AccessApproval/composer.json
+++ b/AccessApproval/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AccessContextManager/composer.json
+++ b/AccessContextManager/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AdsAdManager/composer.json
+++ b/AdsAdManager/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AdsMarketingPlatformAdmin/composer.json
+++ b/AdsMarketingPlatformAdmin/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AdvisoryNotifications/composer.json
+++ b/AdvisoryNotifications/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AiPlatform/composer.json
+++ b/AiPlatform/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AlloyDb/composer.json
+++ b/AlloyDb/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/common-protos": "^4.4"
     },

--- a/AnalyticsAdmin/composer.json
+++ b/AnalyticsAdmin/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AnalyticsData/composer.json
+++ b/AnalyticsData/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ApiGateway/composer.json
+++ b/ApiGateway/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ApiHub/composer.json
+++ b/ApiHub/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ApiKeys/composer.json
+++ b/ApiKeys/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ApigeeConnect/composer.json
+++ b/ApigeeConnect/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ApigeeRegistry/composer.json
+++ b/ApigeeRegistry/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AppEngineAdmin/composer.json
+++ b/AppEngineAdmin/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AppHub/composer.json
+++ b/AppHub/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AppsChat/composer.json
+++ b/AppsChat/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AppsEventsSubscriptions/composer.json
+++ b/AppsEventsSubscriptions/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AppsMeet/composer.json
+++ b/AppsMeet/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ArtifactRegistry/composer.json
+++ b/ArtifactRegistry/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Asset/composer.json
+++ b/Asset/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/access-context-manager": "^1.0",
         "google/cloud-osconfig": "^2.0"

--- a/AssuredWorkloads/composer.json
+++ b/AssuredWorkloads/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/AutoMl/composer.json
+++ b/AutoMl/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BackupDr/composer.json
+++ b/BackupDr/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BareMetalSolution/composer.json
+++ b/BareMetalSolution/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Batch/composer.json
+++ b/Batch/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BeyondCorpAppConnections/composer.json
+++ b/BeyondCorpAppConnections/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BeyondCorpAppConnectors/composer.json
+++ b/BeyondCorpAppConnectors/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BeyondCorpAppGateways/composer.json
+++ b/BeyondCorpAppGateways/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BeyondCorpClientConnectorServices/composer.json
+++ b/BeyondCorpClientConnectorServices/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BeyondCorpClientGateways/composer.json
+++ b/BeyondCorpClientGateways/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.64",
         "ramsey/uuid": "^3.0|^4.0"
     },

--- a/BigQueryAnalyticsHub/composer.json
+++ b/BigQueryAnalyticsHub/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryConnection/composer.json
+++ b/BigQueryConnection/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryDataExchange/composer.json
+++ b/BigQueryDataExchange/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryDataPolicies/composer.json
+++ b/BigQueryDataPolicies/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryDataTransfer/composer.json
+++ b/BigQueryDataTransfer/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryMigration/composer.json
+++ b/BigQueryMigration/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryReservation/composer.json
+++ b/BigQueryReservation/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BigQueryStorage/composer.json
+++ b/BigQueryStorage/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/cloud-core": "^1.57"
     },

--- a/Billing/composer.json
+++ b/Billing/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BillingBudgets/composer.json
+++ b/BillingBudgets/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/BinaryAuthorization/composer.json
+++ b/BinaryAuthorization/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/grafeas": "^1.0.0"
     },

--- a/Build/composer.json
+++ b/Build/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/CertificateManager/composer.json
+++ b/CertificateManager/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Channel/composer.json
+++ b/Channel/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/common-protos": "^3.2||^4.0"
     },

--- a/Chronicle/composer.json
+++ b/Chronicle/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/CommerceConsumerProcurement/composer.json
+++ b/CommerceConsumerProcurement/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/CommonProtos/composer.json
+++ b/CommonProtos/composer.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/googleapis/common-protos-php",
   "license": "Apache-2.0",
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "google/protobuf": "^v3.25.3||^4.26.1"
   },
   "require-dev": {

--- a/Compute/composer.json
+++ b/Compute/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ConfidentialComputing/composer.json
+++ b/ConfidentialComputing/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Config/composer.json
+++ b/Config/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/common-protos": " ^4.4"
     },

--- a/ConfigDelivery/composer.json
+++ b/ConfigDelivery/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ContactCenterInsights/composer.json
+++ b/ContactCenterInsights/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Container/composer.json
+++ b/Container/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ContainerAnalysis/composer.json
+++ b/ContainerAnalysis/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/grafeas": "^1.0.0"
     },

--- a/ControlsPartner/composer.json
+++ b/ControlsPartner/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "rize/uri-template": "~0.3||~0.4",
         "google/auth": "^1.34",
         "guzzlehttp/guzzle": "^6.5.8||^7.4.4",

--- a/DataCatalog/composer.json
+++ b/DataCatalog/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DataCatalogLineage/composer.json
+++ b/DataCatalogLineage/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DataFusion/composer.json
+++ b/DataFusion/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DataLabeling/composer.json
+++ b/DataLabeling/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dataflow/composer.json
+++ b/Dataflow/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dataform/composer.json
+++ b/Dataform/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dataplex/composer.json
+++ b/Dataplex/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dataproc/composer.json
+++ b/Dataproc/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DataprocMetastore/composer.json
+++ b/DataprocMetastore/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.63.0",
         "google/gax": "^1.36.0"
     },

--- a/DatastoreAdmin/composer.json
+++ b/DatastoreAdmin/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Datastream/composer.json
+++ b/Datastream/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Deploy/composer.json
+++ b/Deploy/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DeveloperConnect/composer.json
+++ b/DeveloperConnect/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DeviceStreaming/composer.json
+++ b/DeviceStreaming/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dialogflow/composer.json
+++ b/Dialogflow/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DialogflowCx/composer.json
+++ b/DialogflowCx/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DiscoveryEngine/composer.json
+++ b/DiscoveryEngine/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dlp/composer.json
+++ b/Dlp/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Dms/composer.json
+++ b/Dms/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/DocumentAi/composer.json
+++ b/DocumentAi/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Domains/composer.json
+++ b/Domains/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/EdgeNetwork/composer.json
+++ b/EdgeNetwork/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ErrorReporting/composer.json
+++ b/ErrorReporting/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-logging": "^1.29",
         "google/gax": "^1.36.0"
     },

--- a/EssentialContacts/composer.json
+++ b/EssentialContacts/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Eventarc/composer.json
+++ b/Eventarc/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/EventarcPublishing/composer.json
+++ b/EventarcPublishing/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Filestore/composer.json
+++ b/Filestore/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/cloud-common-protos": "~0.5"
     },

--- a/FinancialServices/composer.json
+++ b/FinancialServices/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-grpc": "*",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0",

--- a/Functions/composer.json
+++ b/Functions/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/GSuiteAddOns/composer.json
+++ b/GSuiteAddOns/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/GeoCommonProtos/composer.json
+++ b/GeoCommonProtos/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/protobuf": "^4.26.1",
         "google/common-protos": "^4.6"
     },

--- a/GkeBackup/composer.json
+++ b/GkeBackup/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/GkeConnectGateway/composer.json
+++ b/GkeConnectGateway/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/GkeHub/composer.json
+++ b/GkeHub/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/GkeMultiCloud/composer.json
+++ b/GkeMultiCloud/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Grafeas/composer.json
+++ b/Grafeas/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Iam/composer.json
+++ b/Iam/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/IamCredentials/composer.json
+++ b/IamCredentials/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Iap/composer.json
+++ b/Iap/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Ids/composer.json
+++ b/Ids/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Kms/composer.json
+++ b/Kms/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/KmsInventory/composer.json
+++ b/KmsInventory/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/cloud-kms": "^2.0"
     },

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },

--- a/LifeSciences/composer.json
+++ b/LifeSciences/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.61",
         "google/gax": "^1.36.0"
     },

--- a/Lustre/composer.json
+++ b/Lustre/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ManagedIdentities/composer.json
+++ b/ManagedIdentities/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ManagedKafka/composer.json
+++ b/ManagedKafka/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ManagedKafkaSchemaRegistry/composer.json
+++ b/ManagedKafkaSchemaRegistry/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/MapsFleetEngine/composer.json
+++ b/MapsFleetEngine/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/geo-common-protos": "^0.2"
     },

--- a/MapsFleetEngineDelivery/composer.json
+++ b/MapsFleetEngineDelivery/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/geo-common-protos": "^0.2"
     },

--- a/MapsRouteOptimization/composer.json
+++ b/MapsRouteOptimization/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/MediaTranslation/composer.json
+++ b/MediaTranslation/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Memcache/composer.json
+++ b/Memcache/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Memorystore/composer.json
+++ b/Memorystore/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/MigrationCenter/composer.json
+++ b/MigrationCenter/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ModelArmor/composer.json
+++ b/ModelArmor/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Monitoring/composer.json
+++ b/Monitoring/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/NetApp/composer.json
+++ b/NetApp/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/NetworkConnectivity/composer.json
+++ b/NetworkConnectivity/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/NetworkManagement/composer.json
+++ b/NetworkManagement/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/NetworkSecurity/composer.json
+++ b/NetworkSecurity/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/NetworkServices/composer.json
+++ b/NetworkServices/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Notebooks/composer.json
+++ b/Notebooks/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Optimization/composer.json
+++ b/Optimization/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/OracleDatabase/composer.json
+++ b/OracleDatabase/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/OrchestrationAirflow/composer.json
+++ b/OrchestrationAirflow/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/OrgPolicy/composer.json
+++ b/OrgPolicy/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/OsConfig/composer.json
+++ b/OsConfig/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/OsLogin/composer.json
+++ b/OsLogin/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Parallelstore/composer.json
+++ b/Parallelstore/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ParameterManager/composer.json
+++ b/ParameterManager/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/common-protos": "^4.9"
     },

--- a/PolicySimulator/composer.json
+++ b/PolicySimulator/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/PolicyTroubleshooter/composer.json
+++ b/PolicyTroubleshooter/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/PolicyTroubleshooterIam/composer.json
+++ b/PolicyTroubleshooterIam/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/cloud-iam": "^1.0.0"
     },

--- a/PrivateCatalog/composer.json
+++ b/PrivateCatalog/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/PrivilegedAccessManager/composer.json
+++ b/PrivilegedAccessManager/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Profiler/composer.json
+++ b/Profiler/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },

--- a/Quotas/composer.json
+++ b/Quotas/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ $spanner = new SpannerClient([
 
 ## PHP Versions Supported
 
-All client libraries support PHP 8.0 and above.
+All client libraries support PHP 8.1 and above.
 
 ## Versioning
 

--- a/RapidMigrationAssessment/composer.json
+++ b/RapidMigrationAssessment/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/RecaptchaEnterprise/composer.json
+++ b/RecaptchaEnterprise/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/RecommendationEngine/composer.json
+++ b/RecommendationEngine/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Recommender/composer.json
+++ b/Recommender/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Redis/composer.json
+++ b/Redis/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-grpc": "*",
         "google/gax": "^1.36.0"
     },

--- a/RedisCluster/composer.json
+++ b/RedisCluster/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ResourceManager/composer.json
+++ b/ResourceManager/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Retail/composer.json
+++ b/Retail/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Run/composer.json
+++ b/Run/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Scheduler/composer.json
+++ b/Scheduler/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecretManager/composer.json
+++ b/SecretManager/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecureSourceManager/composer.json
+++ b/SecureSourceManager/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecurityCenter/composer.json
+++ b/SecurityCenter/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecurityCenterManagement/composer.json
+++ b/SecurityCenterManagement/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecurityPrivateCa/composer.json
+++ b/SecurityPrivateCa/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/SecurityPublicCA/composer.json
+++ b/SecurityPublicCA/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ServiceControl/composer.json
+++ b/ServiceControl/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ServiceDirectory/composer.json
+++ b/ServiceDirectory/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ServiceHealth/composer.json
+++ b/ServiceHealth/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ServiceManagement/composer.json
+++ b/ServiceManagement/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ServiceUsage/composer.json
+++ b/ServiceUsage/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Shell/composer.json
+++ b/Shell/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ShoppingCommonProtos/composer.json
+++ b/ShoppingCommonProtos/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/protobuf": "^v3.25.3||^4.26.1"
     },
     "require-dev": {

--- a/ShoppingCss/composer.json
+++ b/ShoppingCss/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantAccounts/composer.json
+++ b/ShoppingMerchantAccounts/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantConversions/composer.json
+++ b/ShoppingMerchantConversions/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ShoppingMerchantDataSources/composer.json
+++ b/ShoppingMerchantDataSources/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantInventories/composer.json
+++ b/ShoppingMerchantInventories/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantLfp/composer.json
+++ b/ShoppingMerchantLfp/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantNotifications/composer.json
+++ b/ShoppingMerchantNotifications/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantOrderTracking/composer.json
+++ b/ShoppingMerchantOrderTracking/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantProducts/composer.json
+++ b/ShoppingMerchantProducts/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantPromotions/composer.json
+++ b/ShoppingMerchantPromotions/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantQuota/composer.json
+++ b/ShoppingMerchantQuota/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/ShoppingMerchantReports/composer.json
+++ b/ShoppingMerchantReports/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/ShoppingMerchantReviews/composer.json
+++ b/ShoppingMerchantReviews/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/shopping-common-protos": "^0.4.0"
     },

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-grpc": "*",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },

--- a/SqlAdmin/composer.json
+++ b/SqlAdmin/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "ramsey/uuid": "^4.2.3"
     },

--- a/StorageBatchOperations/composer.json
+++ b/StorageBatchOperations/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/StorageControl/composer.json
+++ b/StorageControl/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-grpc": "*",
         "google/gax": "^1.36.0"
     },

--- a/StorageInsights/composer.json
+++ b/StorageInsights/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/StorageTransfer/composer.json
+++ b/StorageTransfer/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Support/composer.json
+++ b/Support/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Talent/composer.json
+++ b/Talent/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Tasks/composer.json
+++ b/Tasks/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/TelcoAutomation/composer.json
+++ b/TelcoAutomation/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/TextToSpeech/composer.json
+++ b/TextToSpeech/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Tpu/composer.json
+++ b/Tpu/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "ramsey/uuid": "^3.0|^4.0",
         "google/gax": "^1.36.0"

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },

--- a/VideoIntelligence/composer.json
+++ b/VideoIntelligence/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VideoLiveStream/composer.json
+++ b/VideoLiveStream/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VideoStitcher/composer.json
+++ b/VideoStitcher/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VideoTranscoder/composer.json
+++ b/VideoTranscoder/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.57",
         "google/gax": "^1.36.0"
     },

--- a/VmMigration/composer.json
+++ b/VmMigration/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/VmwareEngine/composer.json
+++ b/VmwareEngine/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0",
         "google/common-protos": "^4.4"
     },

--- a/VpcAccess/composer.json
+++ b/VpcAccess/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/WebRisk/composer.json
+++ b/WebRisk/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/WebSecurityScanner/composer.json
+++ b/WebSecurityScanner/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/Workflows/composer.json
+++ b/Workflows/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "^1.36.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "rize/uri-template": "~0.3",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.6",

--- a/dev/src/Command/DocFxCommand.php
+++ b/dev/src/Command/DocFxCommand.php
@@ -75,10 +75,6 @@ class DocFxCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (PHP_VERSION_ID < 80000) {
-            throw new RuntimeException('This command must be run on PHP 8.0 or above');
-        }
-
         // YAML dump configuration
         $inline = 11; // The level where you switch to inline YAML
         $indent = 2; // The amount of spaces to use for indentation of nested nodes

--- a/dev/src/Composer.php
+++ b/dev/src/Composer.php
@@ -27,7 +27,7 @@ use vierbergenlars\SemVer\version;
  */
 class Composer
 {
-    private const REQUIRE_PHP = '^8.0';
+    private const REQUIRE_PHP = '^8.1';
 
     /**
      * @var array

--- a/dev/tests/fixtures/component/CustomInput/composer.json
+++ b/dev/tests/fixtures/component/CustomInput/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "GAX_VERSION"
     },
     "require-dev": {

--- a/dev/tests/fixtures/component/SecretManager/composer.json
+++ b/dev/tests/fixtures/component/SecretManager/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/gax": "GAX_VERSION"
     },
     "require-dev": {

--- a/dev/tests/fixtures/component/Vision/composer.json
+++ b/dev/tests/fixtures/component/Vision/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/cloud-core": "^1.43",
         "google/gax": "^1.30"
     },


### PR DESCRIPTION
We are now 20 months past the EOL of PHP 8.0, and support should be dropped

This is also outside our "[Foundational PHP Support](https://github.com/google/oss-policies-info/blob/main/foundational-php-support-matrix.md)" 

See https://github.com/googleapis/gax-php/pull/619
See https://github.com/googleapis/google-auth-library-php/pull/620