### PR TITLE
feat: Add documentation for Snapshot and Transaction for lockHint

### DIFF
--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -2040,7 +2040,7 @@ class Database
      *     @type int $orderBy Set the OrderBy option for the ReadRequest.
      *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\OrderBy}
      *           for more information and available options.
-     *     @type int $lockHint Set the LockHint option for the ReadRequest.
+     *     @type int $lockHint Set the LockHint option for the ReadRequest. Only available when transactionType is read/write.
      *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\LockHint}
      *           for more information and available options.
      * }

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -351,6 +351,13 @@ trait TransactionalReadTrait
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type} to set a value.
+     *     @type int $orderBy Set the OrderBy option for the ReadRequest.
+     *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\OrderBy}
+     *           for more information and available options.
+     *     @type int $lockHint Set the LockHint option for the ReadRequest. Only available for ReadWrite transactions
+     *           and not Snapshots.
+     *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\LockHint}
+     *           for more information and available options.
      * }
      * @return Result
      */

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -17,11 +17,14 @@
 
 namespace Google\Cloud\Spanner\Tests\System;
 
+use Google\Cloud\Core\Exception\BadRequestException;
 use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Core\Exception\DeadlineExceededException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
+use Google\Cloud\Spanner\Session\SessionPoolInterface;
+use Google\Cloud\Spanner\V1\ReadRequest\LockHint;
 use Google\Cloud\Spanner\V1\ReadRequest\OrderBy;
 
 /**
@@ -239,6 +242,35 @@ class ReadTest extends SpannerTestCase
                 'The array is not sorted by id in ascending order.'
             );
         }
+    }
+
+    public function testLockHintReadWriteTransaction()
+    {
+        $db = self::$database;
+        $limit = 10;
+
+        $res = $db->read(self::$rangeTableName, new KeySet(['all' => true]), array_keys(self::$dataset[0]), [
+            'begin' => true,
+            'transactionType' => SessionPoolInterface::CONTEXT_READWRITE,
+            'lockHint' => LockHint::LOCK_HINT_EXCLUSIVE,
+            'limit' => $limit,
+        ]);
+
+        $rows = iterator_to_array($res->rows());
+        $this->assertNotEmpty($rows);
+        $this->assertEquals($limit, count($rows));
+    }
+
+    public function testLockHintOnReadOnlyThrowsAnError()
+    {
+        $db = self::$database;
+        $this->expectException(BadRequestException::class);
+
+        $res = $db->read(self::$rangeTableName, new KeySet(['all' => true]), array_keys(self::$dataset[0]), [
+            'lockHint' => LockHint::LOCK_HINT_EXCLUSIVE
+        ]);
+
+        iterator_to_array($res->rows());
     }
 
     /**

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -585,7 +585,7 @@ class ReadTest extends SpannerTestCase
             $json = json_decode($e->getMessage(), true);
 
             if ($json['status'] == 'ALREADY_EXISTS') {
-                $this->insertUnorderedBatch($data);
+                $this->insertUnorderedBatch();
             } else {
                 throw $e;
             }

--- a/Spanner/tests/System/ReadTest.php
+++ b/Spanner/tests/System/ReadTest.php
@@ -263,6 +263,7 @@ class ReadTest extends SpannerTestCase
 
     public function testLockHintOnReadOnlyThrowsAnError()
     {
+        $this->skipEmulatorTests();
         $db = self::$database;
         $this->expectException(BadRequestException::class);
 

--- a/Spanner/tests/System/SnapshotTest.php
+++ b/Spanner/tests/System/SnapshotTest.php
@@ -17,8 +17,13 @@
 
 namespace Google\Cloud\Spanner\Tests\System;
 
+use Google\Cloud\Core\Exception\BadRequestException;
+use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\Duration;
+use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Timestamp;
+use Google\Cloud\Spanner\V1\ReadRequest\LockHint;
+use Google\Cloud\Spanner\V1\ReadRequest\OrderBy;
 
 /**
  * @group spanner
@@ -235,6 +240,65 @@ class SnapshotTest extends SpannerTestCase
         $db->snapshot([
             'maxStaleness' => new Duration(1)
         ]);
+    }
+
+    public function testOrderByInSnapshot()
+    {
+        $db = self::$database;
+
+        $db->insertBatch(self::$tableName, [
+            [
+                'id' => rand(1, 346464),
+                'number' => 1
+            ],
+            [
+                'id' => rand(1, 346464),
+                'number' => 2
+            ]
+        ]);
+
+        $keySet = new KeySet([
+            'all' => true
+        ]);
+        $cols = ['id', 'number'];
+        $options = [
+            'orderBy' => OrderBy::ORDER_BY_PRIMARY_KEY,
+            'limit' => 2,
+        ];
+
+        $snapshot = $db->snapshot();
+        $res = $snapshot->read(self::$tableName, $keySet, $cols, $options);
+        $rows = iterator_to_array($res->rows());
+
+        // Assert that the returned rows are sorted by the 'id' property.
+        for ($i = 0; $i < count($rows) - 1; $i++) {
+            $this->assertLessThanOrEqual(
+                $rows[$i + 1]['id'],
+                $rows[$i]['id'],
+                'The array is not sorted by id in ascending order.'
+            );
+        }
+    }
+
+    public function testLockHintInSnapshotThrowsAnException()
+    {
+        $this->expectException(BadRequestException::class);
+        $db = self::$database;
+
+        $keySet = new KeySet([
+            'all' => true
+        ]);
+        $cols = ['id', 'number'];
+
+        // LockHint is only for read-write transactions
+        $options = [
+            'lockHint' => LockHint::LOCK_HINT_EXCLUSIVE,
+            'limit' => 2,
+        ];
+
+        $snapshot = $db->snapshot();
+        $res = $snapshot->read(self::$tableName, $keySet, $cols, $options);
+        $rows = iterator_to_array($res->rows());
     }
 
     private function getRow($client, $id)

--- a/Spanner/tests/System/SnapshotTest.php
+++ b/Spanner/tests/System/SnapshotTest.php
@@ -282,6 +282,7 @@ class SnapshotTest extends SpannerTestCase
 
     public function testLockHintInSnapshotThrowsAnException()
     {
+        $this->skipEmulatorTests();
         $this->expectException(BadRequestException::class);
         $db = self::$database;
 


### PR DESCRIPTION
The LockHint is only used for read-write transactions. This change fixes the previous version where this was not documented.

This documentation is also added to the Snapshot::Read method as it is internally using the `transactionalReadTrait` for `$snapshot->read()`.