### PR TITLE
ci: remove unused secrets from kokoro config

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -40,16 +40,6 @@ env_vars: {
     value: ".kokoro/docs/docker/Dockerfile"
 }
 
-# Fetch the token needed for reporting release status to GitHub
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "yoshi-automation-github-key"
-    }
-  }
-}
-
 before_action {
   fetch_keystore {
     keystore_resource {


### PR DESCRIPTION
Removing yoshi-automation-github-key from Kokoro configurations as it is no longer needed.

b/510338703