### PR TITLE
fix: Change the PageIterator logic to avoid making double calls on Current

### DIFF
--- a/Core/src/Iterator/PageIteratorTrait.php
+++ b/Core/src/Iterator/PageIteratorTrait.php
@@ -84,6 +84,11 @@ trait PageIteratorTrait
     private $initialResultToken;
 
     /**
+     * @var bool
+     */
+    private $isInitialized = false;
+
+    /**
      * @param callable $resultMapper Maps a result.
      * @param callable $call The call to execute.
      * @param array $callOptions Options to use with the call.
@@ -142,15 +147,13 @@ trait PageIteratorTrait
     }
 
     /**
-     * Rewind the iterator.
-     *
-     * @return null
+     * Set up the initial pagination state and tokens.
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    private function initialize()
     {
-        $this->itemCount = 0;
-        $this->position = 0;
+        if ($this->isInitialized) {
+            return;
+        }
 
         if ($this->config['firstPage']) {
             list($this->page, $shouldContinue) = $this->mapResults($this->config['firstPage']);
@@ -163,6 +166,23 @@ trait PageIteratorTrait
         if ($nextResultToken) {
             $this->set($this->resultTokenPath, $this->callOptions, $nextResultToken);
         }
+
+        $this->isInitialized = true;
+    }
+
+    /**
+     * Rewind the iterator.
+     *
+     * @return null
+     */
+    #[\ReturnTypeWillChange]
+    public function rewind()
+    {
+        $this->isInitialized = false;
+        $this->initialize();
+
+        $this->itemCount = 0;
+        $this->position = 0;
     }
 
     /**
@@ -173,6 +193,10 @@ trait PageIteratorTrait
     #[\ReturnTypeWillChange]
     public function current()
     {
+        if (!$this->isInitialized) {
+            $this->initialize();
+        }
+
         if ($this->page === null) {
             $this->page = $this->executeCall();
         }

--- a/Core/src/Iterator/PageIteratorTrait.php
+++ b/Core/src/Iterator/PageIteratorTrait.php
@@ -193,9 +193,7 @@ trait PageIteratorTrait
     #[\ReturnTypeWillChange]
     public function current()
     {
-        if (!$this->isInitialized) {
-            $this->initialize();
-        }
+        $this->initialize();
 
         if ($this->page === null) {
             $this->page = $this->executeCall();

--- a/Core/tests/Unit/Iterator/PageIteratorTest.php
+++ b/Core/tests/Unit/Iterator/PageIteratorTest.php
@@ -137,6 +137,33 @@ class PageIteratorTest extends TestCase
         ];
     }
 
+    public function testCurrentWithoutRewindUsesFirstPage()
+    {
+        $hasCalledNetwork = false;
+        $call = function (array $options) use (&$hasCalledNetwork) {
+            $hasCalledNetwork = true;
+            return ['items' => ['should-not-reach-here']];
+        };
+
+        $pages = new PageIterator(
+            function ($result) {
+                return strtoupper($result);
+            },
+            $call,
+            ['itemsKey' => 'items'],
+            [
+                'firstPage' => [
+                    'items' => self::$page1
+                ]
+            ]
+        );
+
+        $currentPage = $pages->current();
+
+        $this->assertFalse($hasCalledNetwork);
+        $this->assertEquals(array_map('strtoupper', self::$page1), $currentPage);
+    }
+
     public function theCall(array $options)
     {
         $options += [


### PR DESCRIPTION
The logic for PageIterator had a hidden bug:
The `PageIterator` implements the `Iterator` class and the usage of PHP iterator. If the user were to use the `current` method on the iterator (eg: `$rows->getIterator()->current()`) the iterator would check if the first page was filled, if not it would perform an API call.

The way it was setup, calling `current` without calling `rewind` would always end up with an API call, meaning that in some cases the users would end up with a repeated API call even when the results where already in memory.

This PR aims to fix that.