### PR TITLE
fix: Fix the `component:new` to pass the component option as an option instead of a parameter to the update command

### DIFF
--- a/dev/src/Command/ComponentNewCommand.php
+++ b/dev/src/Command/ComponentNewCommand.php
@@ -233,7 +233,7 @@ class ComponentNewCommand extends Command
 
         if (!$input->getOption('no-update')) {
             $args = [
-                'component' => $new->componentName,
+                '--component' => [$new->componentName],
                 '--timeout' => $timeout,
             ];
             if (!$this->getApplication()->has('component:update')) {


### PR DESCRIPTION
fixes: #9390 