### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/conformance-tests-bigtable-proxy.yaml
+++ b/.github/workflows/conformance-tests-bigtable-proxy.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 # Github action job to test core java library features on
 # downstream client libraries before they are released.
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -31,22 +34,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           extensions: grpc
 
       - name: Checkout Bigtable conformance tests
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: googleapis/cloud-bigtable-clients-test
           ref: v0.0.3
           path: cloud-bigtable-clients-test
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '>=1.20.2'
 

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -16,10 +16,12 @@ jobs:
         name: GAPIC Showcase Conformance Tests
         steps:
         - name: Checkout code
-          uses: actions/checkout@v7
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+          with:
+            persist-credentials: false
 
         - name: Setup PHP
-          uses: shivammathur/setup-php@v2
+          uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
           with:
             php-version: '8.1'
             extensions: grpc

--- a/.github/workflows/conformance-tests-storage-emulator.yaml
+++ b/.github/workflows/conformance-tests-storage-emulator.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -22,10 +25,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: DocFX Test Suite
 on:
   push:
@@ -12,9 +15,11 @@ jobs:
     env:
       PHPDOC_ENV: prod
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.14'
     - run: pip install --no-deps --require-hashes -r .kokoro/docs/docker/requirements.txt
@@ -24,14 +29,16 @@ jobs:
         php-version: "8.2"
     - name: Extract phpDocumentor
       id: extract
-      uses: shrink/actions-docker-extract@v4
+      uses: shrink/actions-docker-extract@f1ef61065b78731fe3310b4e84e511f6a927a77e # v4
       with:
         image: "phpdoc/phpdoc:3.5.3"
         path: "/opt/phpdoc/."
     - name: Symlink phpDocumentor
-      run: ln -s $(pwd)/${{ steps.extract.outputs.destination }}/bin/phpdoc /usr/local/bin/phpdoc
+      run: ln -s $(pwd)/${STEPS_EXTRACT_OUTPUTS_DESTINATION}/bin/phpdoc /usr/local/bin/phpdoc
+      env:
+        STEPS_EXTRACT_OUTPUTS_DESTINATION: ${{ steps.extract.outputs.destination }}
     - name: Install Dependencies
-      uses: nick-invision/retry@v4
+      uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       with:
         timeout_minutes: 10
         max_attempts: 3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: '3.14'
     - run: pip install --no-deps --require-hashes -r .kokoro/docs/docker/requirements.txt
     - name: Setup PHP
-      uses: shivammathur/setup-php@verbose
+      uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
       with:
         php-version: "8.2"
     - name: Extract phpDocumentor

--- a/.github/workflows/emulator-system-tests-bigtable.yaml
+++ b/.github/workflows/emulator-system-tests-bigtable.yaml
@@ -19,12 +19,14 @@ jobs:
     name: Bigtable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - run: ./.github/emulator/start-emulator.sh bigtable 522.0.0-emulators
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: pecl

--- a/.github/workflows/emulator-system-tests-datastore.yaml
+++ b/.github/workflows/emulator-system-tests-datastore.yaml
@@ -19,12 +19,14 @@ jobs:
     name: Datastore
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - run: ./.github/emulator/start-emulator.sh datastore 522.0.0-emulators
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: pecl

--- a/.github/workflows/emulator-system-tests-firestore.yaml
+++ b/.github/workflows/emulator-system-tests-firestore.yaml
@@ -19,12 +19,14 @@ jobs:
     name: Firestore
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - run: ./.github/emulator/start-emulator.sh firestore 522.0.0-emulators
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: pecl

--- a/.github/workflows/emulator-system-tests-pubsub.yaml
+++ b/.github/workflows/emulator-system-tests-pubsub.yaml
@@ -19,12 +19,14 @@ jobs:
     name: PubSub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - run: ./.github/emulator/start-emulator.sh pubsub
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: pecl

--- a/.github/workflows/emulator-system-tests-spanner.yaml
+++ b/.github/workflows/emulator-system-tests-spanner.yaml
@@ -25,10 +25,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Create Spanner instance
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
         with:
           version: '516.0.0'
       - run: gcloud info
@@ -39,7 +41,7 @@ jobs:
       - run: gcloud spanner instances create google-cloud-php-system-tests --config=emulator-config --description="Test Instance" --nodes=1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           ini-values: grpc.enable_fork_support=1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
 
   style_csfixer:
     name: PHP CS Fixer
-    uses: GoogleCloudPlatform/php-tools/.github/workflows/code-standards.yml@main
+    uses: GoogleCloudPlatform/php-tools/.github/workflows/code-standards.yml@main # zizmor: ignore[unpinned-uses]
     with:
       config: GoogleCloudPlatform/php-tools/.php-cs-fixer.default.php@main
       exclude-patterns: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP Style Check
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: '8.1'
     - name: Install Dependencies
@@ -52,9 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     name: PHPStan Static Analysis
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Install PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: '8.2'
     - name: "Install dependencies"

