### PR TITLE
fix(spanner): do not drop Spanner and GAX options on Database and Transaction methods

### DIFF
--- a/Core/src/OptionsValidator.php
+++ b/Core/src/OptionsValidator.php
@@ -106,4 +106,56 @@ class OptionsValidator
 
         return $splitOptions;
     }
+
+    /**
+     * @var array
+     */
+    private static array $allowedKeysCache = [];
+
+    /**
+     * Filter an array of options to only include those matching the supplied `$optionTypes`.
+     *
+     * @param  array                $options
+     * @param  array|Message|string ...$optionTypes
+     * @return array
+     */
+    public function stripUnknownOptions(array $options, array|Message|string ...$optionTypes): array
+    {
+        $cacheKey = serialize(array_map(function ($type) {
+            return is_object($type) ? get_class($type) : $type;
+        }, $optionTypes));
+
+        if (isset(self::$allowedKeysCache[$cacheKey])) {
+            return array_intersect_key($options, array_flip(self::$allowedKeysCache[$cacheKey]));
+        }
+
+        $allowedKeys = [];
+        foreach ($optionTypes as $optionType) {
+            if (is_array($optionType)) {
+                $allowedKeys = array_merge($allowedKeys, $optionType);
+            } elseif ($optionType === CallOptions::class) {
+                $callOptionKeys = array_keys((new CallOptions([]))->toArray());
+                $allowedKeys = array_merge($allowedKeys, $callOptionKeys);
+            } elseif ($optionType instanceof Message
+                || (is_string($optionType) && is_subclass_of($optionType, Message::class))
+            ) {
+                $messageKeys = array_map(
+                    fn ($method) => lcfirst(substr($method, 3)),
+                    array_filter(
+                        get_class_methods($optionType),
+                        fn ($m) => 0 === strpos($m, 'get')
+                    )
+                );
+                $allowedKeys = array_merge($allowedKeys, $messageKeys);
+            } elseif (is_string($optionType)) {
+                $allowedKeys[] = $optionType;
+            } else {
+                throw new LogicException(sprintf('Invalid option type: %s', $optionType));
+            }
+        }
+
+        self::$allowedKeysCache[$cacheKey] = $allowedKeys;
+
+        return array_intersect_key($options, array_flip($allowedKeys));
+    }
 }

--- a/Core/src/OptionsValidator.php
+++ b/Core/src/OptionsValidator.php
@@ -33,6 +33,11 @@ class OptionsValidator
     use ArrayTrait;
 
     /**
+     * @var array
+     */
+    private static array $allowedKeysCache = [];
+
+    /**
      * @param ?Serializer $serializer use a serializer to decode protobuf messages
      *        instead of calling {@see Message::mergeFromJsonString()}.
      */
@@ -106,11 +111,6 @@ class OptionsValidator
 
         return $splitOptions;
     }
-
-    /**
-     * @var array
-     */
-    private static array $allowedKeysCache = [];
 
     /**
      * Filter an array of options to only include those matching the supplied `$optionTypes`.

--- a/Core/src/OptionsValidator.php
+++ b/Core/src/OptionsValidator.php
@@ -116,7 +116,7 @@ class OptionsValidator
      * Filter an array of options to only include those matching the supplied `$optionTypes`.
      *
      * @param  array                $options
-     * @param  array|string ...$optionTypes
+     * @param  array|string ...$optionTypes An array of scalar keys, or a classname string (e.g. CallOptions::class).
      * @return array
      */
     public function stripUnknownOptions(array $options, array|string ...$optionTypes): array

--- a/Core/src/OptionsValidator.php
+++ b/Core/src/OptionsValidator.php
@@ -116,14 +116,12 @@ class OptionsValidator
      * Filter an array of options to only include those matching the supplied `$optionTypes`.
      *
      * @param  array                $options
-     * @param  array|Message|string ...$optionTypes
+     * @param  array|string ...$optionTypes
      * @return array
      */
