### PR TITLE
fix(Gax): handle non-deterministic map field order in ProtobufMessageComparator

### DIFF
--- a/Gax/src/Testing/ProtobufMessageComparator.php
+++ b/Gax/src/Testing/ProtobufMessageComparator.php
@@ -65,15 +65,29 @@ class ProtobufMessageComparator extends Comparator
      */
     public function assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false)
     {
-        if ($expected->serializeToString() !== $actual->serializeToString()) {
-            throw new ComparisonFailure(
-                $expected,
-                $actual,
-                $this->exporter->shortenedExport($expected),
-                $this->exporter->shortenedExport($actual),
-                false,
-                'Given 2 Message objects are not the same'
-            );
+        if (get_class($expected) === get_class($actual)) {
+            if ($expected->serializeToString() === $actual->serializeToString()) {
+                return;
+            }
+
+            try {
+                $expectedJson = json_decode($expected->serializeToJsonString(), true);
+                $actualJson = json_decode($actual->serializeToJsonString(), true);
+                if ($expectedJson == $actualJson) {
+                    return;
+                }
+            } catch (\Throwable $e) {
+                // Fall through to throw ComparisonFailure
+            }
         }
+
+        throw new ComparisonFailure(
+            $expected,
+            $actual,
+            $this->exporter->shortenedExport($expected),
+            $this->exporter->shortenedExport($actual),
+            false,
+            'Given 2 Message objects are not the same'
+        );
     }
 }

--- a/Gax/src/Testing/ProtobufMessageComparator.php
+++ b/Gax/src/Testing/ProtobufMessageComparator.php
@@ -17,7 +17,11 @@
 
 namespace Google\ApiCore\Testing;
 
