### PR TITLE
chore: Remove unused `kreait/firebase-php` library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,6 @@
         "opis/closure": "^3.7||^4.0",
         "flix-tech/avro-php": "^5.0.0",
         "phpspec/prophecy-phpunit": "^2.1",
-        "kreait/firebase-php": "^6.9",
         "psr/log": "^2.0||^3.0",
         "dg/bypass-finals": "^1.7",
         "squizlabs/php_codesniffer": "3.*",


### PR DESCRIPTION
As the maintainer of the library this feels weird, but… I couldn't find it being used anywhere in the project anymore, so it might be best to remove it 😭.

The failure message in https://github.com/googleapis/google-cloud-php/actions/runs/18658232293/job/53192458852?pr=8654 is what prompted me.

Perhaps I'm wrong and I just didn't find it (full-text search for `kreait`)? 🤞🏻 

:octocat: 