### PR TITLE
fix(storage): restore error handler in StreamWrapperTest

### DIFF
--- a/Storage/tests/Unit/StreamWrapperTest.php
+++ b/Storage/tests/Unit/StreamWrapperTest.php
@@ -267,20 +267,24 @@ class StreamWrapperTest extends TestCase
         set_error_handler(static function (int $errno, string $errstr): never {
             throw new Exception($errstr, $errno);
         }, E_WARNING);
-        $this->expectException(Exception::class);
+        try {
+            $this->expectException(Exception::class);
 
-        $object = $this->prophesize(StorageObject::class);
-        $object->info()->willThrow(NotFoundException::class);
-        $this->bucket->object('non-existent/file.txt')
-            ->shouldBeCalled()
-            ->willReturn($object->reveal());
-        $this->bucket->objects(Argument::allOf(
-            Argument::withEntry('prefix', 'non-existent/file.txt/'),
-            Argument::withEntry('resultLimit', 1),
-            Argument::withEntry('fields', Argument::any())
-        ))->shouldBeCalled()->willReturn(new \ArrayIterator());
+            $object = $this->prophesize(StorageObject::class);
+            $object->info()->willThrow(NotFoundException::class);
+            $this->bucket->object('non-existent/file.txt')
+                ->shouldBeCalled()
+                ->willReturn($object->reveal());
+            $this->bucket->objects(Argument::allOf(
+                Argument::withEntry('prefix', 'non-existent/file.txt/'),
+                Argument::withEntry('resultLimit', 1),
+                Argument::withEntry('fields', Argument::any())
+            ))->shouldBeCalled()->willReturn(new \ArrayIterator());
 
-        stat('gs://my_bucket/non-existent/file.txt');
+            stat('gs://my_bucket/non-existent/file.txt');
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**


### PR DESCRIPTION
While working on migrating the Auth library into the mono repo, there was a failing test related to the sysv cache tests. In Auth under the Cache folder we are using the `@` directive:
```
$data = @shm_get_var($shmid, $this->options['variableKey']);
```
[Link in repo](https://github.com/googleapis/google-auth-library-php/blob/aadf0e0d46a5d6ad0c206cfc23c7785988126df9/src/Cache/SysVCacheItemPool.php#L291)

which suppresses all warnings.

While running the `StreamWrapperTest` tests, Storage sets an error handler that it is never removed. Now that auth is being migrated into the mono repo this caused some errors in our migration.

Edit:
Here is an error that is being fixed by this change:
https://github.com/googleapis/google-cloud-php/actions/runs/31647611005/job/94284698982

That error handling is turning a warning into an exception.
