### PR TITLE
fix: retry options for Storage Client.

### DIFF
--- a/Core/src/RestTrait.php
+++ b/Core/src/RestTrait.php
@@ -95,6 +95,8 @@ trait RestTrait
             'requestTimeout',
             'restRetryFunction',
             'restRetryListener',
+            'restDelayFunction',
+            'restCalcDelayFunction',
         ], $options);
 
         try {

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -332,9 +332,7 @@ class Rest implements ConnectionInterface
         $resultStream = Utils::streamFor(null);
         $transcodedObj = false;
 
-        if (!isset($args['retryStrategy']) && $this->retryStrategy) {
-            $args['retryStrategy'] = $this->retryStrategy;
-        }
+        $args['retryStrategy'] ??= $this->retryStrategy;
 
         list($request, $requestOptions) = $this->buildDownloadObjectParams($args);
 
@@ -805,10 +803,6 @@ class Rest implements ConnectionInterface
         ];
         $retryResource = isset($retryMap[$resource]) ? $retryMap[$resource] : $resource;
 
-        if (!isset($options['retryStrategy']) && $this->retryStrategy) {
-            $options['retryStrategy'] = $this->retryStrategy;
-        }
-
         $options['restRetryFunction'] = $this->restRetryFunction ?? $this->getRestRetryFunction(
             $retryResource,
             $method,
@@ -816,6 +810,7 @@ class Rest implements ConnectionInterface
         );
 
         $options += array_filter([
+            'retryStrategy' => $this->retryStrategy,
             'restDelayFunction' => $this->restDelayFunction,
             'restCalcDelayFunction' => $this->restCalcDelayFunction,
             'restRetryListener' => $this->restRetryListener,

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -351,8 +351,8 @@ class Rest implements ConnectionInterface
         $attempt = null;
         $requestOptions['restRetryListener'] = function (
             \Exception $e,
-                       $retryAttempt,
-                       &$arguments
+            $retryAttempt,
+            &$arguments
         ) use (
             $resultStream,
             $requestedBytes,
@@ -365,7 +365,7 @@ class Rest implements ConnectionInterface
                 && $e->getResponse()->getStatusCode() >= 200
                 && $e->getResponse()->getStatusCode() < 300
             ) {
-                $msg = (string)$e->getResponse()->getBody();
+                $msg = (string) $e->getResponse()->getBody();
 
                 $fetchedStream = Utils::streamFor($msg);
 
@@ -489,9 +489,7 @@ class Rest implements ConnectionInterface
             'userProject' => null,
         ];
 
-        if (!isset($args['retryStrategy']) && $this->retryStrategy) {
-            $args['retryStrategy'] = $this->retryStrategy;
-        }
+        $args['retryStrategy'] ??= $this->retryStrategy;
 
         $args['data'] = Utils::streamFor($args['data']);
 
@@ -817,17 +815,11 @@ class Rest implements ConnectionInterface
             $options
         );
 
-        if (!isset($options['restDelayFunction']) && $this->restDelayFunction) {
-            $options['restDelayFunction'] = $this->restDelayFunction;
-        }
-
-        if (!isset($options['restCalcDelayFunction']) && $this->restCalcDelayFunction) {
-            $options['restCalcDelayFunction'] = $this->restCalcDelayFunction;
-        }
-
-        if (!isset($options['restRetryListener']) && $this->restRetryListener) {
-            $options['restRetryListener'] = $this->restRetryListener;
-        }
+        $options += array_filter([
+            'restDelayFunction' => $this->restDelayFunction,
+            'restCalcDelayFunction' => $this->restCalcDelayFunction,
+            'restRetryListener' => $this->restRetryListener,
+        ]);
 
         $options = $this->addRetryHeaderLogic($options);
 
@@ -850,8 +842,8 @@ class Rest implements ConnectionInterface
         // Adding callback logic to update headers while retrying
         $args['restRetryListener'] = function (
             \Exception $e,
-                       $retryAttempt,
-                       &$arguments
+            $retryAttempt,
+            &$arguments
         ) use (
             $invocationId,
             $userListener
@@ -872,8 +864,8 @@ class Rest implements ConnectionInterface
 
     private function modifyRequestForRetry(
         RequestInterface $request,
-        int              $retryAttempt,
-        string           $invocationId
+        int $retryAttempt,
+        string $invocationId
     )
     {
         $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -861,8 +861,7 @@ class Rest implements ConnectionInterface
         RequestInterface $request,
         int $retryAttempt,
         string $invocationId
-    )
-    {
+    ) {
         $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);
         $headerLine = $request->getHeaderLine(Retry::RETRY_HEADER_KEY);
 

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -101,9 +101,9 @@ class Rest implements ConnectionInterface
     private $restRetryFunction;
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $retryStrategy;
+    private ?string $retryStrategy;
 
     /**
      * @var callable|null

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -101,6 +101,26 @@ class Rest implements ConnectionInterface
     private $restRetryFunction;
 
     /**
+     * @var string
+     */
+    private $retryStrategy;
+
+    /**
+     * @var callable|null
+     */
+    private $restDelayFunction;
+
+    /**
+     * @var callable|null
+     */
+    private $restCalcDelayFunction;
+
+    /**
+     * @var callable|null
+     */
+    private $restRetryListener;
+
+    /**
      * @param array $config
      */
     public function __construct(array $config = [])
@@ -128,6 +148,10 @@ class Rest implements ConnectionInterface
 
         $this->projectId = $this->pluck('projectId', $config, false);
         $this->restRetryFunction = (isset($config['restRetryFunction'])) ? $config['restRetryFunction'] : null;
+        $this->retryStrategy = $config['retryStrategy'] ?? null;
+        $this->restDelayFunction = $config['restDelayFunction'] ?? null;
+        $this->restCalcDelayFunction = $config['restCalcDelayFunction'] ?? null;
+        $this->restRetryListener = $config['restRetryListener'] ?? null;
     }
 
     /**
@@ -308,11 +332,15 @@ class Rest implements ConnectionInterface
         $resultStream = Utils::streamFor(null);
         $transcodedObj = false;
 
+        if (!isset($args['retryStrategy']) && $this->retryStrategy) {
+            $args['retryStrategy'] = $this->retryStrategy;
+        }
+
         list($request, $requestOptions) = $this->buildDownloadObjectParams($args);
 
         $invocationId = Uuid::uuid4()->toString();
         $requestOptions['retryHeaders'] = self::getRetryHeaders($invocationId, 1);
-        $requestOptions['restRetryFunction'] = $this->getRestRetryFunction('objects', 'get', $requestOptions);
+        $requestOptions['restRetryFunction'] = $this->getRestRetryFunction('objects', 'get', $args);
         // We try to deduce if the object is a transcoded object when we receive the headers.
         $requestOptions['restOptions']['on_headers'] = function ($response) use (&$transcodedObj) {
             $header = $response->getHeader(self::TRANSCODED_OBJ_HEADER_KEY);
@@ -323,8 +351,8 @@ class Rest implements ConnectionInterface
         $attempt = null;
         $requestOptions['restRetryListener'] = function (
             \Exception $e,
-            $retryAttempt,
-            &$arguments
+                       $retryAttempt,
+                       &$arguments
         ) use (
             $resultStream,
             $requestedBytes,
@@ -337,7 +365,7 @@ class Rest implements ConnectionInterface
                 && $e->getResponse()->getStatusCode() >= 200
                 && $e->getResponse()->getStatusCode() < 300
             ) {
-                $msg = (string) $e->getResponse()->getBody();
+                $msg = (string)$e->getResponse()->getBody();
 
                 $fetchedStream = Utils::streamFor($msg);
 
@@ -461,6 +489,10 @@ class Rest implements ConnectionInterface
             'userProject' => null,
         ];
 
+        if (!isset($args['retryStrategy']) && $this->retryStrategy) {
+            $args['retryStrategy'] = $this->retryStrategy;
+        }
+
         $args['data'] = Utils::streamFor($args['data']);
 
         if ($args['resumable'] === null) {
@@ -520,7 +552,7 @@ class Rest implements ConnectionInterface
     }
 
     /**
-     * @param  array $args
+     * @param array $args
      */
     public function getBucketIamPolicy(array $args)
     {
@@ -528,7 +560,7 @@ class Rest implements ConnectionInterface
     }
 
     /**
-     * @param  array $args
+     * @param array $args
      */
     public function setBucketIamPolicy(array $args)
     {
@@ -536,7 +568,7 @@ class Rest implements ConnectionInterface
     }
 
     /**
-     * @param  array $args
+     * @param array $args
      */
     public function testBucketIamPermissions(array $args)
     {
@@ -677,7 +709,7 @@ class Rest implements ConnectionInterface
     }
 
     /**
-     * Choose a upload validation method based on user input and platform
+     * Choose an upload validation method based on user input and platform
      * requirements.
      *
      * @param array $args
@@ -748,8 +780,8 @@ class Rest implements ConnectionInterface
     /**
      * Check if hash() supports crc32c.
      *
-     * @deprecated
      * @return bool
+     * @deprecated
      */
     protected function supportsBuiltinCrc32c()
     {
@@ -774,11 +806,28 @@ class Rest implements ConnectionInterface
             'objectAccessControls' => 'object_acl'
         ];
         $retryResource = isset($retryMap[$resource]) ? $retryMap[$resource] : $resource;
+
+        if (!isset($options['retryStrategy']) && $this->retryStrategy) {
+            $options['retryStrategy'] = $this->retryStrategy;
+        }
+
         $options['restRetryFunction'] = $this->restRetryFunction ?? $this->getRestRetryFunction(
             $retryResource,
             $method,
             $options
         );
+
+        if (!isset($options['restDelayFunction']) && $this->restDelayFunction) {
+            $options['restDelayFunction'] = $this->restDelayFunction;
+        }
+
+        if (!isset($options['restCalcDelayFunction']) && $this->restCalcDelayFunction) {
+            $options['restCalcDelayFunction'] = $this->restCalcDelayFunction;
+        }
+
+        if (!isset($options['restRetryListener']) && $this->restRetryListener) {
+            $options['restRetryListener'] = $this->restRetryListener;
+        }
 
         $options = $this->addRetryHeaderLogic($options);
 
@@ -796,19 +845,26 @@ class Rest implements ConnectionInterface
         $invocationId = Uuid::uuid4()->toString();
         $args['retryHeaders'] = self::getRetryHeaders($invocationId, 1);
 
+        $userListener = $args['restRetryListener'] ?? null;
+
         // Adding callback logic to update headers while retrying
         $args['restRetryListener'] = function (
             \Exception $e,
-            $retryAttempt,
-            &$arguments
+                       $retryAttempt,
+                       &$arguments
         ) use (
-            $invocationId
+            $invocationId,
+            $userListener
         ) {
             $arguments[0] = $this->modifyRequestForRetry(
                 $arguments[0],
                 $retryAttempt,
                 $invocationId
             );
+
+            if ($userListener) {
+                $userListener($e, $retryAttempt, $arguments);
+            }
         };
 
         return $args;
@@ -816,9 +872,10 @@ class Rest implements ConnectionInterface
 
     private function modifyRequestForRetry(
         RequestInterface $request,
-        int $retryAttempt,
-        string $invocationId
-    ) {
+        int              $retryAttempt,
+        string           $invocationId
+    )
+    {
         $changes = self::getRetryHeaders($invocationId, $retryAttempt + 1);
         $headerLine = $request->getHeaderLine(Retry::RETRY_HEADER_KEY);
 

--- a/Storage/src/Connection/RetryTrait.php
+++ b/Storage/src/Connection/RetryTrait.php
@@ -31,7 +31,7 @@ trait RetryTrait
      * @var array
      */
     private static $httpRetryCodes = [
-        0, // connetion-refused OR connection-reset gives status code of 0
+        0, // connection-refused OR connection-reset gives status code of 0
         200, // partial download cases
         408,
         429,
@@ -192,7 +192,7 @@ trait RetryTrait
      * @param bool $isIdempotent
      * @param bool $preconditionNeeded
      * @param bool $preconditionSupplied
-     * @param int|null $maxRetries The maximum number of retries allowd.
+     * @param int|null $maxRetries The maximum number of retries allowed.
      * Null for no limit.
      * @return bool
      */

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -107,7 +107,7 @@ class StorageClient
      *           request. **Defaults to** `0` with REST and `60` with gRPC.
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
-     *     @type string $retryStrategy Retry strategy to signify that we never 
+     *     @type string $retryStrategy Retry strategy to signify that we never
      *           want to retry an operation even if the error is retryable.
      *           **Defaults to** `StorageClient::RETRY_IDEMPOTENT`.
      *     @type callable $restDelayFunction Executes a delay, defaults to

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -107,6 +107,23 @@ class StorageClient
      *           request. **Defaults to** `0` with REST and `60` with gRPC.
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
+     *     @type string $retryStrategy Retry strategy to signify that we never 
+     *           want to retry an operation even if the error is retryable.
+     *           **Defaults to** `StorageClient::RETRY_IDEMPOTENT`.
+     *     @type callable $restDelayFunction Executes a delay, defaults to
+     *           utilizing `usleep`. Function signature should match:
+     *           `function (int $delay) : void`.
+     *     @type callable $restCalcDelayFunction Sets the conditions for
+     *           determining how long to wait between attempts to retry. Function
+     *           signature should match: `function (int $attempt) : int`.
+     *     @type callable $restRetryFunction Sets the conditions for whether or
+     *           not a request should attempt to retry. Function signature should
+     *           match: `function (\Exception $ex) : bool`.
+     *     @type callable $restRetryListener Runs after the restRetryFunction.
+     *           This might be used to simply consume the exception and
+     *           $arguments b/w retries. This returns the new $arguments thus
+     *           allowing modification on demand for $arguments. For ex:
+     *           changing the headers in b/w retries.
      *     @type array $scopes Scopes to be used for the request.
      *     @type string $quotaProject Specifies a user project to bill for
      *           access charges associated with the request.

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -491,7 +491,7 @@ class StorageClientTest extends TestCase
             self::getSuccessfulObjectsResponse(), // This should not be reached
         ])[1];
 
-        $this->client = new StorageClient([[
+        $this->client = new StorageClient([
             'projectId' => self::PROJECT,
             // Mock the authHttpHandler so it doesn't make a real request
             'httpHandler' => $httpHandler,
@@ -521,7 +521,7 @@ class StorageClientTest extends TestCase
             self::getCreateBucketSuccessResponse(),
         ])[1];
 
-        $this->client = new StorageClient([[
+        $this->client = new StorageClient([
             'projectId' => self::PROJECT,
             'retryStrategy' => StorageClient::RETRY_ALWAYS,
             // Mock the authHttpHandler so it doesn't make a real request
@@ -548,7 +548,7 @@ class StorageClientTest extends TestCase
             $capturedDelays[] = $delay;
         };
 
-        $this->client = new StorageClient([[
+        $this->client = new StorageClient([
             'projectId' => self::PROJECT,
             'retries' => 2,
             'restCalcDelayFunction' => $restCalcDelayFunction,

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -380,8 +380,8 @@ class StorageClientTest extends TestCase
 
         return [
             $mockHandler,
-            function (\Psr\Http\Message\RequestInterface $request) use ($guzzleClient) {
-                return $guzzleClient->send($request);
+            function (\Psr\Http\Message\RequestInterface $request, array $options) use ($guzzleClient) {
+                return $guzzleClient->send($request, $options);
             }
         ];
     }
@@ -397,18 +397,15 @@ class StorageClientTest extends TestCase
     ) {
         list($mockHandler, $httpHandler) = self::getHttpHandlerMock($mockResponses);
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                'retries' => $retries,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => $httpHandler,
-                // Mock the delay function so the tests execute faster
-                'restDelayFunction' => function () {
-                },
-            ]]
-        );
+        $this->client = new StorageClient([
+            'projectId' => self::PROJECT,
+            'retries' => $retries,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => $httpHandler,
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
 
         if ($exceptionClass) {
             $this->expectException($exceptionClass);
@@ -494,17 +491,14 @@ class StorageClientTest extends TestCase
             self::getSuccessfulObjectsResponse(), // This should not be reached
         ])[1];
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => $httpHandler,
-                // Mock the delay function so the tests execute faster
-                'restDelayFunction' => function () {
-                },
-            ]]
-        );
+        $this->client = new StorageClient([[
+            'projectId' => self::PROJECT,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => $httpHandler,
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
 
         $this->expectException(ServiceException::class);
 
@@ -527,18 +521,15 @@ class StorageClientTest extends TestCase
             self::getCreateBucketSuccessResponse(),
         ])[1];
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                'retryStrategy' => StorageClient::RETRY_ALWAYS,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => $httpHandler,
-                // Mock the delay function so the tests execute faster
-                'restDelayFunction' => function () {
-                },
-            ]]
-        );
+        $this->client = new StorageClient([[
+            'projectId' => self::PROJECT,
+            'retryStrategy' => StorageClient::RETRY_ALWAYS,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => $httpHandler,
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
 
         $this->assertInstanceOf(Bucket::class, $this->client->createBucket('myBucket'));
     }
@@ -557,17 +548,14 @@ class StorageClientTest extends TestCase
             $capturedDelays[] = $delay;
         };
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                'retries' => 2,
-                'restCalcDelayFunction' => $restCalcDelayFunction,
-                'restDelayFunction' => $restDelayFunction,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => $httpHandler,
-            ]]
-        );
+        $this->client = new StorageClient([[
+            'projectId' => self::PROJECT,
+            'retries' => 2,
+            'restCalcDelayFunction' => $restCalcDelayFunction,
+            'restDelayFunction' => $restDelayFunction,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => $httpHandler,
+        ]);
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
         
@@ -589,18 +577,15 @@ class StorageClientTest extends TestCase
             return $e->getCode() === 404;
         };
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                'restRetryFunction' => $customRetryFunction,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => $httpHandler,
-                // Mock the delay function so the tests execute faster
-                'restDelayFunction' => function () {
-                },
-            ]]
-        );
+        $this->client = new StorageClient([
+            'projectId' => self::PROJECT,
+            'restRetryFunction' => $customRetryFunction,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => $httpHandler,
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
 
@@ -630,18 +615,15 @@ class StorageClientTest extends TestCase
             $arguments[0] = $request->withHeader('X-Retry-Attempt', (string) $retryAttempt);
         };
 
-        $this->client = TestHelpers::stub(
-            StorageClient::class,
-            [[
-                'projectId' => self::PROJECT,
-                'restRetryListener' => $retryListenerFunction,
-                // Mock the authHttpHandler so it doesn't make a real request
-                'httpHandler' => fn ($req, $opt) => $guzzleClient->send($req, $opt),
-                // Mock the delay function so the tests execute faster
-                'restDelayFunction' => function () {
-                },
-            ]]
-        );
+        $this->client = new StorageClient([
+            'projectId' => self::PROJECT,
+            'restRetryListener' => $retryListenerFunction,
+            // Mock the authHttpHandler so it doesn't make a real request
+            'httpHandler' => fn ($req, $opt) => $guzzleClient->send($req, $opt),
+            // Mock the delay function so the tests execute faster
+            'restDelayFunction' => function () {
+            },
+        ]);
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -357,7 +357,7 @@ class StorageClientTest extends TestCase
         ];
     }
 