+use Google\ApiCore\Serializer;
+use Google\Protobuf\DescriptorPool;
+use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\Message;
+use Google\Protobuf\Internal\RepeatedField;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Exporter\Exporter;
@@ -65,29 +69,119 @@ class ProtobufMessageComparator extends Comparator
      */
     public function assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false)
     {
-        if (get_class($expected) === get_class($actual)) {
-            if ($expected->serializeToString() === $actual->serializeToString()) {
-                return;
+        if (!self::isProtobufEquals($expected, $actual)) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                $this->exporter->shortenedExport($expected),
+                $this->exporter->shortenedExport($actual),
+                false,
+                'Given 2 Message objects are not the same'
+            );
+        }
+    }
+
+    /**
+     * Checks if two protobuf messages or values are equal.
+     *
+     * @param mixed $expected
+     * @param mixed $actual
+     * @return bool
+     */
+    public static function isProtobufEquals($expected, $actual): bool
+    {
+        if ($expected === $actual) {
+            return true;
+        }
+
+        if (gettype($expected) !== gettype($actual)) {
+            return false;
+        }
+
+        if (is_object($expected)) {
+            if (get_class($expected) !== get_class($actual)) {
+                return false;
             }
 
-            try {
-                $expectedJson = json_decode($expected->serializeToJsonString(), true);
-                $actualJson = json_decode($actual->serializeToJsonString(), true);
-                if ($expectedJson == $actualJson) {
-                    return;
+            if ($expected instanceof Message) {
+                if ($expected->serializeToString() === $actual->serializeToString()) {
+                    return true;
                 }
-            } catch (\Throwable $e) {
-                // Fall through to throw ComparisonFailure
+
+                $pool = DescriptorPool::getGeneratedPool();
+                $descriptor = $pool->getDescriptorByClassName(get_class($expected));
+                if (!$descriptor) {
+                    return false;
+                }
+
+                $oneofCount = $descriptor->getOneofDeclCount();
+                for ($i = 0; $i < $oneofCount; $i++) {
+                    $oneof = $descriptor->getOneofDecl($i);
+                    $getter = Serializer::getGetter($oneof->getName());
+                    if ($expected->$getter() !== $actual->$getter()) {
+                        return false;
+                    }
+                }
+
+                $fieldCount = $descriptor->getFieldCount();
+                for ($i = 0; $i < $fieldCount; $i++) {
+                    $field = $descriptor->getField($i);
+                    $getter = Serializer::getGetter($field->getName());
+                    $expectedVal = $expected->$getter();
+                    $actualVal = $actual->$getter();
+
+                    if (!self::isProtobufEquals($expectedVal, $actualVal)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            if ($expected instanceof MapField) {
+                if (count($expected) !== count($actual)) {
+                    return false;
+                }
+                foreach ($expected as $k => $v) {
+                    if (!isset($actual[$k])) {
+                        return false;
+                    }
+                    if (!self::isProtobufEquals($v, $actual[$k])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            if ($expected instanceof RepeatedField) {
+                if (count($expected) !== count($actual)) {
+                    return false;
+                }
+                $count = count($expected);
+                for ($i = 0; $i < $count; $i++) {
+                    if (!self::isProtobufEquals($expected[$i], $actual[$i])) {
+                        return false;
+                    }
+                }
+                return true;
             }
         }
 
-        throw new ComparisonFailure(
-            $expected,
-            $actual,
-            $this->exporter->shortenedExport($expected),
-            $this->exporter->shortenedExport($actual),
-            false,
-            'Given 2 Message objects are not the same'
-        );
+        if (is_array($expected)) {
+            if (count($expected) !== count($actual)) {
+                return false;
+            }
+            foreach ($expected as $k => $v) {
+                if (!array_key_exists($k, $actual)) {
+                    return false;
+                }
+                if (!self::isProtobufEquals($v, $actual[$k])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return $expected === $actual;
     }
 }

--- a/Gax/src/Testing/ProtobufMessageComparator.php
+++ b/Gax/src/Testing/ProtobufMessageComparator.php
@@ -17,11 +17,7 @@
 
 namespace Google\ApiCore\Testing;
 
-use Google\ApiCore\Serializer;
-use Google\Protobuf\DescriptorPool;
-use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\Message;
-use Google\Protobuf\Internal\RepeatedField;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Exporter\Exporter;
@@ -69,119 +65,27 @@ class ProtobufMessageComparator extends Comparator
      */
     public function assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false)
     {
-        if (!self::isProtobufEquals($expected, $actual)) {
-            throw new ComparisonFailure(
-                $expected,
-                $actual,
-                $this->exporter->shortenedExport($expected),
-                $this->exporter->shortenedExport($actual),
-                false,
-                'Given 2 Message objects are not the same'
-            );
-        }
-    }
-
-    /**
-     * Checks if two protobuf messages or values are equal.
-     *
-     * @param mixed $expected
-     * @param mixed $actual
-     * @return bool
-     */
-    public static function isProtobufEquals($expected, $actual): bool
-    {
-        if ($expected === $actual) {
-            return true;
-        }
-
-        if (gettype($expected) !== gettype($actual)) {
-            return false;
-        }
-
-        if (is_object($expected)) {
-            if (get_class($expected) !== get_class($actual)) {
-                return false;
+        if (get_class($expected) === get_class($actual)) {
+            if ($expected->serializeToString() === $actual->serializeToString()) {
+                return;
             }
 
-            if ($expected instanceof Message) {
-                if ($expected->serializeToString() === $actual->serializeToString()) {
-                    return true;
+            try {
+                if (json_decode($expected->serializeToJsonString(), true) == json_decode($actual->serializeToJsonString(), true)) {
+                    return;
                 }
-
-                $pool = DescriptorPool::getGeneratedPool();
-                $descriptor = $pool->getDescriptorByClassName(get_class($expected));
-                if (!$descriptor) {
-                    return false;
-                }
-
-                $oneofCount = $descriptor->getOneofDeclCount();
-                for ($i = 0; $i < $oneofCount; $i++) {
-                    $oneof = $descriptor->getOneofDecl($i);
-                    $getter = Serializer::getGetter($oneof->getName());
-                    if ($expected->$getter() !== $actual->$getter()) {
-                        return false;
-                    }
-                }
-
-                $fieldCount = $descriptor->getFieldCount();
-                for ($i = 0; $i < $fieldCount; $i++) {
-                    $field = $descriptor->getField($i);
-                    $getter = Serializer::getGetter($field->getName());
-                    $expectedVal = $expected->$getter();
-                    $actualVal = $actual->$getter();
-
-                    if (!self::isProtobufEquals($expectedVal, $actualVal)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if ($expected instanceof MapField) {
-                if (count($expected) !== count($actual)) {
-                    return false;
-                }
-                foreach ($expected as $k => $v) {
-                    if (!isset($actual[$k])) {
-                        return false;
-                    }
-                    if (!self::isProtobufEquals($v, $actual[$k])) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            if ($expected instanceof RepeatedField) {
-                if (count($expected) !== count($actual)) {
-                    return false;
-                }
-                $count = count($expected);
-                for ($i = 0; $i < $count; $i++) {
-                    if (!self::isProtobufEquals($expected[$i], $actual[$i])) {
-                        return false;
-                    }
-                }
-                return true;
+            } catch (\Throwable $e) {
+                // Fall through to throw ComparisonFailure
             }
         }
 
-        if (is_array($expected)) {
-            if (count($expected) !== count($actual)) {
-                return false;
-            }
-            foreach ($expected as $k => $v) {
-                if (!array_key_exists($k, $actual)) {
-                    return false;
-                }
-                if (!self::isProtobufEquals($v, $actual[$k])) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        return $expected === $actual;
+        throw new ComparisonFailure(
+            $expected,
+            $actual,
+            $this->exporter->shortenedExport($expected),
+            $this->exporter->shortenedExport($actual),
+            false,
+            'Given 2 Message objects are not the same'
+        );
     }
 }

--- a/Gax/tests/Unit/ProtobufBandaidTest.php
+++ b/Gax/tests/Unit/ProtobufBandaidTest.php
@@ -31,6 +31,15 @@ class ProtobufBandaidTest extends GeneratedTest
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @dataProvider protobufMessageNotEqualProvider
+     */
+    public function testCompareNotEqual($expected, $actual)
+    {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+        $this->assertEquals($expected, $actual);
+    }
+
     public function protobufMessageProvider()
     {
         $this->autoloadTestdata('generated');
@@ -38,9 +47,44 @@ class ProtobufBandaidTest extends GeneratedTest
 
         $msg1 = new MyMessage();
         $msg2 = new Mymessage();
+
+        $v1 = new \Google\Protobuf\Value();
+        $v1->setStringValue('TEST');
+        $v2 = new \Google\Protobuf\Value();
+        $v2->setStringValue('test');
+
+        $struct1 = new \Google\Protobuf\Struct();
+        $struct1->setFields(['TEST' => $v1, 'test' => $v2]);
+
+        $struct2 = new \Google\Protobuf\Struct();
+        $struct2->setFields(['test' => $v2, 'TEST' => $v1]);
+
         return [
             [$msg1, $msg2],
-            [[$msg1, $msg2], [$msg1, $msg2]]
+            [[$msg1, $msg2], [$msg1, $msg2]],
+            [$struct1, $struct2],
+        ];
+    }
+
+    public function protobufMessageNotEqualProvider()
+    {
+        $v1 = new \Google\Protobuf\Value();
+        $v1->setStringValue('TEST');
+        $v2 = new \Google\Protobuf\Value();
+        $v2->setStringValue('test');
+
+        $struct1 = new \Google\Protobuf\Struct();
+        $struct1->setFields(['TEST' => $v1]);
+
+        $struct2 = new \Google\Protobuf\Struct();
+        $struct2->setFields(['test' => $v2]);
+
+        $status = new \Google\Rpc\Status();
+        $color = new \Google\Type\Color();
+
+        return [
+            [$struct1, $struct2],
+            [$status, $color],
         ];
     }
 }


### PR DESCRIPTION
Protobuf wire format serialization order for map entries is explicitly non-deterministic. When comparing protobuf messages containing map fields (e.g. `Struct` in `SerializerTest::testProperlyHandlesMessage`), two semantically identical messages can have their map entries serialized in different order, resulting in different binary byte strings from `serializeToString()`.

This PR updates `ProtobufMessageComparator` to:
1. Retain the fast path for identical binary wire strings (`$expected->serializeToString() === $actual->serializeToString()`).
2. Fall back to comparing decoded JSON representations (`json_decode($expected->serializeToJsonString(), true) == json_decode($actual->serializeToJsonString(), true)`) when binary strings differ, which allows associative map keys to compare equal regardless of order.
3. Check message class equality.
4. Add unit tests in `ProtobufBandaidTest` verifying that messages with map fields in different insertion orders compare as equal, and non-equal messages fail comparison.