### PR TITLE
chore: update codesniffer

### DIFF
--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3",
         "erusev/parsedown": "^1.6",

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -12,7 +12,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6"

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6"

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.3.3||^6.0",
         "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
         "erusev/parsedown": "^1.6",

--- a/dev/tests/fixtures/component/Vision/composer.json
+++ b/dev/tests/fixtures/component/Vision/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpdocumentor/reflection": "^5.0||^6.0",
         "erusev/parsedown": "^1.6",
         "google/cloud-storage": "^1.12"


### PR DESCRIPTION
fix failing tests from security vulnerability:

```
$ composer audit
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | squizlabs/php_codesniffer                                                        |
| Severity          |                                                                                  |
| CVE               | CVE-2026-67434                                                                   |
| Title             | OS Command injection                                                             |
| URL               | https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg- |
|                   | cxww-wqhq                                                                        |
| Affected versions | <3.13.6|>=4.0.0,<4.0.2                                                           |
| Reported at       | 2026-08-05T23:53:11+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```