### PR TITLE
fix(Spanner): ensure precommit token is set for ILB transactions

### DIFF
--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -736,7 +736,7 @@ class Operation
             'requestOptions' => $beginTransaction->getRequestOptions(),
             'transactionOptions' => $txnOptions,
         ]);
-        return new Transaction(
+        $transaction = new Transaction(
             $this,
             $session,
             $id,

--- a/Spanner/src/Transaction.php
+++ b/Spanner/src/Transaction.php
@@ -476,6 +476,9 @@ class Transaction implements TransactionalReadInterface
             $transaction = $this->operation->transaction($this->session, $operationTransactionOptions);
             // Set the transaction ID of the current transaction.
             $this->transactionId = $transaction->id();
+            if (isset($transaction->precommitToken)) {
+                $this->setPrecommitToken($transaction->precommitToken);
+            }
         }
 
         if (!$this->singleUseState()) {

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -490,6 +490,30 @@ class OperationTest extends TestCase
         $this->assertEquals('foo', $transaction->id());
     }
 
+    public function testTransactionWithPrecommitToken()
+    {
+        $precommitToken = new MultiplexedSessionPrecommitToken([
+            'precommit_token' => 'my-precommit-token',
+        ]);
+        $this->spannerClient->beginTransaction(
+            Argument::cetera()
+        )
+            ->shouldBeCalled()
+            ->willReturn(new TransactionProto([
+                'id' => self::TRANSACTION,
+                'precommit_token' => $precommitToken,
+            ]));
+
+        $t = $this->operation->transaction($this->session);
+        $this->assertInstanceOf(Transaction::class, $t);
+        $this->assertEquals(self::TRANSACTION, $t->id());
+
+        $ref = new \ReflectionClass(Transaction::class);
+        $prop = $ref->getProperty('precommitToken');
+        $this->assertNotNull($prop->getValue($t));
+        $this->assertEquals($precommitToken, $prop->getValue($t));
+    }
+
     public function testExecuteAndExecuteUpdateWithExcludeTxnFromChangeStreams()
     {
         $sql = 'SELECT example FROM sql_query';

--- a/Spanner/tests/Unit/TransactionTest.php
+++ b/Spanner/tests/Unit/TransactionTest.php
@@ -620,6 +620,57 @@ class TransactionTest extends TestCase
         $this->assertEquals(1, $transaction->getCommitStats()->getMutationCount());
     }
 
+    public function testCommitSetsPrecommitTokenFromInlineBegin()
+    {
+        $precommitToken = new MultiplexedSessionPrecommitToken([
+            'precommit_token' => 'my-precommit-token',
+        ]);
+
+        $operation = $this->prophesize(Operation::class);
+
+        // Create the transaction returned by Operation::transaction()
+        $returnedTransaction = new Transaction(
+            $operation->reveal(),
+            $this->session->reveal(),
+            self::TRANSACTION,
+            []
+        );
+        $returnedTransaction->setPrecommitToken($precommitToken);
+
+        $operation->transaction($this->session->reveal(), Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($returnedTransaction);
+
+        // Verify that commit() receives the precommit token in options
+        $operation->commit(
+            $this->session->reveal(),
+            Argument::any(),
+            Argument::that(function ($options) use ($precommitToken) {
+                $this->assertArrayHasKey('precommitToken', $options);
+                $this->assertEquals($precommitToken, $options['precommitToken']);
+                return true;
+            })
+        )
+            ->shouldBeCalled()
+            ->willReturn($this->commitResponseWithCommitStats());
+
+        $transaction = new Transaction(
+            $operation->reveal(),
+            $this->session->reveal(),
+            null, // Null transaction ID to trigger inline begin
+            [
+                'begin' => ['readWrite' => []]
+            ]
+        );
+
+        $transaction->insert('Posts', ['foo' => 'bar']);
+        $transaction->commit();
+
+        $ref = new \ReflectionClass(Transaction::class);
+        $prop = $ref->getProperty('precommitToken');
+        $this->assertNull($prop->getValue($transaction));
+    }
+
     public function testCommitInvalidState()
     {
         $this->expectException(\BadMethodCallException::class);


### PR DESCRIPTION
Fixes #9331

Corrects the return flow in `Operation::transaction()` which previously returned the newly created transaction early before setting the `precommitToken` retrieved from the `beginTransaction` response. 

Additionally, updates `Transaction::commit()` to copy the `precommitToken` from the newly initiated transaction object to the current transaction instance when a transaction is started inline.


