### PR TITLE
fix(gax): RetryMiddleware should determine deadlineMs before first call

### DIFF
--- a/Gax/src/Middleware/RetryMiddleware.php
+++ b/Gax/src/Middleware/RetryMiddleware.php
@@ -100,6 +100,11 @@ class RetryMiddleware implements MiddlewareInterface
             return $nextHandler($call, $options);
         }
 
+        // Set the deadline before making the call, if it has not been set
+        if (is_null($this->deadlineMs)) {
+            $this->deadlineMs = $this->getCurrentTimeMs() + $this->retrySettings->getTotalTimeoutMillis();
+        }
+
         return $nextHandler($call, $options)->then(null, function ($e) use ($call, $options) {
             $retryFunction = $this->getRetryFunction();
 
@@ -136,14 +141,12 @@ class RetryMiddleware implements MiddlewareInterface
         $maxDelayMs = $this->retrySettings->getMaxRetryDelayMillis();
         $timeoutMult = $this->retrySettings->getRpcTimeoutMultiplier();
         $maxTimeoutMs = $this->retrySettings->getMaxRpcTimeoutMillis();
-        $totalTimeoutMs = $this->retrySettings->getTotalTimeoutMillis();
 
         $delayMs = $this->retrySettings->getInitialRetryDelayMillis();
         $timeoutMs = $options['timeoutMillis'];
         $currentTimeMs = $this->getCurrentTimeMs();
-        $deadlineMs = $this->deadlineMs ?: $currentTimeMs + $totalTimeoutMs;
 
-        if ($currentTimeMs >= $deadlineMs) {
+        if ($currentTimeMs >= $this->deadlineMs) {
             throw new ApiException(
                 'Retry total timeout exceeded.',
                 \Google\Rpc\Code::DEADLINE_EXCEEDED,
@@ -155,7 +158,7 @@ class RetryMiddleware implements MiddlewareInterface
         $timeoutMs = (int) min(
             $timeoutMs * $timeoutMult,
             $maxTimeoutMs,
-            $deadlineMs - $this->getCurrentTimeMs()
+            $this->deadlineMs - $this->getCurrentTimeMs()
         );
 
         $nextHandler = new RetryMiddleware(
@@ -163,7 +166,7 @@ class RetryMiddleware implements MiddlewareInterface
             $this->retrySettings->with([
                 'initialRetryDelayMillis' => $nextDelayMs,
             ]),
-            $deadlineMs,
+            $this->deadlineMs,
             $this->retryAttempts + 1,
             $this->delayHandler,
         );
@@ -172,7 +175,7 @@ class RetryMiddleware implements MiddlewareInterface
         $options['timeoutMillis'] = $timeoutMs;
 
         // Sleep for the length of the delay
-        ($this->delayHandler)($delayMs);
+        ($this->delayHandler)((int) $delayMs);
 
         return $nextHandler(
             $call,

--- a/Gax/src/RetrySettings.php
+++ b/Gax/src/RetrySettings.php
@@ -376,7 +376,8 @@ class RetrySettings
             'totalTimeoutMillis' => 600000,
             'retryableCodes' => [],
             'maxRetries' => self::DEFAULT_MAX_RETRIES,
-            'retryFunction' => null]);
+            'retryFunction' => null
+        ]);
     }
 
     /**

--- a/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -35,7 +35,6 @@ namespace Google\ApiCore\Tests\Unit\Middleware;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\ApiCore\Call;
-use Google\ApiCore\Middleware\MiddlewareInterface;
 use Google\ApiCore\Middleware\RetryMiddleware;
 use Google\ApiCore\RetrySettings;
 use Google\Rpc\Code;
@@ -226,8 +225,8 @@ class RetryMiddlewareTest extends TestCase
             $callCount += 1;
             $observedTimeouts[] = $options['timeoutMillis'];
             return $promise = new Promise(function () use (&$promise, $callCount) {
-                // each call needs to take at least 1 millisecond otherwise the rounded timeout will not decrease
-                // with each step of the test.
+                // each call needs to take at least 1 millisecond otherwise the rounded timeout will
+                // not decrease with each step of the test.
                 usleep(1000);
                 if ($callCount < 3) {
                     throw new ApiException('Cancelled!', Code::CANCELLED, ApiStatus::CANCELLED);
@@ -246,7 +245,7 @@ class RetryMiddlewareTest extends TestCase
         $this->assertCount(3, $observedTimeouts);
         $this->assertEquals($observedTimeouts[0], $timeout);
         for ($i = 1; $i < count($observedTimeouts); $i++) {
-            $this->assertTrue($observedTimeouts[$i - 1] > $observedTimeouts[$i]);
+            $this->assertLessThan($observedTimeouts[$i - 1], $observedTimeouts[$i]);
         }
     }
 
@@ -341,7 +340,7 @@ class RetryMiddlewareTest extends TestCase
                 'retriesEnabled' => true,
                 'totalTimeoutMillis' => 1,
                 'retryFunction' => function ($ex, $options) {
-                    usleep(900);
+                    usleep(500);
                     return true;
                 }
             ]);

--- a/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -338,9 +338,9 @@ class RetryMiddlewareTest extends TestCase
         $retrySettings = RetrySettings::constructDefault()
             ->with([
                 'retriesEnabled' => true,
-                'totalTimeoutMillis' => 10,
+                'totalTimeoutMillis' => 100,
                 'retryFunction' => function ($ex, $options) {
-                    usleep(5001);
+                    usleep(50001);
                     return true;
                 }
             ]);
@@ -359,7 +359,7 @@ class RetryMiddlewareTest extends TestCase
             $this->fail('Expected an exception, but didn\'t receive any');
         } catch (ApiException $e) {
             $this->assertEquals('Retry total timeout exceeded.', $e->getMessage());
-            // we used a total timeout of 10 ms and every retry sleeps for 9 ms
+            // we used a total timeout of 100ms and every retry sleeps for 50ms
             // This means that the call count should be 2 (original call and 1 retry)
             $this->assertEquals(2, $callCount);
         }

--- a/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/Gax/tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -338,9 +338,9 @@ class RetryMiddlewareTest extends TestCase
         $retrySettings = RetrySettings::constructDefault()
             ->with([
                 'retriesEnabled' => true,
-                'totalTimeoutMillis' => 1,
+                'totalTimeoutMillis' => 10,
                 'retryFunction' => function ($ex, $options) {
-                    usleep(500);
+                    usleep(5001);
                     return true;
                 }
             ]);
@@ -359,8 +359,8 @@ class RetryMiddlewareTest extends TestCase
             $this->fail('Expected an exception, but didn\'t receive any');
         } catch (ApiException $e) {
             $this->assertEquals('Retry total timeout exceeded.', $e->getMessage());
-            // we used a total timeout of 1 ms and every retry sleeps for .9 ms
-            // This means that the call count should be 2(original call and 1 retry)
+            // we used a total timeout of 10 ms and every retry sleeps for 9 ms
+            // This means that the call count should be 2 (original call and 1 retry)
             $this->assertEquals(2, $callCount);
         }
     }


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/9263

`deadlineMs` was being calculated after the first RPC call, which meant the time that RPC call took to complete was not being accounted for in the total timeout.