### PR TITLE
fix(docs): install --no-dev in publish.sh

### DIFF
--- a/.kokoro/docs/publish.sh
+++ b/.kokoro/docs/publish.sh
@@ -16,8 +16,8 @@ PROJECT_DIR=$(dirname $(dirname $SCRIPT_DIR))
 phpdoc --version
 
 # Run "composer install" if it hasn't been run yet
-if [ ! -d 'dev/vendor/' ]; then
-    composer install -d $PROJECT_DIR/dev
+if [ ! -d "$PROJECT_DIR/dev/vendor" ]; then
+    composer install --no-dev -d "$PROJECT_DIR/dev"
 fi
 STAGING_FLAG="";
 if [ "$STAGING_BUCKET" != "" ]; then

--- a/dev/composer.json
+++ b/dev/composer.json
@@ -41,11 +41,26 @@
             }
         },
         "gapic-generator": {
-            "type": "vcs",
-            "url": "https://github.com/googleapis/gapic-generator-php.git",
+            "type": "package",
             "only": ["google/gapic-generator"],
-            "options": {
-                "submodules": true
+            "package": {
+                "name": "google/gapic-generator",
+                "version": "dev-main",
+                "source": {
+                    "url": "https://github.com/googleapis/gapic-generator-php.git",
+                    "type": "git",
+                    "reference": "main"
+                },
+                "autoload": {
+                    "psr-4": {
+                        "Google\\PostProcessor\\": "src/PostProcessor",
+                        "Google\\Generator\\": "src",
+                        "Google\\Generator\\Tests\\": "tests",
+                        "Google\\": "generated/Google",
+                        "Grpc\\": "generated/Grpc",
+                        "GPBMetadata\\": "generated/GPBMetadata"
+                    }
+                }
             }
         },
         "gapic-showcase": {

--- a/dev/composer.json
+++ b/dev/composer.json
@@ -41,26 +41,11 @@
             }
         },
         "gapic-generator": {
-            "type": "package",
+            "type": "git",
+            "url": "https://github.com/googleapis/gapic-generator-php.git",
             "only": ["google/gapic-generator"],
-            "package": {
-                "name": "google/gapic-generator",
-                "version": "dev-main",
-                "source": {
-                    "url": "https://github.com/googleapis/gapic-generator-php.git",
-                    "type": "git",
-                    "reference": "main"
-                },
-                "autoload": {
-                    "psr-4": {
-                        "Google\\PostProcessor\\": "src/PostProcessor",
-                        "Google\\Generator\\": "src",
-                        "Google\\Generator\\Tests\\": "tests",
-                        "Google\\": "generated/Google",
-                        "Grpc\\": "generated/Grpc",
-                        "GPBMetadata\\": "generated/GPBMetadata"
-                    }
-                }
+            "options": {
+                "submodules": true
             }
         },
         "gapic-showcase": {

--- a/dev/composer.json
+++ b/dev/composer.json
@@ -12,6 +12,7 @@
         "twig/twig": "^3.5",
         "phpstan/phpstan": "^2.0",
         "symfony/finder": "^6.2",
+        "phpdocumentor/reflection": "^6.3",
         "nikic/php-parser": "v5.8.0",
         "kcs/class-finder": "^0.6.1"
     },
@@ -26,7 +27,6 @@
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "swaggest/json-schema": "^0.12.0",
-        "phpdocumentor/reflection": "^6.3",
         "erusev/parsedown": "^1.7",
         "dg/bypass-finals": "^1.7"
     },


### PR DESCRIPTION
Fixes #9433

- Changes repository type for `google/gapic-generator` from `type: vcs` to `type: git` in `dev/composer.json` so Composer clones directly over HTTPS (reading its own `composer.json` and submodules) without attempting GitHub REST API calls or falling back to SSH (`git@github.com:...`).
- Runs `composer install --no-dev` in `publish.sh` so doc publishing only installs required runtime dependencies.