### PR TITLE
chore: add cache for grpc for showcase tests

### DIFF
--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -41,25 +41,25 @@ jobs:
         - name: Install gRPC Extension
           if: steps.cache-grpc.outputs.cache-hit != 'true'
           run: |
-              sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
-              mkdir -p ~/.cache
-              cp ${{ steps.php-info.outputs.ext_dir }}/grpc.so ~/.cache/grpc.so
+            sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+            mkdir -p ~/.cache
+            cp ${{ steps.php-info.outputs.ext_dir }}/grpc.so ~/.cache/grpc.so
 
         - name: Enable gRPC Extension
           run: |
-              sudo cp ~/.cache/grpc.so ${{ steps.php-info.outputs.ext_dir }}/grpc.so
-              echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
-              php -m | grep grpc
+            sudo cp ~/.cache/grpc.so ${{ steps.php-info.outputs.ext_dir }}/grpc.so
+            echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
+            php -m | grep grpc
 
         - name: Install and run GAPIC Showcase
           run: |
-              curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
-              ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
-              sleep 2
+            curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
+            ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
+            sleep 2
 
         - name: Install dependencies
           run: |
-              composer update --prefer-dist --no-interaction --no-suggest -d Gax/
+            composer update --prefer-dist --no-interaction --no-suggest -d Gax/
 
         - name: Run PHPUnit
           run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -7,60 +7,59 @@ on:
 permissions:
   contents: read
 jobs:
-  gapic-showcase:
-    name: GAPIC Showcase Conformance Tests
-    runs-on: ubuntu-latest
-    env:
-      GAPIC_SHOWCASE_VERSION: 0.42.0
-      OS: linux
-      ARCH: amd64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+    gapic-showcase:
+        name: GAPIC Showcase Conformance Tests
+        runs-on: ubuntu-latest
+        env:
+            GAPIC_SHOWCASE_VERSION: 0.42.0
+            OS: linux
+            ARCH: amd64
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v7
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: '8.2'
 
-      - name: Get PHP Extension Directory
-        id: php-info
-        run: |
-          echo "ext_dir=$(php-config --extension-dir)" >> $GITHUB_OUTPUT
-          ini_dir=$(php --ini | grep "Scan this dir" | cut -d: -f2 | xargs)
-          if [ -z "$ini_dir" ]; then ini_dir="/etc/php/8.2/cli/conf.d"; fi
-          echo "ini_dir=$ini_dir" >> $GITHUB_OUTPUT
+        - name: Get PHP Extension Directory
+          id: php-info
+          run: |
+              echo "ext_dir=$(php-config --extension-dir)" >> $GITHUB_OUTPUT
+              ini_dir=$(php --ini | grep "Scan this dir" | cut -d: -f2 | xargs)
+              if [ -z "$ini_dir" ]; then ini_dir="/etc/php/8.2/cli/conf.d"; fi
+              echo "ini_dir=$ini_dir" >> $GITHUB_OUTPUT
 
-      - name: Cache gRPC Extension
-        id: cache-grpc
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/grpc.so
-          key: grpc-1.83.0-php8.2-v3
+        - name: Cache gRPC Extension
+          id: cache-grpc
+          uses: actions/cache@v4
+          with:
+              path: ~/.cache/grpc.so
+              key: grpc-1.83.0-php8.2-v3
 
-      - name: Install gRPC Extension
-        if: steps.cache-grpc.outputs.cache-hit != 'true'
-        run: |
-          sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
-          mkdir -p ~/.cache
-          cp ${{ steps.php-info.outputs.ext_dir }}/grpc.so ~/.cache/grpc.so
+        - name: Install gRPC Extension
+          if: steps.cache-grpc.outputs.cache-hit != 'true'
+          run: |
+              sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+              mkdir -p ~/.cache
+              cp ${{ steps.php-info.outputs.ext_dir }}/grpc.so ~/.cache/grpc.so
 