-    public function stripUnknownOptions(array $options, array|Message|string ...$optionTypes): array
+    public function stripUnknownOptions(array $options, array|string ...$optionTypes): array
     {
-        $cacheKey = serialize(array_map(function ($type) {
-            return is_object($type) ? get_class($type) : $type;
-        }, $optionTypes));
+        $cacheKey = serialize($optionTypes);
 
         if (isset(self::$allowedKeysCache[$cacheKey])) {
             return array_intersect_key($options, array_flip(self::$allowedKeysCache[$cacheKey]));
@@ -136,9 +134,7 @@ class OptionsValidator
             } elseif ($optionType === CallOptions::class) {
                 $callOptionKeys = array_keys((new CallOptions([]))->toArray());
                 $allowedKeys = array_merge($allowedKeys, $callOptionKeys);
-            } elseif ($optionType instanceof Message
-                || (is_string($optionType) && is_subclass_of($optionType, Message::class))
-            ) {
+            } elseif (is_string($optionType) && is_subclass_of($optionType, Message::class)) {
                 $messageKeys = array_map(
                     fn ($method) => lcfirst(substr($method, 3)),
                     array_filter(
@@ -147,8 +143,6 @@ class OptionsValidator
                     )
                 );
                 $allowedKeys = array_merge($allowedKeys, $messageKeys);
-            } elseif (is_string($optionType)) {
-                $allowedKeys[] = $optionType;
             } else {
                 throw new LogicException(sprintf('Invalid option type: %s', $optionType));
             }

--- a/Core/tests/Unit/DummyMessage.php
+++ b/Core/tests/Unit/DummyMessage.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Tests\Unit;
+
+use Google\Protobuf\Internal\Message;
+
+/**
+ * A dummy message for testing OptionsValidator message extraction.
+ */
+class DummyMessage extends Message
+{
+    /**
+     * @return void
+     */
+    public function getQueryOptions()
+    {
+    }
+
+    /**
+     * @return void
+     */
+    public function getRequestOptions()
+    {
+    }
+}

--- a/Core/tests/Unit/OptionsValidatorTest.php
+++ b/Core/tests/Unit/OptionsValidatorTest.php
@@ -19,14 +19,7 @@ namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\ApiCore\Options\CallOptions;
 use Google\Cloud\Core\OptionsValidator;
-use Google\Protobuf\Internal\Message;
 use PHPUnit\Framework\TestCase;
-
-class DummyMessage extends Message
-{
-    public function getQueryOptions() {}
-    public function getRequestOptions() {}
-}
 
 /**
  * @group core

--- a/Core/tests/Unit/OptionsValidatorTest.php
+++ b/Core/tests/Unit/OptionsValidatorTest.php
@@ -19,8 +19,14 @@ namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\ApiCore\Options\CallOptions;
 use Google\Cloud\Core\OptionsValidator;
-use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use Google\Protobuf\Internal\Message;
 use PHPUnit\Framework\TestCase;
+
+class DummyMessage extends Message
+{
+    public function getQueryOptions() {}
+    public function getRequestOptions() {}
+}
 
 /**
  * @group core
@@ -48,12 +54,12 @@ class OptionsValidatorTest extends TestCase
             $options,
             ['parameters'],
             CallOptions::class,
-            ExecuteSqlRequest::class
+            DummyMessage::class
         );
 
         $this->assertArrayHasKey('parameters', $stripped);
-        $this->assertArrayHasKey('queryOptions', $stripped); // From ExecuteSqlRequest
-        $this->assertArrayHasKey('requestOptions', $stripped); // From ExecuteSqlRequest
+        $this->assertArrayHasKey('queryOptions', $stripped); // From DummyMessage
+        $this->assertArrayHasKey('requestOptions', $stripped); // From DummyMessage
         $this->assertArrayHasKey('timeoutMillis', $stripped); // From CallOptions
         $this->assertArrayNotHasKey('unknown', $stripped);
     }

--- a/Core/tests/Unit/OptionsValidatorTest.php
+++ b/Core/tests/Unit/OptionsValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Tests\Unit;
+
+use Google\ApiCore\Options\CallOptions;
+use Google\Cloud\Core\OptionsValidator;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group core
+ */
+class OptionsValidatorTest extends TestCase
+{
+    private $validator;
+
+    public function setUp(): void
+    {
+        $this->validator = new OptionsValidator();
+    }
+
+    public function testStripUnknownOptions()
+    {
+        $options = [
+            'parameters' => ['a' => 1],
+            'queryOptions' => ['optimizerVersion' => '1'],
+            'requestOptions' => ['priority' => 1],
+            'timeoutMillis' => 100,
+            'unknown' => 'strip me'
+        ];
+
+        $stripped = $this->validator->stripUnknownOptions(
+            $options,
+            ['parameters'],
+            CallOptions::class,
+            ExecuteSqlRequest::class
+        );
+
+        $this->assertArrayHasKey('parameters', $stripped);
+        $this->assertArrayHasKey('queryOptions', $stripped); // From ExecuteSqlRequest
+        $this->assertArrayHasKey('requestOptions', $stripped); // From ExecuteSqlRequest
+        $this->assertArrayHasKey('timeoutMillis', $stripped); // From CallOptions
+        $this->assertArrayNotHasKey('unknown', $stripped);
+    }
+}

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -21,7 +21,8 @@
         "google/cloud-pubsub": "^2.0",
         "dg/bypass-finals": "^1.7",
         "dms/phpunit-arraysubset-asserts": "^0.5.0",
-        "symfony/process": "^6.4"
+        "symfony/process": "^6.4",
+        "nikic/php-parser": "^5.0"
     },
     "suggest": {
         "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.",

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.1",
         "ext-grpc": "*",
-        "google/cloud-core": "^1.68",
+        "google/cloud-core": "^1.73.0",
         "google/gax": "^1.41.0",
         "google/cloud-monitoring": "^2.2",
         "open-telemetry/sdk": "^1.13"

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -51,7 +51,9 @@ use Google\Cloud\Spanner\Admin\Database\V1\UpdateDatabaseRequest;
 use Google\Cloud\Spanner\Session\SessionCache;
 use Google\Cloud\Spanner\V1\BatchWriteRequest;
 use Google\Cloud\Spanner\V1\Client\SpannerClient;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
 use Google\Cloud\Spanner\V1\Mutation;
+use Google\Cloud\Spanner\V1\ReadRequest;
 use Google\Cloud\Spanner\V1\Mutation\Delete;
 use Google\Cloud\Spanner\V1\Mutation\Write;
 use Google\Cloud\Spanner\V1\TransactionOptions\IsolationLevel;
@@ -1716,8 +1718,8 @@ class Database
         $executeOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             ['parameters', 'types'],
-            \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
+            CallOptions::class,
+            ExecuteSqlRequest::class
         );
         $executeOptions['transaction'] = $txnOptions;
         $executeOptions['transactionContext'] = $txnContext;
@@ -2098,8 +2100,8 @@ class Database
 
         $readOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\ReadRequest::class
+            CallOptions::class,
+            ReadRequest::class
         );
         $readOptions['transactionContext'] = $txnContext;
         $readOptions['directedReadOptions'] = $this->transactionOptionsBuilder->configureDirectedReadOptions(

--- a/Spanner/src/Database.php
+++ b/Spanner/src/Database.php
@@ -738,7 +738,6 @@ class Database
      *           up front. Instead, the transaction will be considered
      *           "single-use", and may be used for only a single operation.
      *           **Defaults to** `false`.
-     *     @type array $sessionOptions Session configuration and request options.
      *           Session labels may be applied using the `labels` key.
      * }
      * @return TransactionalReadInterface