-    public static function getSuccessfulObjectsResponse()
+    private static function getSuccessfulObjectsResponse()
     {
         return new Response(
             200,

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Storage\Tests\Unit;
 
 use Google\Cloud\Core\Exception\GoogleException;
+use Google\Cloud\Core\Exception\ServiceException;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\Upload\SignedUrlUploader;
@@ -32,6 +33,9 @@ use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 
 /**
  * @group storage
@@ -351,6 +355,300 @@ class StorageClientTest extends TestCase
             ['hmacKey', ['foo']],
             ['createHmacKey', ['foo']]
         ];
+    }
+
+    public static function getSuccessfulObjectsResponse()
+    {
+        return new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(
+                [
+                    'items' => [
+                        ['name' => 'file.txt']
+                    ]
+                ]
+            )
+        );
+    }
+
+    public static function getHttpHandlerMock($mockResponses)
+    {
+        $mockHandler = new MockHandler($mockResponses);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $guzzleClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+
+        return [
+            $mockHandler,
+            function (\Psr\Http\Message\RequestInterface $request, array $options) use ($guzzleClient) {
+                return $guzzleClient->send($request, $options);
+            }
+        ];
+    }
+
+    /**
+     * @dataProvider providesRetriesConfiguration
+     */
+    public function testRetriesConfiguration(
+        $mockResponses,
+        $retries,
+        $expectedRemainingResponses,
+        $exceptionClass = null
+    ) {
+        list($mockHandler, $httpHandler) = self::getHttpHandlerMock($mockResponses);
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retries' => $retries,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
+
+        if ($exceptionClass) {
+            $this->expectException($exceptionClass);
+        }
+
+        $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
+        
+        $this->assertEquals('file.txt', $objects[0]->name());
+        $this->assertEquals($expectedRemainingResponses, $mockHandler->count());
+    }
+
+    public function providesRetriesConfiguration()
+    {
+        return [
+            // Successful
+            [
+                [
+                    new Response(408),
+                    new Response(429),
+                    new Response(500),
+                    new Response(502),
+                    new Response(503),
+                    new Response(504),
+                    self::getSuccessfulObjectsResponse(),
+                ],
+                10,
+                0,
+                null,
+            ],
+            [
+                [
+                    new Response(408),
+                    new Response(504),
+                    self::getSuccessfulObjectsResponse(),
+                ],
+                10,
+                0,
+                null,
+            ],
+            [
+                [
+                    new Response(408),
+                    new Response(504),
+                    self::getSuccessfulObjectsResponse(),
+                ],
+                3,
+                0,
+                null,
+            ],
+            [
+                [
+                    self::getSuccessfulObjectsResponse(),
+                ],
+                10,
+                0,
+                null,
+            ],
+            // Failing with exception
+            [
+                [
+                    new Response(408),
+                    new Response(429),
+                    new Response(500),
+                    new Response(502),
+                    new Response(503),
+                    new Response(504),
+                    self::getSuccessfulObjectsResponse(),
+                ],
+                3,
+                0,
+                ServiceException::class,
+            ],
+        ];
+    }
+
+    public function testDefaultRetryStrategyFailing()
+    {
+        $httpHandler = self::getHttpHandlerMock([
+            new Response(503), // Service Unavailable
+            new Response(503),
+            new Response(503),
+            new Response(503),
+            self::getSuccessfulObjectsResponse(), // This should not be reached
+        ])[1];
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
+
+        $this->expectException(ServiceException::class);
+
+        $this->client->createBucket('myBucket');
+    }
+
+    public static function getCreateBucketSuccessResponse()
+    {
+        return new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['name' => 'myBucket'])
+        );
+    }
+
+    public function testAlwaysRetryStrategySuccessful()
+    {
+        $httpHandler = self::getHttpHandlerMock([
+            new Response(503), // Service Unavailable
+            self::getCreateBucketSuccessResponse(),
+        ])[1];
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retryStrategy' => StorageClient::RETRY_ALWAYS,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
+
+        $this->assertInstanceOf(Bucket::class, $this->client->createBucket('myBucket'));
+    }
+
+    public function testDelayFunctionsConfiguration()
+    {
+        $httpHandler = self::getHttpHandlerMock([
+            new Response(503),
+            new Response(503),
+            self::getSuccessfulObjectsResponse(),
+        ])[1];
+
+        $capturedDelays = [];
+        $restCalcDelayFunction = fn ($attempt) => ($attempt + 1) * 100; // 1st retry: 100, 2nd: 200
+        $restDelayFunction = function ($delay) use (&$capturedDelays) {
+            $capturedDelays[] = $delay;
+        };
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retries' => 2,
+                'restCalcDelayFunction' => $restCalcDelayFunction,
+                'restDelayFunction' => $restDelayFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+            ]]
+        );
+
+        $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
+        
+        $this->assertEquals('file.txt', $objects[0]->name());
+        $this->assertEquals([100, 200], $capturedDelays);
+    }
+
+    public function testCustomRetryFunctionConfiguration()
+    {
+        $mockResponses = [
+            new Response(404), // Not Found - normally not retried
+            self::getSuccessfulObjectsResponse(),
+        ];
+
+        list($mockHandler, $httpHandler) = self::getHttpHandlerMock($mockResponses);
+
+        $customRetryFunction = function (\Exception $e) {
+            // Custom logic: only retry if the error code is 404.
+            return $e->getCode() === 404;
+        };
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'restRetryFunction' => $customRetryFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
+
+        $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
+
+        $this->assertEquals('file.txt', $objects[0]->name());
+        // Should use all the mock responses.
+        $this->assertEquals(0, $mockHandler->count());
+    }
+
+    public function testRetryListenerConfiguration()
+    {
+        $mockResponses = [
+            new Response(503),
+            self::getSuccessfulObjectsResponse(),
+        ];
+        $mockHandler = new MockHandler($mockResponses);
+        $handlerStack = HandlerStack::create($mockHandler);
+        
+        $requestHistory = [];
+        $handlerStack->push(\GuzzleHttp\Middleware::history($requestHistory));
+        $guzzleClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+
+        $listenerInvocations = 0;
+        $retryListenerFunction = function (\Exception $e, $retryAttempt, &$arguments) use (&$listenerInvocations) {
+            $listenerInvocations++;
+            // $arguments is an array: [RequestInterface $request, array $options]
+            $request = $arguments[0];
+            $arguments[0] = $request->withHeader('X-Retry-Attempt', (string) $retryAttempt);
+        };
+
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'restRetryListener' => $retryListenerFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => fn ($req, $opt) => $guzzleClient->send($req, $opt),
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
+
+        $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
+
+        $this->assertEquals('file.txt', $objects[0]->name());
+        $this->assertEquals(1, $listenerInvocations);
+        $this->assertFalse($requestHistory[0]['request']->hasHeader('X-Retry-Attempt'));
+        $this->assertEquals('1', $requestHistory[1]['request']->getHeaderLine('X-Retry-Attempt'));
     }
 }
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -397,15 +397,22 @@ class StorageClientTest extends TestCase
     ) {
         list($mockHandler, $httpHandler) = self::getHttpHandlerMock($mockResponses);
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            'retries' => $retries,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => $httpHandler,
-            // Mock the delay function so the tests execute faster
-            'restDelayFunction' => function () {
-            },
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retries' => $retries,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
 
         if ($exceptionClass) {
             $this->expectException($exceptionClass);
@@ -491,14 +498,21 @@ class StorageClientTest extends TestCase
             self::getSuccessfulObjectsResponse(), // This should not be reached
         ])[1];
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => $httpHandler,
-            // Mock the delay function so the tests execute faster
-            'restDelayFunction' => function () {
-            },
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
 
         $this->expectException(ServiceException::class);
 
