### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,9 @@
 # explicitly taken by someone else.
 *                               @googleapis/cloud-sdk-php-team
 
-/Bigtable       @googleapis/api-bigtable @googleapis/cloud-sdk-php-team
-/Datastore/     @googleapis/api-datastore-sdk @googleapis/cloud-sdk-php-team
-/Firestore/     @googleapis/api-firestore @googleapis/cloud-sdk-php-team
-/Storage/       @googleapis/gcs-sdk-team @googleapis/cloud-sdk-php-team
-/BigQuery*/.    @googleapis/api-bigquery @googleapis/cloud-sdk-php-team
-/PubSub/        @googleapis/api-pubsub @googleapis/cloud-sdk-php-team
+/Bigtable       @googleapis/bigtable-team @googleapis/cloud-sdk-php-team
+/Datastore/     @googleapis/cloud-sdk-php-team
+/Firestore/     @googleapis/firestore-team @googleapis/cloud-sdk-php-team
+/Storage/       @googleapis/gcs-team @googleapis/cloud-sdk-php-team
+/BigQuery*/.    @googleapis/bigquery-team @googleapis/cloud-sdk-php-team
+/PubSub/        @googleapis/pubsub-team @googleapis/cloud-sdk-php-team


### PR DESCRIPTION
This PR replaces old Bigtable, Firestore, BigQuery, PubSub, and Storage teams with their updated names. It also removes @googleapis/api-datastore-sdk. There's no dedicated Datastore team now. The language teams share the maintenance.

b/478003109
