### PR TITLE
chore(Chronicle): update LRO polling intervals to generator defaults

### DIFF
--- a/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_labels.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_scopes.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_scopes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/create_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/create_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/delete_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/delete_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/get_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/get_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/list_watchlists.php
+++ b/Chronicle/samples/V1/EntityServiceClient/list_watchlists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/update_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/update_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/InstanceServiceClient/get_instance.php
+++ b/Chronicle/samples/V1/InstanceServiceClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/create_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/create_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/get_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/get_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/list_reference_lists.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/list_reference_lists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/update_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/update_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/create_retrohunt.php
+++ b/Chronicle/samples/V1/RuleServiceClient/create_retrohunt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/create_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/delete_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/delete_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_retrohunt.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_retrohunt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_rule_deployment.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_rule_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_retrohunts.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_retrohunts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rule_deployments.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rule_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rule_revisions.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rule_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rules.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/update_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/update_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/update_rule_deployment.php
+++ b/Chronicle/samples/V1/RuleServiceClient/update_rule_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/DataAccessControlServiceClient.php
+++ b/Chronicle/src/V1/Client/DataAccessControlServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/EntityServiceClient.php
+++ b/Chronicle/src/V1/Client/EntityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/InstanceServiceClient.php
+++ b/Chronicle/src/V1/Client/InstanceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/ReferenceListServiceClient.php
+++ b/Chronicle/src/V1/Client/ReferenceListServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/RuleServiceClient.php
+++ b/Chronicle/src/V1/Client/RuleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/data_access_control_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/data_access_control_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/data_access_control_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/data_access_control_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/entity_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/entity_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/entity_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/entity_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/instance_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/instance_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/instance_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/instance_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/reference_list_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/reference_list_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/reference_list_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/reference_list_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/rule_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/rule_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ return [
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Chronicle\V1\Retrohunt',
                     'metadataReturnType' => '\Google\Cloud\Chronicle\V1\RetrohuntMetadata',
-                    'initialPollDelayMillis' => '1000',
-                    'pollDelayMultiplier' => '2.0',
-                    'maxPollDelayMillis' => '10000',
-                    'totalPollTimeoutMillis' => '900000',
+                    'initialPollDelayMillis' => '500',
+                    'pollDelayMultiplier' => '1.5',
+                    'maxPollDelayMillis' => '5000',
+                    'totalPollTimeoutMillis' => '300000',
                 ],
                 'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'headerParams' => [

--- a/Chronicle/src/V1/resources/rule_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/rule_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/DataAccessControlServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/DataAccessControlServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/EntityServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/EntityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/InstanceServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/InstanceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/ReferenceListServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/ReferenceListServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/RuleServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/RuleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Librarian generation falls back to the default LRO polling parameters because the microgenerator no longer respects gapic.yaml for these overrides. This aligns the repository with what the generator currently produces.