### PR TITLE
chore(dev): fix dev tests

### DIFF
--- a/dev/tests/Unit/Command/NewComponentCommandTest.php
+++ b/dev/tests/Unit/Command/NewComponentCommandTest.php
@@ -65,7 +65,8 @@ class NewComponentCommandTest extends TestCase
     public function testNewComponent()
     {
         self::$commandTester->setInputs([
-            'Y'    // Does this information look correct? [Y/n]
+            'Y',    // Does this information look correct? [Y/n]
+            'https://cloud.google.com/secret-manager', // What is the product homepage?
         ]);
 
         self::$commandTester->execute([
@@ -185,7 +186,9 @@ class NewComponentCommandTest extends TestCase
         $commandTester = new CommandTester($application->get('new-component'));
 
         $commandTester->setInputs([
-            'Y'    // Does this information look correct? [Y/n]
+            'Y',   // Component already exists. Overwrite it? ? [Y/n]
+            'Y',   // Does this information look correct? [Y/n]
+            'https://cloud.google.com/secret-manager', // What is the product homepage?
         ]);
 
         $commandTester->execute([


### PR DESCRIPTION
fix newly failing tests due to presumably an update in the `symfony/command` component that rightfully is validating that the command tester inputs are correct