### PR TITLE
chore: Remove `@deprecated` annotation from config array fields

### DIFF
--- a/BigQuery/src/BigQueryClient.php
+++ b/BigQuery/src/BigQueryClient.php
@@ -94,7 +94,7 @@ class BigQueryClient
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
      *           Only valid for requests sent over REST.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -116,7 +116,7 @@ class BigQueryClient
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -122,7 +122,7 @@ class FirestoreClient
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -144,7 +144,7 @@ class FirestoreClient
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Logging/src/LoggingClient.php
+++ b/Logging/src/LoggingClient.php
@@ -168,7 +168,7 @@ class LoggingClient
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
      *           Only valid for requests sent over REST.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -190,7 +190,7 @@ class LoggingClient
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -1522,7 +1522,7 @@ class Bucket
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1543,7 +1543,7 @@ class Bucket
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1652,7 +1652,7 @@ class Bucket
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1673,7 +1673,7 @@ class Bucket
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -98,7 +98,7 @@ class StorageClient
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
      *           Only valid for requests sent over REST.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -120,7 +120,7 @@ class StorageClient
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -928,7 +928,7 @@ class StorageObject
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -949,7 +949,7 @@ class StorageObject
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1085,7 +1085,7 @@ class StorageObject
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1106,7 +1106,7 @@ class StorageObject
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1223,7 +1223,7 @@ class StorageObject
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -1244,7 +1244,7 @@ class StorageObject
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.

--- a/Trace/src/TraceClient.php
+++ b/Trace/src/TraceClient.php
@@ -73,7 +73,7 @@ class TraceClient
      *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
      *           fetcher instance.
      *     @type array $keyFile [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.
@@ -95,7 +95,7 @@ class TraceClient
      *           configurations received from external sources.
      *           @see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
     *     @type string $keyFilePath [DEPRECATED]
-     *           @deprecated This option is being deprecated because of a potential security risk.
+     *           This option is being deprecated because of a potential security risk.
      *           This option does not validate the credential configuration. The security
      *           risk occurs when a credential configuration is accepted from a source
      *           that is not under your control and used without validation on your side.


### PR DESCRIPTION
When running PHPStan with the https://github.com/phpstan/phpstan-deprecation-rules/ extension installed, the whole method is seen as deprecated, leading to violations like in https://github.com/kreait/firebase-php/actions/runs/18822790410/job/53700886141

```
Call to deprecated method __construct() of class Google\Cloud\Storage\StorageClient:
This option is being deprecated because of a potential security risk.
```

When hovering about the constructor in PHPStorm, the constructor itself is marked as deprecated as well (here in the `FirestoreClient`):

<img width="480" alt="CleanShot 2025-10-26 at 22 56 23@2x" src="https://github.com/user-attachments/assets/0193a0a5-388f-4297-95db-cb17f7ba23ee" />

I don't know if this an authoritative source, but https://docs.phpdoc.org/guide/references/phpdoc/tags/deprecated.html mentions that `@deprecated` applies to structural elements - I'm not aware that one is supposed to use it to deprecate fields in an array with this.

:octocat:

PS: I couldn't find a source for `@type` "being a thing" 🙈 