@@ -521,15 +535,22 @@ class StorageClientTest extends TestCase
             self::getCreateBucketSuccessResponse(),
         ])[1];
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            'retryStrategy' => StorageClient::RETRY_ALWAYS,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => $httpHandler,
-            // Mock the delay function so the tests execute faster
-            'restDelayFunction' => function () {
-            },
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retryStrategy' => StorageClient::RETRY_ALWAYS,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
 
         $this->assertInstanceOf(Bucket::class, $this->client->createBucket('myBucket'));
     }
@@ -548,14 +569,21 @@ class StorageClientTest extends TestCase
             $capturedDelays[] = $delay;
         };
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            'retries' => 2,
-            'restCalcDelayFunction' => $restCalcDelayFunction,
-            'restDelayFunction' => $restDelayFunction,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => $httpHandler,
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'retries' => 2,
+                'restCalcDelayFunction' => $restCalcDelayFunction,
+                'restDelayFunction' => $restDelayFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+            ]]
+        );
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
         
@@ -577,15 +605,22 @@ class StorageClientTest extends TestCase
             return $e->getCode() === 404;
         };
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            'restRetryFunction' => $customRetryFunction,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => $httpHandler,
-            // Mock the delay function so the tests execute faster
-            'restDelayFunction' => function () {
-            },
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'restRetryFunction' => $customRetryFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => $httpHandler,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
 
