### PR TITLE
[Translate] Remove final from TranslationServiceClient

### DIFF
--- a/Translate/src/V3/Client/TranslationServiceClient.php
+++ b/Translate/src/V3/Client/TranslationServiceClient.php
@@ -140,7 +140,7 @@ use Psr\Log\LoggerInterface;
  * @method PromiseInterface<OperationResponse> updateGlossaryAsync(UpdateGlossaryRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<GlossaryEntry> updateGlossaryEntryAsync(UpdateGlossaryEntryRequest $request, array $optionalArgs = [])
  */
-final class TranslationServiceClient
+class TranslationServiceClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;


### PR DESCRIPTION
Hi @bshaffer 

Since there is the header
```
/*
 * GENERATED CODE WARNING
 * Generated by gapic-generator-php from the file
 * https://github.com/googleapis/googleapis/blob/master/google/cloud/translate/v3/translation_service.proto
 * Updates to the above are reflected here through a refresh process.
 */
```
I dunno if it can be done this way.

This class is final but implements no interface which is really annoying when you want to write unit/functional tests because you cannot mock it.

With PHPUnit `$this->createMock(FooService)` require an interface or a non final classe.

Rather than creating an `TranslationServiceClientInterface` with all the methods, I feel like the simpler solution is to remove the final keyword.

Is it ok for you ?