### PR TITLE
chore: remove logic to remove class_alias from owlbot

### DIFF
--- a/AccessApproval/owlbot.py
+++ b/AccessApproval/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AccessContextManager/owlbot.py
+++ b/AccessContextManager/owlbot.py
@@ -37,15 +37,6 @@ php.owlbot_copy_version(
 # copy V1 protos and GAPIC files
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AdsAdManager/owlbot.py
+++ b/AdsAdManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AdsDataManager/owlbot.py
+++ b/AdsDataManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AdvisoryNotifications/owlbot.py
+++ b/AdvisoryNotifications/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AiPlatform/owlbot.py
+++ b/AiPlatform/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AlloyDb/owlbot.py
+++ b/AlloyDb/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AnalyticsAdmin/owlbot.py
+++ b/AnalyticsAdmin/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AnalyticsData/owlbot.py
+++ b/AnalyticsData/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApiGateway/owlbot.py
+++ b/ApiGateway/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApiHub/owlbot.py
+++ b/ApiHub/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApiKeys/owlbot.py
+++ b/ApiKeys/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApiRegistry/owlbot.py
+++ b/ApiRegistry/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApigeeConnect/owlbot.py
+++ b/ApigeeConnect/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ApigeeRegistry/owlbot.py
+++ b/ApigeeRegistry/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AppEngineAdmin/owlbot.py
+++ b/AppEngineAdmin/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AppHub/owlbot.py
+++ b/AppHub/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AppsChat/owlbot.py
+++ b/AppsChat/owlbot.py
@@ -60,15 +60,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AppsEventsSubscriptions/owlbot.py
+++ b/AppsEventsSubscriptions/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AppsMeet/owlbot.py
+++ b/AppsMeet/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ArtifactRegistry/owlbot.py
+++ b/ArtifactRegistry/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Asset/owlbot.py
+++ b/Asset/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AssuredWorkloads/owlbot.py
+++ b/AssuredWorkloads/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AuditManager/owlbot.py
+++ b/AuditManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/AutoMl/owlbot.py
+++ b/AutoMl/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BackupDr/owlbot.py
+++ b/BackupDr/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BareMetalSolution/owlbot.py
+++ b/BareMetalSolution/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Batch/owlbot.py
+++ b/Batch/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BeyondCorpAppConnections/owlbot.py
+++ b/BeyondCorpAppConnections/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BeyondCorpAppConnectors/owlbot.py
+++ b/BeyondCorpAppConnectors/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BeyondCorpAppGateways/owlbot.py
+++ b/BeyondCorpAppGateways/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BeyondCorpClientConnectorServices/owlbot.py
+++ b/BeyondCorpClientConnectorServices/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BeyondCorpClientGateways/owlbot.py
+++ b/BeyondCorpClientGateways/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryAnalyticsHub/owlbot.py
+++ b/BigQueryAnalyticsHub/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryConnection/owlbot.py
+++ b/BigQueryConnection/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryDataExchange/owlbot.py
+++ b/BigQueryDataExchange/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryDataPolicies/owlbot.py
+++ b/BigQueryDataPolicies/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryDataTransfer/owlbot.py
+++ b/BigQueryDataTransfer/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryMigration/owlbot.py
+++ b/BigQueryMigration/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryReservation/owlbot.py
+++ b/BigQueryReservation/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BigQueryStorage/owlbot.py
+++ b/BigQueryStorage/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Billing/owlbot.py
+++ b/Billing/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BillingBudgets/owlbot.py
+++ b/BillingBudgets/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/BinaryAuthorization/owlbot.py
+++ b/BinaryAuthorization/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Build/owlbot.py
+++ b/Build/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/CapacityPlanner/owlbot.py
+++ b/CapacityPlanner/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/CertificateManager/owlbot.py
+++ b/CertificateManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Ces/owlbot.py
+++ b/Ces/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Channel/owlbot.py
+++ b/Channel/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Chronicle/owlbot.py
+++ b/Chronicle/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/CommerceConsumerProcurement/owlbot.py
+++ b/CommerceConsumerProcurement/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Compute/owlbot.py
+++ b/Compute/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ConfidentialComputing/owlbot.py
+++ b/ConfidentialComputing/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Config/owlbot.py
+++ b/Config/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ConfigDelivery/owlbot.py
+++ b/ConfigDelivery/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ContactCenterInsights/owlbot.py
+++ b/ContactCenterInsights/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Container/owlbot.py
+++ b/Container/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ContainerAnalysis/owlbot.py
+++ b/ContainerAnalysis/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ControlsPartner/owlbot.py
+++ b/ControlsPartner/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DataCatalog/owlbot.py
+++ b/DataCatalog/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DataCatalogLineage/owlbot.py
+++ b/DataCatalogLineage/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DataFusion/owlbot.py
+++ b/DataFusion/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DataLabeling/owlbot.py
+++ b/DataLabeling/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DatabaseCenter/owlbot.py
+++ b/DatabaseCenter/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dataflow/owlbot.py
+++ b/Dataflow/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dataform/owlbot.py
+++ b/Dataform/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dataplex/owlbot.py
+++ b/Dataplex/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dataproc/owlbot.py
+++ b/Dataproc/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DataprocMetastore/owlbot.py
+++ b/DataprocMetastore/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Datastore/owlbot.py
+++ b/Datastore/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DatastoreAdmin/owlbot.py
+++ b/DatastoreAdmin/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Datastream/owlbot.py
+++ b/Datastream/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Deploy/owlbot.py
+++ b/Deploy/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DeveloperConnect/owlbot.py
+++ b/DeveloperConnect/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DeviceStreaming/owlbot.py
+++ b/DeviceStreaming/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dialogflow/owlbot.py
+++ b/Dialogflow/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DialogflowCx/owlbot.py
+++ b/DialogflowCx/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DiscoveryEngine/owlbot.py
+++ b/DiscoveryEngine/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dlp/owlbot.py
+++ b/Dlp/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Dms/owlbot.py
+++ b/Dms/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/DocumentAi/owlbot.py
+++ b/DocumentAi/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Domains/owlbot.py
+++ b/Domains/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/EdgeNetwork/owlbot.py
+++ b/EdgeNetwork/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/EssentialContacts/owlbot.py
+++ b/EssentialContacts/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Eventarc/owlbot.py
+++ b/Eventarc/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/EventarcPublishing/owlbot.py
+++ b/EventarcPublishing/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Filestore/owlbot.py
+++ b/Filestore/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/FinancialServices/owlbot.py
+++ b/FinancialServices/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Functions/owlbot.py
+++ b/Functions/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GSuiteAddOns/owlbot.py
+++ b/GSuiteAddOns/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GeminiDataAnalytics/owlbot.py
+++ b/GeminiDataAnalytics/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GeoCommonProtos/owlbot.py
+++ b/GeoCommonProtos/owlbot.py
@@ -38,13 +38,3 @@ php.owlbot_copy_version(
     copy_excludes=copy_excludes,
     version_string="type",
 )
-
-# remove class_alias code
-s.replace(
-    "src/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-

--- a/GkeBackup/owlbot.py
+++ b/GkeBackup/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GkeConnectGateway/owlbot.py
+++ b/GkeConnectGateway/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GkeHub/owlbot.py
+++ b/GkeHub/owlbot.py
@@ -44,15 +44,6 @@ shutil.rmtree(proto_dir / "RbacRoleBindingActuation")
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GkeMultiCloud/owlbot.py
+++ b/GkeMultiCloud/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/GkeRecommender/owlbot.py
+++ b/GkeRecommender/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Grafeas/owlbot.py
+++ b/Grafeas/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/HypercomputeCluster/owlbot.py
+++ b/HypercomputeCluster/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Iam/owlbot.py
+++ b/Iam/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/IamCredentials/owlbot.py
+++ b/IamCredentials/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Iap/owlbot.py
+++ b/Iap/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Ids/owlbot.py
+++ b/Ids/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Kms/owlbot.py
+++ b/Kms/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/KmsInventory/owlbot.py
+++ b/KmsInventory/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Language/owlbot.py
+++ b/Language/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/LicenseManager/owlbot.py
+++ b/LicenseManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/LifeSciences/owlbot.py
+++ b/LifeSciences/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/LocationFinder/owlbot.py
+++ b/LocationFinder/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Lustre/owlbot.py
+++ b/Lustre/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Maintenance/owlbot.py
+++ b/Maintenance/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ManagedIdentities/owlbot.py
+++ b/ManagedIdentities/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ManagedKafka/owlbot.py
+++ b/ManagedKafka/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ManagedKafkaSchemaRegistry/owlbot.py
+++ b/ManagedKafkaSchemaRegistry/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/MapsFleetEngine/owlbot.py
+++ b/MapsFleetEngine/owlbot.py
@@ -44,15 +44,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/MapsFleetEngineDelivery/owlbot.py
+++ b/MapsFleetEngineDelivery/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/MapsRouteOptimization/owlbot.py
+++ b/MapsRouteOptimization/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/MediaTranslation/owlbot.py
+++ b/MediaTranslation/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Memcache/owlbot.py
+++ b/Memcache/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Memorystore/owlbot.py
+++ b/Memorystore/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/MigrationCenter/owlbot.py
+++ b/MigrationCenter/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ModelArmor/owlbot.py
+++ b/ModelArmor/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Monitoring/owlbot.py
+++ b/Monitoring/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/NetApp/owlbot.py
+++ b/NetApp/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/NetworkConnectivity/owlbot.py
+++ b/NetworkConnectivity/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/NetworkManagement/owlbot.py
+++ b/NetworkManagement/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/NetworkSecurity/owlbot.py
+++ b/NetworkSecurity/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/NetworkServices/owlbot.py
+++ b/NetworkServices/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Notebooks/owlbot.py
+++ b/Notebooks/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Optimization/owlbot.py
+++ b/Optimization/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/OracleDatabase/owlbot.py
+++ b/OracleDatabase/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/OrchestrationAirflow/owlbot.py
+++ b/OrchestrationAirflow/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/OrgPolicy/owlbot.py
+++ b/OrgPolicy/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/OsConfig/owlbot.py
+++ b/OsConfig/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/OsLogin/owlbot.py
+++ b/OsLogin/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Parallelstore/owlbot.py
+++ b/Parallelstore/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ParameterManager/owlbot.py
+++ b/ParameterManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PolicySimulator/owlbot.py
+++ b/PolicySimulator/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PolicyTroubleshooter/owlbot.py
+++ b/PolicyTroubleshooter/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PolicyTroubleshooterIam/owlbot.py
+++ b/PolicyTroubleshooterIam/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PrivateCatalog/owlbot.py
+++ b/PrivateCatalog/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PrivilegedAccessManager/owlbot.py
+++ b/PrivilegedAccessManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Profiler/owlbot.py
+++ b/Profiler/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/PubSub/owlbot.py
+++ b/PubSub/owlbot.py
@@ -39,15 +39,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 s.replace(
     'tests/**/V1/*Test.php',
     r'Copyright \d{4}',

--- a/Quotas/owlbot.py
+++ b/Quotas/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/RapidMigrationAssessment/owlbot.py
+++ b/RapidMigrationAssessment/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/RecaptchaEnterprise/owlbot.py
+++ b/RecaptchaEnterprise/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/RecommendationEngine/owlbot.py
+++ b/RecommendationEngine/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Recommender/owlbot.py
+++ b/Recommender/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Redis/owlbot.py
+++ b/Redis/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/RedisCluster/owlbot.py
+++ b/RedisCluster/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ResourceManager/owlbot.py
+++ b/ResourceManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Retail/owlbot.py
+++ b/Retail/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Run/owlbot.py
+++ b/Run/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Scheduler/owlbot.py
+++ b/Scheduler/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecretManager/owlbot.py
+++ b/SecretManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecureSourceManager/owlbot.py
+++ b/SecureSourceManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecurityCenter/owlbot.py
+++ b/SecurityCenter/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecurityCenterManagement/owlbot.py
+++ b/SecurityCenterManagement/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecurityCompliance/owlbot.py
+++ b/SecurityCompliance/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecurityPrivateCa/owlbot.py
+++ b/SecurityPrivateCa/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SecurityPublicCA/owlbot.py
+++ b/SecurityPublicCA/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ServiceControl/owlbot.py
+++ b/ServiceControl/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ServiceDirectory/owlbot.py
+++ b/ServiceDirectory/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ServiceHealth/owlbot.py
+++ b/ServiceHealth/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ServiceManagement/owlbot.py
+++ b/ServiceManagement/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ServiceUsage/owlbot.py
+++ b/ServiceUsage/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Shell/owlbot.py
+++ b/Shell/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingCommonProtos/owlbot.py
+++ b/ShoppingCommonProtos/owlbot.py
@@ -39,15 +39,6 @@ php.owlbot_copy_version(
     version_string="type",
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingCss/owlbot.py
+++ b/ShoppingCss/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantAccounts/owlbot.py
+++ b/ShoppingMerchantAccounts/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantConversions/owlbot.py
+++ b/ShoppingMerchantConversions/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantDataSources/owlbot.py
+++ b/ShoppingMerchantDataSources/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantInventories/owlbot.py
+++ b/ShoppingMerchantInventories/owlbot.py
@@ -39,15 +39,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantIssueResolution/owlbot.py
+++ b/ShoppingMerchantIssueResolution/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantLfp/owlbot.py
+++ b/ShoppingMerchantLfp/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantNotifications/owlbot.py
+++ b/ShoppingMerchantNotifications/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantOrderTracking/owlbot.py
+++ b/ShoppingMerchantOrderTracking/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantProducts/owlbot.py
+++ b/ShoppingMerchantProducts/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantPromotions/owlbot.py
+++ b/ShoppingMerchantPromotions/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantQuota/owlbot.py
+++ b/ShoppingMerchantQuota/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantReports/owlbot.py
+++ b/ShoppingMerchantReports/owlbot.py
@@ -38,15 +38,6 @@ php.owlbot_main(
     ]
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/ShoppingMerchantReviews/owlbot.py
+++ b/ShoppingMerchantReviews/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Spanner/owlbot.py
+++ b/Spanner/owlbot.py
@@ -70,15 +70,6 @@ s.move(admin_library / f'tests/Unit', 'tests/Unit/Admin/Instance', merge=php._me
 # copy GPBMetadata file to metadata
 s.move(admin_library / f'proto/src/GPBMetadata/Google/Spanner', f'metadata/', merge=php._merge)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # fix relative cloud.google.com links
 s.replace(
     "src/**/V*/**/*.php",

--- a/Speech/owlbot.py
+++ b/Speech/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/SqlAdmin/owlbot.py
+++ b/SqlAdmin/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/StorageBatchOperations/owlbot.py
+++ b/StorageBatchOperations/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/StorageControl/owlbot.py
+++ b/StorageControl/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/StorageInsights/owlbot.py
+++ b/StorageInsights/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/StorageTransfer/owlbot.py
+++ b/StorageTransfer/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Support/owlbot.py
+++ b/Support/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Talent/owlbot.py
+++ b/Talent/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Tasks/owlbot.py
+++ b/Tasks/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/TelcoAutomation/owlbot.py
+++ b/TelcoAutomation/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/TextToSpeech/owlbot.py
+++ b/TextToSpeech/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Tpu/owlbot.py
+++ b/Tpu/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Translate/owlbot.py
+++ b/Translate/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VectorSearch/owlbot.py
+++ b/VectorSearch/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VideoIntelligence/owlbot.py
+++ b/VideoIntelligence/owlbot.py
@@ -38,15 +38,6 @@ s.replace(
     "\$arr->count\(\)",
     "count($arr)")
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VideoLiveStream/owlbot.py
+++ b/VideoLiveStream/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VideoStitcher/owlbot.py
+++ b/VideoStitcher/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VideoTranscoder/owlbot.py
+++ b/VideoTranscoder/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Vision/owlbot.py
+++ b/Vision/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VisionAi/owlbot.py
+++ b/VisionAi/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VmMigration/owlbot.py
+++ b/VmMigration/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VmwareEngine/owlbot.py
+++ b/VmwareEngine/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/VpcAccess/owlbot.py
+++ b/VpcAccess/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/WebRisk/owlbot.py
+++ b/WebRisk/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/WebSecurityScanner/owlbot.py
+++ b/WebSecurityScanner/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/Workflows/owlbot.py
+++ b/Workflows/owlbot.py
@@ -69,15 +69,6 @@ s.move(executions_library / 'proto/src/GPBMetadata/Google/Cloud/Workflows',
     merge=preserve_copyright_year,
 )
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # Fix test namespaces
 s.replace(
     'tests/Unit/Executions/*/*.php',

--- a/WorkloadManager/owlbot.py
+++ b/WorkloadManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/dev/templates/owlbot.py.twig
+++ b/dev/templates/owlbot.py.twig
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/dev/tests/fixtures/component/CustomInput/owlbot.py
+++ b/dev/tests/fixtures/component/CustomInput/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',

--- a/dev/tests/fixtures/component/SecretManager/owlbot.py
+++ b/dev/tests/fixtures/component/SecretManager/owlbot.py
@@ -32,15 +32,6 @@ _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
 
-# remove class_alias code
-s.replace(
-    "src/V*/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-
 # format generated clients
 subprocess.run([
     'npm',


### PR DESCRIPTION
Thanks to upgrading to protobuf 4.31, we no longer manually need to remove the `class_alias` at the bottom of message files