### PR TITLE
feat: Validate options no serializer

### DIFF
--- a/Core/src/ApiHelperTrait.php
+++ b/Core/src/ApiHelperTrait.php
@@ -293,7 +293,7 @@ trait ApiHelperTrait
                 );
                 $messageOptions = $this->pluckArray($messageKeys, $options);
                 if ($optionType instanceof Message) {
-                    $optionType->mergeFromJsonString(json_encode($messageOptions));
+                    $optionType->mergeFromJsonString(json_encode($messageOptions, JSON_FORCE_OBJECT));
                     $validatedOptionGroup = $optionType;
                 } else {
                     $validatedOptionGroup = $messageOptions;

--- a/Core/src/ApiHelperTrait.php
+++ b/Core/src/ApiHelperTrait.php
@@ -19,8 +19,8 @@ namespace Google\Cloud\Core;
 
 use Google\ApiCore\ArrayTrait;
 use Google\ApiCore\Options\CallOptions;
-use Google\Protobuf\NullValue;
 use Google\Protobuf\Internal\Message;
+use Google\Protobuf\NullValue;
 
 /**
  * @internal

--- a/Core/src/ApiHelperTrait.php
+++ b/Core/src/ApiHelperTrait.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Core;
 use Google\ApiCore\ArrayTrait;
 use Google\ApiCore\Options\CallOptions;
 use Google\Protobuf\NullValue;
+use Google\Protobuf\Internal\Message;
 
 /**
  * @internal
@@ -263,5 +264,46 @@ trait ApiHelperTrait
         $optionalArgs = $this->pluckArray($keys, $input);
 
         return [$input, $optionalArgs];
+    }
+
+    /**
+     * Helper method used to validate optons based on the supplied $optionTypes
+     * $optionTypes can be an array of string keys, a protobuf Message classname, or a
+     * the CallOptions classname. Parameters are split and returned in the order
+     * that the options types are provided.
+     */
+    private function validateOptions(array $options, array|Message|string ...$optionTypes): array
+    {
+        $splitOptions = [];
+        foreach ($optionTypes as $optionType) {
+            if (is_array($optionType)) {
+                $splitOptions[] = $this->pluckArray($optionType, $options);
+            } else {
+                if ($optionType === CallOptions::class) {
+                    $callOptionKeys = array_keys((new CallOptions([]))->toArray());
+                    $splitOptions[] = $this->pluckArray($callOptionKeys, $options);
+                } else {
+                    $messageKeys = array_map(
+                        fn ($method) => lcfirst(substr($method, 3)),
+                        array_filter(
+                            get_class_methods($optionType),
+                            fn ($m) => 0 === strpos($m, 'get')
+                        )
+                    );
+                    $messageOptions = $this->pluckArray($messageKeys, $options);
+                    $splitOptions[] = $optionType instanceof Message
+                        ? $this->serializer->decodeMessage($optionType, $messageOptions)
+                        : $messageOptions;
+                }
+            }
+        }
+
+        if (!empty($options)) {
+            throw new \Exception(
+                'Unexpected option(s) provided: ' . implode(', ', array_keys($options))
+            );
+        }
+
+        return $splitOptions;
     }
 }

--- a/Core/src/ApiHelperTrait.php
+++ b/Core/src/ApiHelperTrait.php
@@ -292,9 +292,17 @@ trait ApiHelperTrait
                     )
                 );
                 $messageOptions = $this->pluckArray($messageKeys, $options);
-                $splitOptions[] = $optionType instanceof Message
-                    ? $this->serializer->decodeMessage($optionType, $messageOptions)
-                    : $messageOptions;
+                if ($optionType instanceof Message) {
+                    if (isset($this->serializer)) {
+                        $validatedOptionGroup = $this->serializer->decodeMessage($optionType, $messageOptions);
+                    } else {
+                        $optionType->mergeFromJsonString(json_encode($messageOptions));
+                        $validatedOptionGroup = $optionType;
+                    }
+                } else {
+                    $validatedOptionGroup = $messageOptions;
+                }
+                $splitOptions[] = $validatedOptionGroup;
             } else {
                 throw new LogicException(sprintf('Invalid option type: %s', $optionType));
             }

