### PR TITLE
Solve repeatedField deprecation

### DIFF
--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": "^8.1",
         "google/cloud-core": "^1.57",
-        "google/gax": "^1.36.0"
+        "google/gax": "^1.36.0",
+        "google/protobuf": "^4.31.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Translate/src/V3/AdaptiveMtDataset.php
+++ b/Translate/src/V3/AdaptiveMtDataset.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An Adaptive MT Dataset.
@@ -300,4 +300,3 @@ class AdaptiveMtDataset extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/AdaptiveMtFile.php
+++ b/Translate/src/V3/AdaptiveMtFile.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An AdaptiveMtFile.
@@ -224,4 +224,3 @@ class AdaptiveMtFile extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/AdaptiveMtSentence.php
+++ b/Translate/src/V3/AdaptiveMtSentence.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An AdaptiveMt sentence entry.
@@ -224,4 +224,3 @@ class AdaptiveMtSentence extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/AdaptiveMtTranslateRequest.php
+++ b/Translate/src/V3/AdaptiveMtTranslateRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request for sending an AdaptiveMt translation query.
@@ -80,7 +80,7 @@ class AdaptiveMtTranslateRequest extends \Google\Protobuf\Internal\Message
      *     @type string $dataset
      *           Required. The resource name for the dataset to use for adaptive MT.
      *           `projects/{project}/locations/{location-id}/adaptiveMtDatasets/{dataset}`
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $content
+     *     @type array<string>|\Google\Protobuf\RepeatedField $content
      *           Required. The content of the input in string format.
      *     @type \Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentenceConfig $reference_sentence_config
      *           Configuration for caller provided reference sentences.
