### PR TITLE
build(dev): add repository 'only' filters to dev/composer.json

### DIFF
--- a/dev/composer.json
+++ b/dev/composer.json
@@ -43,12 +43,14 @@
         "gapic-generator": {
             "type": "vcs",
             "url": "https://github.com/googleapis/gapic-generator-php.git",
+            "only": ["google/gapic-generator"],
             "options": {
                 "submodules": true
             }
         },
         "gapic-showcase": {
             "type": "package",
+            "only": ["google/gapic-showcase"],
             "package": {
                 "name": "google/gapic-showcase",
                 "version": "dev-main",


### PR DESCRIPTION
Add `"only": ["google/gapic-generator"]` and `"only": ["google/gapic-showcase"]` to custom repository declarations in `dev/composer.json`.
  
This allows non-interactive installations running `composer install -d dev --no-dev` to skip querying GitHub API for dev-only VCS repositories, preventing unauthenticated GitHub API rate-limit prompts during automated tooling runs.

For https://github.com/googleapis/librarian/issues/7180