--- a/Core/src/ApiHelperTrait.php
+++ b/Core/src/ApiHelperTrait.php
@@ -293,12 +293,8 @@ trait ApiHelperTrait
                 );
                 $messageOptions = $this->pluckArray($messageKeys, $options);
                 if ($optionType instanceof Message) {
-                    if (isset($this->serializer)) {
-                        $validatedOptionGroup = $this->serializer->decodeMessage($optionType, $messageOptions);
-                    } else {
-                        $optionType->mergeFromJsonString(json_encode($messageOptions));
-                        $validatedOptionGroup = $optionType;
-                    }
+                    $optionType->mergeFromJsonString(json_encode($messageOptions));
+                    $validatedOptionGroup = $optionType;
                 } else {
                     $validatedOptionGroup = $messageOptions;
                 }

--- a/Core/tests/Unit/ApiHelperTraitTest.php
+++ b/Core/tests/Unit/ApiHelperTraitTest.php
@@ -20,10 +20,10 @@ namespace Google\Cloud\Core\Tests\Unit;
 use Google\ApiCore\Options\CallOptions;
 use Google\ApiCore\Serializer;
 use Google\ApiCore\Testing\MockRequest;
-use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\Duration;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Tests\Unit\Stubs\ApiHelpersTraitImpl;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -303,12 +303,12 @@ class ApiHelperTraitTest extends TestCase
                 ],
                 [
                     CallOptions::class,
-                    MockRequest::class,
+                    new MockRequest(),
                     ['qux'],
                 ],
                 [
                     ['timeoutMillis' => 123],
-                    ['pageToken' => 'bat'],
+                    (new MockRequest())->setPageToken('bat'),
                     ['qux' => 'quux'],
                 ]
             ],
@@ -318,12 +318,12 @@ class ApiHelperTraitTest extends TestCase
                 ],
                 [
                     ['baz'],
-                    MockRequest::class,
+                    new MockRequest(),
                     CallOptions::class,
                 ],
                 [
                     ['baz' => 'bat'],
-                    [],
+                    new MockRequest(),
                     [],
                 ]
             ],
@@ -344,7 +344,7 @@ class ApiHelperTraitTest extends TestCase
         ];
     }
 
-    public function testValidateOptionsWithUnknownOptionThrowsException()
+    public function testValidateOptionsThrowsException()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unexpected option(s) provided: bar');
@@ -357,8 +357,11 @@ class ApiHelperTraitTest extends TestCase
         $this->implementation->validateOptions($options, ['foo']);
     }
 
-    public function testValidateOptionsWithUnknownClassIsIgnored()
+    public function testValidateOptionsWithClassnameThrowsException()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Invalid option type: ' . Blob::class);
+
         $options = [
             'foo' => 'bar',
             'bar' => 'baz',

--- a/Core/tests/Unit/ApiHelperTraitTest.php
+++ b/Core/tests/Unit/ApiHelperTraitTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Core\Tests\Unit;
 
+use Google\ApiCore\Options\CallOptions;
+use Google\ApiCore\Serializer;
+use Google\ApiCore\Testing\MockRequest;
 use Google\Cloud\Core\Duration;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Tests\Unit\Stubs\ApiHelpersTraitImpl;
@@ -36,6 +39,7 @@ class ApiHelperTraitTest extends TestCase
     public function setUp(): void
     {
         $this->implementation = new ApiHelpersTraitImpl();
+        $this->implementation->serializer = new Serializer();
     }
 
     public function testFormatsTimestamp()
@@ -257,5 +261,98 @@ class ApiHelperTraitTest extends TestCase
                 ]
             ]
         ];
