### PR TITLE
feat(Gax): add the middlewareOptions property to CallOptions class

### DIFF
--- a/Gax/src/Options/CallOptions.php
+++ b/Gax/src/Options/CallOptions.php
@@ -51,6 +51,7 @@ class CallOptions implements ArrayAccess, OptionsInterface
     private array $headers;
     private ?int $timeoutMillis;
     private array $transportOptions;
+    private ?array $middlewareOptions;
 
     /** @var callable|null $metadataCallback */
     private $metadataCallback;
@@ -92,6 +93,7 @@ class CallOptions implements ArrayAccess, OptionsInterface
         $this->setTransportOptions($arr['transportOptions'] ?? []);
         $this->setRetrySettings($arr['retrySettings'] ?? null);
         $this->setMetadataCallback($arr['metadataCallback'] ?? null);
+        $this->setMiddlewareOptions($arr['middlewareOptions'] ?? null);
     }
 
     /**
@@ -158,6 +160,18 @@ class CallOptions implements ArrayAccess, OptionsInterface
     public function setRetrySettings($retrySettings): self
     {
         $this->retrySettings = $retrySettings;
+
+        return $this;
+    }
+
+    /**
+     * @param array|null $middlewareOptions
+     *
+     * @return $this
+     */
+    public function setMiddlewareOptions(array|null $middlewareOptions): self
+    {
+        $this->middlewareOptions = $middlewareOptions;
 
         return $this;
     }

--- a/Gax/tests/Unit/GapicClientTraitTest.php
+++ b/Gax/tests/Unit/GapicClientTraitTest.php
@@ -205,6 +205,69 @@ class GapicClientTraitTest extends TestCase
         $this->assertTrue($prependedCalled, 'Prepended middleware should have been called');
     }
 
+    public function testMiddlewareOptionsPreservedByCallOptionsOnNewSurface()
+    {
+        $middlewareOptions = ["metricsContext" => new \stdClass()];
+        $callOptions = new \Google\ApiCore\Options\CallOptions([
+            "middlewareOptions" => $middlewareOptions,
+        ]);
+        $this->assertEquals($middlewareOptions, $callOptions->toArray()["middlewareOptions"] ?? null);
+
+        $unaryDescriptors = [
+            "callType" => Call::UNARY_CALL,
+            "responseType" => "decodeType"
+        ];
+        $request = new MockRequestBody([]);
+        $transport = $this->prophesize(TransportInterface::class);
+
+        $transport->startUnaryCall(
+            Argument::type(Call::class),
+            Argument::that(function ($options) use ($middlewareOptions) {
+                return isset($options["middlewareOptions"])
+                    && $options["middlewareOptions"] === $middlewareOptions;
+            })
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->prophesize(PromiseInterface::class)->reveal());
+
+        $credentialsWrapper = CredentialsWrapper::build([
+            "keyFile" => __DIR__ . "/testdata/creds/json-key-file.json"
+        ]);
+
+        $client = new class extends StubGapicClient {
+            protected function isNewClientSurface(): bool {
+                return true;
+            }
+        };
+
+        $client->set("agentHeader", []);
+        $client->set(
+            "retrySettings",
+            ["method" => $this->prophesize(RetrySettings::class)->reveal()]
+        );
+        $client->set("transport", $transport->reveal());
+        $client->set("credentialsWrapper", $credentialsWrapper);
+        $client->set("descriptors", ["method" => $unaryDescriptors]);
+
+        $middlewareCalled = false;
+        $client->addMiddleware(function (callable $handler) use (&$middlewareCalled, $middlewareOptions) {
+            return function (Call $call, array $options) use ($handler, &$middlewareCalled, $middlewareOptions) {
+                $middlewareCalled = true;
+                $this->assertArrayHasKey("middlewareOptions", $options);
+                $this->assertEquals($middlewareOptions, $options["middlewareOptions"]);
+                return $handler($call, $options);
+            };
+        });
+
+        $client->startApiCall(
+            "method",
+            $request,
+            ["middlewareOptions" => $middlewareOptions]
+        );
+
+        $this->assertTrue($middlewareCalled, "Middleware should have received middlewareOptions on new surface");
+    }
+
     public function testVersionedHeadersOverwriteBehavior()
     {
         $unaryDescriptors = [
@@ -1692,6 +1755,7 @@ class GapicClientTraitTest extends TestCase
                 'timeoutMillis' => null, // adds null timeoutMillis,
                 'transportOptions' => [],
                 'metadataCallback' => null,
+                'middlewareOptions' => null,
             ]
         )
 
@@ -2109,4 +2173,5 @@ class GapicV2SurfaceClient
     {
         return $this->agentHeader;
     }
+
 }

--- a/Gax/tests/Unit/Options/CallOptionsTest.php
+++ b/Gax/tests/Unit/Options/CallOptionsTest.php
@@ -56,6 +56,18 @@ class CallOptionsTest extends TestCase
         $this->assertSame($callback, $optionsArray['metadataCallback']);
     }
 
+    public function testMiddlewareOptions()
+    {
+        $middlewareOptions = ['metricsContext' => 'testValue'];
+        $options = new CallOptions([
+            'middlewareOptions' => $middlewareOptions,
+        ]);
+
+        $optionsArray = $options->toArray();
+        $this->assertArrayHasKey('middlewareOptions', $optionsArray);
+        $this->assertEquals($middlewareOptions, $optionsArray['middlewareOptions']);
+    }
+
     public function testUnrecognizedOptionsAreIgnored()
     {
         $options = new CallOptions([


### PR DESCRIPTION
While working on the metrics for spanner migration from our custom exporter to the OTLP version, found out that there was a bug where the metrics where not being sent properly anymore.

This is due the metrics context under Spanner sending the context through a `$callOptions['middlewareOptions']['metricsContext']`. This used to work but it seems that some changes might've made this stopped working.

Added the `$middlewareOptions` property to the CallOptions class.