### PR TITLE
chore: update the dev readme for composer troubleshooting

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -31,3 +31,22 @@ Additionally, there are scripts in the `sh` directory which are used in our CI:
 | ------------------- | --------------------------- |
 | `sh/static-analysis`| Run phpstan static ananlysis|
 | `sh/style-fix`      | Run phpcs style check       |
+
+## Installation & Troubleshooting
+
+When installing dependencies in the `dev` directory:
+
+```sh
+composer install -d dev/
+```
+
+If running `composer install` fails with:
+> `No valid composer.json was found in any branch or tag of https://github.com/googleapis/gapic-generator-php.git`
+
+This occurs on machines (such as gLinux or security-hardened Linux setups) where Git enforces `safe.bareRepository = explicit` by default, blocking Composer from accessing its VCS bare repository cache (`~/.cache/composer/vcs/`).
+
+To resolve this safely without changing your global Git security configuration, pass the Git parameter inline when running `composer`:
+
+```sh
+GIT_CONFIG_PARAMETERS="'safe.bareRepository=all'" composer install -d dev/
+```


### PR DESCRIPTION
We added the `showcase:generate` command and added the `gapic-generator-php` as a dependency for this command. Originally used the configuration on `composer.json` to add this dependency as a `vcs` type but that created issues with our doc jobs.

A fix was submitted to this repo changing it to `type:git` but now when you try to do a `composer install --dev` it fails:
```shell
> `No valid composer.json was found in any branch or tag of https://github.com/googleapis/gapic-generator-php.git`
``` 

I updated the `README.md` under dev to document the fix I found to this issue.

Another possible solution is to change it to `type: package` under the `composer.json` but that implies adding all the dependencies from `gapic-generator` into this `composer.json` meaning that if we change dependencies on the generator, we would have to manually edit this file as well which I am not a fan of.

Please feel free to comment and share any thoughts and concerns.