### PR TITLE
fix(ci): add token to prevent rate limit error in release check

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Check for BC breaks (Next Release)"
         if: github.event.pull_request.user.login == 'release-please[bot]'
         # We've already approved and justified the breaking changes. Run the check but continue on error


### PR DESCRIPTION
Should fix the following error we've been seeing intermittently in our release PRs:

<img width="1242" height="253" alt="Screenshot 2025-07-18 at 12 53 58 PM" src="https://github.com/user-attachments/assets/acf49256-d391-4345-9014-2eef79a6d137" />