@@ -155,7 +155,7 @@ class AdaptiveMtTranslateRequest extends \Google\Protobuf\Internal\Message
      * Required. The content of the input in string format.
      *
      * Generated from protobuf field <code>repeated string content = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getContent()
     {
@@ -166,7 +166,7 @@ class AdaptiveMtTranslateRequest extends \Google\Protobuf\Internal\Message
      * Required. The content of the input in string format.
      *
      * Generated from protobuf field <code>repeated string content = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setContent($var)
@@ -254,4 +254,3 @@ class AdaptiveMtTranslateRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/AdaptiveMtTranslateRequest/GlossaryConfig.php
+++ b/Translate/src/V3/AdaptiveMtTranslateRequest/GlossaryConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Configures which glossary is used for a specific target language and
@@ -154,5 +154,3 @@ class GlossaryConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentenceConfig.php
+++ b/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentenceConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Message of caller-provided reference configuration.
@@ -43,7 +43,7 @@ class ReferenceSentenceConfig extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePairList>|\Google\Protobuf\Internal\RepeatedField $reference_sentence_pair_lists
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePairList>|\Google\Protobuf\RepeatedField $reference_sentence_pair_lists
      *           Reference sentences pair lists. Each list will be used as the references
      *           to translate the sentence under "content" field at the corresponding
      *           index. Length of the list is required to be equal to the length of
@@ -66,7 +66,7 @@ class ReferenceSentenceConfig extends \Google\Protobuf\Internal\Message
      * "content" field.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslateRequest.ReferenceSentencePairList reference_sentence_pair_lists = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getReferenceSentencePairLists()
     {
@@ -80,7 +80,7 @@ class ReferenceSentenceConfig extends \Google\Protobuf\Internal\Message
      * "content" field.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslateRequest.ReferenceSentencePairList reference_sentence_pair_lists = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePairList>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePairList>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setReferenceSentencePairLists($var)
@@ -144,5 +144,3 @@ class ReferenceSentenceConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentencePair.php
+++ b/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentencePair.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A pair of sentences used as reference in source and target languages.
@@ -98,5 +98,3 @@ class ReferenceSentencePair extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentencePairList.php
+++ b/Translate/src/V3/AdaptiveMtTranslateRequest/ReferenceSentencePairList.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A list of reference sentence pairs.
@@ -28,7 +28,7 @@ class ReferenceSentencePairList extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePair>|\Google\Protobuf\Internal\RepeatedField $reference_sentence_pairs
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePair>|\Google\Protobuf\RepeatedField $reference_sentence_pairs
      *           Reference sentence pairs.
      * }
      */
@@ -41,7 +41,7 @@ class ReferenceSentencePairList extends \Google\Protobuf\Internal\Message
      * Reference sentence pairs.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslateRequest.ReferenceSentencePair reference_sentence_pairs = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getReferenceSentencePairs()
     {
@@ -52,7 +52,7 @@ class ReferenceSentencePairList extends \Google\Protobuf\Internal\Message
      * Reference sentence pairs.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslateRequest.ReferenceSentencePair reference_sentence_pairs = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePair>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslateRequest\ReferenceSentencePair>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setReferenceSentencePairs($var)
@@ -64,5 +64,3 @@ class ReferenceSentencePairList extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/AdaptiveMtTranslateResponse.php
+++ b/Translate/src/V3/AdaptiveMtTranslateResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An AdaptiveMtTranslate response.
@@ -41,11 +41,11 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\Internal\RepeatedField $translations
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\RepeatedField $translations
      *           Output only. The translation.
      *     @type string $language_code
      *           Output only. The translation's language code.
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\Internal\RepeatedField $glossary_translations
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\RepeatedField $glossary_translations
      *           Text translation response if a glossary is provided in the request. This
      *           could be the same as 'translation' above if no terms apply.
      * }
@@ -59,7 +59,7 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
      * Output only. The translation.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslation translations = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getTranslations()
     {
@@ -70,7 +70,7 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
      * Output only. The translation.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslation translations = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setTranslations($var)
@@ -112,7 +112,7 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
      * could be the same as 'translation' above if no terms apply.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslation glossary_translations = 4;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getGlossaryTranslations()
     {
@@ -124,7 +124,7 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
      * could be the same as 'translation' above if no terms apply.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtTranslation glossary_translations = 4;</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtTranslation>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setGlossaryTranslations($var)
@@ -136,4 +136,3 @@ class AdaptiveMtTranslateResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/AdaptiveMtTranslation.php
+++ b/Translate/src/V3/AdaptiveMtTranslation.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An AdaptiveMt translation.
@@ -64,4 +64,3 @@ class AdaptiveMtTranslation extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchDocumentInputConfig.php
+++ b/Translate/src/V3/BatchDocumentInputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Input configuration for BatchTranslateDocument request.
@@ -120,4 +120,3 @@ class BatchDocumentInputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchDocumentOutputConfig.php
+++ b/Translate/src/V3/BatchDocumentOutputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Output configuration for BatchTranslateDocument request.
@@ -183,4 +183,3 @@ class BatchDocumentOutputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTransferResourcesResponse.php
+++ b/Translate/src/V3/BatchTransferResourcesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for BatchTransferResources.
@@ -28,7 +28,7 @@ class BatchTransferResourcesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\BatchTransferResourcesResponse\TransferResourceResponse>|\Google\Protobuf\Internal\RepeatedField $responses
+     *     @type array<\Google\Cloud\Translate\V3\BatchTransferResourcesResponse\TransferResourceResponse>|\Google\Protobuf\RepeatedField $responses
      *           Responses of the transfer for individual resources.
      * }
      */
@@ -41,7 +41,7 @@ class BatchTransferResourcesResponse extends \Google\Protobuf\Internal\Message
      * Responses of the transfer for individual resources.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.BatchTransferResourcesResponse.TransferResourceResponse responses = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getResponses()
     {
@@ -52,7 +52,7 @@ class BatchTransferResourcesResponse extends \Google\Protobuf\Internal\Message
      * Responses of the transfer for individual resources.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.BatchTransferResourcesResponse.TransferResourceResponse responses = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\BatchTransferResourcesResponse\TransferResourceResponse>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\BatchTransferResourcesResponse\TransferResourceResponse>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setResponses($var)
@@ -64,4 +64,3 @@ class BatchTransferResourcesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTransferResourcesResponse/TransferResourceResponse.php
+++ b/Translate/src/V3/BatchTransferResourcesResponse/TransferResourceResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\BatchTransferResourcesResponse;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Transfer response for a single resource.
@@ -146,5 +146,3 @@ class TransferResourceResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/BatchTranslateDocumentMetadata.php
+++ b/Translate/src/V3/BatchTranslateDocumentMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * State metadata for the batch translation operation.
@@ -408,4 +408,3 @@ class BatchTranslateDocumentMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTranslateDocumentRequest.php
+++ b/Translate/src/V3/BatchTranslateDocumentRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The BatchTranslateDocument request.
@@ -176,12 +176,12 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
      *           Required. The ISO-639 language code of the input document if known, for
      *           example, "en-US" or "sr-Latn". Supported language codes are listed in
      *           [Language Support](https://cloud.google.com/translate/docs/languages).
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $target_language_codes
+     *     @type array<string>|\Google\Protobuf\RepeatedField $target_language_codes
      *           Required. The ISO-639 language code to use for translation of the input
      *           document. Specify up to 10 language codes here. Supported language codes
      *           are listed in [Language
      *           Support](https://cloud.google.com/translate/docs/languages).
-     *     @type array<\Google\Cloud\Translate\V3\BatchDocumentInputConfig>|\Google\Protobuf\Internal\RepeatedField $input_configs
+     *     @type array<\Google\Cloud\Translate\V3\BatchDocumentInputConfig>|\Google\Protobuf\RepeatedField $input_configs
      *           Required. Input configurations.
      *           The total number of files matched should be <= 100.
      *           The total content size to translate should be <= 100M Unicode codepoints.
@@ -304,7 +304,7 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
      * Support](https://cloud.google.com/translate/docs/languages).
      *
      * Generated from protobuf field <code>repeated string target_language_codes = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getTargetLanguageCodes()
     {
@@ -318,7 +318,7 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
      * Support](https://cloud.google.com/translate/docs/languages).
      *
      * Generated from protobuf field <code>repeated string target_language_codes = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setTargetLanguageCodes($var)
@@ -336,7 +336,7 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
      * The files must use UTF-8 encoding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.BatchDocumentInputConfig input_configs = 4 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getInputConfigs()
     {
@@ -350,7 +350,7 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
      * The files must use UTF-8 encoding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.BatchDocumentInputConfig input_configs = 4 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<\Google\Cloud\Translate\V3\BatchDocumentInputConfig>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\BatchDocumentInputConfig>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setInputConfigs($var)
@@ -602,4 +602,3 @@ class BatchTranslateDocumentRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTranslateDocumentResponse.php
+++ b/Translate/src/V3/BatchTranslateDocumentResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -429,4 +429,3 @@ class BatchTranslateDocumentResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTranslateMetadata.php
+++ b/Translate/src/V3/BatchTranslateMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * State metadata for the batch translation operation.
@@ -222,4 +222,3 @@ class BatchTranslateMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTranslateResponse.php
+++ b/Translate/src/V3/BatchTranslateResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -231,4 +231,3 @@ class BatchTranslateResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/BatchTranslateTextRequest.php
+++ b/Translate/src/V3/BatchTranslateTextRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The batch translation request.
@@ -111,7 +111,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      *           Required. Source language code. Supported language codes are listed in
      *           [Language
      *           Support](https://cloud.google.com/translate/docs/languages).
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $target_language_codes
+     *     @type array<string>|\Google\Protobuf\RepeatedField $target_language_codes
      *           Required. Specify up to 10 language codes here. Supported language codes
      *           are listed in [Language
      *           Support](https://cloud.google.com/translate/docs/languages).
@@ -126,7 +126,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      *             `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`,
      *           If the map is empty or a specific model is
      *           not requested for a language pair, then default google model (nmt) is used.
-     *     @type array<\Google\Cloud\Translate\V3\InputConfig>|\Google\Protobuf\Internal\RepeatedField $input_configs
+     *     @type array<\Google\Cloud\Translate\V3\InputConfig>|\Google\Protobuf\RepeatedField $input_configs
      *           Required. Input configurations.
      *           The total number of files matched should be <= 100.
      *           The total content size should be <= 100M Unicode codepoints.
@@ -225,7 +225,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      * Support](https://cloud.google.com/translate/docs/languages).
      *
      * Generated from protobuf field <code>repeated string target_language_codes = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getTargetLanguageCodes()
     {
@@ -238,7 +238,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      * Support](https://cloud.google.com/translate/docs/languages).
      *
      * Generated from protobuf field <code>repeated string target_language_codes = 3 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setTargetLanguageCodes($var)
@@ -300,7 +300,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      * The files must use UTF-8 encoding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.InputConfig input_configs = 5 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getInputConfigs()
     {
@@ -314,7 +314,7 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
      * The files must use UTF-8 encoding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.InputConfig input_configs = 5 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<\Google\Cloud\Translate\V3\InputConfig>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\InputConfig>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setInputConfigs($var)
@@ -432,4 +432,3 @@ class BatchTranslateTextRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateAdaptiveMtDatasetRequest.php
+++ b/Translate/src/V3/CreateAdaptiveMtDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  *  Request message for creating an AdaptiveMtDataset.
@@ -129,4 +129,3 @@ class CreateAdaptiveMtDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateDatasetMetadata.php
+++ b/Translate/src/V3/CreateDatasetMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of create dataset operation.
@@ -196,4 +196,3 @@ class CreateDatasetMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateDatasetRequest.php
+++ b/Translate/src/V3/CreateDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for CreateDataset.
@@ -124,4 +124,3 @@ class CreateDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateGlossaryEntryRequest.php
+++ b/Translate/src/V3/CreateGlossaryEntryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for CreateGlossaryEntry
@@ -124,4 +124,3 @@ class CreateGlossaryEntryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateGlossaryMetadata.php
+++ b/Translate/src/V3/CreateGlossaryMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -144,4 +144,3 @@ class CreateGlossaryMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateGlossaryRequest.php
+++ b/Translate/src/V3/CreateGlossaryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for CreateGlossary.
@@ -124,4 +124,3 @@ class CreateGlossaryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateModelMetadata.php
+++ b/Translate/src/V3/CreateModelMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of create model operation.
@@ -196,4 +196,3 @@ class CreateModelMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/CreateModelRequest.php
+++ b/Translate/src/V3/CreateModelRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for CreateModel.
@@ -129,4 +129,3 @@ class CreateModelRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Dataset.php
+++ b/Translate/src/V3/Dataset.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A dataset that hosts the examples (sentence pairs) used for translation
@@ -403,4 +403,3 @@ class Dataset extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DatasetInputConfig.php
+++ b/Translate/src/V3/DatasetInputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Input configuration for datasets.
@@ -28,7 +28,7 @@ class DatasetInputConfig extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\DatasetInputConfig\InputFile>|\Google\Protobuf\Internal\RepeatedField $input_files
+     *     @type array<\Google\Cloud\Translate\V3\DatasetInputConfig\InputFile>|\Google\Protobuf\RepeatedField $input_files
      *           Files containing the sentence pairs to be imported to the dataset.
      * }
      */
@@ -41,7 +41,7 @@ class DatasetInputConfig extends \Google\Protobuf\Internal\Message
      * Files containing the sentence pairs to be imported to the dataset.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.DatasetInputConfig.InputFile input_files = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getInputFiles()
     {
@@ -52,7 +52,7 @@ class DatasetInputConfig extends \Google\Protobuf\Internal\Message
      * Files containing the sentence pairs to be imported to the dataset.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.DatasetInputConfig.InputFile input_files = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\DatasetInputConfig\InputFile>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\DatasetInputConfig\InputFile>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setInputFiles($var)
@@ -64,4 +64,3 @@ class DatasetInputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DatasetInputConfig/InputFile.php
+++ b/Translate/src/V3/DatasetInputConfig/InputFile.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\DatasetInputConfig;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An input file.
@@ -110,5 +110,3 @@ class InputFile extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/DatasetOutputConfig.php
+++ b/Translate/src/V3/DatasetOutputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Output configuration for datasets.
@@ -72,4 +72,3 @@ class DatasetOutputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteAdaptiveMtDatasetRequest.php
+++ b/Translate/src/V3/DeleteAdaptiveMtDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for deleting an AdaptiveMtDataset.
@@ -83,4 +83,3 @@ class DeleteAdaptiveMtDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteAdaptiveMtFileRequest.php
+++ b/Translate/src/V3/DeleteAdaptiveMtFileRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request for deleting an AdaptiveMt file.
@@ -83,4 +83,3 @@ class DeleteAdaptiveMtFileRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteDatasetMetadata.php
+++ b/Translate/src/V3/DeleteDatasetMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of delete dataset operation.
@@ -196,4 +196,3 @@ class DeleteDatasetMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteDatasetRequest.php
+++ b/Translate/src/V3/DeleteDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for DeleteDataset.
@@ -78,4 +78,3 @@ class DeleteDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteGlossaryEntryRequest.php
+++ b/Translate/src/V3/DeleteGlossaryEntryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for Delete Glossary Entry
@@ -78,4 +78,3 @@ class DeleteGlossaryEntryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteGlossaryMetadata.php
+++ b/Translate/src/V3/DeleteGlossaryMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -144,4 +144,3 @@ class DeleteGlossaryMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteGlossaryRequest.php
+++ b/Translate/src/V3/DeleteGlossaryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for DeleteGlossary.
@@ -78,4 +78,3 @@ class DeleteGlossaryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteGlossaryResponse.php
+++ b/Translate/src/V3/DeleteGlossaryResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -162,4 +162,3 @@ class DeleteGlossaryResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteModelMetadata.php
+++ b/Translate/src/V3/DeleteModelMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of delete model operation.
@@ -196,4 +196,3 @@ class DeleteModelMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DeleteModelRequest.php
+++ b/Translate/src/V3/DeleteModelRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for DeleteModel.
@@ -78,4 +78,3 @@ class DeleteModelRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DetectLanguageRequest.php
+++ b/Translate/src/V3/DetectLanguageRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request message for language detection.
@@ -323,4 +323,3 @@ class DetectLanguageRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DetectLanguageResponse.php
+++ b/Translate/src/V3/DetectLanguageResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response message for language detection.
@@ -29,7 +29,7 @@ class DetectLanguageResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\DetectedLanguage>|\Google\Protobuf\Internal\RepeatedField $languages
+     *     @type array<\Google\Cloud\Translate\V3\DetectedLanguage>|\Google\Protobuf\RepeatedField $languages
      *           The most probable language detected by the Translation API. For each
      *           request, the Translation API will always return only one result.
      * }
@@ -44,7 +44,7 @@ class DetectLanguageResponse extends \Google\Protobuf\Internal\Message
      * request, the Translation API will always return only one result.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.DetectedLanguage languages = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getLanguages()
     {
@@ -56,7 +56,7 @@ class DetectLanguageResponse extends \Google\Protobuf\Internal\Message
      * request, the Translation API will always return only one result.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.DetectedLanguage languages = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\DetectedLanguage>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\DetectedLanguage>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setLanguages($var)
@@ -68,4 +68,3 @@ class DetectLanguageResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DetectedLanguage.php
+++ b/Translate/src/V3/DetectedLanguage.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response message for language detection.
@@ -102,4 +102,3 @@ class DetectedLanguage extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DocumentInputConfig.php
+++ b/Translate/src/V3/DocumentInputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A document translation request input config.
@@ -174,4 +174,3 @@ class DocumentInputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DocumentOutputConfig.php
+++ b/Translate/src/V3/DocumentOutputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A document translation request output config.
@@ -237,4 +237,3 @@ class DocumentOutputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/DocumentTranslation.php
+++ b/Translate/src/V3/DocumentTranslation.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A translated document message.
@@ -46,7 +46,7 @@ class DocumentTranslation extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $byte_stream_outputs
+     *     @type array<string>|\Google\Protobuf\RepeatedField $byte_stream_outputs
      *           The array of translated documents. It is expected to be size 1 for now. We
      *           may produce multiple translated documents in the future for other type of
      *           file formats.
@@ -71,7 +71,7 @@ class DocumentTranslation extends \Google\Protobuf\Internal\Message
      * file formats.
      *
      * Generated from protobuf field <code>repeated bytes byte_stream_outputs = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getByteStreamOutputs()
     {
@@ -84,7 +84,7 @@ class DocumentTranslation extends \Google\Protobuf\Internal\Message
      * file formats.
      *
      * Generated from protobuf field <code>repeated bytes byte_stream_outputs = 1;</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setByteStreamOutputs($var)
@@ -156,4 +156,3 @@ class DocumentTranslation extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Example.php
+++ b/Translate/src/V3/Example.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A sentence pair.
@@ -170,4 +170,3 @@ class Example extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ExportDataMetadata.php
+++ b/Translate/src/V3/ExportDataMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of export data operation.
@@ -196,4 +196,3 @@ class ExportDataMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ExportDataRequest.php
+++ b/Translate/src/V3/ExportDataRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ExportData.
@@ -128,4 +128,3 @@ class ExportDataRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/FileInputSource.php
+++ b/Translate/src/V3/FileInputSource.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * An inlined file.
@@ -132,4 +132,3 @@ class FileInputSource extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GcsDestination.php
+++ b/Translate/src/V3/GcsDestination.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The Google Cloud Storage location for the output content.
@@ -80,4 +80,3 @@ class GcsDestination extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GcsInputSource.php
+++ b/Translate/src/V3/GcsInputSource.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The Google Cloud Storage location for the input content.
@@ -64,4 +64,3 @@ class GcsInputSource extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GcsOutputDestination.php
+++ b/Translate/src/V3/GcsOutputDestination.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The Google Cloud Storage location for the output content.
@@ -72,4 +72,3 @@ class GcsOutputDestination extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GcsSource.php
+++ b/Translate/src/V3/GcsSource.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The Google Cloud Storage location for the input content.
@@ -64,4 +64,3 @@ class GcsSource extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetAdaptiveMtDatasetRequest.php
+++ b/Translate/src/V3/GetAdaptiveMtDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for getting an Adaptive MT dataset.
@@ -83,4 +83,3 @@ class GetAdaptiveMtDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetAdaptiveMtFileRequest.php
+++ b/Translate/src/V3/GetAdaptiveMtFileRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request for getting an AdaptiveMtFile.
@@ -83,4 +83,3 @@ class GetAdaptiveMtFileRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetDatasetRequest.php
+++ b/Translate/src/V3/GetDatasetRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for GetDataset.
@@ -78,4 +78,3 @@ class GetDatasetRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetGlossaryEntryRequest.php
+++ b/Translate/src/V3/GetGlossaryEntryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for the Get Glossary Entry Api
@@ -78,4 +78,3 @@ class GetGlossaryEntryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetGlossaryRequest.php
+++ b/Translate/src/V3/GetGlossaryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for GetGlossary.
@@ -78,4 +78,3 @@ class GetGlossaryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetModelRequest.php
+++ b/Translate/src/V3/GetModelRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for GetModel.
@@ -78,4 +78,3 @@ class GetModelRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GetSupportedLanguagesRequest.php
+++ b/Translate/src/V3/GetSupportedLanguagesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request message for discovering supported languages.
@@ -244,4 +244,3 @@ class GetSupportedLanguagesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Glossary.php
+++ b/Translate/src/V3/Glossary.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Represents a glossary built from user-provided data.
@@ -347,4 +347,3 @@ class Glossary extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Glossary/LanguageCodePair.php
+++ b/Translate/src/V3/Glossary/LanguageCodePair.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\Glossary;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Used with unidirectional glossaries.
@@ -106,5 +106,3 @@ class LanguageCodePair extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/Glossary/LanguageCodesSet.php
+++ b/Translate/src/V3/Glossary/LanguageCodesSet.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\Glossary;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Used with equivalent term set glossaries.
@@ -30,7 +30,7 @@ class LanguageCodesSet extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $language_codes
+     *     @type array<string>|\Google\Protobuf\RepeatedField $language_codes
      *           The ISO-639 language code(s) for terms defined in the glossary.
      *           All entries are unique. The list contains at least two entries.
      *           Expected to be an exact match for GlossaryTerm.language_code.
@@ -47,7 +47,7 @@ class LanguageCodesSet extends \Google\Protobuf\Internal\Message
      * Expected to be an exact match for GlossaryTerm.language_code.
      *
      * Generated from protobuf field <code>repeated string language_codes = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getLanguageCodes()
     {
@@ -60,7 +60,7 @@ class LanguageCodesSet extends \Google\Protobuf\Internal\Message
      * Expected to be an exact match for GlossaryTerm.language_code.
      *
      * Generated from protobuf field <code>repeated string language_codes = 1;</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setLanguageCodes($var)
@@ -72,5 +72,3 @@ class LanguageCodesSet extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/GlossaryEntry.php
+++ b/Translate/src/V3/GlossaryEntry.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Represents a single entry in a glossary.
@@ -181,4 +181,3 @@ class GlossaryEntry extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GlossaryEntry/GlossaryTermsPair.php
+++ b/Translate/src/V3/GlossaryEntry/GlossaryTermsPair.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\GlossaryEntry;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Represents a single entry for an unidirectional glossary.
@@ -118,5 +118,3 @@ class GlossaryTermsPair extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/GlossaryEntry/GlossaryTermsSet.php
+++ b/Translate/src/V3/GlossaryEntry/GlossaryTermsSet.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3\GlossaryEntry;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Represents a single entry for an equivalent term set glossary. This is used
@@ -31,7 +31,7 @@ class GlossaryTermsSet extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\GlossaryTerm>|\Google\Protobuf\Internal\RepeatedField $terms
+     *     @type array<\Google\Cloud\Translate\V3\GlossaryTerm>|\Google\Protobuf\RepeatedField $terms
      *           Each term in the set represents a term that can be replaced by the other
      *           terms.
      * }
@@ -46,7 +46,7 @@ class GlossaryTermsSet extends \Google\Protobuf\Internal\Message
      * terms.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.GlossaryTerm terms = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getTerms()
     {
@@ -58,7 +58,7 @@ class GlossaryTermsSet extends \Google\Protobuf\Internal\Message
      * terms.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.GlossaryTerm terms = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\GlossaryTerm>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\GlossaryTerm>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setTerms($var)
@@ -70,5 +70,3 @@ class GlossaryTermsSet extends \Google\Protobuf\Internal\Message
     }
 
 }
-
-

--- a/Translate/src/V3/GlossaryInputConfig.php
+++ b/Translate/src/V3/GlossaryInputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Input configuration for glossaries.
@@ -117,4 +117,3 @@ class GlossaryInputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/GlossaryTerm.php
+++ b/Translate/src/V3/GlossaryTerm.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Represents a single glossary term
@@ -98,4 +98,3 @@ class GlossaryTerm extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ImportAdaptiveMtFileRequest.php
+++ b/Translate/src/V3/ImportAdaptiveMtFileRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request for importing an AdaptiveMt file along with its sentences.
@@ -158,4 +158,3 @@ class ImportAdaptiveMtFileRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ImportAdaptiveMtFileResponse.php
+++ b/Translate/src/V3/ImportAdaptiveMtFileResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response for importing an AdaptiveMtFile
@@ -74,4 +74,3 @@ class ImportAdaptiveMtFileResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ImportDataMetadata.php
+++ b/Translate/src/V3/ImportDataMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Metadata of import data operation.
@@ -196,4 +196,3 @@ class ImportDataMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ImportDataRequest.php
+++ b/Translate/src/V3/ImportDataRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ImportData.
@@ -128,4 +128,3 @@ class ImportDataRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/InputConfig.php
+++ b/Translate/src/V3/InputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Input configuration for BatchTranslateText request.
@@ -163,4 +163,3 @@ class InputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtDatasetsRequest.php
+++ b/Translate/src/V3/ListAdaptiveMtDatasetsRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for listing all Adaptive MT datasets that the requestor has
@@ -210,4 +210,3 @@ class ListAdaptiveMtDatasetsRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtDatasetsResponse.php
+++ b/Translate/src/V3/ListAdaptiveMtDatasetsResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A list of AdaptiveMtDatasets.
@@ -36,7 +36,7 @@ class ListAdaptiveMtDatasetsResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtDataset>|\Google\Protobuf\Internal\RepeatedField $adaptive_mt_datasets
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtDataset>|\Google\Protobuf\RepeatedField $adaptive_mt_datasets
      *           Output only. A list of Adaptive MT datasets.
      *     @type string $next_page_token
      *           Optional. A token to retrieve a page of results. Pass this value in the
@@ -53,7 +53,7 @@ class ListAdaptiveMtDatasetsResponse extends \Google\Protobuf\Internal\Message
      * Output only. A list of Adaptive MT datasets.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtDataset adaptive_mt_datasets = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getAdaptiveMtDatasets()
     {
@@ -64,7 +64,7 @@ class ListAdaptiveMtDatasetsResponse extends \Google\Protobuf\Internal\Message
      * Output only. A list of Adaptive MT datasets.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtDataset adaptive_mt_datasets = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtDataset>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtDataset>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setAdaptiveMtDatasets($var)
@@ -106,4 +106,3 @@ class ListAdaptiveMtDatasetsResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtFilesRequest.php
+++ b/Translate/src/V3/ListAdaptiveMtFilesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request to list all AdaptiveMt files under a given dataset.
@@ -172,4 +172,3 @@ class ListAdaptiveMtFilesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtFilesResponse.php
+++ b/Translate/src/V3/ListAdaptiveMtFilesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response for listing all AdaptiveMt files under a given dataset.
@@ -36,7 +36,7 @@ class ListAdaptiveMtFilesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtFile>|\Google\Protobuf\Internal\RepeatedField $adaptive_mt_files
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtFile>|\Google\Protobuf\RepeatedField $adaptive_mt_files
      *           Output only. The Adaptive MT files.
      *     @type string $next_page_token
      *           Optional. A token to retrieve a page of results. Pass this value in the
@@ -53,7 +53,7 @@ class ListAdaptiveMtFilesResponse extends \Google\Protobuf\Internal\Message
      * Output only. The Adaptive MT files.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtFile adaptive_mt_files = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getAdaptiveMtFiles()
     {
@@ -64,7 +64,7 @@ class ListAdaptiveMtFilesResponse extends \Google\Protobuf\Internal\Message
      * Output only. The Adaptive MT files.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtFile adaptive_mt_files = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtFile>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtFile>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setAdaptiveMtFiles($var)
@@ -106,4 +106,3 @@ class ListAdaptiveMtFilesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtSentencesRequest.php
+++ b/Translate/src/V3/ListAdaptiveMtSentencesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request for listing Adaptive MT sentences from a Dataset/File.
@@ -175,4 +175,3 @@ class ListAdaptiveMtSentencesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListAdaptiveMtSentencesResponse.php
+++ b/Translate/src/V3/ListAdaptiveMtSentencesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * List AdaptiveMt sentences response.
@@ -34,7 +34,7 @@ class ListAdaptiveMtSentencesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtSentence>|\Google\Protobuf\Internal\RepeatedField $adaptive_mt_sentences
+     *     @type array<\Google\Cloud\Translate\V3\AdaptiveMtSentence>|\Google\Protobuf\RepeatedField $adaptive_mt_sentences
      *           Output only. The list of AdaptiveMtSentences.
      *     @type string $next_page_token
      *           Optional.
@@ -49,7 +49,7 @@ class ListAdaptiveMtSentencesResponse extends \Google\Protobuf\Internal\Message
      * Output only. The list of AdaptiveMtSentences.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtSentence adaptive_mt_sentences = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getAdaptiveMtSentences()
     {
@@ -60,7 +60,7 @@ class ListAdaptiveMtSentencesResponse extends \Google\Protobuf\Internal\Message
      * Output only. The list of AdaptiveMtSentences.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.AdaptiveMtSentence adaptive_mt_sentences = 1 [(.google.api.field_behavior) = OUTPUT_ONLY];</code>
-     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtSentence>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\AdaptiveMtSentence>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setAdaptiveMtSentences($var)
@@ -98,4 +98,3 @@ class ListAdaptiveMtSentencesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListDatasetsRequest.php
+++ b/Translate/src/V3/ListDatasetsRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ListDatasets.
@@ -163,4 +163,3 @@ class ListDatasetsRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListDatasetsResponse.php
+++ b/Translate/src/V3/ListDatasetsResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for ListDatasets.
@@ -36,7 +36,7 @@ class ListDatasetsResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Dataset>|\Google\Protobuf\Internal\RepeatedField $datasets
+     *     @type array<\Google\Cloud\Translate\V3\Dataset>|\Google\Protobuf\RepeatedField $datasets
      *           The datasets read.
      *     @type string $next_page_token
      *           A token to retrieve next page of results.
@@ -53,7 +53,7 @@ class ListDatasetsResponse extends \Google\Protobuf\Internal\Message
      * The datasets read.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Dataset datasets = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getDatasets()
     {
@@ -64,7 +64,7 @@ class ListDatasetsResponse extends \Google\Protobuf\Internal\Message
      * The datasets read.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Dataset datasets = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Dataset>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Dataset>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setDatasets($var)
@@ -106,4 +106,3 @@ class ListDatasetsResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListExamplesRequest.php
+++ b/Translate/src/V3/ListExamplesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ListExamples.
@@ -205,4 +205,3 @@ class ListExamplesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListExamplesResponse.php
+++ b/Translate/src/V3/ListExamplesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for ListExamples.
@@ -36,7 +36,7 @@ class ListExamplesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Example>|\Google\Protobuf\Internal\RepeatedField $examples
+     *     @type array<\Google\Cloud\Translate\V3\Example>|\Google\Protobuf\RepeatedField $examples
      *           The sentence pairs.
      *     @type string $next_page_token
      *           A token to retrieve next page of results.
@@ -53,7 +53,7 @@ class ListExamplesResponse extends \Google\Protobuf\Internal\Message
      * The sentence pairs.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Example examples = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getExamples()
     {
@@ -64,7 +64,7 @@ class ListExamplesResponse extends \Google\Protobuf\Internal\Message
      * The sentence pairs.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Example examples = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Example>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Example>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setExamples($var)
@@ -106,4 +106,3 @@ class ListExamplesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListGlossariesRequest.php
+++ b/Translate/src/V3/ListGlossariesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ListGlossaries.
@@ -256,4 +256,3 @@ class ListGlossariesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListGlossariesResponse.php
+++ b/Translate/src/V3/ListGlossariesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for ListGlossaries.
@@ -36,7 +36,7 @@ class ListGlossariesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Glossary>|\Google\Protobuf\Internal\RepeatedField $glossaries
+     *     @type array<\Google\Cloud\Translate\V3\Glossary>|\Google\Protobuf\RepeatedField $glossaries
      *           The list of glossaries for a project.
      *     @type string $next_page_token
      *           A token to retrieve a page of results. Pass this value in the
@@ -53,7 +53,7 @@ class ListGlossariesResponse extends \Google\Protobuf\Internal\Message
      * The list of glossaries for a project.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Glossary glossaries = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getGlossaries()
     {
@@ -64,7 +64,7 @@ class ListGlossariesResponse extends \Google\Protobuf\Internal\Message
      * The list of glossaries for a project.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Glossary glossaries = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Glossary>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Glossary>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setGlossaries($var)
@@ -106,4 +106,3 @@ class ListGlossariesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListGlossaryEntriesRequest.php
+++ b/Translate/src/V3/ListGlossaryEntriesRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ListGlossaryEntries
@@ -167,4 +167,3 @@ class ListGlossaryEntriesRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListGlossaryEntriesResponse.php
+++ b/Translate/src/V3/ListGlossaryEntriesResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for ListGlossaryEntries
@@ -35,7 +35,7 @@ class ListGlossaryEntriesResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\GlossaryEntry>|\Google\Protobuf\Internal\RepeatedField $glossary_entries
+     *     @type array<\Google\Cloud\Translate\V3\GlossaryEntry>|\Google\Protobuf\RepeatedField $glossary_entries
      *           Optional. The Glossary Entries
      *     @type string $next_page_token
      *           Optional. A token to retrieve a page of results. Pass this value in the
@@ -51,7 +51,7 @@ class ListGlossaryEntriesResponse extends \Google\Protobuf\Internal\Message
      * Optional. The Glossary Entries
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.GlossaryEntry glossary_entries = 1 [(.google.api.field_behavior) = OPTIONAL];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getGlossaryEntries()
     {
@@ -62,7 +62,7 @@ class ListGlossaryEntriesResponse extends \Google\Protobuf\Internal\Message
      * Optional. The Glossary Entries
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.GlossaryEntry glossary_entries = 1 [(.google.api.field_behavior) = OPTIONAL];</code>
-     * @param array<\Google\Cloud\Translate\V3\GlossaryEntry>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\GlossaryEntry>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setGlossaryEntries($var)
@@ -102,4 +102,3 @@ class ListGlossaryEntriesResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListModelsRequest.php
+++ b/Translate/src/V3/ListModelsRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for ListModels.
@@ -205,4 +205,3 @@ class ListModelsRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/ListModelsResponse.php
+++ b/Translate/src/V3/ListModelsResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Response message for ListModels.
@@ -36,7 +36,7 @@ class ListModelsResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Model>|\Google\Protobuf\Internal\RepeatedField $models
+     *     @type array<\Google\Cloud\Translate\V3\Model>|\Google\Protobuf\RepeatedField $models
      *           The models read.
      *     @type string $next_page_token
      *           A token to retrieve next page of results.
@@ -53,7 +53,7 @@ class ListModelsResponse extends \Google\Protobuf\Internal\Message
      * The models read.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Model models = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getModels()
     {
@@ -64,7 +64,7 @@ class ListModelsResponse extends \Google\Protobuf\Internal\Message
      * The models read.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Model models = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Model>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Model>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setModels($var)
@@ -106,4 +106,3 @@ class ListModelsResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Model.php
+++ b/Translate/src/V3/Model.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A trained translation model.
@@ -414,4 +414,3 @@ class Model extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/OutputConfig.php
+++ b/Translate/src/V3/OutputConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Output configuration for BatchTranslateText request.
@@ -246,4 +246,3 @@ class OutputConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Romanization.php
+++ b/Translate/src/V3/Romanization.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A single romanization response.
@@ -118,4 +118,3 @@ class Romanization extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/RomanizeTextRequest.php
+++ b/Translate/src/V3/RomanizeTextRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request message for synchronous romanization.
@@ -81,7 +81,7 @@ class RomanizeTextRequest extends \Google\Protobuf\Internal\Message
      *           `projects/{project-number-or-id}`.
      *           For global calls, use `projects/{project-number-or-id}/locations/global` or
      *           `projects/{project-number-or-id}`.
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $contents
+     *     @type array<string>|\Google\Protobuf\RepeatedField $contents
      *           Required. The content of the input in string format.
      *     @type string $source_language_code
      *           Optional. The ISO-639 language code of the input text if
@@ -138,7 +138,7 @@ class RomanizeTextRequest extends \Google\Protobuf\Internal\Message
      * Required. The content of the input in string format.
      *
      * Generated from protobuf field <code>repeated string contents = 1 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getContents()
     {
@@ -149,7 +149,7 @@ class RomanizeTextRequest extends \Google\Protobuf\Internal\Message
      * Required. The content of the input in string format.
      *
      * Generated from protobuf field <code>repeated string contents = 1 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setContents($var)
@@ -199,4 +199,3 @@ class RomanizeTextRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/RomanizeTextResponse.php
+++ b/Translate/src/V3/RomanizeTextResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response message for synchronous romanization.
@@ -30,7 +30,7 @@ class RomanizeTextResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Romanization>|\Google\Protobuf\Internal\RepeatedField $romanizations
+     *     @type array<\Google\Cloud\Translate\V3\Romanization>|\Google\Protobuf\RepeatedField $romanizations
      *           Text romanization responses.
      *           This field has the same length as
      *           [`contents`][google.cloud.translation.v3.RomanizeTextRequest.contents].
@@ -47,7 +47,7 @@ class RomanizeTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.RomanizeTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Romanization romanizations = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getRomanizations()
     {
@@ -60,7 +60,7 @@ class RomanizeTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.RomanizeTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Romanization romanizations = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Romanization>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Romanization>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setRomanizations($var)
@@ -72,4 +72,3 @@ class RomanizeTextResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/SupportedLanguage.php
+++ b/Translate/src/V3/SupportedLanguage.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A single supported language response corresponds to information related
@@ -183,4 +183,3 @@ class SupportedLanguage extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/SupportedLanguages.php
+++ b/Translate/src/V3/SupportedLanguages.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The response message for discovering supported languages.
@@ -29,7 +29,7 @@ class SupportedLanguages extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\SupportedLanguage>|\Google\Protobuf\Internal\RepeatedField $languages
+     *     @type array<\Google\Cloud\Translate\V3\SupportedLanguage>|\Google\Protobuf\RepeatedField $languages
      *           A list of supported language responses. This list contains an entry
      *           for each language the Translation API supports.
      * }
@@ -44,7 +44,7 @@ class SupportedLanguages extends \Google\Protobuf\Internal\Message
      * for each language the Translation API supports.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.SupportedLanguage languages = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getLanguages()
     {
@@ -56,7 +56,7 @@ class SupportedLanguages extends \Google\Protobuf\Internal\Message
      * for each language the Translation API supports.
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.SupportedLanguage languages = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\SupportedLanguage>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\SupportedLanguage>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setLanguages($var)
@@ -68,4 +68,3 @@ class SupportedLanguages extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TranslateDocumentRequest.php
+++ b/Translate/src/V3/TranslateDocumentRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A document translation request.
@@ -636,4 +636,3 @@ class TranslateDocumentRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TranslateDocumentResponse.php
+++ b/Translate/src/V3/TranslateDocumentResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A translated document response message.
@@ -228,4 +228,3 @@ class TranslateDocumentResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TranslateTextGlossaryConfig.php
+++ b/Translate/src/V3/TranslateTextGlossaryConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Configures which glossary is used for a specific target language and defines
@@ -153,4 +153,3 @@ class TranslateTextGlossaryConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TranslateTextRequest.php
+++ b/Translate/src/V3/TranslateTextRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * The request message for synchronous translation.
@@ -213,7 +213,7 @@ class TranslateTextRequest extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<string>|\Google\Protobuf\Internal\RepeatedField $contents
+     *     @type array<string>|\Google\Protobuf\RepeatedField $contents
      *           Required. The content of the input in string format.
      *           We recommend the total content be less than 30,000 codepoints. The max
      *           length of this field is 1024. Use BatchTranslateText for larger text.
@@ -282,7 +282,7 @@ class TranslateTextRequest extends \Google\Protobuf\Internal\Message
      * length of this field is 1024. Use BatchTranslateText for larger text.
      *
      * Generated from protobuf field <code>repeated string contents = 1 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getContents()
     {
@@ -295,7 +295,7 @@ class TranslateTextRequest extends \Google\Protobuf\Internal\Message
      * length of this field is 1024. Use BatchTranslateText for larger text.
      *
      * Generated from protobuf field <code>repeated string contents = 1 [(.google.api.field_behavior) = REQUIRED];</code>
-     * @param array<string>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<string>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setContents($var)
@@ -607,4 +607,3 @@ class TranslateTextRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TranslateTextResponse.php
+++ b/Translate/src/V3/TranslateTextResponse.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Generated from protobuf message <code>google.cloud.translation.v3.TranslateTextResponse</code>
@@ -38,11 +38,11 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
      * @param array $data {
      *     Optional. Data for populating the Message object.
      *
-     *     @type array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\Internal\RepeatedField $translations
+     *     @type array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\RepeatedField $translations
      *           Text translation responses with no glossary applied.
      *           This field has the same length as
      *           [`contents`][google.cloud.translation.v3.TranslateTextRequest.contents].
-     *     @type array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\Internal\RepeatedField $glossary_translations
+     *     @type array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\RepeatedField $glossary_translations
      *           Text translation responses if a glossary is provided in the request.
      *           This can be the same as
      *           [`translations`][google.cloud.translation.v3.TranslateTextResponse.translations]
@@ -61,7 +61,7 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.TranslateTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Translation translations = 1;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getTranslations()
     {
@@ -74,7 +74,7 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.TranslateTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Translation translations = 1;</code>
-     * @param array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setTranslations($var)
@@ -93,7 +93,7 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.TranslateTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Translation glossary_translations = 3;</code>
-     * @return \Google\Protobuf\Internal\RepeatedField
+     * @return \Google\Protobuf\RepeatedField
      */
     public function getGlossaryTranslations()
     {
@@ -108,7 +108,7 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
      * [`contents`][google.cloud.translation.v3.TranslateTextRequest.contents].
      *
      * Generated from protobuf field <code>repeated .google.cloud.translation.v3.Translation glossary_translations = 3;</code>
-     * @param array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\Internal\RepeatedField $var
+     * @param array<\Google\Cloud\Translate\V3\Translation>|\Google\Protobuf\RepeatedField $var
      * @return $this
      */
     public function setGlossaryTranslations($var)
@@ -120,4 +120,3 @@ class TranslateTextResponse extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/Translation.php
+++ b/Translate/src/V3/Translation.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * A single translation response.
@@ -220,4 +220,3 @@ class Translation extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/TransliterationConfig.php
+++ b/Translate/src/V3/TransliterationConfig.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Configures transliteration feature on top of translation.
@@ -68,4 +68,3 @@ class TransliterationConfig extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/UpdateGlossaryEntryRequest.php
+++ b/Translate/src/V3/UpdateGlossaryEntryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for UpdateGlossaryEntry
@@ -87,4 +87,3 @@ class UpdateGlossaryEntryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/UpdateGlossaryMetadata.php
+++ b/Translate/src/V3/UpdateGlossaryMetadata.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Stored in the
@@ -158,4 +158,3 @@ class UpdateGlossaryMetadata extends \Google\Protobuf\Internal\Message
     }
 
 }
-

--- a/Translate/src/V3/UpdateGlossaryRequest.php
+++ b/Translate/src/V3/UpdateGlossaryRequest.php
@@ -5,8 +5,8 @@
 namespace Google\Cloud\Translate\V3;
 
 use Google\Protobuf\Internal\GPBType;
-use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBUtil;
+use Google\Protobuf\RepeatedField;
 
 /**
  * Request message for the update glossary flow
@@ -138,4 +138,3 @@ class UpdateGlossaryRequest extends \Google\Protobuf\Internal\Message
     }
 
 }
-


### PR DESCRIPTION
Hi @bshaffer 

Since `google/protobuf: 4.31.0`, `Google\Protobuf\Internal\RepeatedField` is deprecated in favor of `Google\Protobuf\Internal\RepeatedField`.

The issue of using the old annotations:
- Static analysis warn about the deprecated class
- Since the declaration is
```
if (false) {
    /**
     * This class is deprecated. Use Google\Protobuf\RepeatedField instead.
     * @deprecated
     */
    class RepeatedField {}
}
```
we have no auto-completion for RepeatedField methods and it triggers static analysis error.

I assume the declaration should have been 
```
if (false) {
    /**
     * This class is deprecated. Use Google\Protobuf\RepeatedField instead.
     * @deprecated
     */
    class RepeatedField extends Google\Protobuf\RepeatedField{}
}
```
instead.

Anyway, I solved all the occurence in the phpdoc.

Then, if accepted, I'll be able in another PR to update some phpdoc to use the generic like
```
/** @return RepeatedField<Translation> */
public function getTranslations()
    {
        return $this->translations;
    }
```