### PR TITLE
feat(ci): add scripts to quickly check and fix code styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Please note that because Datastore and Firestore cannot be active in the same pr
 $ export GOOGLE_CLOUD_PHP_FIRESTORE_TESTS_KEY_PATH='/path/to/keyfile.json'
 ```
 
-## Coding Style
+### Coding Style
 
 Please follow the established coding style in the library. Google Cloud PHP follows the [PSR-2](https://www.php-fig.org/psr/psr-2/) Coding Style.
 This is enforced using both [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) and [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer).
@@ -122,6 +122,16 @@ If these changes look correct, you can automatically fix the issues by running t
 ```sh
 $ composer style-fix
 ```
+
+### Static Analysis
+
+Run PHPStan for static analysis with the following command.
+
+```sh
+$ composer phpstan
+```
+
+Any errors here will have to be fixed manually.
 
 **NOTE**: PHP CS Fixer does not check for or fix line lengths or trailing whitespace, which is the primary reason we use both libraries.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,21 @@ $ export GOOGLE_CLOUD_PHP_FIRESTORE_TESTS_KEY_PATH='/path/to/keyfile.json'
 ## Coding Style
 
 Please follow the established coding style in the library. Google Cloud PHP follows the [PSR-2](https://www.php-fig.org/psr/psr-2/) Coding Style.
+This is enforced using both [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) and [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer).
 
-You can check your code against these rules by running PHPCS with the proper ruleset, like this:
+You can run both of these checks using the `style-check` composer script:
 
 ```sh
-$ composer style
+$ composer style-check
 ```
+
+If these changes look correct, you can automatically fix the issues by running this command:
+
+```sh
+$ composer style-fix
+```
+
+**NOTE**: PHP CS Fixer does not check for or fix line lengths or trailing whitespace, which is the primary reason we use both libraries.
 
 ## Owlbot
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         "style-fix": [
             "vendor/bin/php-tools cs-fixer googleapis/google-cloud-php --ref $(git rev-parse --abbrev-ref HEAD) --flags \"\"",
             "vendor/bin/phpcbf --standard=phpcs-ruleset.xml -p"
+        ],
+        "phpstan": [
+            "dev/sh/static-analysis"
         ]
     },
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,16 @@
     "name": "google/cloud",
     "type": "library",
     "description": "Google Cloud Client Library",
+    "scripts": {
+        "style-check": [
+            "vendor/bin/php-tools cs-fixer googleapis/google-cloud-php --ref $(git rev-parse --abbrev-ref HEAD)",
+            "vendor/bin/phpcs --standard=phpcs-ruleset.xml -p"
+        ],
+        "style-fix": [
+            "vendor/bin/php-tools cs-fixer googleapis/google-cloud-php --ref $(git rev-parse --abbrev-ref HEAD) --flags \"\"",
+            "vendor/bin/phpcbf --standard=phpcs-ruleset.xml -p"
+        ]
+    },
     "keywords": [
         "google apis client",
         "google api client",
@@ -64,7 +74,8 @@
         "phpspec/prophecy-phpunit": "^2.1",
         "kreait/firebase-php": "^6.9",
         "psr/log": "^2.0||^3.0",
-        "dg/bypass-finals": "^1.7"
+        "dg/bypass-finals": "^1.7",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "replace": {
         "google/access-context-manager": "1.0.4",


### PR DESCRIPTION
Now you can run both styles checkers with one line:

```sh
composer style-check
# > vendor/bin/php-tools cs-fixer googleapis/google-cloud-php
# > vendor/bin/phpcs --standard=phpcs-ruleset.xml -p
```

And if that fails you can fix it with another one-liner:

```sh
composer style-fix
# > vendor/bin/php-tools cs-fixer googleapis/google-cloud-php --flags ""
# > vendor/bin/phpcbf --standard=phpcs-ruleset.xml -p
```

And for consistency, you can also use `composer phpstan` as a shortcut to running `dev/sh/static-analysis`:

```sh
composer phpstan
# > dev/sh/static-analysis
```