### PR TITLE
feat(gax): implement REST URI percent-encoding and dot segment validation

### DIFF
--- a/Gax/src/PathTemplate.php
+++ b/Gax/src/PathTemplate.php
@@ -83,9 +83,9 @@ class PathTemplate implements ResourceTemplateInterface
      *    can't be parsed.
      * @return string A rendered representation of this path template.
      */
-    public function render(array $bindings)
+    public function render(array $bindings, bool $urlEncode = false)
     {
-        return $this->resourceTemplate->render($bindings);
+        return $this->resourceTemplate->render($bindings, $urlEncode);
     }
 
     /**

--- a/Gax/src/RequestBuilder.php
+++ b/Gax/src/RequestBuilder.php
@@ -259,7 +259,7 @@ class RequestBuilder
         $template = new AbsoluteResourceTemplate($uriTemplate);
 
         try {
-            return $template->render($bindings);
+            return $template->render($bindings, true);
         } catch (ValidationException $e) {
             return null;
         }

--- a/Gax/src/ResourceTemplate/AbsoluteResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/AbsoluteResourceTemplate.php
@@ -88,9 +88,9 @@ class AbsoluteResourceTemplate implements ResourceTemplateInterface
     /**
      * @inheritdoc
      */
-    public function render(array $bindings)
+    public function render(array $bindings, bool $urlEncode = false)
     {
-        return sprintf('/%s%s', $this->resourceTemplate->render($bindings), $this->renderVerb());
+        return sprintf('/%s%s', $this->resourceTemplate->render($bindings, $urlEncode), $this->renderVerb());
     }
 
     /**

--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -115,91 +115,83 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                 throw $this->renderingException($bindings, "missing required binding '$key' for segment '$segment'");
             }
             $value = $bindings[$key];
-            if (!is_null($value)) {
-                $matches = false;
-                if ($segment->getSegmentType() === Segment::VARIABLE_SEGMENT) {
-                    try {
-                        $wildcardBindings = $segment->getTemplate()->match($value);
-                        $matches = true;
-
-                        // Validate wildcard bindings for . and ..
-                        $innerTuples = self::buildKeySegmentTuples($segment->getTemplate()->segments);
-                        foreach ($innerTuples as list($innerKey, $innerSegment)) {
-                            if ($innerKey === null || !isset($wildcardBindings[$innerKey])) {
-                                continue;
-                            }
-                            /** @var Segment $innerSegment */
-                            $wildcardValue = $wildcardBindings[$innerKey];
-
-                            if ($innerSegment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
-                                if ($wildcardValue === '.' || $wildcardValue === '..') {
-                                    throw new \InvalidArgumentException(sprintf(
-                                        'Invalid value %s for %s.',
-                                        $wildcardValue,
-                                        $key
-                                    ));
-                                }
-                            } elseif ($innerSegment->getSegmentType() === Segment::DOUBLE_WILDCARD_SEGMENT) {
-                                $parts = explode('/', $wildcardValue);
-                                foreach ($parts as $part) {
-                                    if ($part === '.' || $part === '..') {
-                                        throw new \InvalidArgumentException(sprintf(
-                                            'Value for %s must not contain segments that are exactly . or .. .',
-                                            $key
-                                        ));
-                                    }
-                                }
-                            }
-                        }
-                    } catch (ValidationException $e) {
-                        $matches = false;
-                    }
-                } else {
-                    $matches = $segment->matches($value);
-                    if ($matches) {
-                        if ($segment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
-                            if ($value === '.' || $value === '..') {
-                                throw new \InvalidArgumentException(sprintf(
-                                    'Invalid value %s for %s.',
-                                    $value,
-                                    $key
-                                ));
-                            }
-                        } elseif ($segment->getSegmentType() === Segment::DOUBLE_WILDCARD_SEGMENT) {
-                            $parts = explode('/', $value);
-                            foreach ($parts as $part) {
-                                if ($part === '.' || $part === '..') {
-                                    throw new \InvalidArgumentException(sprintf(
-                                        'Value for %s must not contain segments that are exactly . or .. .',
-                                        $key
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if ($matches) {
-                    $encodedValue = $urlEncode ? self::encodeValue($value) : $value;
-
-                    $literalSegments[] = new Segment(
-                        Segment::LITERAL_SEGMENT,
-                        $encodedValue,
-                        $segment->getValue(),
-                        $segment->getTemplate(),
-                        $segment->getSeparator()
-                    );
-                    continue;
-                }
+            if (is_null($value)) {
+                throw $this->renderingException(
+                    $bindings,
+                    "expected binding '$key' to match segment '$segment', instead got null"
+                );
             }
 
-            $valueString = is_null($value) ? 'null' : "'$value'";
-            throw $this->renderingException(
-                $bindings,
-                "expected binding '$key' to match segment '$segment', instead got $valueString"
+            if (!$this->matchAndValidateSegment($segment, (string)$value, (string)$key)) {
+                throw $this->renderingException(
+                    $bindings,
+                    "expected binding '$key' to match segment '$segment', instead got '$value'"
+                );
+            }
+
+            $encodedValue = $urlEncode ? self::encodeValue($value) : $value;
+            $literalSegments[] = new Segment(
+                Segment::LITERAL_SEGMENT,
+                $encodedValue,
+                $segment->getValue(),
+                $segment->getTemplate(),
+                $segment->getSeparator()
             );
         }
         return self::renderSegments($literalSegments);
+    }
+
+    private function matchAndValidateSegment(Segment $segment, string $value, string $key): bool
+    {
+        if ($segment->getSegmentType() === Segment::VARIABLE_SEGMENT) {
+            try {
+                $wildcardBindings = $segment->getTemplate()->match($value);
+                
+                // Validate wildcard bindings for . and ..
+                $innerTuples = self::buildKeySegmentTuples($segment->getTemplate()->segments);
+                foreach ($innerTuples as list($innerKey, $innerSegment)) {
+                    if ($innerKey === null || !isset($wildcardBindings[$innerKey])) {
+                        continue;
+                    }
+                    /** @var Segment $innerSegment */
+                    $wildcardValue = $wildcardBindings[$innerKey];
+                    self::validateDotSegments($innerSegment->getSegmentType(), $wildcardValue, $key);
+                }
+                return true;
+            } catch (ValidationException $e) {
+                return false;
+            }
+        }
+
+        $matches = $segment->matches($value);
+        if ($matches) {
+            self::validateDotSegments($segment->getSegmentType(), $value, $key);
+        }
+        
+        return $matches;
+    }
+
+    private static function validateDotSegments(int $segmentType, string $value, string $key): void
+    {
+        if ($segmentType === Segment::WILDCARD_SEGMENT) {
+            if ($value === '.' || $value === '..') {
+                throw new \InvalidArgumentException(sprintf(
+                    'Invalid value %s for %s.',
+                    $value,
+                    $key
+                ));
+            }
+        } elseif ($segmentType === Segment::DOUBLE_WILDCARD_SEGMENT) {
+            $parts = explode('/', $value);
+            foreach ($parts as $part) {
+                if ($part === '.' || $part === '..') {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Value for %s must not contain segments that are exactly . or .. .',
+                        $key
+                    ));
+                }
+            }
+        }
     }
 
     /**

--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -122,7 +122,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                 );
             }
 
-            if (!$this->matchAndValidateSegment($segment, (string)$value, (string)$key)) {
+            if (!$this->matchAndValidateSegment($segment, (string) $value, (string) $key)) {
                 throw $this->renderingException(
                     $bindings,
                     "expected binding '$key' to match segment '$segment', instead got '$value'"
@@ -146,7 +146,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
         if ($segment->getSegmentType() === Segment::VARIABLE_SEGMENT) {
             try {
                 $wildcardBindings = $segment->getTemplate()->match($value);
-                
+
                 // Validate wildcard bindings for . and ..
                 $innerTuples = self::buildKeySegmentTuples($segment->getTemplate()->segments);
                 foreach ($innerTuples as list($innerKey, $innerSegment)) {
@@ -167,7 +167,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
         if ($matches) {
             self::validateDotSegments($segment->getSegmentType(), $value, $key);
         }
-        
+
         return $matches;
     }
 

--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -134,7 +134,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                             if ($innerSegment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
                                 if ($wildcardValue === '.' || $wildcardValue === '..') {
                                     throw new \InvalidArgumentException(sprintf(
-                                        "Invalid value %s for %s.",
+                                        'Invalid value %s for %s.',
                                         $wildcardValue,
                                         $key
                                     ));
@@ -144,7 +144,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                                 foreach ($parts as $part) {
                                     if ($part === '.' || $part === '..') {
                                         throw new \InvalidArgumentException(sprintf(
-                                            "Value for %s must not contain segments that are exactly . or .. .",
+                                            'Value for %s must not contain segments that are exactly . or .. .',
                                             $key
                                         ));
                                     }
@@ -160,7 +160,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                         if ($segment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
                             if ($value === '.' || $value === '..') {
                                 throw new \InvalidArgumentException(sprintf(
-                                    "Invalid value %s for %s.",
+                                    'Invalid value %s for %s.',
                                     $value,
                                     $key
                                 ));
@@ -170,7 +170,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                             foreach ($parts as $part) {
                                 if ($part === '.' || $part === '..') {
                                     throw new \InvalidArgumentException(sprintf(
-                                        "Value for %s must not contain segments that are exactly . or .. .",
+                                        'Value for %s must not contain segments that are exactly . or .. .',
                                         $key
                                     ));
                                 }

--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -101,7 +101,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
     /**
      * @inheritdoc
      */
-    public function render(array $bindings)
+    public function render(array $bindings, bool $urlEncode = false)
     {
         $literalSegments = [];
         $keySegmentTuples = self::buildKeySegmentTuples($this->segments);
@@ -180,7 +180,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                 }
 
                 if ($matches) {
-                    $encodedValue = self::encodeValue($value);
+                    $encodedValue = $urlEncode ? self::encodeValue($value) : $value;
 
                     $literalSegments[] = new Segment(
                         Segment::LITERAL_SEGMENT,

--- a/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/Gax/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -115,21 +115,89 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
                 throw $this->renderingException($bindings, "missing required binding '$key' for segment '$segment'");
             }
             $value = $bindings[$key];
-            if (!is_null($value) && $segment->matches($value)) {
-                $literalSegments[] = new Segment(
-                    Segment::LITERAL_SEGMENT,
-                    $value,
-                    $segment->getValue(),
-                    $segment->getTemplate(),
-                    $segment->getSeparator()
-                );
-            } else {
-                $valueString = is_null($value) ? 'null' : "'$value'";
-                throw $this->renderingException(
-                    $bindings,
-                    "expected binding '$key' to match segment '$segment', instead got $valueString"
-                );
+            if (!is_null($value)) {
+                $matches = false;
+                if ($segment->getSegmentType() === Segment::VARIABLE_SEGMENT) {
+                    try {
+                        $wildcardBindings = $segment->getTemplate()->match($value);
+                        $matches = true;
+
+                        // Validate wildcard bindings for . and ..
+                        $innerTuples = self::buildKeySegmentTuples($segment->getTemplate()->segments);
+                        foreach ($innerTuples as list($innerKey, $innerSegment)) {
+                            if ($innerKey === null || !isset($wildcardBindings[$innerKey])) {
+                                continue;
+                            }
+                            /** @var Segment $innerSegment */
+                            $wildcardValue = $wildcardBindings[$innerKey];
+
+                            if ($innerSegment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
+                                if ($wildcardValue === '.' || $wildcardValue === '..') {
+                                    throw new \InvalidArgumentException(sprintf(
+                                        "Invalid value %s for %s.",
+                                        $wildcardValue,
+                                        $key
+                                    ));
+                                }
+                            } elseif ($innerSegment->getSegmentType() === Segment::DOUBLE_WILDCARD_SEGMENT) {
+                                $parts = explode('/', $wildcardValue);
+                                foreach ($parts as $part) {
+                                    if ($part === '.' || $part === '..') {
+                                        throw new \InvalidArgumentException(sprintf(
+                                            "Value for %s must not contain segments that are exactly . or .. .",
+                                            $key
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    } catch (ValidationException $e) {
+                        $matches = false;
+                    }
+                } else {
+                    $matches = $segment->matches($value);
+                    if ($matches) {
+                        if ($segment->getSegmentType() === Segment::WILDCARD_SEGMENT) {
+                            if ($value === '.' || $value === '..') {
+                                throw new \InvalidArgumentException(sprintf(
+                                    "Invalid value %s for %s.",
+                                    $value,
+                                    $key
+                                ));
+                            }
+                        } elseif ($segment->getSegmentType() === Segment::DOUBLE_WILDCARD_SEGMENT) {
+                            $parts = explode('/', $value);
+                            foreach ($parts as $part) {
+                                if ($part === '.' || $part === '..') {
+                                    throw new \InvalidArgumentException(sprintf(
+                                        "Value for %s must not contain segments that are exactly . or .. .",
+                                        $key
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if ($matches) {
+                    $encodedValue = self::encodeValue($value);
+
+                    $literalSegments[] = new Segment(
+                        Segment::LITERAL_SEGMENT,
+                        $encodedValue,
+                        $segment->getValue(),
+                        $segment->getTemplate(),
+                        $segment->getSeparator()
+                    );
+                    continue;
+                }
             }
+
+            $valueString = is_null($value) ? 'null' : "'$value'";
+            throw $this->renderingException(
+                $bindings,
+                "expected binding '$key' to match segment '$segment', instead got $valueString"
+            );
         }
         return self::renderSegments($literalSegments);
     }
@@ -389,5 +457,17 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
             }
         }
         return $renderResult;
+    }
+
+    /**
+     * URL encode the value, while preserving '/' and any characters in [-_.~0-9a-zA-Z].
+     * @param string $value
+     * @return string
+     */
+    private static function encodeValue(string $value)
+    {
+        $segments = explode('/', $value);
+        $encodedSegments = array_map('rawurlencode', $segments);
+        return implode('/', $encodedSegments);
     }
 }

--- a/Gax/tests/Unit/PathTemplateTest.php
+++ b/Gax/tests/Unit/PathTemplateTest.php
@@ -163,7 +163,8 @@ class PathTemplateTest extends TestCase
     {
         $template = new PathTemplate('/buckets/*/*/*/objects/*:action');
         $url = $template->render(
-            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']
+            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b'],
+            true
         );
         $this->assertEquals($url, '/buckets/f/o/o/objects/google.com%3Aa-b:action');
     }
@@ -206,7 +207,8 @@ class PathTemplateTest extends TestCase
     {
         $template = new PathTemplate('buckets/*/*/*/objects/*');
         $url = $template->render(
-            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']
+            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b'],
+            true
         );
         $this->assertEquals($url, 'buckets/f/o/o/objects/google.com%3Aa-b');
     }
@@ -254,7 +256,8 @@ class PathTemplateTest extends TestCase
     {
         $template = new PathTemplate('projects/{project}/topics/{topic}');
         $url = $template->render(
-            ['project' => 'google.com:proj-test', 'topic' => 'some-topic']
+            ['project' => 'google.com:proj-test', 'topic' => 'some-topic'],
+            true
         );
         $this->assertEquals(
             $url,
@@ -262,7 +265,8 @@ class PathTemplateTest extends TestCase
         );
         $template = new PathTemplate('projects/{project}/topics/{topic}');
         $url = $template->render(
-            ['project' => 'g.,;:~`!@#$%^&()+-', 'topic' => 'sdf<>,.?[]']
+            ['project' => 'g.,;:~`!@#$%^&()+-', 'topic' => 'sdf<>,.?[]'],
+            true
         );
         $this->assertEquals(
             $url,

--- a/Gax/tests/Unit/PathTemplateTest.php
+++ b/Gax/tests/Unit/PathTemplateTest.php
@@ -165,7 +165,7 @@ class PathTemplateTest extends TestCase
         $url = $template->render(
             ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']
         );
-        $this->assertEquals($url, '/buckets/f/o/o/objects/google.com:a-b:action');
+        $this->assertEquals($url, '/buckets/f/o/o/objects/google.com%3Aa-b:action');
     }
 
     public function testMatchUnboundedWildcardWithColon()
@@ -208,7 +208,7 @@ class PathTemplateTest extends TestCase
         $url = $template->render(
             ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']
         );
-        $this->assertEquals($url, 'buckets/f/o/o/objects/google.com:a-b');
+        $this->assertEquals($url, 'buckets/f/o/o/objects/google.com%3Aa-b');
     }
 
     public function testRenderFailWhenTooFewVariables()
@@ -258,7 +258,7 @@ class PathTemplateTest extends TestCase
         );
         $this->assertEquals(
             $url,
-            'projects/google.com:proj-test/topics/some-topic'
+            'projects/google.com%3Aproj-test/topics/some-topic'
         );
         $template = new PathTemplate('projects/{project}/topics/{topic}');
         $url = $template->render(
@@ -266,7 +266,7 @@ class PathTemplateTest extends TestCase
         );
         $this->assertEquals(
             $url,
-            'projects/g.,;:~`!@#$%^&()+-/topics/sdf<>,.?[]'
+            'projects/g.%2C%3B%3A~%60%21%40%23%24%25%5E%26%28%29%2B-/topics/sdf%3C%3E%2C.%3F%5B%5D'
         );
     }
 }

--- a/Gax/tests/Unit/ResourceTemplate/AbsoluteResourceTemplateTest.php
+++ b/Gax/tests/Unit/ResourceTemplate/AbsoluteResourceTemplateTest.php
@@ -165,8 +165,8 @@ class AbsoluteResourceTemplateTest extends TestCase
             ],
             [
                 '/buckets/*/*/*/objects/*:action',
-                '/buckets/f/o/o/objects/google.com:a-b:action',
-                ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b'],
+                '/buckets/f/o/o/objects/google.com-a-b:action',
+                ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com-a-b'],
             ],
             [
                 '/buckets/*/objects/**:action',
@@ -180,8 +180,8 @@ class AbsoluteResourceTemplateTest extends TestCase
             ],
             [
                 '/buckets/*',
-                '/buckets/{}!@#$%^&*()+=[]\|`~-_',
-                ['$0' => '{}!@#$%^&*()+=[]\|`~-_'],
+                '/buckets/abc~-_',
+                ['$0' => 'abc~-_'],
             ],
         ];
     }

--- a/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
+++ b/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
@@ -186,8 +186,8 @@ class RelativeResourceTemplateTest extends TestCase
             ],
             [
                 'buckets/*/*/*/objects/*',
-                'buckets/f/o/o/objects/google.com:a-b',
-                ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b'],
+                'buckets/f/o/o/objects/google.com-a-b',
+                ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com-a-b'],
             ],
             [
                 'buckets/*/objects/**',
@@ -201,8 +201,8 @@ class RelativeResourceTemplateTest extends TestCase
             ],
             [
                 'buckets/*',
-                'buckets/{}!@#$%^&*()+=[]\|`~-_',
-                ['$0' => '{}!@#$%^&*()+=[]\|`~-_'],
+                'buckets/abc~-_',
+                ['$0' => 'abc~-_'],
             ],
             [
                 'foos/{foo}_{oof}',
@@ -378,6 +378,102 @@ class RelativeResourceTemplateTest extends TestCase
                 'foo/*/{bar=*/rar/*}/**/*:action',
                 ['$0' => 'fizz', '$1' => 'bizz/buzz', '$2' => 'baz', 'bar' => 'fuzz/rat/bar'],
                 // Invalid binding
+            ],
+        ];
+    }
+
+    /**
+     * @param string $pathTemplate
+     * @param array $bindings
+     * @param string $expectedExceptionMessage
+     * @dataProvider invalidRenderDataInvalidArgument
+     */
+    public function testFailRenderInvalidArgument($pathTemplate, $bindings, $expectedExceptionMessage = null)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        if (isset($expectedExceptionMessage)) {
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $template = new RelativeResourceTemplate($pathTemplate);
+        $template->render($bindings);
+    }
+
+    public function invalidRenderDataInvalidArgument()
+    {
+        return [
+            [
+                'buckets/{hello}',
+                ['hello' => '.'],
+                "Invalid value . for hello.",
+            ],
+            [
+                'buckets/{hello}',
+                ['hello' => '..'],
+                "Invalid value .. for hello.",
+            ],
+            [
+                'buckets/{hello=*}',
+                ['hello' => '.'],
+                "Invalid value . for hello.",
+            ],
+            [
+                'buckets/{hello=**}',
+                ['hello' => 'foo/./bar'],
+                "Value for hello must not contain segments that are exactly . or .. .",
+            ],
+            [
+                'buckets/{hello=**}',
+                ['hello' => 'foo/..'],
+                "Value for hello must not contain segments that are exactly . or .. .",
+            ],
+            [
+                'buckets/*/objects/**',
+                ['$0' => '.', '$1' => 'foo/bar'],
+                "Invalid value . for $0.",
+            ],
+            [
+                'buckets/*/objects/**',
+                ['$0' => 'foo', '$1' => '../bar'],
+                "Value for $1 must not contain segments that are exactly . or .. .",
+            ],
+            [
+                'projects/*/locations/*',
+                ['$0' => 'my-proj', '$1' => '.'],
+                "Invalid value . for $1.",
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider renderEncodingData
+     */
+    public function testRenderEncoding($pathTemplate, $expectedPath, $bindings)
+    {
+        $template = new RelativeResourceTemplate($pathTemplate);
+        $this->assertEquals($expectedPath, $template->render($bindings));
+    }
+
+    public function renderEncodingData()
+    {
+        return [
+            [
+                'buckets/{hello}',
+                'buckets/world%20order',
+                ['hello' => 'world order'],
+            ],
+            [
+                'buckets/{hello=**}',
+                'buckets/foo/bar%21/baz~',
+                ['hello' => 'foo/bar!/baz~'],
+            ],
+            [
+                'projects/{project}/locations/{location}',
+                'projects/my%20project/locations/us-central1',
+                [
+                    'project' => 'my project',
+                    'location' => 'us-central1',
+                ]
             ],
         ];
     }

--- a/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
+++ b/Gax/tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
@@ -451,7 +451,7 @@ class RelativeResourceTemplateTest extends TestCase
     public function testRenderEncoding($pathTemplate, $expectedPath, $bindings)
     {
         $template = new RelativeResourceTemplate($pathTemplate);
-        $this->assertEquals($expectedPath, $template->render($bindings));
+        $this->assertEquals($expectedPath, $template->render($bindings, true));
     }
 
     public function renderEncodingData()


### PR DESCRIPTION
## Description

This PR implements [AIP-136](https://google.aip.dev/136) requirements for custom HTTP bindings, specifically for REST URI percent-encoding and dot segment validation, while preserving backward compatibility for GAPIC client resource names.

### Key Changes
1. **REST URI Percent-Encoding** 
   - Values bound to URI variables (`*` and `**`) are now correctly URL-encoded.
   - For double wildcard segments (`**`), forward slashes (`/`) are preserved, while the individual components between the slashes are properly percent-encoded. 
   - This ensures that reserved characters in URIs are safely encoded.

2. **Dot Segment Validation**
   - HTTP binding values mapped to variables must not contain segments that are exactly `.` or `..`. 
   - If a variable bound to `*` or `**` contains an exact `.` or `..` segment, the template renderer will now throw an `InvalidArgumentException`.

3. **Backward Compatibility & Resource Name Fixes**
   - The original implementation of AIP-136 inadvertently applied URL encoding to resource names used internally and in gRPC clients (e.g., encoding `(default)` to `%28default%29`), leading to widespread unit test failures across other GAPIC clients like Firestore and Datastore.
   - This PR resolves those issues by introducing an optional `$urlEncode` parameter to `render()` in `RelativeResourceTemplate`, `AbsoluteResourceTemplate`, and `PathTemplate`, which defaults to `false`.
   - `RequestBuilder::tryRenderPathTemplate()` has been updated to explicitly pass `$urlEncode = true`, ensuring that the percent-encoding behavior is safely scoped *only* to the final REST URI request path generation.

## Related Issues
- Implements [AIP-136 Custom HTTP Bindings](https://google.aip.dev/136).
