### PR TITLE
fix(ci): DocFX and package test failures from parallel cache creation

### DIFF
--- a/.github/run-package-tests.sh
+++ b/.github/run-package-tests.sh
@@ -107,10 +107,11 @@ run_package_test() {
     fi
     echo ""
     if ! composer -q --no-interaction --no-ansi --no-progress ${PREFER_LOWEST} update -d "${DIR}"; then
-        echo "${DIR}: composer install failed" >> "${FAILED_FILE}"
-        # run again but without "-q" so we can see the error
-        composer --no-interaction --no-ansi --no-progress ${PREFER_LOWEST} update -d "${DIR}"
-        return 1
+        # Retry once without -q to see error and heal transient parallel cache contention
+        if ! composer --no-interaction --no-ansi --no-progress ${PREFER_LOWEST} update -d "${DIR}"; then
+            echo "${DIR}: composer install failed" >> "${FAILED_FILE}"
+            return 1
+        fi
     fi
 
     echo "Running ${DIR} Unit Tests"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,7 +42,7 @@ jobs:
       with:
         timeout_minutes: 10
         max_attempts: 3
-        command: composer --no-interaction --no-ansi --no-progress --no-cache update -d dev
+        command: composer --no-interaction --no-ansi --no-progress update -d dev
     - name: Run DocFX Unit Test Suite
       run: dev/vendor/bin/phpunit -c dev/phpunit-docfx.xml.dist
     - name: Run Docs Generator (Dry Run)


### PR DESCRIPTION
1. Remove `--no-cache` from composer update in `docs.yaml` (which prevented Composer's GitDriver from cloning VCS repositories like `gapic-generator`).
2. Treat the second non-quiet `composer update` attempt in `run-package-tests.sh` as an actual retry so transient parallel cache contention during multi-package updates heals gracefully.