### PR TITLE
fix: Support dot notation in docs

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -363,6 +363,7 @@ class BigQueryClient
             'timeoutMs',
             'maxRetries',
             'returnRawResults',
+            'formatOptions',
             'formatOptions.useInt64Timestamp'
         ], $options);
         $queryResultsOptions['initialTimeoutMs'] = 10000;

--- a/dev/src/DocFx/Node/ParameterNode.php
+++ b/dev/src/DocFx/Node/ParameterNode.php
@@ -94,7 +94,7 @@ class ParameterNode
 
         foreach ($nestedParameters as $param) {
             // Parse "@type string $key" syntax
-            if (!preg_match('/^([^ ]+) +([\$\w]+)(.*)?/sm', trim($param), $matches)) {
+            if (!preg_match('/^([^ ]+) +([\$\w\.]+)(.*)?/sm', trim($param), $matches)) {
                 throw new \LogicException('unable to parse nested parameter "' . $param . '"');
             }
             list($_, $type, $name, $description) = $matches + [3 => ''];


### PR DESCRIPTION
Currently, phpdoc will separate field names at "." which causes issues in our docs. This commit fixes it.