### PR TITLE
fix(SecurityCenter): rename class using reserved PHP "object" keyword

### DIFF
--- a/BigQueryStorage/metadata/descriptor_fix.php
+++ b/BigQueryStorage/metadata/descriptor_fix.php
@@ -31,11 +31,12 @@ namespace GPBMetadata\Google\Protobuf {
         public static $is_initialized = false;
 
         public static function initOnce() {
+            $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
+
             if (static::$is_initialized == true) {
-                return;
+            return;
             }
 
-            $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
             if ($pool instanceof \Google\Protobuf\Internal\DescriptorPool) {
                 // add a no-op reference for "google.protobuf.DescriptorProto"
                 $pool->addMessage('google.protobuf.DescriptorProto', \Google\Protobuf\DescriptorProto::class)->finalizeToPool();

--- a/BigQueryStorage/metadata/descriptor_fix.php
+++ b/BigQueryStorage/metadata/descriptor_fix.php
@@ -31,12 +31,11 @@ namespace GPBMetadata\Google\Protobuf {
         public static $is_initialized = false;
 
         public static function initOnce() {
-            $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
-
             if (static::$is_initialized == true) {
-            return;
+                return;
             }
 
+            $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
             if ($pool instanceof \Google\Protobuf\Internal\DescriptorPool) {
                 // add a no-op reference for "google.protobuf.DescriptorProto"
                 $pool->addMessage('google.protobuf.DescriptorProto', \Google\Protobuf\DescriptorProto::class)->finalizeToPool();

--- a/SecurityCenter/composer.json
+++ b/SecurityCenter/composer.json
@@ -7,7 +7,10 @@
         "psr-4": {
             "Google\\Cloud\\SecurityCenter\\": "src",
             "GPBMetadata\\Google\\Cloud\\Securitycenter\\": "metadata"
-        }
+        },
+        "files": [
+            "metadata/descriptor_fix.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/SecurityCenter/metadata/descriptor_fix.php
+++ b/SecurityCenter/metadata/descriptor_fix.php
@@ -28,7 +28,7 @@
  */
 namespace GPBMetadata\Google\Cloud\Securitycenter\V1 {
 
-    class KubernetesDescriptorFix
+    class DescriptorFix
     {
         public static $is_initialized = false;
 
@@ -37,19 +37,18 @@ namespace GPBMetadata\Google\Cloud\Securitycenter\V1 {
                 return;
             }
 
-            // This is required to load the descriptor for PBObject
-            \GPBMetadata\Google\Cloud\Securitycenter\V1\Kubernetes::initOnce();
-
             $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
-            $pool->addMessage(
-                'google.cloud.securitycenter.v1.Kubernetes.Object',
-                \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject::class
-            )->finalizeToPool();
+            if ($pool instanceof \Google\Protobuf\Internal\DescriptorPool) {
+                $pool->addMessage(
+                    'google.cloud.securitycenter.v1.Kubernetes.Object',
+                    \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject::class
+                )->finalizeToPool();
+            }
 
             static::$is_initialized = true;
         }
     }
 
-    KubernetesDescriptorFix::initOnce();
+    DescriptorFix::initOnce();
 }
 

--- a/SecurityCenter/metadata/descriptor_fix.php
+++ b/SecurityCenter/metadata/descriptor_fix.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * IMPORTANT: This file prevents an exception when `PBObject` is used.
+ * The `Object` class from `google/cloud/securitycenter/v1/kubernetes.proto` was manually
+ * renamed to `PBObject` in PHP to avoid a conflict with a PHP reserved keyword.
+ * This file ensures that the `PBObject` class is correctly registered with the
+ * Protobuf descriptor pool under its original `Object` descriptor.
+ *
+ * This file can be removed once the protobuf library introduces a fix for
+ * descriptor pool issues when classes are renamed due to reserved keywords.
+ * @see https://github.com/protocolbuffers/protobuf/pull/27456
+ */
+namespace GPBMetadata\Google\Cloud\Securitycenter\V1 {
+
+    class KubernetesDescriptorFix
+    {
+        public static $is_initialized = false;
+
+        public static function initOnce() {
+            if (static::$is_initialized == true) {
+                return;
+            }
+
+            // This is required to load the descriptor for PBObject
+            \GPBMetadata\Google\Cloud\Securitycenter\V1\Kubernetes::initOnce();
+
+            $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
+            $pool->addMessage(
+                'google.cloud.securitycenter.v1.Kubernetes.Object',
+                \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject::class
+            )->finalizeToPool();
+
+            static::$is_initialized = true;
+        }
+    }
+
+    KubernetesDescriptorFix::initOnce();
+}
+

--- a/SecurityCenter/owlbot.py
+++ b/SecurityCenter/owlbot.py
@@ -15,6 +15,7 @@
 """This script is used to synthesize generated parts of this library."""
 
 import logging
+import os
 from pathlib import Path
 import subprocess
 
@@ -31,6 +32,26 @@ dest = Path().resolve()
 _tracked_paths.add(src)
 
 php.owlbot_main(src=src, dest=dest)
+
+# Rename "Object" to "PBObject" because "Object" is a reserved word in PHP
+for version in ["V1", "V2"]:
+    path = f'src/{version}/Kubernetes/Object.php'
+    if Path(path).exists():
+        s.replace(
+            path,
+            r'class Object',
+            r'class PBObject'
+        )
+        s.move(path, f'src/{version}/Kubernetes/PBObject.php')
+        if Path(path).exists():
+            os.remove(path)
+
+# Update typehints
+s.replace(
+    'src/**/*.php',
+    r'Kubernetes\\Object',
+    r'Kubernetes\\PBObject'
+)
 
 # format generated clients
 subprocess.run([

--- a/SecurityCenter/src/V1/Kubernetes.php
+++ b/SecurityCenter/src/V1/Kubernetes.php
@@ -100,7 +100,7 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      *     @type \Google\Cloud\SecurityCenter\V1\Kubernetes\AccessReview[] $access_reviews
      *           Provides information on any Kubernetes access reviews (privilege checks)
      *           relevant to the finding.
-     *     @type \Google\Cloud\SecurityCenter\V1\Kubernetes\Object[] $objects
+     *     @type \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject[] $objects
      *           Kubernetes objects related to the finding.
      * }
      */
@@ -293,7 +293,7 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      * Kubernetes objects related to the finding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.securitycenter.v1.Kubernetes.Object objects = 7;</code>
-     * @return RepeatedField<\Google\Cloud\SecurityCenter\V1\Kubernetes\Object>
+     * @return RepeatedField<\Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject>
      */
     public function getObjects()
     {
@@ -304,12 +304,12 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      * Kubernetes objects related to the finding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.securitycenter.v1.Kubernetes.Object objects = 7;</code>
-     * @param \Google\Cloud\SecurityCenter\V1\Kubernetes\Object[] $var
+     * @param \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject[] $var
      * @return $this
      */
     public function setObjects($var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Cloud\SecurityCenter\V1\Kubernetes\Object::class);
+        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Cloud\SecurityCenter\V1\Kubernetes\PBObject::class);
         $this->objects = $arr;
 
         return $this;

--- a/SecurityCenter/src/V1/Kubernetes/PBObject.php
+++ b/SecurityCenter/src/V1/Kubernetes/PBObject.php
@@ -15,7 +15,7 @@ use Google\Protobuf\RepeatedField;
  *
  * Generated from protobuf message <code>google.cloud.securitycenter.v1.Kubernetes.Object</code>
  */
-class Object extends \Google\Protobuf\Internal\Message
+class PBObject extends \Google\Protobuf\Internal\Message
 {
     /**
      * Kubernetes object group, such as "policy.k8s.io/v1".

--- a/SecurityCenter/src/V2/Kubernetes.php
+++ b/SecurityCenter/src/V2/Kubernetes.php
@@ -100,7 +100,7 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      *     @type \Google\Cloud\SecurityCenter\V2\Kubernetes\AccessReview[] $access_reviews
      *           Provides information on any Kubernetes access reviews (privilege checks)
      *           relevant to the finding.
-     *     @type \Google\Cloud\SecurityCenter\V2\Kubernetes\Object[] $objects
+     *     @type \Google\Cloud\SecurityCenter\V2\Kubernetes\PBObject[] $objects
      *           Kubernetes objects related to the finding.
      * }
      */
@@ -293,7 +293,7 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      * Kubernetes objects related to the finding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.securitycenter.v2.Kubernetes.Object objects = 7;</code>
-     * @return RepeatedField<\Google\Cloud\SecurityCenter\V2\Kubernetes\Object>
+     * @return RepeatedField<\Google\Cloud\SecurityCenter\V2\Kubernetes\PBObject>
      */
     public function getObjects()
     {
@@ -304,12 +304,12 @@ class Kubernetes extends \Google\Protobuf\Internal\Message
      * Kubernetes objects related to the finding.
      *
      * Generated from protobuf field <code>repeated .google.cloud.securitycenter.v2.Kubernetes.Object objects = 7;</code>
-     * @param \Google\Cloud\SecurityCenter\V2\Kubernetes\Object[] $var
+     * @param \Google\Cloud\SecurityCenter\V2\Kubernetes\PBObject[] $var
      * @return $this
      */
     public function setObjects($var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Cloud\SecurityCenter\V2\Kubernetes\Object::class);
+        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Cloud\SecurityCenter\V2\Kubernetes\PBObject::class);
         $this->objects = $arr;
 
         return $this;

--- a/SecurityCenter/src/V2/Kubernetes/PBObject.php
+++ b/SecurityCenter/src/V2/Kubernetes/PBObject.php
@@ -15,7 +15,7 @@ use Google\Protobuf\RepeatedField;
  *
  * Generated from protobuf message <code>google.cloud.securitycenter.v2.Kubernetes.Object</code>
  */
-class Object extends \Google\Protobuf\Internal\Message
+class PBObject extends \Google\Protobuf\Internal\Message
 {
     /**
      * Kubernetes object group, such as "policy.k8s.io/v1".

--- a/composer.json
+++ b/composer.json
@@ -797,7 +797,8 @@
             "Grafeas\\": "Grafeas/src"
         },
         "files": [
-            "BigQueryStorage/metadata/descriptor_fix.php"
+            "BigQueryStorage/metadata/descriptor_fix.php",
+            "SecurityCenter/metadata/descriptor_fix.php"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
fixes #9193 manually
unblocks https://github.com/googleapis/google-cloud-php/pull/9188

I submitted a fix to core protobuf, (https://github.com/protocolbuffers/protobuf/pull/27456) but it will be a while before that can be merged, released, and we can upgrade our generator to use it, so we need to patch it for now.

BREAKING_CHANGE_REASON= the removed class (`Kubernetes\Object`) throws a PHP fatal error when loaded, so removing it will not break anyone