### PR TITLE
feat: (BigQuery) Add documentation for the new view option on the table resource

### DIFF
--- a/BigQuery/src/Table.php
+++ b/BigQuery/src/Table.php
@@ -41,10 +41,6 @@ class Table
 {
     const MAX_RETRIES = 100;
     const INSERT_CREATE_MAX_DELAY_MICROSECONDS = 60000000;
-    public const BASIC_METADATA_VIEW = 'BASIC';
-    public const FULL_METADATA_VIEW = 'FULL';
-    public const STORAGE_STATS_METADATA_VIEW = 'STORAGE_STATS';
-    public const UNSPECIFIED_METADATA_VIEW = 'TABLE_METADATA_VIEW_UNSPECIFIED';
 
     use ArrayTrait;
     use ConcurrencyControlTrait;
@@ -724,6 +720,14 @@ class Table
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type string $selectedFields List of table schema fields to return
+     *           (comma-separated). If unspecified, all fields are returned.
+     *     @type string $view Specifies the view that determines which table
+     *           information is returned. Acceptable values are defined in
+     *           {@see \Google\Cloud\BigQuery\TableMetadataView}. By default,
+     *           basic table information and storage statistics (STORAGE_STATS)
+     *           are returned.
+     *
      *     **Note:** If metadata is already cached, $options will be ignored.
      *     Use {@see Table::reload()} to force a refresh with specific options.
      *
@@ -755,6 +759,14 @@ class Table
      *
      * @param array $options [optional] {
      *     Configuration options.
+     *
+     *     @type string $selectedFields List of table schema fields to return
+     *           (comma-separated). If unspecified, all fields are returned.
+     *     @type string $view Specifies the view that determines which table
+     *           information is returned. Acceptable values are defined in
+     *           {@see \Google\Cloud\BigQuery\TableMetadataView}. By default,
+     *           basic table information and storage statistics (STORAGE_STATS)
+     *           are returned.
      *
      *     More information:
      *     https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/tables/get#query-parameters

--- a/BigQuery/src/Table.php
+++ b/BigQuery/src/Table.php
@@ -41,6 +41,10 @@ class Table
 {
     const MAX_RETRIES = 100;
     const INSERT_CREATE_MAX_DELAY_MICROSECONDS = 60000000;
+    public const BASIC_METADATA_VIEW = 'BASIC';
+    public const FULL_METADATA_VIEW = 'FULL';
+    public const STORAGE_STATS_METADATA_VIEW = 'STORAGE_STATS';
+    public const UNSPECIFIED_METADATA_VIEW = 'TABLE_METADATA_VIEW_UNSPECIFIED';
 
     use ArrayTrait;
     use ConcurrencyControlTrait;
@@ -717,7 +721,15 @@ class Table
      *
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables Tables resource documentation.
      *
-     * @param array $options [optional] Configuration options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     **Note:** If metadata is already cached, $options will be ignored.
+     *     Use {@see Table::reload()} to force a refresh with specific options.
+     *
+     *     More information:
+     *     https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/tables/get#query-parameters
+     * }
      * @return array
      */
     public function info(array $options = [])
@@ -741,7 +753,12 @@ class Table
      *
      * @see https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/get Tables get API documentation.
      *
-     * @param array $options [optional] Configuration options.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     More information:
+     *     https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/tables/get#query-parameters
+     * }
      * @return array
      */
     public function reload(array $options = [])

--- a/BigQuery/src/TableMetadataView.php
+++ b/BigQuery/src/TableMetadataView.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+class TableMetadataView
+{
+    /**
+     * Includes basic table information including schema and partitioning specification.
+     * This view does not include storage statistics such as numRows or numBytes.
+     * This view is significantly more efficient and should be used to support high query rates.
+     */
+    public const BASIC = 'BASIC';
+
+    /**
+     * Includes all table information, including storage statistics.
+     * It returns same information as STORAGE_STATS view, but may contain additional information in the future.
+     */
+    public const FULL = 'FULL';
+
+    /**
+     * Includes all information in the BASIC view as well as storage statistics
+     * (numBytes, numLongTermBytes, numRows and lastModifiedTime).
+     */
+    public const STORAGE_STATS = 'STORAGE_STATS';
+
+    /**
+     * The default value. Default to the STORAGE_STATS view.
+     */
+    public const UNSPECIFIED = 'TABLE_METADATA_VIEW_UNSPECIFIED';
+}

--- a/BigQuery/tests/System/ManageTablesTest.php
+++ b/BigQuery/tests/System/ManageTablesTest.php
@@ -454,4 +454,33 @@ class ManageTablesTest extends BigQueryTestCase
             ],
         ];
     }
+
+    public function testTableView()
+    {
+        $id = uniqid(self::TESTING_PREFIX);
+        $table = self::$dataset->createTable($id, [
+            'schema' => [
+                'fields' => [
+                    ['name' => 'column', 'type' => 'STRING']
+                ]
+            ]
+        ]);
+
+        $this->runJob($table->load('{"column": "test"}' . PHP_EOL, [
+            'configuration' => [
+                'load' => [
+                    'sourceFormat' => 'NEWLINE_DELIMITED_JSON'
+                ]
+            ]
+        ]));
+
+        // BASIC view should not include storage statistics
+        $info = $table->reload(['view' => Table::BASIC_METADATA_VIEW]);
+        $this->assertArrayNotHasKey('numRows', $info);
+
+        // FULL view should include storage statistics
+        $info = $table->reload(['view' => Table::FULL_METADATA_VIEW]);
+        $this->assertArrayHasKey('numRows', $info);
+        $this->assertEquals(1, $info['numRows']);
+    }
 }

--- a/BigQuery/tests/System/ManageTablesTest.php
+++ b/BigQuery/tests/System/ManageTablesTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\BigQuery\Tests\System;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Table;
+use Google\Cloud\BigQuery\TableMetadataView;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Core\Exception\FailedPreconditionException;
 
@@ -475,11 +476,11 @@ class ManageTablesTest extends BigQueryTestCase
         ]));
 
         // BASIC view should not include storage statistics
-        $info = $table->reload(['view' => Table::BASIC_METADATA_VIEW]);
+        $info = $table->reload(['view' => TableMetadataView::BASIC]);
         $this->assertArrayNotHasKey('numRows', $info);
 
         // FULL view should include storage statistics
-        $info = $table->reload(['view' => Table::FULL_METADATA_VIEW]);
+        $info = $table->reload(['view' => TableMetadataView::FULL]);
         $this->assertArrayHasKey('numRows', $info);
         $this->assertEquals(1, $info['numRows']);
     }


### PR DESCRIPTION
Adds documentation linking to the `tables.get` options documentation to refer to the newly added `view` parameter. The code automatically accepts this option, but we needed to document it for our users.

b/236283039