### PR TITLE
feat(docs): add deprecation notice to methods and constants

### DIFF
--- a/dev/src/DocFx/Node/ClassNode.php
+++ b/dev/src/DocFx/Node/ClassNode.php
@@ -24,6 +24,7 @@ use SimpleXMLElement;
  */
 class ClassNode
 {
+    use DeprecatedTrait;
     use DocblockTrait;
     use NameTrait;
 
@@ -115,9 +116,6 @@ class ClassNode
     {
         if ($this->xmlNode->docblock) {
             foreach ($this->xmlNode->docblock->tag as $tag) {
-                if ((string) $tag['name'] === 'deprecated') {
-                    return 'deprecated';
-                }
                 if ((string) $tag['name'] === 'experimental') {
                     return 'beta';
                 }
@@ -268,7 +266,7 @@ class ClassNode
         }
 
         // Skip deprecated classes
-        if ('deprecated' === $this->getStatus()) {
+        if ($this->isDeprecated()) {
             return true;
         }
 

--- a/dev/src/DocFx/Node/ConstantNode.php
+++ b/dev/src/DocFx/Node/ConstantNode.php
@@ -24,6 +24,7 @@ use SimpleXMLElement;
  */
 class ConstantNode
 {
+    use DeprecatedTrait;
     use DocblockTrait;
     use ParentNodeTrait;
     use VisibilityTrait;

--- a/dev/src/DocFx/Node/DeprecatedTrait.php
+++ b/dev/src/DocFx/Node/DeprecatedTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocFx\Node;
+
+/**
+ * @internal
+ */
+trait DeprecatedTrait
+{
+    public function isDeprecated(): bool
+    {
+        if ($this->xmlNode->docblock) {
+            foreach ($this->xmlNode->docblock->tag as $tag) {
+                if ($tag['name'] == 'deprecated') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public function getDeprecatedDescription(): string
+    {
+        if ($this->xmlNode->docblock) {
+            foreach ($this->xmlNode->docblock->tag as $tag) {
+                if ($tag['name'] == 'deprecated') {
+                    return $tag['description'] ?? '';
+                }
+            }
+        }
+        return '';
+    }
+}

--- a/dev/src/DocFx/Node/MethodNode.php
+++ b/dev/src/DocFx/Node/MethodNode.php
@@ -24,6 +24,7 @@ use SimpleXMLElement;
  */
 class MethodNode
 {
+    use DeprecatedTrait;
     use DocblockTrait {
         getContent as getDocblockContent;
     }

--- a/dev/src/DocFx/Node/ParameterNode.php
+++ b/dev/src/DocFx/Node/ParameterNode.php
@@ -174,4 +174,9 @@ class ParameterNode
         $resolved = $resolver->resolve($name, $context);
         return (string) $resolved;
     }
+
+    public function isDeprecated()
+    {
+        return false !== strpos($this->getDescription(), '[DEPRECATED]');
+    }
 }

--- a/dev/src/DocFx/Page/Page.php
+++ b/dev/src/DocFx/Page/Page.php
@@ -183,11 +183,16 @@ class Page
         if ($parameters = $method->getParameters()) {
             $methodItem['syntax']['parameters'] = [];
             foreach ($parameters as $parameter) {
-                $methodItem['syntax']['parameters'][] = [
+                $param = [
                     'id' => $parameter->getName(),
                     'var_type' => $parameter->getType(),
                     'description' => $parameter->getDescription(),
                 ];
+                if ($parameter->isDeprecated()) {
+                    $param['notice_type'] = 'deprecated';
+                }
+
+                $methodItem['syntax']['parameters'][] = $param;
             }
         }
         if ($returnType = $method->getReturnType()) {
@@ -196,6 +201,10 @@ class Page
                 'var_type' => $returnType,
                 'description' => $method->getReturnDescription(),
             ]);
+        }
+        if ($method->isDeprecated()) {
+            $methodItem['notice_type'] = 'deprecated';
+            $methodItem['notice_content'] = $method->getDeprecatedDescription();
         }
         return $methodItem;
     }
@@ -216,6 +225,8 @@ class Page
                 'syntax' => [
                     'content' => 'Value: ' . $constant->getValue(),
                 ],
+                'notice_type' => $constant->isDeprecated() ? 'deprecated' : null,
+                'notice_content' => $constant->getDeprecatedDescription(),
             ]);
 
             $constants[$constantItem['uid']] = $constantItem;

--- a/dev/tests/Unit/DocFx/NodeTest.php
+++ b/dev/tests/Unit/DocFx/NodeTest.php
@@ -44,7 +44,7 @@ class NodeTest extends TestCase
         $params = $method->getParameters();
 
         // Assert the parameters have been parsed
-        $this->assertCount(9, $params);
+        $this->assertCount(10, $params);
 
         // Assert parent option parameter
         $this->assertEquals('data', $params[1]->getName());

--- a/dev/tests/Unit/DocFx/PageTest.php
+++ b/dev/tests/Unit/DocFx/PageTest.php
@@ -17,11 +17,15 @@
 
 namespace Google\Cloud\Dev\Tests\Unit\DocFx;
 
+use Google\Auth\Credentials\AppIdentityCredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Auth\Iam;
+use Google\Auth\OAuth2;
 use PHPUnit\Framework\TestCase;
 use Google\Cloud\Dev\DocFx\Node\ClassNode;
 use Google\Cloud\Dev\DocFx\Node\InterfaceNode;
+use Google\Cloud\Dev\DocFx\Node\MethodNode;
 use Google\Cloud\Dev\DocFx\Page\OverviewPage;
 use Google\Cloud\Dev\DocFx\Page\Page;
 use Google\Cloud\Dev\DocFx\Page\PageTree;
@@ -114,32 +118,61 @@ class PageTest extends TestCase
 
     public function testInterfacePage()
     {
-        $structureXml = __DIR__ . '/../../fixtures/phpdoc/auth.xml';
-        $componentPath = __DIR__ . '/../../../vendor/google/auth';
-        $protoPackages = [];
         $pageTree = new PageTree(
-            $structureXml,
+            __DIR__ . '/../../fixtures/phpdoc/auth.xml',
             'Google\Auth',
             'Google Auth',
-            $componentPath,
-            $protoPackages
+            __DIR__ . '/../../../vendor/google/auth',
+            [],
         );
 
-        $pages = $pageTree->getPages();
-        $interfacePage = null;
-        foreach ($pages as $page) {
-            if (ltrim($page->getClassNode()->getFullname(), '\\') === FetchAuthTokenInterface::class) {
-                $interfacePage = $page;
-                break;
-            }
-        }
-
+        $interfacePage = $this->findNode($pageTree->getPages(), FetchAuthTokenInterface::class);;
         $this->assertNotNull($interfacePage);
-        $description = $interfacePage->getItems()[0]['summary'] ?? '';
+        $description = $interfacePage->getLongDescription();
         $this->assertStringContainsString(
             ServiceAccountCredentials::class,
             $description
         );
+    }
+
+    public function testDeprecatedNodes()
+    {
+        $pageTree = new PageTree(
+            __DIR__ . '/../../fixtures/phpdoc/auth.xml',
+            'Google\Auth',
+            'Google Auth',
+            __DIR__ . '/../../../vendor/google/auth',
+            [],
+        );
+
+        $deprecatedXml = file_get_contents(__DIR__ . '/../../fixtures/phpdoc/deprecated.xml');
+        $deprecatedClass = new ClassNode(new SimpleXMLElement($deprecatedXml), []);
+        $this->assertTrue($deprecatedClass->isDeprecated());
+        $this->assertEquals('this is now deprecated', $deprecatedClass->getDeprecatedDescription());
+
+        $deprecatedConstant = $this->findNode($pageTree->getPages(), Iam::class, 'IAM_API_ROOT');
+        $this->assertNotNull($deprecatedConstant);
+        $this->assertTrue($deprecatedConstant->isDeprecated());
+        $this->assertEquals('', $deprecatedConstant->getDeprecatedDescription());
+
+        $deprecatedMethod = $this->findNode($pageTree->getPages(), OAuth2::class, 'getCacheKey');
+        $this->assertNotNull($deprecatedMethod);
+        $this->assertTrue($deprecatedMethod->isDeprecated());
+        $this->assertNotEquals('', $deprecatedMethod->getDeprecatedDescription());
+
+        $deprecatedParam = $deprecatedClass->getMethods()[0]->getParameters()[0];
+        $this->assertTrue($deprecatedParam->isDeprecated());
+
+        $deprecatedNestedParam = null;
+        $nestedParamsXml = file_get_contents(__DIR__ . '/../../fixtures/phpdoc/nestedparams.xml');
+        $methodWithDeprecatedParams = new MethodNode(new SimpleXMLElement($nestedParamsXml), '', [], '');
+        foreach ($methodWithDeprecatedParams->getParameters() as $nestedParam) {
+            if ($nestedParam->getName() === '↳ obsoleteParam') {
+                $deprecatedNestedParam = $nestedParam;
+            }
+        }
+        $this->assertNotNull($deprecatedNestedParam);
+        $this->assertTrue($deprecatedNestedParam->isDeprecated());
     }
 
     public function testHandleSample()
@@ -157,5 +190,28 @@ class PageTest extends TestCase
         $this->assertNotEmpty($rpcMethod['example']);
         $this->assertCount(1, $rpcMethod['example']);
         $this->assertStringContainsString('function an_rpc_method_sample', $rpcMethod['example'][0]);
+    }
+
+    private function findNode(array $pages, string $className, string $methodOrConstant = '')
+    {
+        foreach ($pages as $page) {
+            if ($page->getClassNode()->getFullname() === '\\' . $className) {
+                if (!$methodOrConstant) {
+                    return $page->getClassNode();
+                }
+
+                foreach ($page->getClassNode()->getMethods() as $method) {
+                    if ($method->getFullname() === '\\' . $className . '::' . $methodOrConstant . '()') {
+                        return $method;
+                    }
+                }
+
+                foreach ($page->getClassNode()->getConstants() as $constant) {
+                    if ($constant->getFullname() === '\\' . $className . '::' . $methodOrConstant) {
+                        return $constant;
+                    }
+                }
+            }
+        }
     }
 }

--- a/dev/tests/fixtures/docfx/Vision/V1.EntityAnnotation.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.EntityAnnotation.yml
@@ -239,6 +239,8 @@ items:
       returns:
         -
           var_type: float
+    notice_type: deprecated
+    notice_content: ''
   -
     uid: '\Google\Cloud\Vision\V1\EntityAnnotation::setConfidence()'
     name: setConfidence
@@ -263,6 +265,8 @@ items:
       returns:
         -
           var_type: $this
+    notice_type: deprecated
+    notice_content: ''
   -
     uid: '\Google\Cloud\Vision\V1\EntityAnnotation::getTopicality()'
     name: getTopicality

--- a/dev/tests/fixtures/docfx/Vision/V1.WebDetectionParams.yml
+++ b/dev/tests/fixtures/docfx/Vision/V1.WebDetectionParams.yml
@@ -49,6 +49,8 @@ items:
       returns:
         -
           var_type: bool
+    notice_type: deprecated
+    notice_content: ''
   -
     uid: '\Google\Cloud\Vision\V1\WebDetectionParams::setIncludeGeoResults()'
     name: setIncludeGeoResults
@@ -67,3 +69,5 @@ items:
       returns:
         -
           var_type: $this
+    notice_type: deprecated
+    notice_content: ''

--- a/dev/tests/fixtures/phpdoc/deprecated.xml
+++ b/dev/tests/fixtures/phpdoc/deprecated.xml
@@ -1,0 +1,36 @@
+<class final="false" abstract="false" namespace="\Test" line="59">
+    <name>DeprecatedClass</name>
+    <full_name>\Test\DeprecatedClass</full_name>
+    <docblock line="59">
+        <description>Some class we no longer use.</description>
+        <long-description></long-description>
+        <tag
+            name="deprecated"
+            description="this is now deprecated"
+        />
+        <tag
+            name="package"
+            description="Application"
+        />
+    </docblock>
+    <method final="false" abstract="false" static="false" namespace="\Test" line="85" visibility="public" returnByReference="false">
+        <name>__construct</name>
+        <full_name>\Test\DeprecatedClass::__construct()</full_name>
+        <value></value>
+        <argument line="85" by_reference="false">
+            <name>scope</name>
+            <default>[]</default>
+            <type>string|string[]</type>
+        </argument>
+        <docblock line="85">
+            <description></description>
+            <long-description></long-description>
+            <tag
+                name="param"
+                description="[DEPRECATED] One or more scopes."
+                variable="scope"
+                type="string|string[]"
+            />
+        </docblock>
+    </method>
+</class>

--- a/dev/tests/fixtures/phpdoc/nestedparams.xml
+++ b/dev/tests/fixtures/phpdoc/nestedparams.xml
@@ -42,6 +42,8 @@
           Ensure special chars are decoded, such as alice&#64;example.com.
     @type string $escapedType
           Ensure @ is escaped, such as in \@type.
+    @type string $obsoleteParam
+          Optional. [DEPRECATED]. This parameter has been deprecated
 }"
             variable="data"
             type="array"


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/6792

adds `deprecated` notice to classes, methods, constants, parameters, and nested parameters

 - Classes can now receive this, but we exclude deprecated classes from the reference documentation. This was done because when we first published the reference documentation, there was no need for deprecated classes. Once we release a GAX and Auth library 2.0, it would make sense to add them back. Once we do, the deprecation notices will show up.
 - Parameters and Nested Parameters can now receive this, but it's important to note there's no consistent way in phpdoc to mark a parameter as deprecated. The closest we have is to prefix the description with `[DEPRECATED]`. In protobuf, sometimes this is after the keyword `Optional`, so if `[DEPRECATED]` shows up anywhere in the parameter or nested parameter description, it's considered deprecated.
 - Constants and methods look for `@deprecated` as expected, but this should be at the END of the constant or method description, otherwise the `notice_content` will contain the phpdoc content instead of just the deprecation content.