### PR TITLE
chore: fix showcase conformance yaml whitespace

### DIFF
--- a/.github/workflows/conformance-tests-gax-showcase.yaml
+++ b/.github/workflows/conformance-tests-gax-showcase.yaml
@@ -7,32 +7,32 @@ on:
 permissions:
   contents: read
 jobs:
-    gapic-showcase:
-        runs-on: ubuntu-latest
-        env:
-            GAPIC_SHOWCASE_VERSION: 0.42.0
-            OS: linux
-            ARCH: amd64
-        name: GAPIC Showcase Conformance Tests
-        steps:
-        - name: Checkout code
-          uses: actions/checkout@v7
+  gapic-showcase:
+    runs-on: ubuntu-latest
+    env:
+      GAPIC_SHOWCASE_VERSION: 0.42.0
+      OS: linux
+      ARCH: amd64
+    name: GAPIC Showcase Conformance Tests
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
 
-        - name: Setup PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: '8.2'
-            extensions: grpc-1.83.0
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        extensions: grpc-1.83.0
 
-        - name: Install and run GAPIC Showcase
-          run: |
-            curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
-            ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
-            sleep 2
+    - name: Install and run GAPIC Showcase
+      run: |
+        curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | tar -zx
+        ./gapic-showcase run --port :7469 --tls --ca-cert-output-file Gax/tests/Conformance/showcase.pem &
+        sleep 2
 
-        - name: Install dependencies
-          run: |
-            composer update --prefer-dist --no-interaction --no-suggest -d Gax/
+    - name: Install dependencies
+      run: |
+        composer update --prefer-dist --no-interaction --no-suggest -d Gax/
 
-        - name: Run PHPUnit
-          run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist
+    - name: Run PHPUnit
+      run: Gax/vendor/bin/phpunit -c Gax/phpunit-conformance.xml.dist


### PR DESCRIPTION
Gax's showcase test file is not indented properly. It has a mixture of 2 and 4 spaces indentation. This PR aims to make this consistent with the rest of the yml files in the repository.