### PR TITLE
fix(docs): protobuf docs uploads were wrapped in quotes

### DIFF
--- a/.kokoro/docs/publish.sh
+++ b/.kokoro/docs/publish.sh
@@ -53,7 +53,7 @@ $PROJECT_DIR/dev/google-cloud docfx \
 
 # Add protobuf
 PROTOBUF_DIR=$PROJECT_DIR/dev/vendor/google/protobuf
-PROTOBUF_VERSION=$(composer info google/protobuf -f json -d $PROJECT_DIR/dev | jq .versions[0])
+PROTOBUF_VERSION=$(composer info google/protobuf -f json -d $PROJECT_DIR/dev | jq -r .versions[0])
 $PROJECT_DIR/dev/google-cloud docfx \
     --path $PROTOBUF_DIR \
     --out protobuf-out \


### PR DESCRIPTION
Protobuf docs uploads were showing up with quotes around their version name:

```
gcloud storage ls '*docfx-php-protobuf-*'
gs://docs-staging-v2/docfx-php-protobuf-"v5.35.1".tar.gz
```