### PR TITLE
fix(dev): showcase:generate outdir

### DIFF
--- a/dev/src/Command/ShowcaseGenerateCommand.php
+++ b/dev/src/Command/ShowcaseGenerateCommand.php
@@ -190,7 +190,7 @@ class ShowcaseGenerateCommand extends Command
         foreach ($mappings as $source => $dest) {
             $srcDir = $tmpOutputDir . $source;
             if (is_dir($srcDir)) {
-                $this->fs->mirror($srcDir, $outDir . $dest);
+                $this->fs->mirror($srcDir, $targetDir . $dest);
             }
         }
 


### PR DESCRIPTION
use `$targetDir` rather than `$outDir` for showcase sync, to use the resolved path and to to be consistent with the "remove" line above it:

https://github.com/googleapis/google-cloud-php/blob/7912a78c4522fe17c90964a1627d52fff90af375/dev/src/Command/ShowcaseGenerateCommand.php#L181