--- a/.github/workflows/major-version-approval.yaml
+++ b/.github/workflows/major-version-approval.yaml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.user.login == 'release-please[bot]' && contains(github.event.pull_request.body, 'MAJOR_VERSION_ALLOWED=')
     steps:
       - name: Run Approval Check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           GH_TOKEN: ${{ secrets.SPLIT_TOKEN }}
         with:

--- a/.github/workflows/owlbot-checks.yaml
+++ b/.github/workflows/owlbot-checks.yaml
@@ -29,9 +29,11 @@ jobs:
         id: compatibility-checker
         continue-on-error: true
         # OwlBot PRs which are not labelled feat should not add new files or methods
+        env:
+          PR_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \
-            --from=origin/${{ github.head_ref || github.ref_name }} \
+            --from=origin/"$PR_REF" \
             --to=origin/main
       - name: "Print the action item"
         run: |

--- a/.github/workflows/owlbot-checks.yaml
+++ b/.github/workflows/owlbot-checks.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: OwlBot Checks
 on:
   pull_request:
@@ -12,11 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'gcf-owl-bot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.1"
       - name: "Install dependencies"
@@ -31,7 +35,7 @@ jobs:
             --to=origin/main
       - name: "Print the action item"
         run: |
-          if [[ "${{ steps.compatibility-checker.outcome }}" == 'failure' ]]; then
+          if [[ "${STEPS_COMPATIBILITY_CHECKER_OUTCOME}" == 'failure' ]]; then
             if [[ "${{ startsWith(github.event.pull_request.title, 'feat') }}" == "false" ]]; then
               echo "Action item: Change the conventional commit to use 'feat'"
               exit 1
@@ -40,6 +44,8 @@ jobs:
             echo "Action item: No features found, do not use 'feat' for the conventional commit"
             exit 1
           fi
+        env:
+          STEPS_COMPATIBILITY_CHECKER_OUTCOME: ${{ steps.compatibility-checker.outcome }}
 
   # Ensure the "owl-bot-staging" directory doesn't exist
   owl-bot-staging-directory-check:
@@ -47,7 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'gcf-owl-bot[bot]' && github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Ensure
         run: |
           directory_to_check="owl-bot-staging"

--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Get Latest Release
         if: github.event.pull_request.user.login == 'release-please[bot]'
         id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
         with:
           repository: ${{ github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
 
   next-release-label-check:
     name: Check for "next release" label
-    uses: GoogleCloudPlatform/php-tools/.github/workflows/release-checks.yml@main
+    uses: GoogleCloudPlatform/php-tools/.github/workflows/release-checks.yml@main # zizmor: ignore[unpinned-uses]
     if: github.event.pull_request.user.login == 'release-please[bot]'
     with:
       next-release-label-check: true

--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -11,11 +11,12 @@ jobs:
     name: Breaking Change Detector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.1"
       - name: "Ensure that branch is up to date with main branch"
@@ -54,8 +55,10 @@ jobs:
         continue-on-error: true
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \
-              --from=${{ steps.latest-release.outputs.release }} \
+              --from=${STEPS_LATEST_RELEASE_OUTPUTS_RELEASE} \
               --to=origin/main --format=github-actions
+        env:
+          STEPS_LATEST_RELEASE_OUTPUTS_RELEASE: ${{ steps.latest-release.outputs.release }}
 
   # Ensure the release PR does not contain an unexpected (e.g. 2.0.0) major version release
   # Add "MAJOR_VERSION_ALLOWED=component1,component2" to the PR description to allow major version
@@ -65,11 +68,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'release-please[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Parse allowed major versions
-        uses: actions-ecosystem/action-regex-match@v2
+        uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2
         id: allowed-major-versions
         with:
           text: ${{ github.event.pull_request.body }}
@@ -78,7 +82,7 @@ jobs:
       - name: "Check for unexpected major version"
         run: |
           # parse allowed major versions into an array
-          IFS=', ' read -r -a ALLOWED_MAJOR_VERSIONS <<< "${{ steps.allowed-major-versions.outputs.group1 }}"
+          IFS=', ' read -r -a ALLOWED_MAJOR_VERSIONS <<< "${STEPS_ALLOWED_MAJOR_VERSIONS_OUTPUTS_GROUP1}"
           # get all changed components
           COMPONENTS=$(git diff origin/main --name-only | grep VERSION | xargs dirname)
           FAIL=""
@@ -102,6 +106,8 @@ jobs:
             echo "major version releases for those components"
             exit 1
           fi
+        env:
+          STEPS_ALLOWED_MAJOR_VERSIONS_OUTPUTS_GROUP1: ${{ steps.allowed-major-versions.outputs.group1 }}
 
   next-release-label-check:
     name: Check for "next release" label
@@ -116,11 +122,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'release-please[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.2"
       - name: "Install dependencies"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
             repository: libgit2/libgit2
             ref: v1.5.1
             path: libgit2
+            persist-credentials: false
         - name: Install libgit2
           run: |
             mkdir libgit2/build && cd libgit2/build
@@ -35,23 +36,24 @@ jobs:
             repository: splitsh/lite
             ref: v2.0.0
             path: lite
+            persist-credentials: false
         - name: Build splitsh-lite
           run: |
             cd lite
             go build -o splitsh-lite github.com/splitsh/lite
             mv splitsh-lite /usr/local/bin/splitsh-lite
         - name: Checkout google/cloud
-          uses: actions/checkout@v7
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
           with:
             persist-credentials: false
             fetch-depth: 0
         - name: Setup PHP
-          uses: shivammathur/setup-php@v2
+          uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
           with:
             php-version: '8.2'
             ini-values: memory_limit=2048M
         - name: Install Dependencies
-          uses: nick-fields/retry@v4
+          uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
           with:
             timeout_minutes: 10
             max_attempts: 3
@@ -62,15 +64,16 @@ jobs:
         - name: Run Subtree Split and Release
           env:
             RELEASE_TAG: ${{ inputs.tag != '' && inputs.tag || steps.getTag.outputs.tag }}
+            VARS_PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME }}
           run: |
             ./dev/google-cloud split $GITHUB_REPOSITORY $RELEASE_TAG \
               --splitsh=/usr/local/bin/splitsh-lite \
               -t ${{ secrets.SPLIT_TOKEN }} \
