### PR TITLE
chore: cap paratest version to < 7.0 for PHPUnit 9 compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
         },
         {
             "matchPackageNames": [
+                "brianium/paratest"
+            ],
+            "allowedVersions": "< 7.0"
+        },
+        {
+            "matchPackageNames": [
                 "squizlabs/php_codesniffer"
             ],
             "allowedVersions": "< 3.0"


### PR DESCRIPTION
paratest v7 requires PHPUnit 10, which we do not use yet. This PR limits Renovate to propose paratest updates < 7.0.