-      - name: Enable gRPC Extension
-        run: |
-          sudo cp ~/.cache/grpc.so ${{ steps.php-info.outputs.ext_dir }}/grpc.so
-          echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
-          php -m | grep grpc
+        - name: Enable gRPC Extension
+          run: |
+              sudo cp ~/.cache/grpc.so ${{ steps.php-info.outputs.ext_dir }}/grpc.so
+              echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
+              php -m | grep grpc
 
-      - name: Install and run GAPIC Showcase
-        run: |
-          curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
-          ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
-          sleep 2
+        - name: Install and run GAPIC Showcase
+          run: |
+              curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
+              ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
+              sleep 2
 
-      - name: Install dependencies
-        run: |
-          composer update --prefer-dist --no-interaction --no-suggest -d Gax/
+        - name: Install dependencies
+          run: |
+              composer update --prefer-dist --no-interaction --no-suggest -d Gax/
 
-      - name: Run PHPUnit
-        run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist
-
+        - name: Run PHPUnit
+          run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -7,54 +7,57 @@ on:
 permissions:
   contents: read
 jobs:
-    gapic-showcase:
-        runs-on: ubuntu-latest
-        env:
-            GAPIC_SHOWCASE_VERSION: 0.42.0
-            OS: linux
-            ARCH: amd64
-        name: GAPIC Showcase Conformance Tests
-        steps:
-        - name: Checkout code
-          uses: actions/checkout@v7
+  gapic-showcase:
+    name: GAPIC Showcase Conformance Tests
+    runs-on: ubuntu-latest
+    env:
+      GAPIC_SHOWCASE_VERSION: 0.42.0
+      OS: linux
+      ARCH: amd64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-        - name: Setup PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: '8.2'
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
 
-        - name: Get PHP Extension Directory
-          id: php-info
-          run: |
-            echo "ext_dir=$(php-config --extension-dir)" >> $GITHUB_OUTPUT
-            echo "ini_dir=$(php -r 'echo ini_get("scan_dir");')" >> $GITHUB_OUTPUT
+      - name: Get PHP Extension Directory
+        id: php-info
+        run: |
+          echo "ext_dir=$(php-config --extension-dir)" >> $GITHUB_OUTPUT
+          ini_dir=$(php --ini | grep "Scan this dir" | cut -d: -f2 | xargs)
+          if [ -z "$ini_dir" ]; then ini_dir="/etc/php/8.2/cli/conf.d"; fi
+          echo "ini_dir=$ini_dir" >> $GITHUB_OUTPUT
 
-        - name: Cache gRPC Extension
-          id: cache-grpc
-          uses: actions/cache@v4
-          with:
-            path: ${{ steps.php-info.outputs.ext_dir }}/grpc.so
-            key: grpc-1.83.0-php8.2-v2
+      - name: Cache gRPC Extension
+        id: cache-grpc
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.php-info.outputs.ext_dir }}/grpc.so
+          key: grpc-1.83.0-php8.2-v2
 
-        - name: Install gRPC Extension
-          if: steps.cache-grpc.outputs.cache-hit != 'true'
-          run: |
-            sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+      - name: Install gRPC Extension
+        if: steps.cache-grpc.outputs.cache-hit != 'true'
+        run: |
+          sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
 
-        - name: Enable gRPC Extension
-          run: |
-            echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
-            php -m | grep grpc
+      - name: Enable gRPC Extension
+        run: |
+          echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
+          php -m | grep grpc
 
-        - name: Install and run GAPIC Showcase
-          run: |
-            curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
-            ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
-            sleep 2
+      - name: Install and run GAPIC Showcase
+        run: |
+          curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
+          ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
+          sleep 2
 
-        - name: Install dependencies
-          run: |
-            composer update --prefer-dist --no-interaction --no-suggest -d Gax/
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-suggest -d Gax/
 
-        - name: Run PHPUnit
-          run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist
+      - name: Run PHPUnit
+        run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist
+

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -24,7 +24,7 @@ jobs:
           with:
             php-version: '8.2'
             extensions: grpc-1.83.0
-            key: cache-key-1 #increment to bust the cache
+            key: cache-key-grpc-1.38
 
         - name: Cache extensions
           uses: actions/cache@v4

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -18,6 +18,20 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v7
 
