### PR TITLE
fix(Spanner): Preserve dataBoostEnabled in partitioned query and read

### DIFF
--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -905,7 +905,7 @@ class Operation
         $partitions = [];
         $queryPartitionOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            ['parameters', 'types', 'maxPartitions', 'partitionSizeBytes'],
+            ['parameters', 'types', 'maxPartitions', 'partitionSizeBytes', 'dataBoostEnabled'],
             CallOptions::class
         );
 
@@ -991,7 +991,7 @@ class Operation
         $partitions = [];
         $readPartitionOptions = $this->optionsValidator->stripUnknownOptions(
             $options,
-            ['index', 'maxPartitions', 'partitionSizeBytes'],
+            ['index', 'maxPartitions', 'partitionSizeBytes', 'dataBoostEnabled'],
             CallOptions::class
         );
         /** @var RepeatedField<Partition> $protoPartitions */

--- a/Spanner/tests/Unit/OperationTest.php
+++ b/Spanner/tests/Unit/OperationTest.php
@@ -622,13 +622,15 @@ class OperationTest extends TestCase
             ]));
 
         $res = $this->operation->partitionQuery($this->session, $transactionId, $sql, [
-            'parameters' => $params
+            'parameters' => $params,
+            'dataBoostEnabled' => true
         ]);
 
         $this->assertContainsOnlyInstancesOf(QueryPartition::class, $res);
         $this->assertCount(2, $res);
         $this->assertEquals($partitionToken1, $res[0]->token());
         $this->assertEquals($partitionToken2, $res[1]->token());
+        $this->assertTrue($res[0]->options()['dataBoostEnabled']);
     }
 
     public function testPartitionRead()
@@ -680,6 +682,7 @@ class OperationTest extends TestCase
             'retrySettings' => ['retriesEnabled' => false],
             'timeoutMillis' => 1234,
             'transportOptions' => ['grpc' => ['timeout' => 100]],
+            'dataBoostEnabled' => true,
         ];
 
         $this->spannerClient->partitionRead(
@@ -711,6 +714,7 @@ class OperationTest extends TestCase
         $this->assertContainsOnlyInstancesOf(ReadPartition::class, $res);
         $this->assertCount(1, $res);
         $this->assertEquals($partitionToken1, $res[0]->token());
+        $this->assertTrue($res[0]->options()['dataBoostEnabled']);
     }
 
     public function testCommitWithPrecommitTokenOnRetry()


### PR DESCRIPTION
## Description
Fixes #9292.

This PR addresses an issue where the `dataBoostEnabled` option was being silently dropped when calling `partitionQuery()` and `partitionRead()` on a `BatchSnapshot`.

The root cause was that `OptionsValidator::stripUnknownOptions()` was filtering out the `dataBoostEnabled` key because it wasn't in the explicit list of allowed options for partitioned queries/reads in `Operation.php`. This resulted in `data_boost_enabled` never being passed to the `ExecuteSqlRequest` and `ReadRequest`.

### Changes made
- Added `'dataBoostEnabled'` to the allowed options list in `Operation::partitionQuery()` and `Operation::partitionRead()`.
- Added unit tests in `OperationTest.php` to verify that `dataBoostEnabled` is properly preserved in the partition options.