+    }
+
+    /**
+     * @dataProvider validateOptionsProvider
+     */
+    public function testValidateOptions($options, $optionTypes, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->implementation->validateOptions($options, ...$optionTypes)
+        );
+    }
+
+    public function validateOptionsProvider()
+    {
+        return [
+            [
+                [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                    'qux' => 'quux',
+                ],
+                [
+                    ['foo', 'baz', 'qux'],
+                ],
+                [
+                    [
+                        'foo' => 'bar',
+                        'baz' => 'bat',
+                        'qux' => 'quux',
+                    ],
+                ]
+            ],
+            [
+                [
+                    'pageToken' => 'bat',
+                    'qux' => 'quux',
+                    'timeoutMillis' => 123,
+                ],
+                [
+                    CallOptions::class,
+                    MockRequest::class,
+                    ['qux'],
+                ],
+                [
+                    ['timeoutMillis' => 123],
+                    ['pageToken' => 'bat'],
+                    ['qux' => 'quux'],
+                ]
+            ],
+            [
+                [
+                    'baz' => 'bat',
+                ],
+                [
+                    ['baz'],
+                    MockRequest::class,
+                    CallOptions::class,
+                ],
+                [
+                    ['baz' => 'bat'],
+                    [],
+                    [],
+                ]
+            ],
+            [
+                [
+                    'baz' => 'bat',
+                    'pageToken' => 'foo1',
+                ],
+                [
+                    ['baz'],
+                    new MockRequest(),
+                ],
+                [
+                    ['baz' => 'bat'],
+                    (new MockRequest())->setPageToken('foo1'),
+                ]
+            ],
+        ];
+    }
+
+    public function testValidateOptionsThrowsException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unexpected option(s) provided: bar');
+
+        $options = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ];
+
+        $this->implementation->validateOptions($options, ['foo']);
     }
 }

--- a/Core/tests/Unit/ApiHelperTraitTest.php
+++ b/Core/tests/Unit/ApiHelperTraitTest.php
@@ -273,6 +273,11 @@ class ApiHelperTraitTest extends TestCase
             $expected,
             $this->implementation->validateOptions($options, ...$optionTypes)
         );
+        // test using an implementation without a serializer
+        $this->assertEquals(
+            $expected,
+            (new ApiHelpersTraitImpl)->validateOptions($options, ...$optionTypes)
+        );
     }
 
     public function validateOptionsProvider()

--- a/Core/tests/Unit/ApiHelperTraitTest.php
+++ b/Core/tests/Unit/ApiHelperTraitTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Core\Tests\Unit;
 use Google\ApiCore\Options\CallOptions;
 use Google\ApiCore\Serializer;
 use Google\ApiCore\Testing\MockRequest;
+use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\Duration;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Tests\Unit\Stubs\ApiHelpersTraitImpl;
@@ -343,7 +344,7 @@ class ApiHelperTraitTest extends TestCase
         ];
     }
 
-    public function testValidateOptionsThrowsException()
+    public function testValidateOptionsWithUnknownOptionThrowsException()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unexpected option(s) provided: bar');
@@ -354,5 +355,22 @@ class ApiHelperTraitTest extends TestCase
         ];
 
         $this->implementation->validateOptions($options, ['foo']);
+    }
+
+    public function testValidateOptionsWithUnknownClassIsIgnored()
+    {
+        $options = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ];
+
+        [$blob, $validated] = $this->implementation->validateOptions(
+            $options,
+            Blob::class,
+            ['foo', 'bar']
+        );
+
+        $this->assertEquals([], $blob);
+        $this->assertEquals($options, $validated);
     }
 }

--- a/Core/tests/Unit/Stubs/ApiHelpersTraitImpl.php
+++ b/Core/tests/Unit/Stubs/ApiHelpersTraitImpl.php
@@ -31,5 +31,8 @@ class ApiHelpersTraitImpl
         formatDurationForApi as public;
         formatValueForApi as public;
         unpackValue as public;
+        validateOptions as public;
     }
+
+    public $serializer;
 }


### PR DESCRIPTION
We decided to remove the use of the serializer method on the `validateOptions` method as it makes certain cases more complicated to utilize.

