### PR TITLE
feat(Gax): configure InsecureCredentialsWrapper when hasEmulator is true

### DIFF
--- a/Gax/src/GapicClientTrait.php
+++ b/Gax/src/GapicClientTrait.php
@@ -353,6 +353,8 @@ trait GapicClientTrait
                 $options['apiKey'],
                 $options['credentialsConfig']['quotaProject'] ?? null
             );
+        } elseif ($hasEmulator && !isset($options['credentials'])) {
+            $this->credentialsWrapper = new InsecureCredentialsWrapper();
         } else {
             $enableRegionalAccessBoundary = filter_var(
                 getenv('GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT'),

--- a/Gax/tests/Unit/GapicClientTraitTest.php
+++ b/Gax/tests/Unit/GapicClientTraitTest.php
@@ -1861,6 +1861,7 @@ class GapicClientTraitTest extends TestCase
             use GapicClientTrait {
                 buildClientOptions as public;
                 setClientOptions as public;
+                getCredentialsWrapper as public;
             }
             use ClientDefaultsTrait {
                 ClientDefaultsTrait::getClientDefaults insteadof GapicClientTrait;
@@ -1881,6 +1882,10 @@ class GapicClientTraitTest extends TestCase
         $gapic->setClientOptions($options);
 
         $this->assertTrue($gapic->hasEmulator);
+        $this->assertInstanceOf(
+            \Google\ApiCore\InsecureCredentialsWrapper::class,
+            $gapic->getCredentialsWrapper()
+        );
     }
 
     public function testGetServiceScopes()


### PR DESCRIPTION
When `hasEmulator` is configured and no credentials are provided, set `InsecureCredentialsWrapper` so that GAPIC client authentication does not attempt default ADC lookup.