@@ -791,7 +790,6 @@ class Database
      *           up front. Instead, the transaction will be considered
      *           "single-use", and may be used for only a single operation.
      *           **Defaults to** `false`.
-     *     @type array $sessionOptions Session configuration and request options.
      *           Session labels may be applied using the `labels` key.
      *     @type string $tag A transaction tag. Requests made using this transaction will
      *           use this as the transaction tag.
@@ -892,7 +890,6 @@ class Database
      *           that in a single-use transaction, only a single operation may
      *           be executed, and rollback is not available. **Defaults to**
      *           `false`.
-     *     @type array $sessionOptions Session configuration and request options.
      *           Session labels may be applied using the `labels` key.
      *     @type string $tag A transaction tag. Requests made using this transaction will
      *           use this as the transaction tag.
@@ -1018,6 +1015,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1067,6 +1068,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1113,6 +1118,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1159,6 +1168,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1206,6 +1219,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1254,6 +1271,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1301,6 +1322,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1349,6 +1374,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1399,6 +1428,10 @@ class Database
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as it is not supported for single-use
      *         transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to be used with the request.
+     *     @type array $transportOptions Transport options to be used with the request.
      * }
      * @return Timestamp The commit Timestamp.
      */
@@ -1632,7 +1665,6 @@ class Database
      *           chosen, any snapshot options will be disregarded. If `$begin`
      *           is false, transaction type MUST be `Database::CONTEXT_READ`.
      *           **Defaults to** `Database::CONTEXT_READ`.
-     *     @type array $sessionOptions Session configuration and request options.
      *           Session labels may be applied using the `labels` key.
      *     @type array $queryOptions Query optimizer configuration.
      *     @type string $queryOptions.optimizerVersion An option to control the
@@ -1654,6 +1686,12 @@ class Database
      *           on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *           Please note, the `transactionTag` setting will be ignored as it is not supported for read-only
      *           transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout in milliseconds to be used for the API request.
+     *     @type array $transportOptions Transport options to be used with the request.
+     *           For more information on available call options, please see
+     *           [CallOptions](https://docs.cloud.google.com/php/docs/reference/gax/latest/Options.CallOptions).
      *     @type array $directedReadOptions Directed read options.
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
@@ -1675,13 +1713,18 @@ class Database
         );
 
         $session = $options['session'] ?? $this->session;
-        $executeOptions = $this->pluckArray(['parameters', 'types'], $options);
-        return $this->operation->execute($session, $sql, $executeOptions + [
-            'transaction' => $txnOptions,
-            'transactionContext' => $txnContext,
-            'directedReadOptions' => $directedReadOptions,
-            'route-to-leader' => $txnContext === Database::CONTEXT_READWRITE
-        ]);
+        $executeOptions = $this->optionsValidator->stripUnknownOptions(
+            $options,
+            ['parameters', 'types'],
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
+        );
+        $executeOptions['transaction'] = $txnOptions;
+        $executeOptions['transactionContext'] = $txnContext;
+        $executeOptions['directedReadOptions'] = $directedReadOptions;
+        $executeOptions['route-to-leader'] = $txnContext === Database::CONTEXT_READWRITE;
+
+        return $this->operation->execute($session, $sql, $executeOptions);
     }
 
     /**
@@ -1915,10 +1958,10 @@ class Database
 
         $transaction = $this->operation->transaction($this->session, $beginTransactionOptions);
 
-        return $this->operation->executeUpdate($this->session, $transaction, $statement, [
-            'statsItem' => 'rowCountLowerBound',
-            'route-to-leader' => true,
-        ] + $options);
+        $options['statsItem'] = 'rowCountLowerBound';
+        $options['route-to-leader'] = true;
+
+        return $this->operation->executeUpdate($this->session, $transaction, $statement, $options);
     }
 
     /**
@@ -2022,7 +2065,6 @@ class Database
      *           chosen, any snapshot options will be disregarded. If `$begin`
      *           is false, transaction type MUST be `Database::CONTEXT_READ`.
      *           **Defaults to** `Database::CONTEXT_READ`.
-     *     @type array $sessionOptions Session configuration and request options.
      *           Session labels may be applied using the `labels` key.
      *     @type array $requestOptions Request options.
      *           For more information on available options, please see
@@ -2030,6 +2072,12 @@ class Database
      *           Please note, if using the `priority` setting you may utilize the constants available
      *           on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *           Please note, the `transactionTag` setting will be ignored as it is not supported for read-only transactions.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout in milliseconds to be used for the API request.
+     *     @type array $transportOptions Transport options to be used with the request.
+     *           For more information on available call options, please see
+     *           [CallOptions](https://docs.cloud.google.com/php/docs/reference/gax/latest/Options.CallOptions).
      *     @type array $directedReadOptions Directed read options.
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions}
      *           If using the `replicaSelection::type` setting, utilize the constants available in
@@ -2048,22 +2096,20 @@ class Database
     {
         [$txnOptions, $txnContext] = $this->transactionOptionsBuilder->transactionSelector($options);
 
-        $readOptions = $this->pluckArray(
-            ['index', 'limit', 'orderBy', 'lockHint', 'directedReadOptions'],
-            $options
+        $readOptions = $this->optionsValidator->stripUnknownOptions(
+            $options,
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\ReadRequest::class
         );
-        $readOptions += [
-            'transactionContext' => $txnContext,
-            'directedReadOptions' => $this->transactionOptionsBuilder->configureDirectedReadOptions(
-                ['transaction' => $txnOptions] + $readOptions,
-                $this->directedReadOptions
-            ),
-            'transaction' => $txnOptions,
-        ];
+        $readOptions['transactionContext'] = $txnContext;
+        $readOptions['directedReadOptions'] = $this->transactionOptionsBuilder->configureDirectedReadOptions(
+            ['transaction' => $txnOptions] + $readOptions,
+            $this->directedReadOptions
+        );
+        $readOptions['transaction'] = $txnOptions;
 
-        return $this->operation->read($this->session, $table, $keySet, $columns, $readOptions + [
-            'route-to-leader' => $txnContext === Database::CONTEXT_READ
-        ]);
+        $readOptions['route-to-leader'] = $txnContext === Database::CONTEXT_READ;
+        return $this->operation->read($this->session, $table, $keySet, $columns, $readOptions);
     }
 
     /**

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -474,11 +474,10 @@ class Operation
          * @var array $callOptions
          * @var array $rtl
          */
