### PR TITLE
feat(ci): add release check for "next release" label

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -128,4 +128,4 @@ jobs:
     uses: GoogleCloudPlatform/php-tools/.github/workflows/release-checks.yml@main
     if: github.event.pull_request.user.login == 'release-please[bot]'
     with:
-      next-release-label-check: false
+      next-release-label-check: true


### PR DESCRIPTION
Verify that there are no open PRs with the `next release` label before merging a release PR.

Here's what the check looks like [when it fails](https://github.com/googleapis/google-cloud-php/actions/runs/17245802205/job/48934967367?pr=8541). 