### PR TITLE
feat(dev): add packagist complaince check

### DIFF
--- a/dev/src/Packagist.php
+++ b/dev/src/Packagist.php
@@ -91,6 +91,16 @@ class Packagist
         return $data['downloads']['total'] ?? 0;
     }
 
+    public function getMaintainers(string $packageName): array
+    {
+        $response = $this->client->get("https://packagist.org/packages/$packageName.json");
+        $data = json_decode($response->getBody()->getContents(), true);
+        return array_map(
+            fn ($m) => $m['name'],
+            $data['package']['maintainers']
+        );
+    }
+
     /**
      * Log an exception
      *


### PR DESCRIPTION
clean up `repo-info` output and show the packagist maintainers for a package as well:
**Before**
```
+----------------------------------------+------------+--------------+----------+-----------+-----------------+--------------------+
| Name                                   | Has Issues | Has Projects | Has Wiki | Has Pages | Has Discussions | Teams              |
+----------------------------------------+------------+--------------+----------+-----------+-----------------+--------------------+
| google-cloud-php-access-approval       | false      | false        | false    | false     | false           | **Token Required** |
```

**After**
```
+----------------------------------------+--------------------+------------------+--------------------+
| Name                                   | Repo Config        | Packagist Config | Teams              |
+----------------------------------------+--------------------+------------------+--------------------+
| google-cloud-php-access-approval       | issues: false      | bshaffer         | **Token Required** |
|                                        | projects: false    | google-cloud     |                    |
|                                        | wiki: false        |                  |                    |
|                                        | pages: false       |                  |                    |
|                                        | discussions: false |                  |                    |
```