### PR TITLE
fix: Fix a null value record not returning null and causing a type mismatch on function call

### DIFF
--- a/BigQuery/src/ValueMapper.php
+++ b/BigQuery/src/ValueMapper.php
@@ -121,6 +121,10 @@ class ValueMapper
                     ? $this->int64TimestampFromBigQuery($value)
                     : $this->floatTimestampFromBigQuery($value);
             case self::TYPE_RECORD:
+                if (is_null($value)) {
+                    return null;
+                }
+
                 return $this->recordFromBigQuery($value, $schema['fields']);
             case self::TYPE_GEOGRAPHY:
                 return new Geography((string) $value);

--- a/BigQuery/tests/Unit/ValueMapperTest.php
+++ b/BigQuery/tests/Unit/ValueMapperTest.php
@@ -225,6 +225,25 @@ class ValueMapperTest extends TestCase
             ],
             [
                 [
+                    'v' => null
+                ],
+                [
+                    'type' => 'RECORD',
+                    'fields' => [
+                        [
+                            'name' => 'Say',
+                            'type' => 'STRING'
+                        ],
+                        [
+                            'name' => 'To the',
+                            'type' => 'STRING'
+                        ]
+                    ]
+                ],
+                null
+            ],
+            [
+                [
                     'v' => [
                         ['v' => 'Hello'],
                         ['v' => 'World']


### PR DESCRIPTION
Issue: #8872 

Added a null check on the `TYPE_RECORD` handling for the value mapper. This is to:
* Avoid calling a method with the incorrect type crashing the program
* Return the correct value for null (Which would be null)