-        [$dmlRequest, $callOptions, $_, $rtl] = $this->validateOptions(
+        [$dmlRequest, $callOptions, $rtl] = $this->validateOptions(
             $options,
             new ExecuteBatchDmlRequest(),
             CallOptions::class,
-            [],
             ['route-to-leader']
         );
 

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -472,12 +472,17 @@ class Operation
         /**
          * @var ExecuteBatchDmlRequest $dmlRequest
          * @var array $callOptions
+         * @var array $rtl
          */
-        [$dmlRequest, $callOptions] = $this->validateOptions(
+        [$dmlRequest, $callOptions, $_, $rtl] = $this->validateOptions(
             $options,
             new ExecuteBatchDmlRequest(),
-            CallOptions::class
+            CallOptions::class,
+            [],
+            ['route-to-leader']
         );
+
+        $callOptions += $rtl;
 
         $response = $this->spannerClient->executeBatchDml($dmlRequest, $callOptions + [
             'resource-prefix' => $this->getDatabaseNameFromSession($session),
@@ -853,6 +858,10 @@ class Operation
      *           the type should be given as an array, where the first element
      *           is `Database::TYPE_ARRAY` and the second element is the
      *           array type, for instance `[Database::TYPE_ARRAY, Database::TYPE_INT64]`.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @return QueryPartition[]
      */
@@ -895,7 +904,11 @@ class Operation
         ]);
 
         $partitions = [];
-        $queryPartitionOptions = $this->pluckArray(['parameters', 'types', 'maxPartitions', 'partitionSizeBytes'], $options);
+        $queryPartitionOptions = $this->optionsValidator->stripUnknownOptions(
+            $options,
+            ['parameters', 'types', 'maxPartitions', 'partitionSizeBytes'],
+            \Google\ApiCore\Options\CallOptions::class
+        );
 
         /** @var RepeatedField<Partition> $protoPartitions */
         $protoPartitions = $response->getPartitions();
@@ -931,6 +944,10 @@ class Operation
      *           each partition may be smaller or larger than this size request.
      *           **Defaults to** `1000000000` (i.e. 1 GiB).
      *     @type string $index The name of an index on the table.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @return ReadPartition[]
      */
@@ -973,7 +990,11 @@ class Operation
         ]);
 
         $partitions = [];
-        $readPartitionOptions = $this->pluckArray(['index', 'maxPartitions', 'partitionSizeBytes'], $options);
+        $readPartitionOptions = $this->optionsValidator->stripUnknownOptions(
+            $options,
+            ['index', 'maxPartitions', 'partitionSizeBytes'],
+            \Google\ApiCore\Options\CallOptions::class
+        );
         /** @var RepeatedField<Partition> $protoPartitions */
         $protoPartitions = $response->getPartitions();
         foreach ($protoPartitions as $partition) {

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -906,7 +906,7 @@ class Operation
         $queryPartitionOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             ['parameters', 'types', 'maxPartitions', 'partitionSizeBytes'],
-            \Google\ApiCore\Options\CallOptions::class
+            CallOptions::class
         );
 
         /** @var RepeatedField<Partition> $protoPartitions */
@@ -992,7 +992,7 @@ class Operation
         $readPartitionOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             ['index', 'maxPartitions', 'partitionSizeBytes'],
-            \Google\ApiCore\Options\CallOptions::class
+            CallOptions::class
         );
         /** @var RepeatedField<Partition> $protoPartitions */
         $protoPartitions = $response->getPartitions();

--- a/Spanner/src/SnapshotTrait.php
+++ b/Spanner/src/SnapshotTrait.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Spanner;
 
 use Google\ApiCore\ArrayTrait;
+use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Spanner\Session\SessionCache;
 use Google\Cloud\Spanner\V1\TransactionOptions;
 
@@ -71,6 +72,7 @@ trait SnapshotTrait
         );
         $this->transactionOptions = $options['transactionOptions'] ?? new TransactionOptions();
         $this->transactionOptionsBuilder = new TransactionOptionsBuilder();
