### PR TITLE
feat(Storage): update StorageObject::exists to use HEAD request instead of GET

### DIFF
--- a/Storage/src/Connection/ConnectionInterface.php
+++ b/Storage/src/Connection/ConnectionInterface.php
@@ -132,6 +132,12 @@ interface ConnectionInterface
 
     /**
      * @param array $args
+     * @return array
+     */
+    public function headObject(array $args = []);
+
+    /**
+     * @param array $args
      */
     public function listObjects(array $args = []);
 

--- a/Storage/src/Connection/ConnectionInterface.php
+++ b/Storage/src/Connection/ConnectionInterface.php
@@ -134,7 +134,7 @@ interface ConnectionInterface
      * @param array $args
      * @return array
      */
-    public function headObject(array $args = []);
+    public function headObject(array $args = []): array;
 
     /**
      * @param array $args

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -310,7 +310,7 @@ class Rest implements ConnectionInterface
      * @param array $args
      * @return array
      */
-    public function headObject(array $args = [])
+    public function headObject(array $args = []): array
     {
         $args += [
             'prettyPrint' => false,
@@ -345,7 +345,8 @@ class Rest implements ConnectionInterface
         $request = $this->requestBuilder->build('objects', 'get', $args);
         $request = $request->withMethod('HEAD');
 
-        return $this->requestWrapper->send($request, $requestOptions);
+        $response = $this->requestWrapper->send($request, $requestOptions);
+        return $response->getHeaders();
     }
 
     /**

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -308,6 +308,48 @@ class Rest implements ConnectionInterface
 
     /**
      * @param array $args
+     * @return array
+     */
+    public function headObject(array $args = [])
+    {
+        $args += [
+            'prettyPrint' => false,
+        ];
+
+        $args['restRetryFunction'] = $this->restRetryFunction ?? $this->getRestRetryFunction(
+            'objects',
+            'get',
+            $args
+        );
+
+        $args += array_filter([
+            'retryStrategy' => $this->retryStrategy,
+            'restDelayFunction' => $this->restDelayFunction,
+            'restCalcDelayFunction' => $this->restCalcDelayFunction,
+            'restRetryListener' => $this->restRetryListener,
+        ]);
+
+        $args = $this->addRetryHeaderLogic($args);
+
+        $requestOptions = $this->pluckArray([
+            'restOptions',
+            'retries',
+            'retryHeaders',
+            'requestTimeout',
+            'restRetryFunction',
+            'restRetryListener',
+            'restDelayFunction',
+            'restCalcDelayFunction',
+        ], $args);
+
+        $request = $this->requestBuilder->build('objects', 'get', $args);
+        $request = $request->withMethod('HEAD');
+
+        return $this->requestWrapper->send($request, $requestOptions);
+    }
+
+    /**
+     * @param array $args
      */
     public function listObjects(array $args = [])
     {

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -146,7 +146,7 @@ class StorageObject
     public function exists(array $options = [])
     {
         try {
-            $this->connection->getObject($this->identity + $options + ['fields' => 'name']);
+            $this->connection->headObject($this->identity + $options);
         } catch (NotFoundException $ex) {
             return false;
         }

--- a/Storage/tests/Snippet/StorageObjectTest.php
+++ b/Storage/tests/Snippet/StorageObjectTest.php
@@ -81,7 +81,7 @@ class StorageObjectTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(StorageObject::class, 'exists');
         $snippet->addLocal('object', $this->object);
 
-        $this->connection->getObject(Argument::any())
+        $this->connection->headObject(Argument::any())
             ->shouldBeCalled()
             ->willReturn([]);
 

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -82,7 +82,7 @@ class StorageObjectTest extends TestCase
 
     public function testDoesExistTrue()
     {
-        $this->connection->getObject(Argument::any())->willReturn(['name' => self::OBJECT]);
+        $this->connection->headObject(Argument::any())->willReturn([]);
         $object = new StorageObject($this->connection->reveal(), self::OBJECT, self::BUCKET);
 
         $this->assertTrue($object->exists());
@@ -90,7 +90,7 @@ class StorageObjectTest extends TestCase
 
     public function testDoesExistFalse()
     {
-        $this->connection->getObject(Argument::any())->willThrow(new NotFoundException(null));
+        $this->connection->headObject(Argument::any())->willThrow(new NotFoundException(null));
         $object = new StorageObject($this->connection->reveal(), self::OBJECT, self::BUCKET);
 
         $this->assertFalse($object->exists());


### PR DESCRIPTION
## Fixes / Addresses
Addresses b/437200793

## Behavior Change & Motivation
Previously, `StorageObject::exists()` invoked `getObject()` (making an HTTP `GET` request) to verify if an object existed. Following a server-side enhancement to Google Cloud Storage Audit Logs, failed `GET` requests against non-existent objects started emitting severity `ERROR` log messages rather than `INFO`.

Because checking whether an object exists is intended for workflows where an object may not be present, it should not generate false-alarm error severity records in Cloud Audit Logs or trigger unnecessary payload data downloads. 

## Technical Implementation
- Introduced `headObject()` definition in `ConnectionInterface` and implemented it in `Rest`.
- Updated `StorageObject::exists()` to use `headObject()` (HTTP `HEAD`) instead of `getObject()` (HTTP `GET`).
- Updated corresponding snippet and unit test expectations.
