### PR TITLE
chore(tests): ensure failing components are reported

### DIFF
--- a/.github/run-package-tests.sh
+++ b/.github/run-package-tests.sh
@@ -110,7 +110,6 @@ run_package_test() {
         echo "${DIR}: composer install failed" >> "${FAILED_FILE}"
         # run again but without "-q" so we can see the error
         composer --no-interaction --no-ansi --no-progress ${PREFER_LOWEST} update -d "${DIR}"
-        echo "${DIR}: failed" >> "${FAILED_FILE}"
         return 1
     fi
 
@@ -160,7 +159,7 @@ export FAILED_FILE
 MAX_JOBS=${MAX_JOBS:-$(nproc 2>/dev/null || echo 8)}
 
 # Run the test suites concurrently using xargs -P
-printf "%s\n" ${DIRS} | xargs -P "${MAX_JOBS}" -I {} bash -c 'run_package_test_parallel "$@"' _ {}
+printf "%s\n" ${DIRS} | xargs -P "${MAX_JOBS}" -I {} bash -c 'run_package_test_parallel "$@"' _ {} || true
 
 if [ -f "${FAILED_FILE}" ]; then
     echo "--------- Failed tests --------------"

--- a/.github/run-package-tests.sh
+++ b/.github/run-package-tests.sh
@@ -110,6 +110,7 @@ run_package_test() {
         echo "${DIR}: composer install failed" >> "${FAILED_FILE}"
         # run again but without "-q" so we can see the error
         composer --no-interaction --no-ansi --no-progress ${PREFER_LOWEST} update -d "${DIR}"
+        echo "${DIR}: failed" >> "${FAILED_FILE}"
         return 1
     fi
 


### PR DESCRIPTION
Ensures failing components are reported when they fail in individual package tests. This issue was intruduced in #9400 because the call to `xargs` fails the entire script if any of the parallel processes fail.

You can see in the [failing tests](https://github.com/googleapis/google-cloud-php/actions/runs/31108010116/job/92638119216?pr=9439) that the failing components are now reported.

```
--------- Failed tests --------------
AccessContextManager: composer install failed
BigQuery: composer install failed
Core: composer install failed
Datastore: composer install failed
Firestore: composer install failed
Language: composer install failed
Logging: composer install failed
PubSub: composer install failed
Speech: composer install failed
Storage: composer install failed
Trace: composer install failed
Translate: composer install failed
Vision: composer install failed
-------------------------------------
```

Relies on https://github.com/googleapis/google-cloud-php/pull/9438 to fix errors