### PR TITLE
chore: Don't set `keyFile` when `credentialsFetcher` is given

### DIFF
--- a/Core/tests/Unit/ClientTraitTest.php
+++ b/Core/tests/Unit/ClientTraitTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Core\Tests\Unit;
 
 use Exception;
+use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\Compute\Metadata;
 use Google\Cloud\Core\Exception\GoogleException;
@@ -163,6 +164,28 @@ class ClientTraitTest extends TestCase
 
         $this->assertEquals($keyFile, $conf['keyFile']);
         $this->assertEquals('example_project', $this->impl->___getProperty('projectId'));
+    }
+
+    public function testIgnoreKeyFileWhenUsingCredentialsFetcher()
+    {
+        $credentials = new ServiceAccountCredentials([], Fixtures::SERVICE_ACCOUNT_FIXTURE());
+
+        $conf = $this->impl->call('configureAuthentication', [[
+            'credentialsFetcher' => $credentials,
+        ]]);
+
+        $this->assertArrayNotHasKey('keyFile', $conf);
+    }
+
+    public function testGetProjectIdFromCredentialsFetcher()
+    {
+        $credentials = new ServiceAccountCredentials([], Fixtures::SERVICE_ACCOUNT_FIXTURE());
+
+        $this->impl->call('configureAuthentication', [[
+            'credentialsFetcher' => $credentials,
+        ]]);
+
+        $this->assertEquals('example-project-12345', $this->impl->___getProperty('projectId'));
     }
 
     public function testConfigureAuthenticationWithInvalidKeyFilePath()

--- a/Core/tests/Unit/Fixtures.php
+++ b/Core/tests/Unit/Fixtures.php
@@ -25,6 +25,11 @@ class Fixtures
         return __DIR__ . '/fixtures/json-key-fixture.json';
     }
 
+    public static function SERVICE_ACCOUNT_FIXTURE()
+    {
+        return __DIR__ . '/fixtures/service-account-fixture.json';
+    }
+
     public static function SERVICE_FIXTURE()
     {
         return __DIR__ . '/fixtures/service-fixture.json';

--- a/Core/tests/Unit/fixtures/service-account-fixture.json
+++ b/Core/tests/Unit/fixtures/service-account-fixture.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "example-project-12345",
+  "private_key_id": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC4ziPSL1C/RTMN\nEUen4AyKlQf/W/X4XOtdOP0kBtrhwvFnCdWIc1mb4UjTE/vCCI94VHnDaktuQoFx\nQbMV3USDKYLtIf0wfEtBkucDBZLBDdBAhNCC5aWZWLAXJKw1lPofe8W5088WWjVs\n8Wl4Q6YooZeEYt1DNMnIqEAes4ftBW4V0WUf26YVye9z2p8R7tsI51Z0x0O3fb33\n4oqxmlyP2L/qeyjofFFFNHn25sbENUgO/2r5/qbIWZvlSK3UeHrBbfC3yBuq2wp+\nhHTVwKAgXVt0W5sJ9nw9tVvzoo1NjtSz/Suw83/0/lp1WnY6/qdnXSNXnAqKeP5Y\nMXZS7pM1AgMBAAECggEAL/dBEOK7AIoDcBbWFFpwpt97jenec7IaXL3X5ivpT8N7\nSJUi2SGnVnAoqLB9HaV/J2o1mGTUYy/bzPuScdBWYfy6QLYbsyPvnHt2fjBKINVn\nAff27qKQUrbULY2VLOsX6GgFr++rxk9vonEeQNq+G7mlS/UlHLZs0SnqSo2qb/gR\n1d7Q8lSa3U/5lEQkm7sSUmTUBSkFGSO1I9/1/TjbZ7RTirl3HHNlvdRsu0CiesRx\nPt0utn028cvkJYB0DvDNDqoRIfI6rgf1UPu4UtvFBiubv+eAr8qWc2+Abv0Gobow\nh9SsEJGgBUhiE/lvkilUBeHINUEdwmz/vpCKU15PmQKBgQDiH7HCQbDoZP9FTAOw\nF0gNttFyl/jfr/VR4gB00dPBa2s+SCcTakzw6US57ozQ5CsDpLYEzRvvPYm0z+zh\nuKKxvQsvVwVbyZFDXRn/fMit8eWt4A3yDeMd7Gn/PaiAnMRoOTeY8XgjB74ES9bR\nNDjTIvxbr1rmrb+APBr2B8/IbwKBgQDROOfRkNEdj2Xv1Vb+36/UyyFSY8I5+jdy\n/BIoN5/ywTju4Y2jNGcHPq1H8E+j5FSdKQYKtODURcASKmOwqq0uMOqwlP5l7/9Z\nu7FLQlT8mNTHQwt2IFtk2VEVRrxKSzidoennyq8JJRxYvtE4Ehte1DqFgxdYmqyE\nWNNGSs9ImwKBgQCgn3TskS8yFTQDLHjeJ9uF6lwjM3KUqm/vZ0N9t+LcXQqD5krj\njrny0zB/hsU+SSWI5AJrrKrwKV1dM+mHeVkQOkHssbrbtXXbTRH/mssOTGsjNKmT\nTGwNQHcW2NyN503Y3vPwT25QK9q9QIXqe1b2G774/bnrbHZAh/F63JerPwKBgD59\n58gRoFRa+5CaQWTZfVRq4+YPA/l7Qkqm/eljS/QfQJkhZ8PiqA9i6jD9l1wVnCxh\nD3vtMOZWexsx7Brdr+KHG+JobmAWQkgUJs2a33WfVJa78NV0rre9rVlUinMKaruy\nnAHu6T8rBX+AZ09/IQu/CkfMsxF1CahyO5DYUXeXAoGASocxulMRKaa3NbcsDl0t\nRK89ZgBxii6SgwvARpODTmsnGex5pNI6XVNCPcevyAhuWpoXPeEeg9Qj3FpyGTtz\nZUfKfFtFAAb3TU2C5PF0mTn+4vEL55YBXD4tfeimXzMhg/t2d6FP38g7wN2ejJPr\nBbFaAE9VZFi2OcxtIysoxek=\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-service-account@example-project-12345.iam.gserviceaccount.com",
+  "client_id": "123456789012345678901",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service-account%40example-project-12345.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-php/pull/8617/ marked `keyFile` and `keyFilePath` options as deprecated.

When initializing, for example, `Google\Cloud\Storage\StorageClient`, with

```php
<?php

use Google\Auth\ApplicationDefaultCredentials;
use Google\Cloud\Storage\StorageClient;

putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json');
$credentialsFetcher = new ApplicationDefaultCredentials([], '/path/to/other/credentials.json');

$client = new StorageClient(['credentialsFetcher' => $credentialsFetcher]);
```

the `ClientTrait` will still look for a `keyFile` or `keyFilePath` option and if it doesn't find one, fall back to checking the environment variable or a well known file, and then set the `keyFile` option with it.

With the changes of this PR, the `ClientTrait` will check if the `credentialsFetcher` is set and implements `FetchAuthTokenInterface`, and if it is, it will not look for or set the `keyFile` option. When determining the project ID, it will also check if the `credentialsFetcher` implements the `ProjectIdProviderInterface` to determine the project it.

If no `credentialsFetcher` is given, it will fall back to the currently existing behavior.

:octocat: 