### PR TITLE
chore: Change the breaking change detector to rebase and run the test against the rebased code

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -18,11 +18,14 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
-      - name: "Ensure that branch is up to date with main branch"
+      - name: "Rebase PR branch onto main branch"
         if: github.event.pull_request.user.login != 'release-please[bot]'
         run: |
-          if ! git merge-base --is-ancestor origin/main ${{ github.event.pull_request.head.sha }}; then
-            echo "PR branch is out of date with main. Please merge or rebase main into your branch to avoid false BC break detections."
+          git config user.name "Github Actions"
+          git config user.email "actions@github.com"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          if ! git rebase origin/main; then
+            echo "Failed to rebase PR branch onto main. There may be conflicts. Please resolve conflicts or rebase manually."
             exit 1
           fi
       - name: "Install dependencies"

--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -10,6 +10,7 @@ jobs:
   backwards-compatibility-check:
     name: Breaking Change Detector
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -32,13 +33,9 @@ jobs:
         run: composer global require "roave/backward-compatibility-check:^8.2"
       - name: "Check for BC breaks"
         if: github.event.pull_request.user.login != 'release-please[bot]'
-        # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
-        continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check --from=origin/main --format=github-actions
       - name: "Check for BC label"
-        # Ensure the build still passes by adding BREAKING_CHANGE_REASON=[reason] to the PR description.
-        continue-on-error: ${{ contains(github.event.pull_request.body, 'BREAKING_CHANGE_REASON=') }}
         run: |
           if [[ "true" == "${{ contains(github.event.pull_request.title, '!:') }}" ]]; then
             echo "Breaking change label found in PR title"


### PR DESCRIPTION
Updates the breaking change detector to rebase the PR branch against main and runs the checks against the updated branch to avoid false negatives that we've seen in the past.