-              --packagist-username=${{ vars.PACKAGIST_USERNAME }} \
+              --packagist-username=${VARS_PACKAGIST_USERNAME} \
               --packagist-token=${{ secrets.PACKAGIST_TOKEN }} \
               --packagist-safe-token=${{ secrets.PACKAGIST_SAFE_TOKEN }}
         - name: Verify all releases made it to Packagist
-          uses: nick-fields/retry@v4
+          uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
           with:
             command: |
               ./dev/google-cloud release:verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         steps:
         - name: Clone libgit2
-          uses: actions/checkout@master
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
           with:
             repository: libgit2/libgit2
             ref: v1.5.1
@@ -31,7 +31,7 @@ jobs:
             cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
             sudo cmake --build . --target install
         - name: Clone splitsh/lite
-          uses: actions/checkout@master
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
           with:
             repository: splitsh/lite
             ref: v2.0.0

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: System Tests
 on:
   # This is failing because we don't have a service account key
@@ -12,9 +15,10 @@ jobs:
     env:
       ASSET_TEST_BUCKET: cloud-php-testdata
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@verbose
         with:

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@verbose
+        uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
         with:
           php-version: "8.1"
           extensions: grpc

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,18 +32,20 @@ jobs:
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     - name: Setup cache environment
       id: extcache
-      uses: shivammathur/cache-extensions@v1
+      uses: shivammathur/cache-extensions@9b476298b44f2e4d4268dd103ff4c3e216314e27 # v1
       with:
         php-version: ${{ matrix.php }}
         extensions: sodium, ${{ matrix.extensions }}
         key: cache-key-1 # increment to bust the cache
 
     - name: Cache extensions
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.extcache.outputs.dir }}
         key: ${{ steps.extcache.outputs.key }}
@@ -56,7 +58,7 @@ jobs:
         extensions: sodium, sysvshm, ${{ matrix.extensions }}
 
     - name: Install Dependencies
-      uses: nick-invision/retry@v4
+      uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -74,7 +76,9 @@ jobs:
     name: Package Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup PHP
       uses: shivammathur/setup-php@verbose
       with:
@@ -87,7 +91,9 @@ jobs:
     name: Package Tests (Lowest Dependencies)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup PHP
       uses: shivammathur/setup-php@verbose
       with:
@@ -102,7 +108,9 @@ jobs:
     name: Dev Commands Unit Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup PHP
       uses: shivammathur/setup-php@verbose
       with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -52,7 +52,7 @@ jobs:
         restore-keys: ${{ steps.extcache.outputs.key }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@verbose
+      uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
       with:
         php-version: ${{ matrix.php }}
         extensions: sodium, sysvshm, ${{ matrix.extensions }}
@@ -80,7 +80,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup PHP
-      uses: shivammathur/setup-php@verbose
+      uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
       with:
         php-version: '8.1'
         extensions: grpc
@@ -95,7 +95,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup PHP
-      uses: shivammathur/setup-php@verbose
+      uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
       with:
         php-version: '8.1'
         extensions: grpc
@@ -112,7 +112,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup PHP
-      uses: shivammathur/setup-php@verbose
+      uses: shivammathur/setup-php@verbose # zizmor: ignore[unpinned-uses]
       with:
         php-version: "8.2"
     - name: "Install dependencies"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "config:base"
+        "config:best-practices"
     ],
     "pinVersions": false,
     "rebaseStalePrs": true,


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