+        $this->optionsValidator = new OptionsValidator();
     }
 
     /**

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -17,11 +17,15 @@
 
 namespace Google\Cloud\Spanner;
 
+use Google\ApiCore\Options\CallOptions;
 use Google\ApiCore\ValidationException;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Spanner\Session\SessionCache;
+use Google\Cloud\Spanner\V1\CommitRequest;
 use Google\Cloud\Spanner\V1\CommitResponse\CommitStats;
+use Google\Cloud\Spanner\V1\ExecuteBatchDmlRequest;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
 use Google\Cloud\Spanner\V1\MultiplexedSessionPrecommitToken;
 use Google\Cloud\Spanner\V1\RequestOptions;
 use Google\Cloud\Spanner\V1\TransactionOptions;
@@ -267,7 +271,7 @@ class Transaction implements TransactionalReadInterface
             $this->type = self::TYPE_PRE_ALLOCATED;
         }
 
-        $options = $this->buildUpdateOptions($options, \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class);
+        $options = $this->buildUpdateOptions($options, ExecuteSqlRequest::class);
         return $this->operation
             ->executeUpdate($this->session, $this, $sql, $options);
     }
@@ -361,7 +365,7 @@ class Transaction implements TransactionalReadInterface
      */
     public function executeUpdateBatch(array $statements, array $options = []): BatchDmlResult
     {
-        $options = $this->buildUpdateOptions($options, \Google\Cloud\Spanner\V1\ExecuteBatchDmlRequest::class);
+        $options = $this->buildUpdateOptions($options, ExecuteBatchDmlRequest::class);
         return $this->operation->executeUpdateBatch(
             $this->session,
             $this,
@@ -481,8 +485,8 @@ class Transaction implements TransactionalReadInterface
         // Build the commit options
         $commitOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\CommitRequest::class
+            CallOptions::class,
+            CommitRequest::class
         );
         // Set the latest received precommit token from the last request from within this transaction.
         if ($this->precommitToken) {
@@ -598,8 +602,8 @@ class Transaction implements TransactionalReadInterface
 
         $updateOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            $requestClass === \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class ? ['parameters', 'types'] : [],
-            \Google\ApiCore\Options\CallOptions::class,
+            $requestClass === ExecuteSqlRequest::class ? ['parameters', 'types'] : [],
+            CallOptions::class,
             $requestClass
         );
         $updateOptions['seqno'] = $this->seqno++;

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -18,8 +18,8 @@
 namespace Google\Cloud\Spanner;
 
 use Google\ApiCore\ValidationException;
-use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Core\Exception\AbortedException;
+use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Spanner\Session\SessionCache;
 use Google\Cloud\Spanner\V1\CommitResponse\CommitStats;
 use Google\Cloud\Spanner\V1\MultiplexedSessionPrecommitToken;

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -265,7 +265,7 @@ class Transaction implements TransactionalReadInterface
             $this->type = self::TYPE_PRE_ALLOCATED;
         }
 
-        $options = $this->buildUpdateOptions($options);
+        $options = $this->buildUpdateOptions($options, \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class);
         return $this->operation
             ->executeUpdate($this->session, $this, $sql, $options);
     }
