### PR TITLE
chore(ShoppingCss): update Prettier glob pattern to format unit tests

### DIFF
--- a/ShoppingCss/owlbot.py
+++ b/ShoppingCss/owlbot.py
@@ -46,7 +46,7 @@ subprocess.run([
     '--package=@prettier/plugin-php@^0.19',
     '--',
     'prettier',
-    '**/src/**/Client/*',
+    '**/Client/*',
     '--write',
     '--parser=php',
     '--single-quote',


### PR DESCRIPTION
Update Prettier glob pattern in `ShoppingCss/owlbot.py` from `**/src/**/Client/*` to `**/Client/*`.

This aligns `ShoppingCss` with the rest of the repository (211 other libraries) and the new `librarian` generator tool, ensuring generated unit tests under `tests/Unit/.../Client/*` are formatted by Prettier.
