### PR TITLE
feat(Spanner): migrate the metrics exporter from a custom one to a native OTLP one.

### DIFF
--- a/Spanner/README.md
+++ b/Spanner/README.md
@@ -192,7 +192,7 @@ All captured metrics are aggregated in-memory and exported synchronously during 
 
 #### Prerequisites
 
-1. **IAM Permissions**: The credentials used by your application require `monitoring.timeSeries.create` permission to publish metrics. Predefined Spanner roles (such as `roles/spanner.databaseAdmin`, `roles/spanner.databaseUser`, and `roles/spanner.databaseReader`) already include this permission by default. If you are using a custom IAM role, ensure this permission is added.
+1. **IAM Permissions & Scope**: The credentials used by your application require the `monitoring.timeSeries.create` permission (provided by the **Metric Writer** role `roles/monitoring.metricWriter`). Standard Spanner roles (`roles/spanner.databaseAdmin`, `roles/spanner.databaseUser`, and `roles/spanner.databaseReader`) already include this permission. The library automatically configures the required `https://www.googleapis.com/auth/monitoring.write` OAuth scope.
 2. **OpenTelemetry Extension**: Installing the [`ext-opentelemetry`](https://pecl.php.net/package/opentelemetry) PHP extension is highly advised to optimize metrics collection and export performance.
 
 ### Debugging

--- a/Spanner/README.md
+++ b/Spanner/README.md
@@ -192,7 +192,9 @@ All captured metrics are aggregated in-memory and exported synchronously during 
 
 #### Prerequisites
 
-1. **IAM Permissions & Scope**: The credentials used by your application require the `monitoring.timeSeries.create` permission (provided by the **Metric Writer** role `roles/monitoring.metricWriter`). Standard Spanner roles (`roles/spanner.databaseAdmin`, `roles/spanner.databaseUser`, and `roles/spanner.databaseReader`) already include this permission. The library automatically configures the required `https://www.googleapis.com/auth/monitoring.write` OAuth scope.
+1. **IAM Permissions & OAuth Scopes**: The credentials used by your application require the `monitoring.timeSeries.create` permission (provided by the **Metric Writer** role `roles/monitoring.metricWriter`). Standard Spanner roles (`roles/spanner.databaseAdmin`, `roles/spanner.databaseUser`, and `roles/spanner.databaseReader`) already include this permission.
+   * When using Application Default Credentials (ADC) or keyfiles, the required `https://www.googleapis.com/auth/monitoring.write` OAuth scope is automatically configured.
+   * If you supply a pre-instantiated credentials object (implementing `FetchAuthTokenInterface` or `CredentialsWrapper`), ensure that `https://www.googleapis.com/auth/monitoring.write` (or `https://www.googleapis.com/auth/cloud-platform`) scope is included when creating your credentials object.
 2. **OpenTelemetry Extension**: Installing the [`ext-opentelemetry`](https://pecl.php.net/package/opentelemetry) PHP extension is highly advised to optimize metrics collection and export performance.
 
 ### Debugging

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -8,8 +8,8 @@
         "ext-grpc": "*",
         "google/cloud-core": "^1.73.0",
         "google/gax": "^1.41.0",
-        "google/cloud-monitoring": "^2.2",
-        "open-telemetry/sdk": "^1.13"
+        "open-telemetry/sdk": "^1.13",
+        "open-telemetry/exporter-otlp": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/Spanner/src/Middleware/MetricsAttemptMiddleware.php
+++ b/Spanner/src/Middleware/MetricsAttemptMiddleware.php
@@ -63,13 +63,9 @@ class MetricsAttemptMiddleware implements MiddlewareInterface
 
     /** @var callable */
     private $nextHandler;
-    private string $projectId;
     private string $clientId;
     private string $clientName;
-    private string $location;
     private bool $directPathEnabled;
-
-    private const INSTANCE_CONFIG = 'unknown';
 
     private const BUCKET_BOUNDS = [
         0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
@@ -86,57 +82,51 @@ class MetricsAttemptMiddleware implements MiddlewareInterface
      * @param callable $nextHandler
      * @param MeterInterface $meter
      * @param string $clientId
-     * @param string $projectId
      * @param string $clientName
-     * @param string $location
      */
     public function __construct(
         callable $nextHandler,
         MeterInterface $meter,
         string $clientId,
-        string $projectId,
-        string $clientName,
-        string $location
+        string $clientName
     ) {
         $this->nextHandler = $nextHandler;
         $advisory = ['ExplicitBucketBoundaries' => self::BUCKET_BOUNDS];
         $this->attemptLatencyHistogram = $meter->createHistogram(
-            'attempt_latencies',
+            'spanner.googleapis.com/internal/client/attempt_latencies',
             'ms',
             'The latency of an RPC attempt',
             $advisory
         );
         $this->attemptCountCounter = $meter->createCounter(
-            'attempt_count',
+            'spanner.googleapis.com/internal/client/attempt_count',
             '1',
             'The number of RPC attempts'
         );
         $this->attemptGfeHistogram = $meter->createHistogram(
-            'gfe_latencies',
+            'spanner.googleapis.com/internal/client/gfe_latencies',
             'ms',
             'Latency between Google\'s network receiving an RPC and reading back the first byte of the response',
             $advisory
         );
         $this->gfeConnectivityErrorCounter = $meter->createCounter(
-            'gfe_connectivity_error_count',
+            'spanner.googleapis.com/internal/client/gfe_connectivity_error_count',
             '1',
             'Number of RPC attempts that failed to reach the GFE or returned no GFE headers'
         );
         $this->attemptAfeHistogram = $meter->createHistogram(
-            'afe_latencies',
+            'spanner.googleapis.com/internal/client/afe_latencies',
             'ms',
             'Latency between Spanner Spanner AFE receiving and returning a response.',
             $advisory
         );
         $this->afeConnectivityErrorCounter = $meter->createCounter(
-            'afe_connectivity_error_count',
+            'spanner.googleapis.com/internal/client/afe_connectivity_error_count',
             '1',
             'Number of connectivity errors for Spanner AFE'
         );
         $this->clientId = $clientId;
-        $this->projectId = $projectId;
         $this->clientName = 'spanner-php/' . $clientName;
-        $this->location = $location;
         $this->directPathEnabled = filter_var(
             getenv('GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS'),
             FILTER_VALIDATE_BOOLEAN
@@ -323,13 +313,9 @@ class MetricsAttemptMiddleware implements MiddlewareInterface
         return [
             'method' => $methodName,
             'status' => $codeName,
-            'instance_id' => $instanceId,
             'database' => $databaseId,
-            'project_id' => $this->projectId,
             'client_uid' => $this->clientId,
             'client_name' => $this->clientName,
-            'instance_config' => self::INSTANCE_CONFIG,
-            'location' => $this->location,
             'directpath_enabled' => $this->directPathEnabled ? 'true' : 'false',
             'directpath_used' => $directPathUsed ? 'true' : 'false'
         ];

--- a/Spanner/src/Middleware/MetricsOperationMiddleware.php
+++ b/Spanner/src/Middleware/MetricsOperationMiddleware.php
@@ -56,13 +56,9 @@ class MetricsOperationMiddleware implements MiddlewareInterface
 
     /** @var callable */
     private $nextHandler;
-    private string $projectId;
     private string $clientId;
     private string $clientName;
-    private string $location;
     private bool $directPathEnabled;
-
-    private const INSTANCE_CONFIG = 'unknown';
 
     private const BUCKET_BOUNDS = [
         0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
@@ -79,34 +75,28 @@ class MetricsOperationMiddleware implements MiddlewareInterface
      * @param callable $nextHandler
      * @param MeterInterface $meter
      * @param string $clientId
-     * @param string $projectId
-     * @param string $location
      */
     public function __construct(
         callable $nextHandler,
         MeterInterface $meter,
         string $clientId,
-        string $projectId,
-        string $clientName,
-        string $location
+        string $clientName
     ) {
         $this->nextHandler = $nextHandler;
         $advisory = ['ExplicitBucketBoundaries' => self::BUCKET_BOUNDS];
         $this->operationLatencyHistogram = $meter->createHistogram(
-            'operation_latencies',
+            'spanner.googleapis.com/internal/client/operation_latencies',
             'ms',
             'The latency of an RPC operations',
             $advisory
         );
         $this->operationCountCounter = $meter->createCounter(
-            'operation_count',
+            'spanner.googleapis.com/internal/client/operation_count',
             '1',
             'The number of RPC operations'
         );
         $this->clientId = $clientId;
-        $this->projectId = $projectId;
         $this->clientName = 'spanner-php/' . $clientName;
-        $this->location = $location;
         $this->directPathEnabled = filter_var(
             getenv('GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS'),
             FILTER_VALIDATE_BOOLEAN
@@ -222,13 +212,9 @@ class MetricsOperationMiddleware implements MiddlewareInterface
         $labels = [
             'method' => $methodName,
             'status' => $codeName,
-            'instance_id' => $instanceId,
             'database' => $databaseId,
-            'project_id' => $this->projectId,
             'client_uid' => $this->clientId,
             'client_name' => $this->clientName,
-            'instance_config' => self::INSTANCE_CONFIG,
-            'location' => $this->location,
             'directpath_enabled' => $this->directPathEnabled ? 'true' : 'false',
             'directpath_used' => $directPathUsed ? 'true' : 'false'
         ];

--- a/Spanner/src/OpenTelemetry/MetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/MetricsExporter.php
@@ -32,291 +32,134 @@
 
 namespace Google\Cloud\Spanner\OpenTelemetry;
 
-use Google\Api\Distribution;
-use Google\Api\Distribution\BucketOptions;
-use Google\Api\Distribution\BucketOptions\Explicit;
-use Google\Api\Metric;
-use Google\Api\MetricDescriptor\MetricKind;
-use Google\Api\MetricDescriptor\ValueType;
-use Google\Api\MonitoredResource;
-use Google\Cloud\Monitoring\V3\Client\MetricServiceClient;
-use Google\Cloud\Monitoring\V3\CreateTimeSeriesRequest;
-use Google\Cloud\Monitoring\V3\Point;
-use Google\Cloud\Monitoring\V3\TimeInterval;
-use Google\Cloud\Monitoring\V3\TimeSeries;
-use Google\Cloud\Monitoring\V3\TypedValue;
-use Google\Protobuf\Timestamp;
+use Google\Auth\ApplicationDefaultCredentials;
+use Google\Auth\Middleware\AuthTokenMiddleware;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use OpenTelemetry\Contrib\Otlp\MetricExporter as OtlpMetricExporter;
+use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
-use OpenTelemetry\SDK\Metrics\Data\DataInterface;
-use OpenTelemetry\SDK\Metrics\Data\Histogram;
-use OpenTelemetry\SDK\Metrics\Data\HistogramDataPoint;
 use OpenTelemetry\SDK\Metrics\Data\Metric as OTelMetric;
-use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
-use OpenTelemetry\SDK\Metrics\Data\Sum;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 /**
- * MetricsExporter exports Spanner client metrics to Google Cloud Monitoring
- * using the internal service endpoint.
+ * MetricsExporter encapsulates the standard OpenTelemetry OTLP MetricExporter
+ * targeting Google Cloud Telemetry endpoint.
+ *
+ * @internal
  */
 class MetricsExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
-    private const SPANNER_RESOURCE_TYPE = 'spanner_instance_client';
-    private const NATIVE_METRICS_PREFIX = 'spanner.googleapis.com/internal/client/';
-    private const SEND_BATCH_SIZE = 200;
+    private const DEFAULT_ENDPOINT = 'https://telemetry.googleapis.com/v1/metrics';
+    private const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
+    private const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 
-    /**
-     * Labels that belong to the MonitoredResource rather than the Metric.
-     */
-    private static array $MONITORED_RES_LABELS = [
-        'project_id' => true,
-        'instance_id' => true,
-        'instance_config' => true,
-        'location' => true,
-        'client_hash' => true,
-    ];
-
-    private MetricServiceClient $client;
     private string $projectId;
-    private string $clientHash;
-    private int $timeoutMillis;
+    private PushMetricExporterInterface $otlpExporter;
 
     /**
-     * @param MetricServiceClient $client The monitoring client.
      * @param string $projectId The GCP project ID metrics will be written to.
-     * @param string $clientUid The unique client identifier.
      * @param int $timeoutMillis The timeout defined for the metrics client during export.
+     * @param array $options Optional configuration parameters.
+     * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
      */
-    public function __construct(MetricServiceClient $client, string $projectId, string $clientUid, int $timeoutMillis)
-    {
-        $this->client = $client;
+    public function __construct(
+        string $projectId,
+        int $timeoutMillis = 5000,
+        array $options = [],
+        ?PushMetricExporterInterface $otlpExporter = null
+    ) {
         $this->projectId = $projectId;
-        $this->clientHash = $this->generateClientHash($clientUid);
-        $this->timeoutMillis = $timeoutMillis;
+
+        if ($otlpExporter !== null) {
+            $this->otlpExporter = $otlpExporter;
+            return;
+        }
+
+        $endpoint = $options['endpoint'] ?? self::DEFAULT_ENDPOINT;
+
+        $handlerStack = HandlerStack::create();
+        try {
+            $fetcher = ApplicationDefaultCredentials::getCredentials([
+                self::MONITORING_WRITE_SCOPE,
+                self::CLOUD_PLATFORM_SCOPE
+            ]);
+
+            $handlerStack->push(new AuthTokenMiddleware($fetcher));
+        } catch (Throwable $e) {
+            // Proceed without auth middleware if ADC is unavailable
+        }
+
+        $guzzleClient = $options['guzzleClient'] ?? new GuzzleClient([
+            'handler' => $handlerStack,
+            'auth' => 'google_auth',
+            'timeout' => $timeoutMillis / 1000,
+        ]);
+
+        $transport = (new PsrTransportFactory($guzzleClient))->create(
+            $endpoint,
+            'application/x-protobuf'
+        );
+
+        $this->otlpExporter = new OtlpMetricExporter($transport, Temporality::CUMULATIVE);
     }
 
     /**
-     * Exports a batch of OTel metrics to Cloud Monitoring.
+     * Exports a batch of OTel metrics using the inner OTLP exporter.
      *
      * @param iterable<OTelMetric> $batch
      * @return bool
      */
     public function export(iterable $batch): bool
     {
-        $timeSeriesList = [];
-        foreach ($batch as $otelMetric) {
-            $timeSeriesList = array_merge($timeSeriesList, $this->mapMetric($otelMetric));
+        try {
+            return $this->otlpExporter->export($batch);
+        } catch (Throwable $e) {
+            return false;
         }
-
-        if (empty($timeSeriesList)) {
-            return true;
-        }
-
-        $projectName = MetricServiceClient::projectName($this->projectId);
-        $chunks = array_chunk($timeSeriesList, self::SEND_BATCH_SIZE);
-
-        foreach ($chunks as $chunk) {
-            $request = new CreateTimeSeriesRequest();
-            $request->setName($projectName);
-            $request->setTimeSeries($chunk);
-
-            try {
-                $this->client->createServiceTimeSeries($request, [
-                    'timeoutMillis' => $this->timeoutMillis
-                ]);
-            } catch (\Exception $e) {
-                // Fail silently during shutdown to avoid user-visible errors.
-            }
-        }
-
-        return true;
     }
 
     /**
-     * Implementation of the forcePush method for PushMetricExporter interface.
+     * Implementation of forceFlush method for PushMetricExporterInterface.
      *
-     * @return true
+     * @return bool
      */
     public function forceFlush(): bool
     {
-        return true;
+        try {
+            return $this->otlpExporter->forceFlush();
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     /**
-     * Implementation of the shutdown method for PushMetricExporterInterface.
+     * Implementation of shutdown method for PushMetricExporterInterface.
      *
-     * @return true
+     * @return bool
      */
     public function shutdown(): bool
     {
-        $this->client->close();
-        return true;
+        try {
+            return $this->otlpExporter->shutdown();
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     /**
      * Returns the aggregation temporality for the given metric.
      *
-     * @param MetricMetadataInterface $metadata
-     * @return string
+     * @param MetricMetadataInterface $metric
+     * @return Temporality|string|null
      */
-    public function temporality(MetricMetadataInterface $metadata): string
+    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
     {
         return Temporality::CUMULATIVE;
-    }
-
-    /**
-     * Maps an OTel Metric object to one or more GCM TimeSeries objects.
-     *
-     * @param OTelMetric $otelMetric
-     */
-    private function mapMetric(OTelMetric $otelMetric): array
-    {
-        $timeSeriesList = [];
-        $metricType = $this->formatMetricName($otelMetric->name);
-
-        $data = $otelMetric->data;
-        if ($data instanceof Sum || $data instanceof Histogram) {
-            foreach ($data->dataPoints as $point) {
-                $timeSeriesList[] = $this->createTimeSeries($metricType, $point, $otelMetric->unit, $data);
-            }
-        }
-
-        return $timeSeriesList;
-    }
-
-    /**
-     * Creates a single GCM TimeSeries from an OTel DataPoint.
-     *
-     * @param string $metricType
-     * @param NumberDataPoint|HistogramDataPoint $otelPoint
-     * @param string|null $unit
-     * @param DataInterface $otelData
-     * @return TimeSeries
-     */
-    private function createTimeSeries(
-        string $metricType,
-        NumberDataPoint|HistogramDataPoint $otelPoint,
-        ?string $unit,
-        DataInterface $otelData
-    ): TimeSeries {
-        $ts = new TimeSeries();
-        $unit = $unit ?? '1';
-
-        $metricLabels = [];
-        $resourceLabels = [
-            'client_hash' => $this->clientHash,
-        ];
-
-        // Distribute attributes between Resource and Metric labels
-        foreach ($otelPoint->attributes as $key => $value) {
-            $labelKey = str_replace('.', '_', $key);
-            if (isset(self::$MONITORED_RES_LABELS[$labelKey])) {
-                $resourceLabels[$labelKey] = (string) $value;
-            } else {
-                $metricLabels[$labelKey] = (string) $value;
-            }
-        }
-
-        $metric = new Metric();
-        $metric->setType($metricType);
-        $metric->setLabels($metricLabels);
-        $ts->setMetric($metric);
-
-        $resource = new MonitoredResource();
-        $resource->setType(self::SPANNER_RESOURCE_TYPE);
-        $resource->setLabels($resourceLabels);
-        $ts->setResource($resource);
-
-        $ts->setUnit($unit);
-
-        $point = new Point();
-        $interval = new TimeInterval();
-
-        // Convert nanoseconds to Protobuf Timestamp
-        $interval->setStartTime($this->toTimestamp($otelPoint->startTimestamp));
-        $interval->setEndTime($this->toTimestamp($otelPoint->timestamp));
-        $point->setInterval($interval);
-
-        $value = new TypedValue();
-        if ($otelData instanceof Sum) {
-            $ts->setMetricKind($otelData->monotonic ? MetricKind::CUMULATIVE : MetricKind::GAUGE);
-            if (is_int($otelPoint->value)) {
-                $value->setInt64Value($otelPoint->value);
-                $ts->setValueType(ValueType::INT64);
-            } else {
-                $value->setDoubleValue((float) $otelPoint->value);
-                $ts->setValueType(ValueType::DOUBLE);
-            }
-        } elseif ($otelData instanceof Histogram) {
-            $ts->setMetricKind(MetricKind::CUMULATIVE);
-            $ts->setValueType(ValueType::DISTRIBUTION);
-
-            $dist = new Distribution();
-            $dist->setCount($otelPoint->count);
-            if ($otelPoint->count > 0) {
-                $dist->setMean($otelPoint->sum / $otelPoint->count);
-            }
-            $dist->setBucketCounts($otelPoint->bucketCounts);
-
-            $bucketOptions = new BucketOptions();
-            $explicit = new Explicit();
-            $explicit->setBounds($otelPoint->explicitBounds);
-            $bucketOptions->setExplicitBuckets($explicit);
-            $dist->setBucketOptions($bucketOptions);
-
-            $value->setDistributionValue($dist);
-        }
-
-        $point->setValue($value);
-        $ts->setPoints([$point]);
-
-        return $ts;
-    }
-
-    /**
-     * Formats the metric name for Cloud Monitoring.
-     * Built-in metrics MUST use the specific internal namespace.
-     *
-     * @param string $name The OTel instrument name.
-     * @return string The fully qualified GCM metric type.
-     */
-    private function formatMetricName(string $name): string
-    {
-        return self::NATIVE_METRICS_PREFIX . $name;
-    }
-
-    /**
-     * Converts nanoseconds to a php Timestamp
-     *
-     * @param int $nanos
-     * @return Timestamp
-     */
-    private function toTimestamp(int $nanos): Timestamp
-    {
-        $timestamp = new Timestamp();
-        $timestamp->setSeconds((int) ($nanos / 1_000_000_000));
-        $timestamp->setNanos((int) ($nanos % 1_000_000_000));
-        return $timestamp;
-    }
-
-    /**
-     * Returns a hash of the client UUID for the metrics
-     *
-     * @param string $clientUid
-     * @return string
-     */
-    private function generateClientHash(string $clientUid): string
-    {
-        if ($clientUid === '') {
-            return '000000';
-        }
-
-        $hashHex = hash('fnv164', $clientUid);
-        $firstFour = substr($hashHex, 0, 4);
-        $intVal = hexdec($firstFour);
-        $tenBits = $intVal >> 6;
-        return sprintf('%06x', $tenBits);
     }
 }

--- a/Spanner/src/OpenTelemetry/MetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/MetricsExporter.php
@@ -33,11 +33,8 @@
 namespace Google\Cloud\Spanner\OpenTelemetry;
 
 use Google\ApiCore\CredentialsWrapper;
-use Google\Auth\ApplicationDefaultCredentials;
-use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
 use OpenTelemetry\Contrib\Otlp\MetricExporter as OtlpMetricExporter;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
@@ -46,7 +43,6 @@ use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
 /**
@@ -61,25 +57,20 @@ class MetricsExporter implements PushMetricExporterInterface, AggregationTempora
     public const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
     public const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 
-    private string $projectId;
     private PushMetricExporterInterface $otlpExporter;
 
     /**
      * @param CredentialsWrapper $metricsCredentials The credentials wrapper for metric export.
-     * @param string $projectId The GCP project ID metrics will be written to.
      * @param int $timeoutMillis The timeout defined for the metrics client during export.
      * @param array $options Optional configuration parameters.
      * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
      */
     public function __construct(
         CredentialsWrapper $metricsCredentials,
-        string $projectId,
         int $timeoutMillis = 5000,
         array $options = [],
         ?PushMetricExporterInterface $otlpExporter = null
     ) {
-        $this->projectId = $projectId;
-
         if ($otlpExporter !== null) {
             $this->otlpExporter = $otlpExporter;
             return;

--- a/Spanner/src/OpenTelemetry/MetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/MetricsExporter.php
@@ -32,131 +32,293 @@
 
 namespace Google\Cloud\Spanner\OpenTelemetry;
 
-use Google\ApiCore\CredentialsWrapper;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\HandlerStack;
-use OpenTelemetry\Contrib\Otlp\MetricExporter as OtlpMetricExporter;
-use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
+use Google\Api\Distribution;
+use Google\Api\Distribution\BucketOptions;
+use Google\Api\Distribution\BucketOptions\Explicit;
+use Google\Api\Metric;
+use Google\Api\MetricDescriptor\MetricKind;
+use Google\Api\MetricDescriptor\ValueType;
+use Google\Api\MonitoredResource;
+use Google\Cloud\Monitoring\V3\Client\MetricServiceClient;
+use Google\Cloud\Monitoring\V3\CreateTimeSeriesRequest;
+use Google\Cloud\Monitoring\V3\Point;
+use Google\Cloud\Monitoring\V3\TimeInterval;
+use Google\Cloud\Monitoring\V3\TimeSeries;
+use Google\Cloud\Monitoring\V3\TypedValue;
+use Google\Protobuf\Timestamp;
 use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
+use OpenTelemetry\SDK\Metrics\Data\DataInterface;
+use OpenTelemetry\SDK\Metrics\Data\Histogram;
+use OpenTelemetry\SDK\Metrics\Data\HistogramDataPoint;
 use OpenTelemetry\SDK\Metrics\Data\Metric as OTelMetric;
+use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
+use OpenTelemetry\SDK\Metrics\Data\Sum;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
-use Psr\Http\Message\RequestInterface;
-use Throwable;
 
 /**
- * MetricsExporter encapsulates the standard OpenTelemetry OTLP MetricExporter
- * targeting Google Cloud Telemetry endpoint.
+ * MetricsExporter exports Spanner client metrics to Google Cloud Monitoring
+ * using the internal service endpoint.
  *
- * @internal
+ * @deprecated
  */
 class MetricsExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
-    private const DEFAULT_ENDPOINT = 'https://telemetry.googleapis.com/v1/metrics';
-    public const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
-    public const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
-
-    private PushMetricExporterInterface $otlpExporter;
+    private const SPANNER_RESOURCE_TYPE = 'spanner_instance_client';
+    private const NATIVE_METRICS_PREFIX = 'spanner.googleapis.com/internal/client/';
+    private const SEND_BATCH_SIZE = 200;
 
     /**
-     * @param CredentialsWrapper $metricsCredentials The credentials wrapper for metric export.
-     * @param int $timeoutMillis The timeout defined for the metrics client during export.
-     * @param array $options Optional configuration parameters.
-     * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
+     * Labels that belong to the MonitoredResource rather than the Metric.
      */
-    public function __construct(
-        CredentialsWrapper $metricsCredentials,
-        int $timeoutMillis = 5000,
-        array $options = [],
-        ?PushMetricExporterInterface $otlpExporter = null
-    ) {
-        if ($otlpExporter !== null) {
-            $this->otlpExporter = $otlpExporter;
-            return;
-        }
+    private static array $MONITORED_RES_LABELS = [
+        'project_id' => true,
+        'instance_id' => true,
+        'instance_config' => true,
+        'location' => true,
+        'client_hash' => true,
+    ];
 
-        $authCallback = $metricsCredentials->getAuthorizationHeaderCallback();
-        $quotaProject = $metricsCredentials->getQuotaProject();
-        $handlerStack = $options['handlerStack'] ?? HandlerStack::create();
-        $handlerStack->push(function (callable $handler) use ($authCallback, $quotaProject) {
-            return function (RequestInterface $request, array $options) use ($authCallback, $handler, $quotaProject) {
-                $headers = $authCallback ? $authCallback() : [];
-                foreach ($headers as $name => $values) {
-                    $request = $request->withHeader($name, $values);
-                }
-                if ($quotaProject) {
-                    $request = $request->withHeader('x-goog-user-project', $quotaProject);
-                }
-                return $handler($request, $options);
-            };
-        });
+    private MetricServiceClient $client;
+    private string $projectId;
+    private string $clientHash;
+    private int $timeoutMillis;
 
-        $guzzleClient = $options['guzzleClient'] ?? new GuzzleClient([
-            'handler' => $handlerStack,
-            'auth' => 'google_auth',
-            'timeout' => $timeoutMillis / 1000,
-        ]);
-
-        $transport = (new PsrTransportFactory($guzzleClient))->create(
-            self::DEFAULT_ENDPOINT,
-            'application/x-protobuf'
-        );
-
-        $this->otlpExporter = new OtlpMetricExporter($transport, Temporality::CUMULATIVE);
+    /**
+     * @param MetricServiceClient $client The monitoring client.
+     * @param string $projectId The GCP project ID metrics will be written to.
+     * @param string $clientUid The unique client identifier.
+     * @param int $timeoutMillis The timeout defined for the metrics client during export.
+     */
+    public function __construct(MetricServiceClient $client, string $projectId, string $clientUid, int $timeoutMillis)
+    {
+        $this->client = $client;
+        $this->projectId = $projectId;
+        $this->clientHash = $this->generateClientHash($clientUid);
+        $this->timeoutMillis = $timeoutMillis;
     }
 
     /**
-     * Exports a batch of OTel metrics using the inner OTLP exporter.
+     * Exports a batch of OTel metrics to Cloud Monitoring.
      *
      * @param iterable<OTelMetric> $batch
      * @return bool
      */
     public function export(iterable $batch): bool
     {
-        try {
-            return $this->otlpExporter->export($batch);
-        } catch (Throwable $e) {
-            return false;
+        $timeSeriesList = [];
+        foreach ($batch as $otelMetric) {
+            $timeSeriesList = array_merge($timeSeriesList, $this->mapMetric($otelMetric));
         }
+
+        if (empty($timeSeriesList)) {
+            return true;
+        }
+
+        $projectName = MetricServiceClient::projectName($this->projectId);
+        $chunks = array_chunk($timeSeriesList, self::SEND_BATCH_SIZE);
+
+        foreach ($chunks as $chunk) {
+            $request = new CreateTimeSeriesRequest();
+            $request->setName($projectName);
+            $request->setTimeSeries($chunk);
+
+            try {
+                $this->client->createServiceTimeSeries($request, [
+                    'timeoutMillis' => $this->timeoutMillis
+                ]);
+            } catch (\Exception $e) {
+                // Fail silently during shutdown to avoid user-visible errors.
+            }
+        }
+
+        return true;
     }
 
     /**
-     * Implementation of forceFlush method for PushMetricExporterInterface.
+     * Implementation of the forcePush method for PushMetricExporter interface.
      *
-     * @return bool
+     * @return true
      */
     public function forceFlush(): bool
     {
-        try {
-            return $this->otlpExporter->forceFlush();
-        } catch (Throwable $e) {
-            return false;
-        }
+        return true;
     }
 
     /**
-     * Implementation of shutdown method for PushMetricExporterInterface.
+     * Implementation of the shutdown method for PushMetricExporterInterface.
      *
-     * @return bool
+     * @return true
      */
     public function shutdown(): bool
     {
-        try {
-            return $this->otlpExporter->shutdown();
-        } catch (Throwable $e) {
-            return false;
-        }
+        $this->client->close();
+        return true;
     }
 
     /**
      * Returns the aggregation temporality for the given metric.
      *
-     * @param MetricMetadataInterface $metric
-     * @return Temporality|string|null
+     * @param MetricMetadataInterface $metadata
+     * @return string
      */
-    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
+    public function temporality(MetricMetadataInterface $metadata): string
     {
         return Temporality::CUMULATIVE;
+    }
+
+    /**
+     * Maps an OTel Metric object to one or more GCM TimeSeries objects.
+     *
+     * @param OTelMetric $otelMetric
+     */
+    private function mapMetric(OTelMetric $otelMetric): array
+    {
+        $timeSeriesList = [];
+        $metricType = $this->formatMetricName($otelMetric->name);
+
+        $data = $otelMetric->data;
+        if ($data instanceof Sum || $data instanceof Histogram) {
+            foreach ($data->dataPoints as $point) {
+                $timeSeriesList[] = $this->createTimeSeries($metricType, $point, $otelMetric->unit, $data);
+            }
+        }
+
+        return $timeSeriesList;
+    }
+
+    /**
+     * Creates a single GCM TimeSeries from an OTel DataPoint.
+     *
+     * @param string $metricType
+     * @param NumberDataPoint|HistogramDataPoint $otelPoint
+     * @param string|null $unit
+     * @param DataInterface $otelData
+     * @return TimeSeries
+     */
+    private function createTimeSeries(
+        string $metricType,
+        NumberDataPoint|HistogramDataPoint $otelPoint,
+        ?string $unit,
+        DataInterface $otelData
+    ): TimeSeries {
+        $ts = new TimeSeries();
+        $unit = $unit ?? '1';
+
+        $metricLabels = [];
+        $resourceLabels = [
+            'client_hash' => $this->clientHash,
+        ];
+
+        // Distribute attributes between Resource and Metric labels
+        foreach ($otelPoint->attributes as $key => $value) {
+            $labelKey = str_replace('.', '_', $key);
+            if (isset(self::$MONITORED_RES_LABELS[$labelKey])) {
+                $resourceLabels[$labelKey] = (string) $value;
+            } else {
+                $metricLabels[$labelKey] = (string) $value;
+            }
+        }
+
+        $metric = new Metric();
+        $metric->setType($metricType);
+        $metric->setLabels($metricLabels);
+        $ts->setMetric($metric);
+
+        $resource = new MonitoredResource();
+        $resource->setType(self::SPANNER_RESOURCE_TYPE);
+        $resource->setLabels($resourceLabels);
+        $ts->setResource($resource);
+
+        $ts->setUnit($unit);
+
+        $point = new Point();
+        $interval = new TimeInterval();
+
+        // Convert nanoseconds to Protobuf Timestamp
+        $interval->setStartTime($this->toTimestamp($otelPoint->startTimestamp));
+        $interval->setEndTime($this->toTimestamp($otelPoint->timestamp));
+        $point->setInterval($interval);
+
+        $value = new TypedValue();
+        if ($otelData instanceof Sum) {
+            $ts->setMetricKind($otelData->monotonic ? MetricKind::CUMULATIVE : MetricKind::GAUGE);
+            if (is_int($otelPoint->value)) {
+                $value->setInt64Value($otelPoint->value);
+                $ts->setValueType(ValueType::INT64);
+            } else {
+                $value->setDoubleValue((float) $otelPoint->value);
+                $ts->setValueType(ValueType::DOUBLE);
+            }
+        } elseif ($otelData instanceof Histogram) {
+            $ts->setMetricKind(MetricKind::CUMULATIVE);
+            $ts->setValueType(ValueType::DISTRIBUTION);
+
+            $dist = new Distribution();
+            $dist->setCount($otelPoint->count);
+            if ($otelPoint->count > 0) {
+                $dist->setMean($otelPoint->sum / $otelPoint->count);
+            }
+            $dist->setBucketCounts($otelPoint->bucketCounts);
+
+            $bucketOptions = new BucketOptions();
+            $explicit = new Explicit();
+            $explicit->setBounds($otelPoint->explicitBounds);
+            $bucketOptions->setExplicitBuckets($explicit);
+            $dist->setBucketOptions($bucketOptions);
+
+            $value->setDistributionValue($dist);
+        }
+
+        $point->setValue($value);
+        $ts->setPoints([$point]);
+
+        return $ts;
+    }
+
+    /**
+     * Formats the metric name for Cloud Monitoring.
+     * Built-in metrics MUST use the specific internal namespace.
+     *
+     * @param string $name The OTel instrument name.
+     * @return string The fully qualified GCM metric type.
+     */
+    private function formatMetricName(string $name): string
+    {
+        return self::NATIVE_METRICS_PREFIX . $name;
+    }
+
+    /**
+     * Converts nanoseconds to a php Timestamp
+     *
+     * @param int $nanos
+     * @return Timestamp
+     */
+    private function toTimestamp(int $nanos): Timestamp
+    {
+        $timestamp = new Timestamp();
+        $timestamp->setSeconds((int) ($nanos / 1_000_000_000));
+        $timestamp->setNanos((int) ($nanos % 1_000_000_000));
+        return $timestamp;
+    }
+
+    /**
+     * Returns a hash of the client UUID for the metrics
+     *
+     * @param string $clientUid
+     * @return string
+     */
+    private function generateClientHash(string $clientUid): string
+    {
+        if ($clientUid === '') {
+            return '000000';
+        }
+
+        $hashHex = hash('fnv164', $clientUid);
+        $firstFour = substr($hashHex, 0, 4);
+        $intVal = hexdec($firstFour);
+        $tenBits = $intVal >> 6;
+        return sprintf('%06x', $tenBits);
     }
 }

--- a/Spanner/src/OpenTelemetry/MetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/MetricsExporter.php
@@ -32,10 +32,12 @@
 
 namespace Google\Cloud\Spanner\OpenTelemetry;
 
+use Google\ApiCore\CredentialsWrapper;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use OpenTelemetry\Contrib\Otlp\MetricExporter as OtlpMetricExporter;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
@@ -56,19 +58,21 @@ use Throwable;
 class MetricsExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
     private const DEFAULT_ENDPOINT = 'https://telemetry.googleapis.com/v1/metrics';
-    private const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
-    private const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+    public const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
+    public const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 
     private string $projectId;
     private PushMetricExporterInterface $otlpExporter;
 
     /**
+     * @param CredentialsWrapper $metricsCredentials The credentials wrapper for metric export.
      * @param string $projectId The GCP project ID metrics will be written to.
      * @param int $timeoutMillis The timeout defined for the metrics client during export.
      * @param array $options Optional configuration parameters.
      * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
      */
     public function __construct(
+        CredentialsWrapper $metricsCredentials,
         string $projectId,
         int $timeoutMillis = 5000,
         array $options = [],
@@ -81,19 +85,21 @@ class MetricsExporter implements PushMetricExporterInterface, AggregationTempora
             return;
         }
 
-        $endpoint = $options['endpoint'] ?? self::DEFAULT_ENDPOINT;
-
-        $handlerStack = HandlerStack::create();
-        try {
-            $fetcher = ApplicationDefaultCredentials::getCredentials([
-                self::MONITORING_WRITE_SCOPE,
-                self::CLOUD_PLATFORM_SCOPE
-            ]);
-
-            $handlerStack->push(new AuthTokenMiddleware($fetcher));
-        } catch (Throwable $e) {
-            // Proceed without auth middleware if ADC is unavailable
-        }
+        $authCallback = $metricsCredentials->getAuthorizationHeaderCallback();
+        $quotaProject = $metricsCredentials->getQuotaProject();
+        $handlerStack = $options['handlerStack'] ?? HandlerStack::create();
+        $handlerStack->push(function (callable $handler) use ($authCallback, $quotaProject) {
+            return function (RequestInterface $request, array $options) use ($authCallback, $handler, $quotaProject) {
+                $headers = $authCallback ? $authCallback() : [];
+                foreach ($headers as $name => $values) {
+                    $request = $request->withHeader($name, $values);
+                }
+                if ($quotaProject) {
+                    $request = $request->withHeader('x-goog-user-project', $quotaProject);
+                }
+                return $handler($request, $options);
+            };
+        });
 
         $guzzleClient = $options['guzzleClient'] ?? new GuzzleClient([
             'handler' => $handlerStack,
@@ -102,7 +108,7 @@ class MetricsExporter implements PushMetricExporterInterface, AggregationTempora
         ]);
 
         $transport = (new PsrTransportFactory($guzzleClient))->create(
-            $endpoint,
+            self::DEFAULT_ENDPOINT,
             'application/x-protobuf'
         );
 

--- a/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
@@ -54,8 +54,6 @@ use Throwable;
 class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
     private const DEFAULT_ENDPOINT = 'https://telemetry.googleapis.com/v1/metrics';
-    public const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
-    public const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 
     private PushMetricExporterInterface $otlpExporter;
 
@@ -67,7 +65,7 @@ class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTem
      */
     public function __construct(
         CredentialsWrapper $metricsCredentials,
-        int $timeoutMillis = 5000,
+        int $timeoutMillis = 100,
         array $options = [],
         ?PushMetricExporterInterface $otlpExporter = null
     ) {

--- a/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
@@ -1,0 +1,162 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\Cloud\Spanner\OpenTelemetry;
+
+use Google\ApiCore\CredentialsWrapper;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\HandlerStack;
+use OpenTelemetry\Contrib\Otlp\MetricExporter as OtlpMetricExporter;
+use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
+use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
+use OpenTelemetry\SDK\Metrics\Data\Metric as OTelMetric;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
+use Psr\Http\Message\RequestInterface;
+use Throwable;
+
+/**
+ * OtlpMetricsExporter encapsulates the standard OpenTelemetry OTLP MetricExporter
+ * targeting Google Cloud Telemetry endpoint.
+ *
+ * @internal
+ */
+class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
+{
+    private const DEFAULT_ENDPOINT = 'https://telemetry.googleapis.com/v1/metrics';
+    public const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
+    public const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+
+    private PushMetricExporterInterface $otlpExporter;
+
+    /**
+     * @param CredentialsWrapper $metricsCredentials The credentials wrapper for metric export.
+     * @param int $timeoutMillis The timeout defined for the metrics client during export.
+     * @param array $options Optional configuration parameters.
+     * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
+     */
+    public function __construct(
+        CredentialsWrapper $metricsCredentials,
+        int $timeoutMillis = 5000,
+        array $options = [],
+        ?PushMetricExporterInterface $otlpExporter = null
+    ) {
+        if ($otlpExporter !== null) {
+            $this->otlpExporter = $otlpExporter;
+            return;
+        }
+
+        $authCallback = $metricsCredentials->getAuthorizationHeaderCallback();
+        $quotaProject = $metricsCredentials->getQuotaProject();
+        $handlerStack = $options['handlerStack'] ?? HandlerStack::create();
+        $handlerStack->push(function (callable $handler) use ($authCallback, $quotaProject) {
+            return function (RequestInterface $request, array $options) use ($authCallback, $handler, $quotaProject) {
+                $headers = $authCallback ? $authCallback() : [];
+                foreach ($headers as $name => $values) {
+                    $request = $request->withHeader($name, $values);
+                }
+                if ($quotaProject) {
+                    $request = $request->withHeader('x-goog-user-project', $quotaProject);
+                }
+                return $handler($request, $options);
+            };
+        });
+
+        $guzzleClient = $options['guzzleClient'] ?? new GuzzleClient([
+            'handler' => $handlerStack,
+            'auth' => 'google_auth',
+            'timeout' => $timeoutMillis / 1000,
+        ]);
+
+        $transport = (new PsrTransportFactory($guzzleClient))->create(
+            self::DEFAULT_ENDPOINT,
+            'application/x-protobuf'
+        );
+
+        $this->otlpExporter = new OtlpMetricExporter($transport, Temporality::CUMULATIVE);
+    }
+
+    /**
+     * Exports a batch of OTel metrics using the inner OTLP exporter.
+     *
+     * @param iterable<OTelMetric> $batch
+     * @return bool
+     */
+    public function export(iterable $batch): bool
+    {
+        try {
+            return $this->otlpExporter->export($batch);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Implementation of forceFlush method for PushMetricExporterInterface.
+     *
+     * @return bool
+     */
+    public function forceFlush(): bool
+    {
+        try {
+            return $this->otlpExporter->forceFlush();
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Implementation of shutdown method for PushMetricExporterInterface.
+     *
+     * @return bool
+     */
+    public function shutdown(): bool
+    {
+        try {
+            return $this->otlpExporter->shutdown();
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the aggregation temporality for the given metric.
+     *
+     * @param MetricMetadataInterface $metric
+     * @return Temporality|string|null
+     */
+    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
+    {
+        return Temporality::CUMULATIVE;
+    }
+}

--- a/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
@@ -58,13 +58,13 @@ class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTem
     private PushMetricExporterInterface $otlpExporter;
 
     /**
-     * @param CredentialsWrapper $metricsCredentials The credentials wrapper for metric export.
+     * @param CredentialsWrapper $credentials The credentials wrapper for metric export.
      * @param int $timeoutMillis The timeout defined for the metrics client during export.
      * @param array $options Optional configuration parameters.
      * @param PushMetricExporterInterface|null $otlpExporter Optional inner exporter for testing.
      */
     public function __construct(
-        CredentialsWrapper $metricsCredentials,
+        CredentialsWrapper $credentials,
         int $timeoutMillis = 100,
         array $options = [],
         ?PushMetricExporterInterface $otlpExporter = null
@@ -74,8 +74,8 @@ class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTem
             return;
         }
 
-        $authCallback = $metricsCredentials->getAuthorizationHeaderCallback();
-        $quotaProject = $metricsCredentials->getQuotaProject();
+        $authCallback = $credentials->getAuthorizationHeaderCallback();
+        $quotaProject = $credentials->getQuotaProject();
         $handlerStack = $options['handlerStack'] ?? HandlerStack::create();
         $handlerStack->push(function (callable $handler) use ($authCallback, $quotaProject) {
             return function (RequestInterface $request, array $options) use ($authCallback, $handler, $quotaProject) {

--- a/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
+++ b/Spanner/src/OpenTelemetry/OtlpMetricsExporter.php
@@ -92,7 +92,7 @@ class OtlpMetricsExporter implements PushMetricExporterInterface, AggregationTem
             };
         });
 
-        $guzzleClient = $options['guzzleClient'] ?? new GuzzleClient([
+        $guzzleClient = new GuzzleClient([
             'handler' => $handlerStack,
             'auth' => 'google_auth',
             'timeout' => $timeoutMillis / 1000,

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -25,6 +25,7 @@ use Google\ApiCore\Middleware\MiddlewareInterface;
 use Google\ApiCore\Options\CallOptions;
 use Google\ApiCore\ValidationException;
 use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\GetUniverseDomainInterface;
 use Google\Cloud\Core\ApiHelperTrait;
 use Google\Cloud\Core\Compute\Metadata;
@@ -1060,7 +1061,10 @@ class SpannerClient
         return $config;
     }
 
-    private function configureMetrics(array $options, mixed $rawCredentials = null): void
+    private function configureMetrics(
+        array $options,
+        string|array|FetchAuthTokenInterface|CredentialsWrapper|null $rawCredentials = null
+    ): void
     {
         $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 100;
 
@@ -1183,7 +1187,10 @@ class SpannerClient
         return sprintf('%06x', $tenBits);
     }
 
-    private function buildMetricsCredentials(mixed $credentials, array $options): CredentialsWrapper
+    private function buildMetricsCredentials(
+        string|array|FetchAuthTokenInterface|CredentialsWrapper|null $credentials,
+        array $options
+    ): CredentialsWrapper
     {
         $credentialsConfig = [
             'scopes' => [

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -47,7 +47,7 @@ use Google\Cloud\Spanner\Middleware\MetricsAttemptMiddleware;
 use Google\Cloud\Spanner\Middleware\MetricsOperationMiddleware;
 use Google\Cloud\Spanner\Middleware\RequestIdHeaderMiddleware;
 use Google\Cloud\Spanner\Middleware\SpannerMiddleware;
-use Google\Cloud\Spanner\OpenTelemetry\MetricsExporter;
+use Google\Cloud\Spanner\OpenTelemetry\OtlpMetricsExporter;
 use Google\Cloud\Spanner\V1\Client\SpannerClient as GapicSpannerClient;
 use Google\Cloud\Spanner\V1\TransactionOptions\IsolationLevel;
 use Google\Cloud\Spanner\V1\TransactionOptions\ReadWrite\ReadLockMode;
@@ -1083,7 +1083,7 @@ class SpannerClient
 
         $metricsCredentials = $this->buildMetricsCredentials($options);
 
-        $exporter = new MetricsExporter($metricsCredentials, $timeoutMillis, $options);
+        $exporter = new OtlpMetricsExporter($metricsCredentials, $timeoutMillis, $options);
         $reader = new ExportingReader($exporter);
         $this->meterProvider = MeterProvider::builder()
             ->setResource($resource)
@@ -1192,8 +1192,8 @@ class SpannerClient
 
         $credentialsConfig = [
             'scopes' => [
-                MetricsExporter::MONITORING_WRITE_SCOPE,
-                MetricsExporter::CLOUD_PLATFORM_SCOPE
+                OtlpMetricsExporter::MONITORING_WRITE_SCOPE,
+                OtlpMetricsExporter::CLOUD_PLATFORM_SCOPE
             ]
         ];
 

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -19,10 +19,12 @@ namespace Google\Cloud\Spanner;
 
 use Exception;
 use Google\ApiCore\ClientOptionsTrait;
+use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Middleware\MiddlewareInterface;
 use Google\ApiCore\Options\CallOptions;
 use Google\ApiCore\ValidationException;
 use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\GetUniverseDomainInterface;
 use Google\Cloud\Core\ApiHelperTrait;
 use Google\Cloud\Core\Compute\Metadata;
 use Google\Cloud\Core\DetectProjectIdTrait;
@@ -205,10 +207,10 @@ class SpannerClient
      *     @type CacheItemPoolInterface $cacheItemPool
      *     @type bool $enableBuiltInMetrics If true, built-in metrics collection will be enabled.
      *           **Defaults to** false.
-     *     @type int $metricsTimeoutMillis The timeout in milliseconds for the internal
-     *           `MetricServiceClient` used to export metrics. **Defaults to** 100.
-     *     @type MetricServiceClient $metricServiceClient An explicit instance of
-     *           `MetricServiceClient` to use for exporting metrics.
+     *     @type int $metricsTimeoutMillis The timeout in milliseconds for exporting metrics.
+     *           **Defaults to** 5000.
+     *     @type string|array|FetchAuthTokenInterface|CredentialsWrapper $metricsCredentials
+     *           Optional dedicated credentials to use for exporting built-in metrics.
      * }
      * @throws GoogleException If the gRPC extension is not enabled.
      */
@@ -252,6 +254,10 @@ class SpannerClient
         } else {
             $options['credentialsConfig']['scopes'] = $scopes;
         }
+
+        $metricsCredentials = $options['metricsCredentials']
+            ?? $options['credentials']
+            ?? null;
 
         if ($emulatorHost) {
             $emulatorConfig = $this->emulatorGapicConfig($emulatorHost);
@@ -300,6 +306,7 @@ class SpannerClient
         $this->instanceAdminClient->addMiddleware($middleware);
         $this->databaseAdminClient->addMiddleware($middleware);
 
+        $options['metricsCredentials'] = $metricsCredentials;
         $this->configureMetrics($options);
 
         $this->projectName = InstanceAdminClient::projectName($this->projectId);
@@ -1074,7 +1081,9 @@ class SpannerClient
             'location'          => $location !== 'global' ? $location : 'us-central1',
         ]));
 
-        $exporter = new MetricsExporter($this->projectId, $timeoutMillis, $options);
+        $metricsCredentials = $this->buildMetricsCredentials($options);
+
+        $exporter = new MetricsExporter($metricsCredentials, $this->projectId, $timeoutMillis, $options);
         $reader = new ExportingReader($exporter);
         $this->meterProvider = MeterProvider::builder()
             ->setResource($resource)
@@ -1173,5 +1182,25 @@ class SpannerClient
         $intVal = hexdec($firstFour);
         $tenBits = $intVal >> 6;
         return sprintf('%06x', $tenBits);
+    }
+
+    private function buildMetricsCredentials(array $options): CredentialsWrapper
+    {
+        $metricsCredentials = $options['metricsCredentials']
+            ?? $options['credentials']
+            ?? null;
+
+        $credentialsConfig = [
+            'scopes' => [
+                MetricsExporter::MONITORING_WRITE_SCOPE,
+                MetricsExporter::CLOUD_PLATFORM_SCOPE
+            ]
+        ];
+
+        $universeDomain = $options['universeDomain'] ?? GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN;
+
+        $credentialsWrapper = $this->createCredentialsWrapper($metricsCredentials, $credentialsConfig, $universeDomain);
+
+        return $credentialsWrapper;
     }
 }

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -1083,7 +1083,7 @@ class SpannerClient
 
         $metricsCredentials = $this->buildMetricsCredentials($options);
 
-        $exporter = new MetricsExporter($metricsCredentials, $this->projectId, $timeoutMillis, $options);
+        $exporter = new MetricsExporter($metricsCredentials, $timeoutMillis, $options);
         $reader = new ExportingReader($exporter);
         $this->meterProvider = MeterProvider::builder()
             ->setResource($resource)
@@ -1093,7 +1093,7 @@ class SpannerClient
         $this->meter = $this->meterProvider->getMeter('google-cloud-spanner');
         ShutdownHandler::register([$this->meterProvider, 'shutdown']);
 
-        $attemptMetricsMiddleware = function (MiddlewareInterface $handler) use ($metricsClientId, $location) {
+        $attemptMetricsMiddleware = function (MiddlewareInterface $handler) use ($metricsClientId) {
             return new MetricsAttemptMiddleware(
                 $handler,
                 $this->meter,
@@ -1102,7 +1102,7 @@ class SpannerClient
             );
         };
 
-        $operationMetricsMiddleware = function (MiddlewareInterface $handler) use ($metricsClientId, $location) {
+        $operationMetricsMiddleware = function (MiddlewareInterface $handler) use ($metricsClientId) {
             return new MetricsOperationMiddleware(
                 $handler,
                 $this->meter,

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -33,7 +33,6 @@ use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\LongRunning\LongRunningClientConnection;
 use Google\Cloud\Core\LongRunning\LongRunningOperation;
 use Google\Cloud\Core\OptionsValidator;
-use Google\Cloud\Monitoring\V3\Client\MetricServiceClient;
 use Google\Cloud\Spanner\Admin\Database\V1\Client\DatabaseAdminClient;
 use Google\Cloud\Spanner\Admin\Instance\V1\Client\InstanceAdminClient;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceConfig;
@@ -54,9 +53,11 @@ use Google\LongRunning\Operation as OperationProto;
 use Google\Protobuf\Duration;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\MeterProviderInterface;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Util\ShutdownHandler;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\StreamInterface;
 use Ramsey\Uuid\Uuid as RUUID;
@@ -1055,42 +1056,28 @@ class SpannerClient
 
     private function configureMetrics(array $options): void
     {
-        $metricsClient = $this->pluck('metricServiceClient', $options, false);
-        $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 100;
+        $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 5000;
 
         if (!$this->pluck('enableBuiltInMetrics', $options, false)) {
             return;
         }
 
-        if (!$metricsClient) {
-            $metricsOptions = [
-                'projectId' => $this->projectId,
-                'keyFile' => $options['keyFile'] ?? null,
-                'keyFilePath' => $options['keyFilePath'] ?? null,
-                'credentials' => $options['credentials'] ?? null,
-                'credentialsConfig' => $options['credentialsConfig'] ?? null,
-                'universeDomain' => $options['universeDomain'] ?? null,
-                'transport' => $options['transport'] ?? null,
-                'transportConfig' => $options['transportConfig'] ?? null
-            ];
-
-            try {
-                $metricsClient = new MetricServiceClient(array_filter($metricsOptions));
-            } catch (ValidationException $e) {
-                // If we cannot instantiate the metrics client, we should not stop the execution
-                return;
-            }
-        }
-
-        if (!$metricsClient instanceof MetricServiceClient) {
-            throw new ValidationException('The "metricServiceClient" option must be a MetricServiceClient instance.');
-        }
-
         $location = $this->getLocation();
         $metricsClientId = RUUID::uuid4()->toString() . '-' . getmypid();
-        $exporter = new MetricsExporter($metricsClient, $this->projectId, $metricsClientId, $timeoutMillis);
+        $clientHash = $this->generateClientHash($metricsClientId);
+
+        $resource = ResourceInfo::create(Attributes::create([
+            'gcp.resource_type' => 'spanner_instance_client',
+            'gcp.project_id'    => $this->projectId,
+            'project_id'        => $this->projectId,
+            'client_hash'       => $clientHash,
+            'location'          => $location !== 'global' ? $location : 'us-central1',
+        ]));
+
+        $exporter = new MetricsExporter($this->projectId, $timeoutMillis, $options);
         $reader = new ExportingReader($exporter);
         $this->meterProvider = MeterProvider::builder()
+            ->setResource($resource)
             ->addReader($reader)
             ->build();
 
@@ -1102,9 +1089,7 @@ class SpannerClient
                 $handler,
                 $this->meter,
                 $metricsClientId,
-                $this->projectId,
-                $this->clientVersion(),
-                $location
+                $this->clientVersion()
             );
         };
 
@@ -1113,9 +1098,7 @@ class SpannerClient
                 $handler,
                 $this->meter,
                 $metricsClientId,
-                $this->projectId,
-                $this->clientVersion(),
-                $location
+                $this->clientVersion()
             );
         };
 
@@ -1171,5 +1154,24 @@ class SpannerClient
         }
 
         return $location;
+    }
+
+    /**
+     * Returns a hash of the client UUID for the metrics.
+     *
+     * @param string $clientUid
+     * @return string
+     */
+    private function generateClientHash(string $clientUid): string
+    {
+        if ($clientUid === '') {
+            return '000000';
+        }
+
+        $hashHex = hash('fnv1a64', $clientUid);
+        $firstFour = substr($hashHex, 0, 4);
+        $intVal = hexdec($firstFour);
+        $tenBits = $intVal >> 6;
+        return sprintf('%06x', $tenBits);
     }
 }

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -257,7 +257,7 @@ class SpannerClient
             $options['credentialsConfig']['scopes'] = $scopes;
         }
 
-        $metricsCredentials = $options['credentials'] ?? null;
+        $rawCredentials = $options['credentials'] ?? null;
 
         if ($emulatorHost) {
             $emulatorConfig = $this->emulatorGapicConfig($emulatorHost);
@@ -306,8 +306,7 @@ class SpannerClient
         $this->instanceAdminClient->addMiddleware($middleware);
         $this->databaseAdminClient->addMiddleware($middleware);
 
-        $options['metricsCredentials'] = $metricsCredentials;
-        $this->configureMetrics($options);
+        $this->configureMetrics($options, $rawCredentials);
 
         $this->projectName = InstanceAdminClient::projectName($this->projectId);
         $this->cacheItemPool = $options['cacheItemPool'];
@@ -1061,7 +1060,7 @@ class SpannerClient
         return $config;
     }
 
-    private function configureMetrics(array $options): void
+    private function configureMetrics(array $options, mixed $rawCredentials = null): void
     {
         $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 100;
 
@@ -1081,9 +1080,9 @@ class SpannerClient
             'location'          => $location !== 'global' ? $location : 'us-central1',
         ]));
 
-        $metricsCredentials = $this->buildMetricsCredentials($options);
+        $credentialsWrapper = $this->buildMetricsCredentials($rawCredentials, $options);
 
-        $exporter = new OtlpMetricsExporter($metricsCredentials, $timeoutMillis, $options);
+        $exporter = new OtlpMetricsExporter($credentialsWrapper, $timeoutMillis, $options);
         $reader = new ExportingReader($exporter);
         $this->meterProvider = MeterProvider::builder()
             ->setResource($resource)
@@ -1184,10 +1183,8 @@ class SpannerClient
         return sprintf('%06x', $tenBits);
     }
 
-    private function buildMetricsCredentials(array $options): CredentialsWrapper
+    private function buildMetricsCredentials(mixed $credentials, array $options): CredentialsWrapper
     {
-        $metricsCredentials = $options['metricsCredentials'] ?? $options['credentials'] ?? null;
-
         $credentialsConfig = [
             'scopes' => [
                 self::MONITORING_WRITE_SCOPE
@@ -1196,8 +1193,6 @@ class SpannerClient
 
         $universeDomain = $options['universeDomain'] ?? GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN;
 
-        $credentialsWrapper = $this->createCredentialsWrapper($metricsCredentials, $credentialsConfig, $universeDomain);
-
-        return $credentialsWrapper;
+        return $this->createCredentialsWrapper($credentials, $credentialsConfig, $universeDomain);
     }
 }

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -1064,8 +1064,7 @@ class SpannerClient
     private function configureMetrics(
         array $options,
         string|array|FetchAuthTokenInterface|CredentialsWrapper|null $rawCredentials = null
-    ): void
-    {
+    ): void {
         $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 100;
 
         if (!$this->pluck('enableBuiltInMetrics', $options, false)) {
@@ -1190,8 +1189,7 @@ class SpannerClient
     private function buildMetricsCredentials(
         string|array|FetchAuthTokenInterface|CredentialsWrapper|null $credentials,
         array $options
-    ): CredentialsWrapper
-    {
+    ): CredentialsWrapper {
         $credentialsConfig = [
             'scopes' => [
                 self::MONITORING_WRITE_SCOPE

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2016 Google Inc.
  *
@@ -133,6 +134,7 @@ class SpannerClient
 
     const FULL_CONTROL_SCOPE = 'https://www.googleapis.com/auth/spanner.data';
     const ADMIN_SCOPE = 'https://www.googleapis.com/auth/spanner.admin';
+    private const MONITORING_WRITE_SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
     private const GRPC_KEEPALIVE_MILLISECONDS = 120 * 1000;
 
     private const SERVICE_NAME = 'google.spanner.v1.Spanner';
@@ -208,9 +210,9 @@ class SpannerClient
      *     @type bool $enableBuiltInMetrics If true, built-in metrics collection will be enabled.
      *           **Defaults to** false.
      *     @type int $metricsTimeoutMillis The timeout in milliseconds for exporting metrics.
-     *           **Defaults to** 5000.
-     *     @type string|array|FetchAuthTokenInterface|CredentialsWrapper $metricsCredentials
-     *           Optional dedicated credentials to use for exporting built-in metrics.
+     *           **Defaults to** 100.
+     *     @type MetricServiceClient @deprecated $metricServiceClient An explicit instance of
+     *           `MetricServiceClient` to use for exporting metrics.
      * }
      * @throws GoogleException If the gRPC extension is not enabled.
      */
@@ -255,9 +257,7 @@ class SpannerClient
             $options['credentialsConfig']['scopes'] = $scopes;
         }
 
-        $metricsCredentials = $options['metricsCredentials']
-            ?? $options['credentials']
-            ?? null;
+        $metricsCredentials = $options['credentials'] ?? null;
 
         if ($emulatorHost) {
             $emulatorConfig = $this->emulatorGapicConfig($emulatorHost);
@@ -556,10 +556,10 @@ class SpannerClient
                     $operation->getName(),
                     [
                         'type.googleapis.com/google.spanner.admin.instance.v1.ListInstanceConfigMetadata' =>
-                            fn (InstanceConfig $config) => $this->instanceConfiguration(
-                                $config->getName(),
-                                $this->handleResponse($config)
-                            ),
+                        fn(InstanceConfig $config) => $this->instanceConfiguration(
+                            $config->getName(),
+                            $this->handleResponse($config)
+                        ),
                     ],
                     $this->handleResponse($operation)
                 );
@@ -996,8 +996,8 @@ class SpannerClient
         if (!$this->isGrpcLoaded()) {
             throw new GoogleException(
                 'The requested client requires the gRPC extension. '
-                . 'Please see https://cloud.google.com/php/grpc for installation '
-                . 'instructions.'
+                    . 'Please see https://cloud.google.com/php/grpc for installation '
+                    . 'instructions.'
             );
         }
     }
@@ -1063,7 +1063,7 @@ class SpannerClient
 
     private function configureMetrics(array $options): void
     {
-        $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 5000;
+        $timeoutMillis = $this->pluck('metricsTimeoutMillis', $options, false) ?? 100;
 
         if (!$this->pluck('enableBuiltInMetrics', $options, false)) {
             return;
@@ -1186,14 +1186,11 @@ class SpannerClient
 
     private function buildMetricsCredentials(array $options): CredentialsWrapper
     {
-        $metricsCredentials = $options['metricsCredentials']
-            ?? $options['credentials']
-            ?? null;
+        $metricsCredentials = $options['metricsCredentials'] ?? $options['credentials'] ?? null;
 
         $credentialsConfig = [
             'scopes' => [
-                OtlpMetricsExporter::MONITORING_WRITE_SCOPE,
-                OtlpMetricsExporter::CLOUD_PLATFORM_SCOPE
+                self::MONITORING_WRITE_SCOPE
             ]
         ];
 

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -211,7 +211,7 @@ class SpannerClient
      *           **Defaults to** false.
      *     @type int $metricsTimeoutMillis The timeout in milliseconds for exporting metrics.
      *           **Defaults to** 100.
-     *     @type MetricServiceClient @deprecated $metricServiceClient An explicit instance of
+     *     @type MetricServiceClient $metricServiceClient **[DEPRECATED]** An explicit instance of
      *           `MetricServiceClient` to use for exporting metrics.
      * }
      * @throws GoogleException If the gRPC extension is not enabled.
@@ -556,7 +556,7 @@ class SpannerClient
                     $operation->getName(),
                     [
                         'type.googleapis.com/google.spanner.admin.instance.v1.ListInstanceConfigMetadata' =>
-                        fn(InstanceConfig $config) => $this->instanceConfiguration(
+                        fn (InstanceConfig $config) => $this->instanceConfiguration(
                             $config->getName(),
                             $this->handleResponse($config)
                         ),

--- a/Spanner/tests/Unit/Middleware/BuiltInMetricsAttemptMiddlewareTest.php
+++ b/Spanner/tests/Unit/Middleware/BuiltInMetricsAttemptMiddlewareTest.php
@@ -58,40 +58,40 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
         $this->meter = $this->prophesize(MeterInterface::class);
 
         $this->meter->createHistogram(
-            'attempt_latencies',
+            'spanner.googleapis.com/internal/client/attempt_latencies',
             'ms',
             Argument::any(),
             Argument::any()
         )->willReturn($this->attemptHistogram->reveal());
 
         $this->meter->createCounter(
-            'attempt_count',
+            'spanner.googleapis.com/internal/client/attempt_count',
             '1',
             Argument::any()
         )->willReturn($this->attemptCounter->reveal());
 
         $this->meter->createHistogram(
-            'gfe_latencies',
+            'spanner.googleapis.com/internal/client/gfe_latencies',
             'ms',
             Argument::any(),
             Argument::any()
         )->willReturn($this->gfeHistogram->reveal());
 
         $this->meter->createCounter(
-            'gfe_connectivity_error_count',
+            'spanner.googleapis.com/internal/client/gfe_connectivity_error_count',
             '1',
             Argument::any()
         )->willReturn($this->gfeErrorCounter->reveal());
 
         $this->meter->createHistogram(
-            'afe_latencies',
+            'spanner.googleapis.com/internal/client/afe_latencies',
             'ms',
             Argument::any(),
             Argument::any()
         )->willReturn($this->afeHistogram->reveal());
 
         $this->meter->createCounter(
-            'afe_connectivity_error_count',
+            'spanner.googleapis.com/internal/client/afe_connectivity_error_count',
             '1',
             Argument::any()
         )->willReturn($this->afeErrorCounter->reveal());
@@ -118,9 +118,7 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
             $this->nextHandler,
             $this->meter->reveal(),
             $clientId,
-            $projectId,
-            $version,
-            $location
+            $version
         );
 
         $call = $this->prophesize(Call::class);
@@ -137,13 +135,9 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
         $expectedLabels = [
             'method' => 'Commit',
             'status' => 'OK',
-            'instance_id' => 'i',
             'database' => 'd',
-            'project_id' => $projectId,
             'client_uid' => $clientId,
             'client_name' => $expectedClientName,
-            'instance_config' => 'unknown',
-            'location' => $location,
             'directpath_enabled' => 'false',
             'directpath_used' => 'true'
         ];
@@ -174,9 +168,7 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
             $this->nextHandler,
             $this->meter->reveal(),
             'client',
-            'project',
-            'name',
-            'global'
+            'name'
         );
 
         $call = $this->prophesize(Call::class);
@@ -209,9 +201,7 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
             $this->nextHandler,
             $this->meter->reveal(),
             'client',
-            'project',
-            'name',
-            'global'
+            'name'
         );
 
         $call = $this->prophesize(Call::class);
@@ -239,9 +229,7 @@ class BuiltInMetricsAttemptMiddlewareTest extends TestCase
             $this->nextHandler,
             $this->meter->reveal(),
             'client',
-            'project',
-            'name',
-            'global'
+            'name'
         );
 
         $call = $this->prophesize(Call::class);

--- a/Spanner/tests/Unit/Middleware/BuiltInMetricsOperationMiddlewareTest.php
+++ b/Spanner/tests/Unit/Middleware/BuiltInMetricsOperationMiddlewareTest.php
@@ -46,14 +46,14 @@ class BuiltInMetricsOperationMiddlewareTest extends TestCase
         $this->meter = $this->prophesize(MeterInterface::class);
 
         $this->meter->createHistogram(
-            'operation_latencies',
+            'spanner.googleapis.com/internal/client/operation_latencies',
             'ms',
             Argument::any(),
             Argument::any()
         )->willReturn($this->histogram->reveal());
 
         $this->meter->createCounter(
-            'operation_count',
+            'spanner.googleapis.com/internal/client/operation_count',
             '1',
             Argument::any()
         )->willReturn($this->counter->reveal());
@@ -75,9 +75,7 @@ class BuiltInMetricsOperationMiddlewareTest extends TestCase
             $this->nextHandler,
             $this->meter->reveal(),
             $clientId,
-            $projectId,
-            $version,
-            $location
+            $version
         );
 
         $call = $this->prophesize(Call::class);
@@ -93,13 +91,9 @@ class BuiltInMetricsOperationMiddlewareTest extends TestCase
         $expectedLabels = [
             'method' => 'ExecuteSql',
             'status' => 'OK',
-            'instance_id' => 'i',
             'database' => 'd',
-            'project_id' => $projectId,
             'client_uid' => $clientId,
             'client_name' => $expectedClientName,
-            'instance_config' => 'unknown',
-            'location' => $location,
             'directpath_enabled' => 'false',
             'directpath_used' => 'false'
         ];

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2026 Google LLC
  *
@@ -42,6 +43,14 @@ class BuiltInMetricsExporterTest extends TestCase
     const PROJECT_ID = 'test-project';
     const CLIENT_ID = 'test-client-id';
     const DEFAULT_TIMEOUT = 100;
+
+    protected function setUp(): void
+    {
+        // This is due us removing a no longer needed dependency and we can skip the tests without removing the tests.
+        if (!class_exists(MetricServiceClient::class)) {
+            $this->markTestSkipped('Google\Cloud\Monitoring\V3\Client\MetricServiceClient class is not available.');
+        }
+    }
 
     /**
      * @dataProvider hashDataProvider
@@ -115,9 +124,11 @@ class BuiltInMetricsExporterTest extends TestCase
 
             // Verify Labels
             $labels = $timeSeries->getMetric()->getLabels();
-            if ($labels['method'] !== 'ExecuteSql' ||
+            if (
+                $labels['method'] !== 'ExecuteSql' ||
                 $labels['status'] !== 'OK' ||
-                $labels['database'] !== 'my-db') {
+                $labels['database'] !== 'my-db'
+            ) {
                 return false;
             }
 

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -46,7 +46,7 @@ class BuiltInMetricsExporterTest extends TestCase
 
     protected function setUp(): void
     {
-        // This is due us removing a no longer needed dependency and we can skip the tests without removing the tests.
+        // This is due to us removing a no longer needed dependency and we can skip the tests without removing the tests.
         if (!class_exists(MetricServiceClient::class)) {
             $this->markTestSkipped('Google\Cloud\Monitoring\V3\Client\MetricServiceClient class is not available.');
         }

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -71,8 +71,9 @@ class BuiltInMetricsExporterTest extends TestCase
 
     public function testExport()
     {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
         $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
-        $exporter = new MetricsExporter(self::PROJECT_ID, 100, [], $mockOtlpExporter->reveal());
+        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, 100, [], $mockOtlpExporter->reveal());
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
         $resource = ResourceInfo::create(Attributes::create([
@@ -104,9 +105,10 @@ class BuiltInMetricsExporterTest extends TestCase
 
     public function testExportCustomTimeout()
     {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
         $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
         $timeout = 500;
-        $exporter = new MetricsExporter(self::PROJECT_ID, $timeout, [], $mockOtlpExporter->reveal());
+        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, $timeout, [], $mockOtlpExporter->reveal());
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
         $resource = ResourceInfo::create(Attributes::create([]));
@@ -123,11 +125,50 @@ class BuiltInMetricsExporterTest extends TestCase
 
     public function testConstructWithCustomMetricsCredentials()
     {
-        $mockCredentials = $this->prophesize(\Google\Auth\FetchAuthTokenInterface::class);
-        $exporter = new MetricsExporter(self::PROJECT_ID, 5000, [
-            'metricsCredentials' => $mockCredentials->reveal()
-        ]);
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, 5000, []);
 
         $this->assertInstanceOf(MetricsExporter::class, $exporter);
+    }
+
+    public function testGuzzleMiddlewareAttachesAuthorizationAndQuotaProjectHeaders()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $mockCredentials->getAuthorizationHeaderCallback()->willReturn(function () {
+            return ['authorization' => ['Bearer test-metric-token']];
+        });
+        $mockCredentials->getQuotaProject()->willReturn('test-quota-project-id');
+
+        $recordedRequests = [];
+        $mockHandler = new \GuzzleHttp\Handler\MockHandler([
+            new \GuzzleHttp\Psr7\Response(200, [], '')
+        ]);
+        $handlerStack = \GuzzleHttp\HandlerStack::create($mockHandler);
+
+        $exporter = new MetricsExporter(
+            $mockCredentials->reveal(),
+            self::PROJECT_ID,
+            5000,
+            ['handlerStack' => $handlerStack]
+        );
+
+        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create([]));
+        $point = new NumberDataPoint(1, Attributes::create([]), 1711368000000000000, 1711368060000000000);
+        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
+        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
+
+        // Access the internal otlpExporter via reflection to trigger HTTP call through transport
+        $reflection = new ReflectionClass(MetricsExporter::class);
+        $property = $reflection->getProperty('otlpExporter');
+        $property->setAccessible(true);
+        $otlpExporter = $property->getValue($exporter);
+
+        $otlpExporter->export([$metric]);
+
+        $lastRequest = $mockHandler->getLastRequest();
+        $this->assertNotNull($lastRequest);
+        $this->assertEquals(['Bearer test-metric-token'], $lastRequest->getHeader('authorization'));
+        $this->assertEquals(['test-quota-project-id'], $lastRequest->getHeader('x-goog-user-project'));
     }
 }

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Spanner\Tests\Unit\OpenTelemetry;
 
+use Google\Cloud\Monitoring\V3\Client\MetricServiceClient;
+use Google\Cloud\Monitoring\V3\CreateTimeSeriesRequest;
 use Google\Cloud\Spanner\OpenTelemetry\MetricsExporter;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
@@ -25,7 +27,6 @@ use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
 use OpenTelemetry\SDK\Metrics\Data\Sum;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
-use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -38,6 +39,7 @@ class BuiltInMetricsExporterTest extends TestCase
 {
     use ProphecyTrait;
 
+    const PROJECT_ID = 'test-project';
     const CLIENT_ID = 'test-client-id';
     const DEFAULT_TIMEOUT = 100;
 
@@ -46,44 +48,35 @@ class BuiltInMetricsExporterTest extends TestCase
      */
     public function testGenerateClientHash($clientUid, $expected)
     {
-        $reflection = new ReflectionClass(\Google\Cloud\Spanner\SpannerClient::class);
+        $client = $this->prophesize(MetricServiceClient::class);
+        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, self::DEFAULT_TIMEOUT);
+
+        $reflection = new ReflectionClass(MetricsExporter::class);
         $method = $reflection->getMethod('generateClientHash');
         $method->setAccessible(true);
 
-        $client = new ReflectionClass(\Google\Cloud\Spanner\SpannerClient::class);
-        $instance = $client->newInstanceWithoutConstructor();
-
-        $result = $method->invoke($instance, $clientUid);
+        $result = $method->invoke($exporter, $clientUid);
         $this->assertEquals($expected, $result);
     }
 
     public function hashDataProvider()
     {
         return [
-            ['exampleUID', '000194'],
+            ['exampleUID', '00006b'],
             ['', '000000'],
-            ['!@#$%^&*()', '000129'],
-            ['aVeryLongUniqueIdentifierThatExceedsNormalLength', '00008e'],
-            ['1234567890', '00018d'],
+            ['!@#$%^&*()', '000389'],
+            ['aVeryLongUniqueIdentifierThatExceedsNormalLength', '000125'],
+            ['1234567890', '00003e'],
         ];
     }
 
     public function testExport()
     {
-        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
-        $exporter = new MetricsExporter(
-            $mockCredentials->reveal(),
-            100,
-            [],
-            $mockOtlpExporter->reveal()
-        );
+        $client = $this->prophesize(MetricServiceClient::class);
+        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, 100);
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
-        $resource = ResourceInfo::create(Attributes::create([
-            'gcp.resource_type' => 'spanner_instance_client',
-            'client_hash' => '000212'
-        ]));
+        $resource = ResourceInfo::create(Attributes::create(['service.name' => 'spanner']));
 
         $attributes = Attributes::create([
             'method' => 'ExecuteSql',
@@ -100,99 +93,70 @@ class BuiltInMetricsExporterTest extends TestCase
         );
 
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric(
-            $scope,
-            $resource,
-            'spanner.googleapis.com/internal/client/attempt_count',
-            '1',
-            'desc',
-            $sum
-        );
+        $metric = new OTelMetric($scope, $resource, 'attempt_count', '1', 'desc', $sum);
 
-        $mockOtlpExporter->export(Argument::type('iterable'))->shouldBeCalled()->willReturn(true);
+        $client->createServiceTimeSeries(Argument::that(function ($request) {
+            if (!$request instanceof CreateTimeSeriesRequest) {
+                return false;
+            }
+
+            $projectName = MetricServiceClient::projectName(self::PROJECT_ID);
+            if ($request->getName() !== $projectName) {
+                return false;
+            }
+
+            $timeSeries = $request->getTimeSeries()[0];
+
+            // Verify Metric Type
+            $expectedMetric = 'spanner.googleapis.com/internal/client/attempt_count';
+            if ($timeSeries->getMetric()->getType() !== $expectedMetric) {
+                return false;
+            }
+
+            // Verify Labels
+            $labels = $timeSeries->getMetric()->getLabels();
+            if ($labels['method'] !== 'ExecuteSql' ||
+                $labels['status'] !== 'OK' ||
+                $labels['database'] !== 'my-db') {
+                return false;
+            }
+
+            // Verify Resource
+            $resLabels = $timeSeries->getResource()->getLabels();
+            if ($resLabels['instance_id'] !== 'my-instance') {
+                return false;
+            }
+
+            // Verify Client Hash
+            if ($resLabels['client_hash'] !== '000369') {
+                return false;
+            }
+
+            return true;
+        }), Argument::withEntry('timeoutMillis', 100))->shouldBeCalled();
 
         $this->assertTrue($exporter->export([$metric]));
     }
 
     public function testExportCustomTimeout()
     {
-        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
+        $client = $this->prophesize(MetricServiceClient::class);
         $timeout = 500;
-        $exporter = new MetricsExporter($mockCredentials->reveal(), $timeout, [], $mockOtlpExporter->reveal());
+        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, $timeout);
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
-        $resource = ResourceInfo::create(Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create(['service.name' => 'spanner']));
 
         $attributes = Attributes::create([]);
         $point = new NumberDataPoint(1, $attributes, 1711368000000000000, 1711368060000000000);
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric(
-            $scope,
-            $resource,
-            'spanner.googleapis.com/internal/client/attempt_count',
-            '1',
-            'desc',
-            $sum
-        );
+        $metric = new OTelMetric($scope, $resource, 'attempt_count', '1', 'desc', $sum);
 
-        $mockOtlpExporter->export(Argument::any())->shouldBeCalled()->willReturn(true);
+        $client->createServiceTimeSeries(
+            Argument::type(CreateTimeSeriesRequest::class),
+            Argument::withEntry('timeoutMillis', $timeout)
+        )->shouldBeCalled();
 
-        $this->assertTrue($exporter->export([$metric]));
-    }
-
-    public function testConstructWithCustomMetricsCredentials()
-    {
-        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $exporter = new MetricsExporter($mockCredentials->reveal(), 5000, []);
-
-        $this->assertInstanceOf(MetricsExporter::class, $exporter);
-    }
-
-    public function testGuzzleMiddlewareAttachesAuthorizationAndQuotaProjectHeaders()
-    {
-        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $mockCredentials->getAuthorizationHeaderCallback()->willReturn(function () {
-            return ['authorization' => ['Bearer test-metric-token']];
-        });
-        $mockCredentials->getQuotaProject()->willReturn('test-quota-project-id');
-
-        $recordedRequests = [];
-        $mockHandler = new \GuzzleHttp\Handler\MockHandler([
-            new \GuzzleHttp\Psr7\Response(200, [], '')
-        ]);
-        $handlerStack = \GuzzleHttp\HandlerStack::create($mockHandler);
-
-        $exporter = new MetricsExporter(
-            $mockCredentials->reveal(),
-            5000,
-            ['handlerStack' => $handlerStack]
-        );
-
-        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
-        $resource = ResourceInfo::create(Attributes::create([]));
-        $point = new NumberDataPoint(1, Attributes::create([]), 1711368000000000000, 1711368060000000000);
-        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric(
-            $scope,
-            $resource,
-            'spanner.googleapis.com/internal/client/attempt_count',
-            '1',
-            'desc',
-            $sum
-        );
-
-        // Access the internal otlpExporter via reflection to trigger HTTP call through transport
-        $reflection = new ReflectionClass(MetricsExporter::class);
-        $property = $reflection->getProperty('otlpExporter');
-        $property->setAccessible(true);
-        $otlpExporter = $property->getValue($exporter);
-
-        $otlpExporter->export([$metric]);
-
-        $lastRequest = $mockHandler->getLastRequest();
-        $this->assertNotNull($lastRequest);
-        $this->assertEquals(['Bearer test-metric-token'], $lastRequest->getHeader('authorization'));
-        $this->assertEquals(['test-quota-project-id'], $lastRequest->getHeader('x-goog-user-project'));
+        $exporter->export([$metric]);
     }
 }

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -46,7 +46,8 @@ class BuiltInMetricsExporterTest extends TestCase
 
     protected function setUp(): void
     {
-        // This is due to us removing a no longer needed dependency and we can skip the tests without removing the tests.
+        // This is due to us removing a no longer needed dependency
+        // and we can skip the tests without removing the tests.
         if (!class_exists(MetricServiceClient::class)) {
             $this->markTestSkipped('Google\Cloud\Monitoring\V3\Client\MetricServiceClient class is not available.');
         }

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -38,7 +38,6 @@ class BuiltInMetricsExporterTest extends TestCase
 {
     use ProphecyTrait;
 
-    const PROJECT_ID = 'test-project';
     const CLIENT_ID = 'test-client-id';
     const DEFAULT_TIMEOUT = 100;
 
@@ -73,7 +72,12 @@ class BuiltInMetricsExporterTest extends TestCase
     {
         $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
         $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
-        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, 100, [], $mockOtlpExporter->reveal());
+        $exporter = new MetricsExporter(
+            $mockCredentials->reveal(),
+            100,
+            [],
+            $mockOtlpExporter->reveal()
+        );
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
         $resource = ResourceInfo::create(Attributes::create([
@@ -96,7 +100,14 @@ class BuiltInMetricsExporterTest extends TestCase
         );
 
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
 
         $mockOtlpExporter->export(Argument::type('iterable'))->shouldBeCalled()->willReturn(true);
 
@@ -108,7 +119,7 @@ class BuiltInMetricsExporterTest extends TestCase
         $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
         $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
         $timeout = 500;
-        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, $timeout, [], $mockOtlpExporter->reveal());
+        $exporter = new MetricsExporter($mockCredentials->reveal(), $timeout, [], $mockOtlpExporter->reveal());
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
         $resource = ResourceInfo::create(Attributes::create([]));
@@ -116,7 +127,14 @@ class BuiltInMetricsExporterTest extends TestCase
         $attributes = Attributes::create([]);
         $point = new NumberDataPoint(1, $attributes, 1711368000000000000, 1711368060000000000);
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
 
         $mockOtlpExporter->export(Argument::any())->shouldBeCalled()->willReturn(true);
 
@@ -126,7 +144,7 @@ class BuiltInMetricsExporterTest extends TestCase
     public function testConstructWithCustomMetricsCredentials()
     {
         $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $exporter = new MetricsExporter($mockCredentials->reveal(), self::PROJECT_ID, 5000, []);
+        $exporter = new MetricsExporter($mockCredentials->reveal(), 5000, []);
 
         $this->assertInstanceOf(MetricsExporter::class, $exporter);
     }
@@ -147,7 +165,6 @@ class BuiltInMetricsExporterTest extends TestCase
 
         $exporter = new MetricsExporter(
             $mockCredentials->reveal(),
-            self::PROJECT_ID,
             5000,
             ['handlerStack' => $handlerStack]
         );
@@ -156,7 +173,14 @@ class BuiltInMetricsExporterTest extends TestCase
         $resource = ResourceInfo::create(Attributes::create([]));
         $point = new NumberDataPoint(1, Attributes::create([]), 1711368000000000000, 1711368060000000000);
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
 
         // Access the internal otlpExporter via reflection to trigger HTTP call through transport
         $reflection = new ReflectionClass(MetricsExporter::class);

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -124,8 +124,7 @@ class BuiltInMetricsExporterTest extends TestCase
 
             // Verify Labels
             $labels = $timeSeries->getMetric()->getLabels();
-            if (
-                $labels['method'] !== 'ExecuteSql' ||
+            if ($labels['method'] !== 'ExecuteSql' ||
                 $labels['status'] !== 'OK' ||
                 $labels['database'] !== 'my-db'
             ) {

--- a/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/BuiltInMetricsExporterTest.php
@@ -17,8 +17,6 @@
 
 namespace Google\Cloud\Spanner\Tests\Unit\OpenTelemetry;
 
-use Google\Cloud\Monitoring\V3\Client\MetricServiceClient;
-use Google\Cloud\Monitoring\V3\CreateTimeSeriesRequest;
 use Google\Cloud\Spanner\OpenTelemetry\MetricsExporter;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
@@ -27,6 +25,7 @@ use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
 use OpenTelemetry\SDK\Metrics\Data\Sum;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -48,35 +47,38 @@ class BuiltInMetricsExporterTest extends TestCase
      */
     public function testGenerateClientHash($clientUid, $expected)
     {
-        $client = $this->prophesize(MetricServiceClient::class);
-        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, self::DEFAULT_TIMEOUT);
-
-        $reflection = new ReflectionClass(MetricsExporter::class);
+        $reflection = new ReflectionClass(\Google\Cloud\Spanner\SpannerClient::class);
         $method = $reflection->getMethod('generateClientHash');
         $method->setAccessible(true);
 
-        $result = $method->invoke($exporter, $clientUid);
+        $client = new ReflectionClass(\Google\Cloud\Spanner\SpannerClient::class);
+        $instance = $client->newInstanceWithoutConstructor();
+
+        $result = $method->invoke($instance, $clientUid);
         $this->assertEquals($expected, $result);
     }
 
     public function hashDataProvider()
     {
         return [
-            ['exampleUID', '00006b'],
+            ['exampleUID', '000194'],
             ['', '000000'],
-            ['!@#$%^&*()', '000389'],
-            ['aVeryLongUniqueIdentifierThatExceedsNormalLength', '000125'],
-            ['1234567890', '00003e'],
+            ['!@#$%^&*()', '000129'],
+            ['aVeryLongUniqueIdentifierThatExceedsNormalLength', '00008e'],
+            ['1234567890', '00018d'],
         ];
     }
 
     public function testExport()
     {
-        $client = $this->prophesize(MetricServiceClient::class);
-        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, 100);
+        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
+        $exporter = new MetricsExporter(self::PROJECT_ID, 100, [], $mockOtlpExporter->reveal());
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
-        $resource = ResourceInfo::create(Attributes::create(['service.name' => 'spanner']));
+        $resource = ResourceInfo::create(Attributes::create([
+            'gcp.resource_type' => 'spanner_instance_client',
+            'client_hash' => '000212'
+        ]));
 
         $attributes = Attributes::create([
             'method' => 'ExecuteSql',
@@ -93,70 +95,39 @@ class BuiltInMetricsExporterTest extends TestCase
         );
 
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric($scope, $resource, 'attempt_count', '1', 'desc', $sum);
+        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
 
-        $client->createServiceTimeSeries(Argument::that(function ($request) {
-            if (!$request instanceof CreateTimeSeriesRequest) {
-                return false;
-            }
-
-            $projectName = MetricServiceClient::projectName(self::PROJECT_ID);
-            if ($request->getName() !== $projectName) {
-                return false;
-            }
-
-            $timeSeries = $request->getTimeSeries()[0];
-
-            // Verify Metric Type
-            $expectedMetric = 'spanner.googleapis.com/internal/client/attempt_count';
-            if ($timeSeries->getMetric()->getType() !== $expectedMetric) {
-                return false;
-            }
-
-            // Verify Labels
-            $labels = $timeSeries->getMetric()->getLabels();
-            if ($labels['method'] !== 'ExecuteSql' ||
-                $labels['status'] !== 'OK' ||
-                $labels['database'] !== 'my-db') {
-                return false;
-            }
-
-            // Verify Resource
-            $resLabels = $timeSeries->getResource()->getLabels();
-            if ($resLabels['instance_id'] !== 'my-instance') {
-                return false;
-            }
-
-            // Verify Client Hash
-            if ($resLabels['client_hash'] !== '000369') {
-                return false;
-            }
-
-            return true;
-        }), Argument::withEntry('timeoutMillis', 100))->shouldBeCalled();
+        $mockOtlpExporter->export(Argument::type('iterable'))->shouldBeCalled()->willReturn(true);
 
         $this->assertTrue($exporter->export([$metric]));
     }
 
     public function testExportCustomTimeout()
     {
-        $client = $this->prophesize(MetricServiceClient::class);
+        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
         $timeout = 500;
-        $exporter = new MetricsExporter($client->reveal(), self::PROJECT_ID, self::CLIENT_ID, $timeout);
+        $exporter = new MetricsExporter(self::PROJECT_ID, $timeout, [], $mockOtlpExporter->reveal());
 
         $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
-        $resource = ResourceInfo::create(Attributes::create(['service.name' => 'spanner']));
+        $resource = ResourceInfo::create(Attributes::create([]));
 
         $attributes = Attributes::create([]);
         $point = new NumberDataPoint(1, $attributes, 1711368000000000000, 1711368060000000000);
         $sum = new Sum([$point], Temporality::CUMULATIVE, true);
-        $metric = new OTelMetric($scope, $resource, 'attempt_count', '1', 'desc', $sum);
+        $metric = new OTelMetric($scope, $resource, 'spanner.googleapis.com/internal/client/attempt_count', '1', 'desc', $sum);
 
-        $client->createServiceTimeSeries(
-            Argument::type(CreateTimeSeriesRequest::class),
-            Argument::withEntry('timeoutMillis', $timeout)
-        )->shouldBeCalled();
+        $mockOtlpExporter->export(Argument::any())->shouldBeCalled()->willReturn(true);
 
-        $exporter->export([$metric]);
+        $this->assertTrue($exporter->export([$metric]));
+    }
+
+    public function testConstructWithCustomMetricsCredentials()
+    {
+        $mockCredentials = $this->prophesize(\Google\Auth\FetchAuthTokenInterface::class);
+        $exporter = new MetricsExporter(self::PROJECT_ID, 5000, [
+            'metricsCredentials' => $mockCredentials->reveal()
+        ]);
+
+        $this->assertInstanceOf(MetricsExporter::class, $exporter);
     }
 }

--- a/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
@@ -111,7 +111,7 @@ class OtlpMetricsExporterTest extends TestCase
         $this->assertTrue($exporter->export([$metric]));
     }
 
-    public function testConstructWithCustomMetricsCredentials()
+    public function testConstructWithCredentialsWrapper()
     {
         $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
         $exporter = new OtlpMetricsExporter($mockCredentials->reveal(), 100, []);

--- a/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
@@ -114,7 +114,7 @@ class OtlpMetricsExporterTest extends TestCase
     public function testConstructWithCustomMetricsCredentials()
     {
         $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
-        $exporter = new OtlpMetricsExporter($mockCredentials->reveal(), 5000, []);
+        $exporter = new OtlpMetricsExporter($mockCredentials->reveal(), 100, []);
 
         $this->assertInstanceOf(OtlpMetricsExporter::class, $exporter);
     }
@@ -134,7 +134,7 @@ class OtlpMetricsExporterTest extends TestCase
 
         $exporter = new OtlpMetricsExporter(
             $mockCredentials->reveal(),
-            5000,
+            100,
             ['handlerStack' => $handlerStack]
         );
 
@@ -163,5 +163,29 @@ class OtlpMetricsExporterTest extends TestCase
         $this->assertNotNull($lastRequest);
         $this->assertEquals(['Bearer test-metric-token'], $lastRequest->getHeader('authorization'));
         $this->assertEquals(['test-quota-project-id'], $lastRequest->getHeader('x-goog-user-project'));
+    }
+
+    public function testExportFailureReturnsFalse()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
+
+        $mockOtlpExporter->export(Argument::any())->willThrow(new \Exception('Connection failed'));
+
+        $exporter = new OtlpMetricsExporter(
+            $mockCredentials->reveal(),
+            100,
+            [],
+            $mockOtlpExporter->reveal()
+        );
+
+        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create([]));
+        $point = new NumberDataPoint(1, Attributes::create([]), 1000, 2000);
+        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
+        $metric = new OTelMetric($scope, $resource, 'attempt_count', '1', 'desc', $sum);
+
+        $result = $exporter->export([$metric]);
+        $this->assertFalse($result);
     }
 }

--- a/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
+++ b/Spanner/tests/Unit/OpenTelemetry/OtlpMetricsExporterTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Spanner\Tests\Unit\OpenTelemetry;
+
+use Google\Cloud\Spanner\OpenTelemetry\OtlpMetricsExporter;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
+use OpenTelemetry\SDK\Metrics\Data\Metric as OTelMetric;
+use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
+use OpenTelemetry\SDK\Metrics\Data\Sum;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionClass;
+
+/**
+ * @group spanner
+ */
+class OtlpMetricsExporterTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testExport()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
+        $exporter = new OtlpMetricsExporter(
+            $mockCredentials->reveal(),
+            100,
+            [],
+            $mockOtlpExporter->reveal()
+        );
+
+        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create([
+            'gcp.resource_type' => 'spanner_instance_client',
+            'client_hash' => '000212'
+        ]));
+
+        $attributes = Attributes::create([
+            'method' => 'ExecuteSql',
+            'status' => 'OK',
+            'instance_id' => 'my-instance',
+            'database' => 'my-db'
+        ]);
+
+        $point = new NumberDataPoint(
+            1,
+            $attributes,
+            1711368000000000000,
+            1711368060000000000
+        );
+
+        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
+
+        $mockOtlpExporter->export(Argument::type('iterable'))->shouldBeCalled()->willReturn(true);
+
+        $this->assertTrue($exporter->export([$metric]));
+    }
+
+    public function testExportCustomTimeout()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $mockOtlpExporter = $this->prophesize(PushMetricExporterInterface::class);
+        $timeout = 500;
+        $exporter = new OtlpMetricsExporter($mockCredentials->reveal(), $timeout, [], $mockOtlpExporter->reveal());
+
+        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create([]));
+
+        $attributes = Attributes::create([]);
+        $point = new NumberDataPoint(1, $attributes, 1711368000000000000, 1711368060000000000);
+        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
+
+        $mockOtlpExporter->export(Argument::any())->shouldBeCalled()->willReturn(true);
+
+        $this->assertTrue($exporter->export([$metric]));
+    }
+
+    public function testConstructWithCustomMetricsCredentials()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $exporter = new OtlpMetricsExporter($mockCredentials->reveal(), 5000, []);
+
+        $this->assertInstanceOf(OtlpMetricsExporter::class, $exporter);
+    }
+
+    public function testGuzzleMiddlewareAttachesAuthorizationAndQuotaProjectHeaders()
+    {
+        $mockCredentials = $this->prophesize(\Google\ApiCore\CredentialsWrapper::class);
+        $mockCredentials->getAuthorizationHeaderCallback()->willReturn(function () {
+            return ['authorization' => ['Bearer test-metric-token']];
+        });
+        $mockCredentials->getQuotaProject()->willReturn('test-quota-project-id');
+
+        $mockHandler = new \GuzzleHttp\Handler\MockHandler([
+            new \GuzzleHttp\Psr7\Response(200, [], '')
+        ]);
+        $handlerStack = \GuzzleHttp\HandlerStack::create($mockHandler);
+
+        $exporter = new OtlpMetricsExporter(
+            $mockCredentials->reveal(),
+            5000,
+            ['handlerStack' => $handlerStack]
+        );
+
+        $scope = new InstrumentationScope('google-cloud-spanner', '1.0.0', null, Attributes::create([]));
+        $resource = ResourceInfo::create(Attributes::create([]));
+        $point = new NumberDataPoint(1, Attributes::create([]), 1711368000000000000, 1711368060000000000);
+        $sum = new Sum([$point], Temporality::CUMULATIVE, true);
+        $metric = new OTelMetric(
+            $scope,
+            $resource,
+            'spanner.googleapis.com/internal/client/attempt_count',
+            '1',
+            'desc',
+            $sum
+        );
+
+        // Access the internal otlpExporter via reflection to trigger HTTP call through transport
+        $reflection = new ReflectionClass(OtlpMetricsExporter::class);
+        $property = $reflection->getProperty('otlpExporter');
+        $property->setAccessible(true);
+        $otlpExporter = $property->getValue($exporter);
+
+        $otlpExporter->export([$metric]);
+
+        $lastRequest = $mockHandler->getLastRequest();
+        $this->assertNotNull($lastRequest);
+        $this->assertEquals(['Bearer test-metric-token'], $lastRequest->getHeader('authorization'));
+        $this->assertEquals(['test-quota-project-id'], $lastRequest->getHeader('x-goog-user-project'));
+    }
+}

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -901,6 +901,22 @@ class SpannerClientTest extends TestCase
         ]);
     }
 
+    public function testBuiltinMetricsCanBeEnabledWithoutCredentials()
+    {
+        $gapicSpannerClient = $this->prophesize(GapicSpannerClient::class);
+        $gapicSpannerClient->prependMiddleware(Argument::any())
+            ->shouldBeCalledTimes(2);
+        $gapicSpannerClient->addMiddleware(Argument::any())
+            ->shouldBeCalledTimes(2);
+
+        new SpannerClient([
+            'projectId' => self::PROJECT,
+            'gapicSpannerClient' => $gapicSpannerClient->reveal(),
+            'enableBuiltInMetrics' => true,
+        ]);
+    }
+
+
     /**
      * @runInSeparateProcess
      */

--- a/Spanner/tests/Unit/SpannerClientTest.php
+++ b/Spanner/tests/Unit/SpannerClientTest.php
@@ -901,22 +901,6 @@ class SpannerClientTest extends TestCase
         ]);
     }
 
-    public function testBuiltinMetricsCanBeEnabledWithoutCredentials()
-    {
-        $gapicSpannerClient = $this->prophesize(GapicSpannerClient::class);
-        $gapicSpannerClient->prependMiddleware(Argument::any())
-            ->shouldBeCalledTimes(2);
-        $gapicSpannerClient->addMiddleware(Argument::any())
-            ->shouldBeCalledTimes(2);
-
-        new SpannerClient([
-            'projectId' => self::PROJECT,
-            'gapicSpannerClient' => $gapicSpannerClient->reveal(),
-            'enableBuiltInMetrics' => true,
-        ]);
-    }
-
-
     /**
      * @runInSeparateProcess
      */
@@ -931,7 +915,7 @@ class SpannerClientTest extends TestCase
             'credentials' => Fixtures::KEYFILE_STUB_FIXTURE()
         ]);
         $end = microtime(true);
-        
+
         // Assert that the client instantiated quickly.
         // If it probed the GCE metadata server without a mock, it would take ~1.5s to time out.
         $this->assertLessThan(1.0, $end - $start);

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "google/protobuf": "^4.31||^5.34",
         "google/grpc-gcp": "^0.4",
         "ramsey/uuid": "^4.0",
-        "open-telemetry/sdk": "^1.13"
+        "open-telemetry/sdk": "^1.13",
+        "open-telemetry/exporter-otlp": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
## Summary
In the past when we introduced client metrics, we implemented a custom exporter (`MetricServiceClient`) to translate metrics into Google Cloud Monitoring `TimeSeries` objects because GCP did not yet support the native OTLP protocol. 

Google Cloud now natively supports OTLP metric ingestion at `https://telemetry.googleapis.com/v1/metrics`. This PR updates the Spanner PHP SDK built-in metrics exporter to use standard OTLP HTTP export and adds support for configurable metrics credentials.

## Key Changes
- **OTLP Exporter Migration**: Replaced legacy `MetricServiceClient` GCM translation in `MetricsExporter` with standard OTLP HTTP exporter (`OpenTelemetry\Contrib\Otlp\MetricExporter`) targeting `https://telemetry.googleapis.com/v1/metrics`.
- **Configurable & Re-scoped Credentials**:
  - Added support for dedicated `$options['metricsCredentials']` in `SpannerClient`.
  - Automatically re-scopes credentials to `https://www.googleapis.com/auth/monitoring.write` and `https://www.googleapis.com/auth/cloud-platform` using `CredentialsWrapper` to prevent OAuth scope mismatch errors.
  - Falls back gracefully to main client credentials or Application Default Credentials (ADC).
- **Guzzle Authorization Middleware**: Dynamically attaches `Authorization: Bearer <token>` and `x-goog-user-project` headers to outgoing OTLP HTTP requests via Guzzle middleware.
