### PR TITLE
fix(gax): reject path with insufficient segments for double wildcard

### DIFF
--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -184,6 +184,9 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
             assert($segment->getSegmentType() !== Segment::VARIABLE_SEGMENT);
 
             if ($segment->getSegmentType() == Segment::DOUBLE_WILDCARD_SEGMENT) {
+                if ($doubleWildcardPieceCount < 1) {
+                    throw $this->matchException($path, 'path does not contain enough segments to be matched');
+                }
                 $pathPiecesForSegment = array_slice($slashPathPieces, $pathPiecesIndex, $doubleWildcardPieceCount);
                 $pathPiece = implode('/', $pathPiecesForSegment);
                 $pathPiecesIndex += $doubleWildcardPieceCount;

--- a/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
+++ b/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
@@ -281,6 +281,10 @@ class RelativeResourceTemplateTest extends TestCase
                 'foo/bar', // Missing middle wildcard
             ],
             [
+                'a/**/{y=*}/{x=*}/f',
+                'a/e/f', // Missing segments for double wildcard and variables
+            ],
+            [
                 'buckets',
                 'bouquets', // Wrong literal
             ],


### PR DESCRIPTION
Fixes #9425

### Summary

`RelativeResourceTemplate::match()` incorrectly returned a false-positive match with contradictory bindings when a template contained a `**` path wildcard followed by wildcard variable segments, and the input path had fewer segments than required. 

The bug was caused by a negative length being passed to `array_slice()` for the `**` token when the path was too short, allowing it to slice pieces from the end, advance the piece index negatively, and incorrectly parse previously-matched segments into variables. 

This PR adds a guard that throws a `ValidationException` immediately when the path does not have enough pieces to satisfy the double wildcard (i.e., when `doubleWildcardPieceCount < 1`), along with a regression test case.