@@ -615,15 +650,22 @@ class StorageClientTest extends TestCase
             $arguments[0] = $request->withHeader('X-Retry-Attempt', (string) $retryAttempt);
         };
 
-        $this->client = new StorageClient([
-            'projectId' => self::PROJECT,
-            'restRetryListener' => $retryListenerFunction,
-            // Mock the authHttpHandler so it doesn't make a real request
-            'httpHandler' => fn ($req, $opt) => $guzzleClient->send($req, $opt),
-            // Mock the delay function so the tests execute faster
-            'restDelayFunction' => function () {
-            },
-        ]);
+        $this->client = TestHelpers::stub(
+            StorageClient::class,
+            [[
+                'projectId' => self::PROJECT,
+                'restRetryListener' => $retryListenerFunction,
+                // Mock the authHttpHandler so it doesn't make a real request
+                'httpHandler' => fn ($req, $opt) => $guzzleClient->send($req, $opt),
+                // Mock the authHttpHandler so it doesn't make a real request
+                'authHttpHandler' => function () {
+                    return new Response(200, [], '{"access_token": "abc"}');
+                },
+                // Mock the delay function so the tests execute faster
+                'restDelayFunction' => function () {
+                },
+            ]]
+        );
 
         $objects = iterator_to_array($this->client->bucket('myBucket')->objects());
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -380,8 +380,8 @@ class StorageClientTest extends TestCase
 
         return [
             $mockHandler,
-            function (\Psr\Http\Message\RequestInterface $request, array $options) use ($guzzleClient) {
-                return $guzzleClient->send($request, $options);
+            function (\Psr\Http\Message\RequestInterface $request) use ($guzzleClient) {
+                return $guzzleClient->send($request);
             }
         ];
     }


### PR DESCRIPTION
- fixed support for retry strategy
- override support for - delay function, calc delay function, retry function
- added restDelayFunction and restCalcDelayFunction support for RestTrait.
- added phpDoc for `StorageClient` on available options
- fixed language typos
- fixed minor formatting issues

Fixes #8309.