### PR TITLE
feat: Add getServiceScopes method to GapicClientTrait to prevent BC breaks

### DIFF
--- a/Gax/src/GapicClientTrait.php
+++ b/Gax/src/GapicClientTrait.php
@@ -158,6 +158,16 @@ trait GapicClientTrait
     }
 
     /**
+     * Get the default scopes required by the service.
+     *
+     * @return array
+     */
+    public static function getServiceScopes(): array
+    {
+        return self::$serviceScopes;
+    }
+
+    /**
      * Initiates an orderly shutdown in which preexisting calls continue but new
      * calls are immediately cancelled.
      *

--- a/Gax/tests/Unit/GapicClientTraitTest.php
+++ b/Gax/tests/Unit/GapicClientTraitTest.php
@@ -1882,6 +1882,14 @@ class GapicClientTraitTest extends TestCase
 
         $this->assertTrue($gapic->hasEmulator);
     }
+
+    public function testGetServiceScopes()
+    {
+        $this->assertEquals(
+            ['default-scope-1', 'default-scope-2'],
+            DefaultScopeAndAudienceGapicClient::getServiceScopes()
+        );
+    }
 }
 
 class StubGapicClient


### PR DESCRIPTION
Goes with https://github.com/googleapis/gapic-generator-php/pull/841
Fixes #9358

### Description
This PR adds a `getServiceScopes()` static method to `GapicClientTrait`. This provides a stable, method-based accessor for the default service scopes, allowing us to discourage direct access to the generated `public static $serviceScopes` property on individual clients.

This change is required so that we can mark the `$serviceScopes` property as `@internal` in `gapic-generator-php`. By doing so, we prevent `roave/backward-compatibility-check` from incorrectly flagging BC breaks whenever a new scope is added or modified in the API definitions. 

### Changes
* Added `public static function getServiceScopes()` to `Gax/src/GapicClientTrait.php`.
* Added `testGetServiceScopes()` to `Gax/tests/Unit/GapicClientTraitTest.php`.

### Validation
* **Unit Testing**: The `testGetServiceScopes()` test was executed via PHPUnit and passes successfully, confirming that the new method correctly accesses the `$serviceScopes` property.
  ```text
  $ vendor/bin/phpunit tests/Unit/GapicClientTraitTest.php --filter testGetServiceScopes
  PHPUnit 9.6.35 by Sebastian Bergmann and contributors.

  .                                                                   1 / 1 (100%)

  Time: 00:00.009, Memory: 12.00 MB

  OK (1 test, 1 assertion)
  ```