### PR TITLE
chore(Gax): update common protos minimum version

### DIFF
--- a/Gax/composer.json
+++ b/Gax/composer.json
@@ -15,7 +15,7 @@
         "google/protobuf": "^4.31||^5.34",
         "guzzlehttp/promises": "^2.0",
         "guzzlehttp/psr7": "^2.0",
-        "google/common-protos": "^4.4",
+        "google/common-protos": "^4.9",
         "google/longrunning": "~0.4",
         "ramsey/uuid": "^4.0"
     },

--- a/SecretManager/composer.json
+++ b/SecretManager/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.1",
-        "google/gax": "^1.38.0"
+        "google/gax": "^1.44.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"


### PR DESCRIPTION
This should fix the [failing secretmanager tests](https://github.com/googleapis/google-cloud-php/actions/runs/29248457081/job/86810961969?pr=9339)