### PR TITLE
fix(core): merge per-call restOptions with the client-level ones

### DIFF
--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -465,12 +465,26 @@ class RequestWrapper
     /**
      * Gets a set of request options.
      *
+     * Per-call options are merged over the client-level ones rather than replacing
+     * them, so that transport settings configured once on the client (`proxy`,
+     * `verify`, `cert`, ...) still apply to calls that supply their own options.
+     * The merge is shallow, because Guzzle options are a flat list of mostly
+     * scalar values; `headers` is the one nested array worth merging on its own,
+     * so that a per-call header does not drop the client's default headers.
+     *
      * @param array $options
      * @return array
      */
     private function getRequestOptions(array $options)
     {
-        $restOptions = $options['restOptions'] ?? $this->restOptions;
+        $perCallRestOptions = $options['restOptions'] ?? [];
+        $headers = ($perCallRestOptions['headers'] ?? []) + ($this->restOptions['headers'] ?? []);
+        $restOptions = $perCallRestOptions + $this->restOptions;
+
+        if ($headers) {
+            $restOptions['headers'] = $headers;
+        }
+
         $timeout = $options['requestTimeout'] ?? $this->requestTimeout;
 
         if ($timeout && !array_key_exists('timeout', $restOptions)) {

--- a/Core/src/RequestWrapper.php
+++ b/Core/src/RequestWrapper.php
@@ -477,11 +477,9 @@ class RequestWrapper
      */
     private function getRequestOptions(array $options)
     {
-        $perCallRestOptions = $options['restOptions'] ?? [];
-        $headers = ($perCallRestOptions['headers'] ?? []) + ($this->restOptions['headers'] ?? []);
-        $restOptions = $perCallRestOptions + $this->restOptions;
+        $restOptions = ($options['restOptions'] ?? []) + $this->restOptions;
 
-        if ($headers) {
+        if ($headers = ($options['restOptions']['headers'] ?? []) + ($this->restOptions['headers'] ?? [])) {
             $restOptions['headers'] = $headers;
         }
 

--- a/Core/tests/Unit/RequestWrapperTest.php
+++ b/Core/tests/Unit/RequestWrapperTest.php
@@ -106,6 +106,73 @@ class RequestWrapperTest extends TestCase
         );
     }
 
+    public function testClientLevelRestOptionsSurvivePerCallRestOptions()
+    {
+        $actualOptions = [];
+        $requestWrapper = new RequestWrapper([
+            'accessToken' => 'abc',
+            'restOptions' => ['proxy' => 'http://proxy.example.com:8080', 'verify' => false],
+            'httpHandler' => function ($request, $options = []) use (&$actualOptions) {
+                $actualOptions = $options;
+                return new Response(200);
+            }
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com'),
+            ['restOptions' => ['headers' => ['X-Goog-Hash' => 'crc32c=abc']]]
+        );
+
+        $this->assertEquals('http://proxy.example.com:8080', $actualOptions['proxy']);
+        $this->assertFalse($actualOptions['verify']);
+        $this->assertEquals(['X-Goog-Hash' => 'crc32c=abc'], $actualOptions['headers']);
+    }
+
+    public function testPerCallRestOptionsTakePrecedenceOverClientLevelOnes()
+    {
+        $actualOptions = [];
+        $requestWrapper = new RequestWrapper([
+            'accessToken' => 'abc',
+            'restOptions' => ['proxy' => 'http://proxy.example.com:8080', 'debug' => false],
+            'httpHandler' => function ($request, $options = []) use (&$actualOptions) {
+                $actualOptions = $options;
+                return new Response(200);
+            }
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com'),
+            ['restOptions' => ['debug' => true]]
+        );
+
+        $this->assertTrue($actualOptions['debug']);
+        $this->assertEquals('http://proxy.example.com:8080', $actualOptions['proxy']);
+    }
+
+    public function testRestOptionHeadersAreMergedRatherThanReplaced()
+    {
+        $actualOptions = [];
+        $requestWrapper = new RequestWrapper([
+            'accessToken' => 'abc',
+            'restOptions' => ['headers' => ['X-Client' => 'default', 'X-Keep' => 'yes']],
+            'httpHandler' => function ($request, $options = []) use (&$actualOptions) {
+                $actualOptions = $options;
+                return new Response(200);
+            }
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com'),
+            ['restOptions' => ['headers' => ['X-Client' => 'per-call', 'X-Goog-Hash' => 'crc32c=abc']]]
+        );
+
+        $this->assertEquals([
+            'X-Client' => 'per-call',
+            'X-Goog-Hash' => 'crc32c=abc',
+            'X-Keep' => 'yes',
+        ], $actualOptions['headers']);
+    }
+
     public function testSendAsyncRetriesOnFailure()
     {
         $actualDelays = 0;


### PR DESCRIPTION
Fixes #9212.

### Problem

`RequestWrapper::getRequestOptions()` replaces the client-level `restOptions` with the per-call ones whenever a call supplies any:

```php
$restOptions = $options['restOptions'] ?? $this->restOptions;
```

Transport settings configured once on the client — `proxy`, `verify`, `cert` — are therefore silently dropped for any call that passes its own `restOptions`.

Storage made this visible in v1.51.0. The `X-Goog-Hash` checksum header added in #8825 travels as a per-call `restOptions` entry, so **every upload** loses the client's proxy configuration. Downloads reach the same code path through the `on_headers` callback used to detect transcoded objects. In proxy-only environments uploads and downloads stop working, while metadata and auth calls — which pass no per-call `restOptions` — keep succeeding, which makes the failure look unrelated to the upgrade.

This is not Storage-specific: any component that sets per-call `restOptions` drops client transport configuration the same way.

### Fix

Merge instead of replace. Per-call options win on conflict, and nested `headers` arrays are merged on their own so a per-call header does not drop the client's default headers.

The merge is deliberately shallow otherwise. `array_merge_recursive` is not usable here: Guzzle options mix scalars and arrays, and colliding scalars such as `proxy` would be turned into arrays that Guzzle rejects.

### Tests

Three cases added to `Core/tests/Unit/RequestWrapperTest.php`:

- client-level `proxy`/`verify` survive a call that supplies its own `restOptions` (the Storage upload scenario)
- per-call options take precedence over client-level ones on conflict
- `headers` merge rather than replace

The first two fail on `main` with `Undefined array key "proxy"`. The full `Core` unit suite passes (534 tests), as does `phpcs --standard=phpcs-ruleset.xml` on both changed files.

### Credit

The root cause analysis and the merge strategy are @salilg-eng's, from the discussion in #9212. I'm opening the PR since the issue has been sitting for a couple of months and it is currently blocking us from upgrading past `google/cloud-storage` 1.50.