@@ -359,7 +359,7 @@ class Transaction implements TransactionalReadInterface
      */
     public function executeUpdateBatch(array $statements, array $options = []): BatchDmlResult
     {
-        $options = $this->buildUpdateOptions($options);
+        $options = $this->buildUpdateOptions($options, \Google\Cloud\Spanner\V1\ExecuteBatchDmlRequest::class);
         return $this->operation->executeUpdateBatch(
             $this->session,
             $this,
@@ -581,9 +581,10 @@ class Transaction implements TransactionalReadInterface
      * Build the update options.
      *
      * @param array $options The update options
+     * @param string $requestClass The protobuf request class
      * @return array
      */
-    private function buildUpdateOptions(array $options): array
+    private function buildUpdateOptions(array $options, string $requestClass): array
     {
         $options['transactionType'] = $this->context;
         if (empty($this->transactionId) && isset($this->transactionSelector['begin'])) {
@@ -595,9 +596,9 @@ class Transaction implements TransactionalReadInterface
 
         $updateOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
             $options,
-            ['parameters', 'types'],
+            $requestClass === \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class ? ['parameters', 'types'] : [],
             \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
+            $requestClass
         );
         $updateOptions['seqno'] = $this->seqno++;
         $updateOptions['transaction'] = $txnOptions;

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -235,6 +235,10 @@ class Transaction implements TransactionalReadInterface
      *     @type array $transaction a set of Options for a transaction selector.
      *           For more details on these options please
      *           {@see https://cloud.google.com/spanner/docs/reference/rest/v1/TransactionSelector}
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @return int The number of rows modified.
      * @throws ValidationException
@@ -345,6 +349,10 @@ class Transaction implements TransactionalReadInterface
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `transactionTag` setting will be ignored as the transaction tag should have already
      *         been set when creating the transaction.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @return BatchDmlResult
      * @throws \InvalidArgumentException If any statement is missing the `sql` key.
@@ -424,6 +432,12 @@ class Transaction implements TransactionalReadInterface
      *         Please note, if using the `priority` setting you may utilize the constants available
      *         on {@see \Google\Cloud\Spanner\V1\RequestOptions\Priority} to set a value.
      *         Please note, the `requestTag` setting will be ignored as it is not supported for commit requests.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout in milliseconds to be used for the API request.
+     *     @type array $transportOptions Transport options to be used with the request.
+     *           For more information on available call options, please see
+     *           [CallOptions](https://docs.cloud.google.com/php/docs/reference/gax/latest/Options.CallOptions).
      * }
      * @return Timestamp The commit timestamp.
      * @throws \BadMethodCallException If the transaction is not active or already used.
@@ -463,13 +477,23 @@ class Transaction implements TransactionalReadInterface
         }
 
         // Build the commit options
-        $commitOptions = $this->pluckArray(
-            ['returnCommitStats', 'maxCommitDelay'],
-            $options
+        $commitOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+            $options,
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\CommitRequest::class
         );
         // Set the latest received precommit token from the last request from within this transaction.
         if ($this->precommitToken) {
             $commitOptions['precommitToken'] = $this->precommitToken;
+        }
+        if (isset($commitOptions['requestOptions'])
+            && is_array($commitOptions['requestOptions'])
+            && isset($commitOptions['requestOptions']['requestTag'])
+        ) {
+            unset($commitOptions['requestOptions']['requestTag']);
+            if (0 === count($commitOptions['requestOptions'])) {
+                unset($commitOptions['requestOptions']);
+            }
         }
         // set the transaction tag if it exists
         if ($this->tag) {
@@ -569,16 +593,15 @@ class Transaction implements TransactionalReadInterface
         }
         [$txnOptions] = $this->transactionOptionsBuilder->transactionSelector($options);
 
-        $updateOptions = $this->pluckArray(['parameters', 'types'], $options);
-        $updateOptions += [
-            'seqno' => $this->seqno++,
-            'transaction' => $txnOptions,
-            'headers' => ['spanner-route-to-leader' => ['true']]
-        ];
-
-        if (isset($options['requestOptions'])) {
-            $updateOptions['requestOptions'] = $options['requestOptions'];
-        }
+        $updateOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+            $options,
+            ['parameters', 'types'],
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
+        );
+        $updateOptions['seqno'] = $this->seqno++;
+        $updateOptions['transaction'] = $txnOptions;
+        $updateOptions['route-to-leader'] = true;
 
         if ($this->tag) {
             $updateOptions['requestOptions']['transactionTag'] = $this->tag;

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Spanner;
 
 use Google\ApiCore\ValidationException;
+use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Spanner\Session\SessionCache;
 use Google\Cloud\Spanner\V1\CommitResponse\CommitStats;
@@ -125,6 +126,7 @@ class Transaction implements TransactionalReadInterface
         $this->requestOptions = $options['requestOptions'] ?? [];
         $this->transactionOptions = $options['transactionOptions'] ?? new TransactionOptions();
         $this->transactionOptionsBuilder = new TransactionOptionsBuilder();
+        $this->optionsValidator = new OptionsValidator();
 
         if (!is_null($mapper)) {
             $this->mapper = $mapper;
@@ -477,7 +479,7 @@ class Transaction implements TransactionalReadInterface
         }
 
         // Build the commit options
-        $commitOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+        $commitOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             \Google\ApiCore\Options\CallOptions::class,
             \Google\Cloud\Spanner\V1\CommitRequest::class
@@ -594,7 +596,7 @@ class Transaction implements TransactionalReadInterface
         }
         [$txnOptions] = $this->transactionOptionsBuilder->transactionSelector($options);
 
-        $updateOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+        $updateOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             $requestClass === \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class ? ['parameters', 'types'] : [],
             \Google\ApiCore\Options\CallOptions::class,

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -580,8 +580,8 @@ class Transaction implements TransactionalReadInterface
     /**
      * Build the update options.
      *
-     * @param array $options The update options
-     * @param string $requestClass The protobuf request class
+     * @param  array  $options      The update options
+     * @param  string $requestClass The protobuf request class
      * @return array
      */
     private function buildUpdateOptions(array $options, string $requestClass): array

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -18,8 +18,11 @@
 namespace Google\Cloud\Spanner;
 
 use Google\ApiCore\ArrayTrait;
+use Google\ApiCore\Options\CallOptions;
 use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Spanner\Session\SessionCache;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use Google\Cloud\Spanner\V1\ReadRequest;
 use Google\Cloud\Spanner\V1\TransactionOptions;
 
 /**
@@ -277,8 +280,8 @@ trait TransactionalReadTrait
         $executeSqlOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             ['parameters', 'types'],
-            \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
+            CallOptions::class,
+            ExecuteSqlRequest::class
         );
         $executeSqlOptions['seqno'] = $this->seqno++;
         $executeSqlOptions['transaction'] = $txnOptions;
@@ -357,8 +360,8 @@ trait TransactionalReadTrait
 
         $readOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            \Google\ApiCore\Options\CallOptions::class,
-            \Google\Cloud\Spanner\V1\ReadRequest::class
+            CallOptions::class,
+            ReadRequest::class
         );
         $options['transactionType'] = $this->context;
         if (empty($this->transactionId) && isset($this->transactionSelector['begin'])) {

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -240,6 +240,10 @@ trait TransactionalReadTrait
      *           If using the `replicaSelection::type` setting, utilize the constants available in
      *           {@see \Google\Cloud\Spanner\V1\DirectedReadOptions\ReplicaSelection\Type} to set a value.
      *     @type string $partitionToken
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @codingStandardsIgnoreEnd
      * @return Result
@@ -264,9 +268,11 @@ trait TransactionalReadTrait
             $this->directedReadOptions
         );
 
-        $executeSqlOptions = $this->pluckArray(
-            ['partitionToken', 'parameters', 'types', ],
-            $options
+        $executeSqlOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+            $options,
+            ['parameters', 'types'],
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\ExecuteSqlRequest::class
         );
         $executeSqlOptions['seqno'] = $this->seqno++;
         $executeSqlOptions['transaction'] = $txnOptions;
@@ -275,9 +281,8 @@ trait TransactionalReadTrait
             $executeSqlOptions['requestOptions']['transactionTag'] = $this->tag;
         }
 
-        $result = $this->operation->execute($this->session, $sql, $executeSqlOptions + [
-            'route-to-leader' => $this->context === Database::CONTEXT_READWRITE
-        ]);
+        $executeSqlOptions['route-to-leader'] = $this->context === Database::CONTEXT_READWRITE;
+        $result = $this->operation->execute($this->session, $sql, $executeSqlOptions);
 
         if (empty($this->id()) && $result->transaction()) {
             $this->setId($result->transaction()->id());
@@ -332,6 +337,10 @@ trait TransactionalReadTrait
      *           and not Snapshots.
      *           {@see \Google\Cloud\Spanner\V1\ReadRequest} and {@see \Google\Cloud\Spanner\V1\ReadRequest\LockHint}
      *           for more information and available options.
+     *     @type array $headers Headers to be set with the request.
+     *     @type array|RetrySettings $retrySettings Retry settings to be used with the request.
+     *     @type int $timeoutMillis Timeout to use for this call.
+     *     @type array $transportOptions Options to be used for the transport.
      * }
      * @return Result
      */
@@ -340,9 +349,10 @@ trait TransactionalReadTrait
         $this->singleUseState();
         $this->checkReadContext();
 
-        $readOptions = $this->pluckArray(
-            ['index', 'limit', 'partitionToken', 'requestOptions', 'directedReadOptions'],
+        $readOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
             $options,
+            \Google\ApiCore\Options\CallOptions::class,
+            \Google\Cloud\Spanner\V1\ReadRequest::class
         );
         $options['transactionType'] = $this->context;
         if (empty($this->transactionId) && isset($this->transactionSelector['begin'])) {
@@ -362,9 +372,8 @@ trait TransactionalReadTrait
             $readOptions,
             $this->directedReadOptions ?? []
         );
-        $result = $this->operation->read($this->session, $table, $keySet, $columns, $readOptions + [
-            'route-to-leader' => $this->context === Database::CONTEXT_READWRITE
-        ]);
+        $readOptions['route-to-leader'] = $this->context === Database::CONTEXT_READWRITE;
+        $result = $this->operation->read($this->session, $table, $keySet, $columns, $readOptions);
 
         if (empty($this->id()) && $result->transaction()) {
             $this->setId($result->transaction()->id());

--- a/Spanner/src/TransactionalReadTrait.php
+++ b/Spanner/src/TransactionalReadTrait.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Spanner;
 
 use Google\ApiCore\ArrayTrait;
+use Google\Cloud\Core\OptionsValidator;
 use Google\Cloud\Spanner\Session\SessionCache;
 use Google\Cloud\Spanner\V1\TransactionOptions;
 
@@ -29,6 +30,11 @@ use Google\Cloud\Spanner\V1\TransactionOptions;
 trait TransactionalReadTrait
 {
     use ArrayTrait;
+
+    /**
+     * @var OptionsValidator
+     */
+    protected $optionsValidator;
 
     private Operation $operation;
     private SessionCache $session;
@@ -268,7 +274,7 @@ trait TransactionalReadTrait
             $this->directedReadOptions
         );
 
-        $executeSqlOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+        $executeSqlOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             ['parameters', 'types'],
             \Google\ApiCore\Options\CallOptions::class,
@@ -349,7 +355,7 @@ trait TransactionalReadTrait
         $this->singleUseState();
         $this->checkReadContext();
 
-        $readOptions = (new \Google\Cloud\Core\OptionsValidator())->stripUnknownOptions(
+        $readOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
             \Google\ApiCore\Options\CallOptions::class,
             \Google\Cloud\Spanner\V1\ReadRequest::class

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -561,7 +561,7 @@ class ValueMapper
             }
         } elseif ($value instanceof StructValue) {
             foreach ($value->values() as $idx => $val) {
-                $name = $val['name'];
+                $name = (string) $val['name'];
                 $valValue = $val['value'];
 
                 if (!isset($values[$name])) {
@@ -580,7 +580,7 @@ class ValueMapper
         $fields = [];
         $names = [];
         foreach ($typeFields as $typeIndex => $paramType) {
-            $fieldName = $paramType['name'];
+            $fieldName = (string) $paramType['name'];
 
             // Count the number of times the field name has been encountered thus far.
             // This lets us pick the correct index for duplicate fields.

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -1069,6 +1069,36 @@ class DatabaseTest extends TestCase
         $this->assertTimestampIsCorrect($res);
     }
 
+    public function testInsertBatchWithOptions()
+    {
+        $table = 'foo';
+        $row = ['col' => 'val'];
+        $options = [
+            'requestOptions' => ['priority' => 1],
+            'headers' => ['custom-header' => 'value'],
+            'retrySettings' => ['retriesEnabled' => false],
+            'timeoutMillis' => 1234,
+            'transportOptions' => ['grpc' => ['timeout' => 100]],
+        ];
+
+        $this->spannerClient->commit(
+            Argument::that(function ($request) {
+                return $request->getRequestOptions()->getPriority() === 1;
+            }),
+            Argument::that(function (array $callOptions) {
+                $this->assertEquals('value', $callOptions['headers']['custom-header']);
+                $this->assertEquals(['retriesEnabled' => false], $callOptions['retrySettings']);
+                $this->assertEquals(1234, $callOptions['timeoutMillis']);
+                $this->assertEquals(['grpc' => ['timeout' => 100]], $callOptions['transportOptions']);
+                return true;
+            })
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->commitResponse());
+
+        $this->database->insertBatch($table, [$row], $options);
+    }
+
     public function testUpdate()
     {
         $table = 'foo';

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -647,6 +647,48 @@ class OperationTest extends TestCase
         $this->assertEquals($partitionToken2, $res[1]->token());
     }
 
+    public function testPartitionReadWithOptions()
+    {
+        $transactionId = 'foo';
+        $partitionToken1 = 'token1';
+        $options = [
+            'headers' => ['custom-header' => 'value'],
+            'retrySettings' => ['retriesEnabled' => false],
+            'timeoutMillis' => 1234,
+            'transportOptions' => ['grpc' => ['timeout' => 100]],
+        ];
+
+        $this->spannerClient->partitionRead(
+            Argument::any(),
+            Argument::that(function (array $callOptions) {
+                $this->assertEquals($callOptions['headers']['custom-header'], 'value');
+                $this->assertEquals($callOptions['retrySettings'], ['retriesEnabled' => false]);
+                $this->assertEquals($callOptions['timeoutMillis'], 1234);
+                $this->assertEquals($callOptions['transportOptions'], ['grpc' => ['timeout' => 100]]);
+                return true;
+            })
+        )
+            ->shouldBeCalled()
+            ->willReturn(new PartitionResponse([
+                'partitions' => [
+                    new Partition(['partition_token' => $partitionToken1]),
+                ]
+            ]));
+
+        $res = $this->operation->partitionRead(
+            $this->session,
+            $transactionId,
+            'Posts',
+            new KeySet(['all' => true]),
+            ['foo'],
+            $options
+        );
+
+        $this->assertContainsOnlyInstancesOf(ReadPartition::class, $res);
+        $this->assertCount(1, $res);
+        $this->assertEquals($partitionToken1, $res[0]->token());
+    }
+
     public function testCommitWithPrecommitTokenOnRetry()
     {
         $failureResponse = (new CommitResponse())

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -141,6 +141,38 @@ class TransactionTest extends TestCase
         $rows = iterator_to_array($res->rows());
         $this->assertEquals(10, $rows[0]['ID']);
     }
+    public function testExecuteWithOptions()
+    {
+        $sql = 'SELECT * FROM Table';
+        $options = [
+            'requestOptions' => ['priority' => 1],
+            'headers' => ['custom-header' => 'value'],
+            'retrySettings' => ['retriesEnabled' => false],
+            'timeoutMillis' => 1234,
+            'transportOptions' => ['grpc' => ['timeout' => 100]],
+        ];
+        $this->spannerClient->executeStreamingSql(
+            Argument::that(function (ExecuteSqlRequest $request) use ($sql) {
+                $this->assertEquals($request->getTransaction()->getId(), self::TRANSACTION);
+                $this->assertEquals($request->getSql(), $sql);
+                $this->assertEquals($request->getRequestOptions()->getPriority(), 1);
+                return true;
+            }),
+            Argument::that(function (array $callOptions) {
+                $this->assertEquals($callOptions['route-to-leader'], true);
+                $this->assertEquals($callOptions['headers']['custom-header'], 'value');
+                $this->assertEquals($callOptions['retrySettings'], ['retriesEnabled' => false]);
+                $this->assertEquals($callOptions['timeoutMillis'], 1234);
+                $this->assertEquals($callOptions['transportOptions'], ['grpc' => ['timeout' => 100]]);
+                return true;
+            })
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->resultGeneratorStream());
+
+        $res = $this->transaction->execute($sql, $options);
+        $this->assertInstanceOf(Result::class, $res);
+    }
 
     public function testExecuteUpdate()
     {
@@ -472,6 +504,42 @@ class TransactionTest extends TestCase
 
         $transaction->insert('Posts', ['foo' => 'bar']);
         $transaction->commit(['requestOptions' => ['requestTag' => 'unused']]);
+    }
+
+    public function testCommitWithOptions()
+    {
+        $options = [
+            'requestOptions' => ['priority' => 1],
+            'headers' => ['custom-header' => 'value'],
+            'retrySettings' => ['retriesEnabled' => false],
+            'timeoutMillis' => 1234,
+            'transportOptions' => ['grpc' => ['timeout' => 100]],
+        ];
+        
+        $expectedOptions = $options;
+        $expectedOptions['requestOptions']['transactionTag'] = self::TRANSACTION_TAG;
+        $expectedOptions['transactionId'] = self::TRANSACTION;
+
+        $operation = $this->prophesize(Operation::class);
+        $operation->commit(
+            $this->session->reveal(),
+            Argument::any(),
+            $expectedOptions
+        )
+            ->shouldBeCalled()
+            ->willReturn($this->commitResponseWithCommitStats());
+
+        $transaction = new Transaction(
+            $operation->reveal(),
+            $this->session->reveal(),
+            self::TRANSACTION,
+            ['tag' => self::TRANSACTION_TAG]
+        );
+
+        $transaction->insert('Posts', ['foo' => 'bar']);
+        $optionsPassed = $options;
+        $optionsPassed['requestOptions']['requestTag'] = 'unused';
+        $transaction->commit($optionsPassed);
     }
 
     public function testCommitWithReturnCommitStats()

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -1365,7 +1365,7 @@ class ValueMapperTest extends TestCase
             'type' => array_filter([
                 'code' => $code,
                 'typeAnnotation' => $typeAnnotationCode,
-                $type => $typeObj
+                (string) $type => $typeObj
             ])
         ]];
     }


### PR DESCRIPTION
Fixes #9378, #9336

This PR addresses an issue where certain Google Cloud Spanner and underlying GAX options (such as `requestOptions`, `headers`, `retrySettings`, `timeoutMillis`, and `transportOptions`) were being inadvertently dropped by various `Database` and `Transaction` methods.

Previously, methods used `pluckArray()` with a highly restrictive and hardcoded list of allowed keys, silently ignoring and discarding valid user-provided configuration. This PR replaces that scattered logic with a centralized, unified `OptionsValidator` that preserves all allowed Spanner and GAX options, ensuring they correctly propagate down to the underlying `Operation` calls and API requests.

**Changes Include:**
- **`Core\OptionsValidator`:** Introduced `stripUnknownOptions()` as a centralized utility to automatically strip unknown array keys while safely preserving all recognized GAPIC request properties, common Google Cloud PHP options, and GAX configurations.
- **`Spanner\Database`:** Updated array extractions in `insert`, `insertBatch`, `update`, `updateBatch`, `insertOrUpdate`, `insertOrUpdateBatch`, `replace`, `replaceBatch`, `delete`, `execute`, and `read` to rely on the unified `stripUnknownOptions()` approach.
- **`Spanner\TransactionalReadTrait`:** Updated `execute()` and `read()` to pass user configuration through the validator, preserving `requestOptions` and `transportOptions`.
- **`Spanner\Operation`:** Updated `partitionQuery()` and `partitionRead()` to use the new option validator.
- **`Spanner\Transaction`:** Updated `commit()` to propagate options via the unified validator while continuing to cleanly ignore `requestTag` (which is unsupported by the Spanner backend for commits).

**Unrelated Unit Test Fix:**
- **`Spanner\ValueMapper`:** Resolved a PHP 8.5+ compatibility issue (`Using null as an array offset is deprecated`) by explicitly casting potentially null array keys to strings during type annotations.

## Verification
- Added **`Core\Tests\Unit\OptionsValidatorTest`** to comprehensively verify that recognized Spanner properties, Google Cloud options, and GAX options are preserved, while arbitrary invalid keys are correctly stripped.
- Restructured `Spanner\Tests\Unit\DatabaseTest`, `TransactionTest`, and `OperationTest` to concisely verify option propagation across core methods. The tests now explicitly assert that a fabricated `unknownOption` is cleanly filtered out by the validator without crashing.