+        - name: Setup cache environment
+          id: extcache
+          uses: shivammathur/cache-extensions@v1
+          with:
+            php-version: '8.2'
+            extensions: grpc-1.83.0
+            key: cache-key-1 #increment to bust the cache
+
+        - name: Cache extensions
+          uses: actions/cache@v4
+          with:
+            path: ${{ steps.extcache.outputs.dir }}
+            key: ${{ steps.extcache.outputs.key }}
+
         - name: Setup PHP
           uses: shivammathur/setup-php@v2
           with:

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -35,16 +35,19 @@ jobs:
         id: cache-grpc
         uses: actions/cache@v4
         with:
-          path: ${{ steps.php-info.outputs.ext_dir }}/grpc.so
-          key: grpc-1.83.0-php8.2-v2
+          path: ~/.cache/grpc.so
+          key: grpc-1.83.0-php8.2-v3
 
       - name: Install gRPC Extension
         if: steps.cache-grpc.outputs.cache-hit != 'true'
         run: |
           sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+          mkdir -p ~/.cache
+          cp ${{ steps.php-info.outputs.ext_dir }}/grpc.so ~/.cache/grpc.so
 
       - name: Enable gRPC Extension
         run: |
+          sudo cp ~/.cache/grpc.so ${{ steps.php-info.outputs.ext_dir }}/grpc.so
           echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
           php -m | grep grpc
 

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -42,6 +42,7 @@ jobs:
           if: steps.cache-grpc.outputs.cache-hit != 'true'
           run: |
             sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+            echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
 
         - name: Install and run GAPIC Showcase
           run: |

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -18,25 +18,30 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v7
 
-        - name: Setup cache environment
-          id: extcache
-          uses: shivammathur/cache-extensions@v1
-          with:
-            php-version: '8.2'
-            extensions: grpc-1.83.0
-            key: cache-key-grpc-1.38
-
-        - name: Cache extensions
-          uses: actions/cache@v4
-          with:
-            path: ${{ steps.extcache.outputs.dir }}
-            key: ${{ steps.extcache.outputs.key }}
-
         - name: Setup PHP
           uses: shivammathur/setup-php@v2
           with:
             php-version: '8.2'
-            extensions: grpc-1.83.0
+
+        - name: Get PHP Extension Directory
+          id: php-info
+          run: |
+            echo "ext_dir=$(php-config --extension-dir)" >> $GITHUB_OUTPUT
+            echo "ini_dir=$(php -r 'echo ini_get("scan_dir");')" >> $GITHUB_OUTPUT
+
+        - name: Cache gRPC Extension
+          id: cache-grpc
+          uses: actions/cache@v4
+          with:
+            path: |
+              ${{ steps.php-info.outputs.ext_dir }}/grpc.so
+              ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
+            key: grpc-1.83.0-php8.2-v1
+
+        - name: Install gRPC Extension
+          if: steps.cache-grpc.outputs.cache-hit != 'true'
+          run: |
+            sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
 
         - name: Install and run GAPIC Showcase
           run: |

--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -33,16 +33,18 @@ jobs:
           id: cache-grpc
           uses: actions/cache@v4
           with:
-            path: |
-              ${{ steps.php-info.outputs.ext_dir }}/grpc.so
-              ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
-            key: grpc-1.83.0-php8.2-v1
+            path: ${{ steps.php-info.outputs.ext_dir }}/grpc.so
+            key: grpc-1.83.0-php8.2-v2
 
         - name: Install gRPC Extension
           if: steps.cache-grpc.outputs.cache-hit != 'true'
           run: |
             sudo MAKEFLAGS="-j$(nproc)" pecl install grpc-1.83.0
+
+        - name: Enable gRPC Extension
+          run: |
             echo "extension=grpc.so" | sudo tee ${{ steps.php-info.outputs.ini_dir }}/20-grpc.ini
+            php -m | grep grpc
 
         - name: Install and run GAPIC Showcase
           run: |


### PR DESCRIPTION
We added pqc tests to our showcase tests. These tests are taking too long to run so we decided to cache the grpc extension to make this tests run in a shorter time.