### PR TITLE
fix(Storage): Revert "Implement path containment to prevent traversal attacks"

### DIFF
--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -688,24 +688,9 @@ class StorageObject
      *           If provided one must also include an `encryptionKey`.
      * }
      * @return StreamInterface
-     * @throws \RuntimeException
      */
     public function downloadToFile($path, array $options = [])
     {
-        // throws an exception in the case of `..` segments, paths
-        // starting with `/`, and Windows drive letters (e.g., `C:`).
-        $normalizedPath = str_replace('\\', '/', $path);
-        $pathSegments = explode('/', $normalizedPath);
-
-        if (in_array('..', $pathSegments, true) ||
-            strpos($normalizedPath, '/') === 0 ||
-            preg_match('/^[a-zA-Z]:\//', $normalizedPath)
-        ) {
-            throw new \RuntimeException(
-                'Path traversal is not allowed. File path is outside the designated directory.'
-            );
-        }
-
         $source = $this->downloadAsStream($options);
         $destination = Utils::streamFor(fopen($path, 'w'));
 

--- a/Storage/tests/System/ManageObjectsTest.php
+++ b/Storage/tests/System/ManageObjectsTest.php
@@ -443,7 +443,7 @@ class ManageObjectsTest extends StorageTestCase
         $objectName = uniqid(self::TESTING_PREFIX);
         $testObject = self::$bucket->object($objectName);
         $exceptionString = 'No such object';
-        $downloadFilePath = $objectName;
+        $downloadFilePath = __DIR__ . '/' . $objectName;
 
         $throws = false;
         try {
@@ -455,31 +455,6 @@ class ManageObjectsTest extends StorageTestCase
 
         $this->assertTrue($throws);
         $this->assertFileDoesNotExist($downloadFilePath);
-    }
-
-    /**
-     * @dataProvider provideInvalidFilePaths
-     */
-    public function testDownloadsToFileShouldBlockPathTraversal(string $invalidFilePath)
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'Path traversal is not allowed. File path is outside the designated directory.'
-        );
-
-        $objectName = uniqid(self::TESTING_PREFIX);
-        $testObject = self::$bucket->object($objectName);
-
-        $testObject->downloadToFile($invalidFilePath . $objectName);
-    }
-
-    public function provideInvalidFilePaths()
-    {
-        return [
-            ['storage/../..'], // relative traversal
-            ['/storage/'], // absolute filepath
-            ['C:/storage/'], // windows drive letters
-        ];
     }
 
     public function testDownloadsPublicFileWithUnauthenticatedClient()

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -540,7 +540,7 @@ class StorageObjectTest extends TestCase
         $this->connection->downloadObject(Argument::any())
             ->willThrow(new NotFoundException($exceptionString));
         $object = 'non_existent_object.txt';
-        $downloadFilePath = 'storage_test_downloads_to_file.txt';
+        $downloadFilePath = __DIR__ . '/storage_test_downloads_to_file.txt';
         $object = new StorageObject($this->connection->reveal(), $object, self::BUCKET);
         $throws = false;
         try {
@@ -552,33 +552,6 @@ class StorageObjectTest extends TestCase
 
         $this->assertTrue($throws);
         $this->assertFileDoesNotExist($downloadFilePath);
-    }
-
-    /**
-     * @dataProvider provideInvalidFilePaths
-     */
-    public function testDownloadsToFileShouldBlockPathTraversal(string $invalidFilePath)
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'Path traversal is not allowed. File path is outside the designated directory.'
-        );
-        $stream = Utils::streamFor('mock content');
-        $this->connection->downloadObject(Argument::any())
-            ->willReturn($stream);
-        $objectName = 'storage_test_downloads_to_file.txt';
-        $object = new StorageObject($this->connection->reveal(), $objectName, self::BUCKET);
-
-        $object->downloadToFile($invalidFilePath . $objectName);
-    }
-
-    public function provideInvalidFilePaths()
-    {
-        return [
-            ['storage/../..'], // relative traversal
-            ['/storage/'], // absolute filepath
-            ['C:/storage/'], // windows drive letters
-        ];
     }
 
     public function testDownloadAsStreamWithoutExtraOptions()


### PR DESCRIPTION
This reverts commit 81a39cc71757e837798c8969ee93a6851ca9ed38.

see https://github.com/googleapis/google-cloud-php/issues/8690