### PR TITLE
chore(Shopping): accept pre-1.0 for common protos

### DIFF
--- a/ShoppingCss/composer.json
+++ b/ShoppingCss/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantAccounts/composer.json
+++ b/ShoppingMerchantAccounts/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantDataSources/composer.json
+++ b/ShoppingMerchantDataSources/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantInventories/composer.json
+++ b/ShoppingMerchantInventories/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantIssueResolution/composer.json
+++ b/ShoppingMerchantIssueResolution/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantLfp/composer.json
+++ b/ShoppingMerchantLfp/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantNotifications/composer.json
+++ b/ShoppingMerchantNotifications/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantOrderTracking/composer.json
+++ b/ShoppingMerchantOrderTracking/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantProducts/composer.json
+++ b/ShoppingMerchantProducts/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantPromotions/composer.json
+++ b/ShoppingMerchantPromotions/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantReports/composer.json
+++ b/ShoppingMerchantReports/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/ShoppingMerchantReviews/composer.json
+++ b/ShoppingMerchantReviews/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "google/gax": "^1.38.0",
-        "google/shopping-common-protos": "~0.4.0"
+        "google/shopping-common-protos": "~0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/9373

Ensures shopping packages use any common protos which are `0.4 <= x < 1.0`

This was a mistake on my part (see https://github.com/googleapis/google-cloud-php/pull/9024#issuecomment-4084116780), the `~` is typically used to mean this, but because we used `0.4.0` instead of `0.4`, we were still restricting the version constraint to be `0.4 <= x < 0.5` isntead.