### PR TITLE
chore(PubSub): add prettier formatting step to owlbot.py and format clients

### DIFF
--- a/PubSub/owlbot.py
+++ b/PubSub/owlbot.py
@@ -75,3 +75,17 @@ s.replace(
     r"(.{0,})\]\((/.{0,})\)",
     r"\1](https://cloud.google.com\2)"
 )
+
+# format generated clients
+subprocess.run([
+    'npm',
+    'exec',
+    '--yes',
+    '--package=@prettier/plugin-php@^0.19',
+    '--',
+    'prettier',
+    '**/Client/*',
+    '--write',
+    '--parser=php',
+    '--single-quote',
+    '--print-width=120'])

--- a/PubSub/src/V1/Client/PublisherClient.php
+++ b/PubSub/src/V1/Client/PublisherClient.php
@@ -447,8 +447,10 @@ final class PublisherClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function detachSubscription(DetachSubscriptionRequest $request, array $callOptions = []): DetachSubscriptionResponse
-    {
+    public function detachSubscription(
+        DetachSubscriptionRequest $request,
+        array $callOptions = []
+    ): DetachSubscriptionResponse {
         return $this->startApiCall('DetachSubscription', $request, $callOptions)->wait();
     }
 
@@ -529,8 +531,10 @@ final class PublisherClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listTopicSubscriptions(ListTopicSubscriptionsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listTopicSubscriptions(
+        ListTopicSubscriptionsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListTopicSubscriptions', $request, $callOptions);
     }
 
@@ -698,8 +702,10 @@ final class PublisherClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function testIamPermissions(TestIamPermissionsRequest $request, array $callOptions = []): TestIamPermissionsResponse
-    {
+    public function testIamPermissions(
+        TestIamPermissionsRequest $request,
+        array $callOptions = []
+    ): TestIamPermissionsResponse {
         return $this->startApiCall('TestIamPermissions', $request, $callOptions)->wait();
     }
 

--- a/PubSub/src/V1/Client/SchemaServiceClient.php
+++ b/PubSub/src/V1/Client/SchemaServiceClient.php
@@ -624,8 +624,10 @@ final class SchemaServiceClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function testIamPermissions(TestIamPermissionsRequest $request, array $callOptions = []): TestIamPermissionsResponse
-    {
+    public function testIamPermissions(
+        TestIamPermissionsRequest $request,
+        array $callOptions = []
+    ): TestIamPermissionsResponse {
         return $this->startApiCall('TestIamPermissions', $request, $callOptions)->wait();
     }
 

--- a/PubSub/src/V1/Client/SubscriberClient.php
+++ b/PubSub/src/V1/Client/SubscriberClient.php
@@ -947,8 +947,10 @@ final class SubscriberClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function testIamPermissions(TestIamPermissionsRequest $request, array $callOptions = []): TestIamPermissionsResponse
-    {
+    public function testIamPermissions(
+        TestIamPermissionsRequest $request,
+        array $callOptions = []
+    ): TestIamPermissionsResponse {
         return $this->startApiCall('TestIamPermissions', $request, $callOptions)->wait();
     }
 

--- a/PubSub/tests/Unit/V1/Client/PublisherClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/PublisherClientTest.php
@@ -67,7 +67,9 @@ class PublisherClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return PublisherClient */
@@ -98,8 +100,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $name = 'name3373707';
-        $request = (new Topic())
-            ->setName($name);
+        $request = (new Topic())->setName($name);
         $response = $gapicClient->createTopic($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -123,17 +124,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $name = 'name3373707';
-        $request = (new Topic())
-            ->setName($name);
+        $request = (new Topic())->setName($name);
         try {
             $gapicClient->createTopic($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -160,8 +163,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new DeleteTopicRequest())
-            ->setTopic($formattedTopic);
+        $request = (new DeleteTopicRequest())->setTopic($formattedTopic);
         $gapicClient->deleteTopic($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -184,17 +186,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new DeleteTopicRequest())
-            ->setTopic($formattedTopic);
+        $request = (new DeleteTopicRequest())->setTopic($formattedTopic);
         try {
             $gapicClient->deleteTopic($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -221,8 +225,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new DetachSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new DetachSubscriptionRequest())->setSubscription($formattedSubscription);
         $response = $gapicClient->detachSubscription($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -246,17 +249,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new DetachSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new DetachSubscriptionRequest())->setSubscription($formattedSubscription);
         try {
             $gapicClient->detachSubscription($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -289,8 +294,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new GetTopicRequest())
-            ->setTopic($formattedTopic);
+        $request = (new GetTopicRequest())->setTopic($formattedTopic);
         $response = $gapicClient->getTopic($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -314,17 +318,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new GetTopicRequest())
-            ->setTopic($formattedTopic);
+        $request = (new GetTopicRequest())->setTopic($formattedTopic);
         try {
             $gapicClient->getTopic($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -349,17 +355,14 @@ class PublisherClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $snapshotsElement = 'snapshotsElement1339034092';
-        $snapshots = [
-            $snapshotsElement,
-        ];
+        $snapshots = [$snapshotsElement];
         $expectedResponse = new ListTopicSnapshotsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSnapshots($snapshots);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new ListTopicSnapshotsRequest())
-            ->setTopic($formattedTopic);
+        $request = (new ListTopicSnapshotsRequest())->setTopic($formattedTopic);
         $response = $gapicClient->listTopicSnapshots($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -386,17 +389,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new ListTopicSnapshotsRequest())
-            ->setTopic($formattedTopic);
+        $request = (new ListTopicSnapshotsRequest())->setTopic($formattedTopic);
         try {
             $gapicClient->listTopicSnapshots($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -421,17 +426,14 @@ class PublisherClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $subscriptionsElement = 'subscriptionsElement1698708147';
-        $subscriptions = [
-            $subscriptionsElement,
-        ];
+        $subscriptions = [$subscriptionsElement];
         $expectedResponse = new ListTopicSubscriptionsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSubscriptions($subscriptions);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new ListTopicSubscriptionsRequest())
-            ->setTopic($formattedTopic);
+        $request = (new ListTopicSubscriptionsRequest())->setTopic($formattedTopic);
         $response = $gapicClient->listTopicSubscriptions($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -458,17 +460,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new ListTopicSubscriptionsRequest())
-            ->setTopic($formattedTopic);
+        $request = (new ListTopicSubscriptionsRequest())->setTopic($formattedTopic);
         try {
             $gapicClient->listTopicSubscriptions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -493,17 +497,14 @@ class PublisherClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $topicsElement = new Topic();
-        $topics = [
-            $topicsElement,
-        ];
+        $topics = [$topicsElement];
         $expectedResponse = new ListTopicsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setTopics($topics);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListTopicsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListTopicsRequest())->setProject($formattedProject);
         $response = $gapicClient->listTopics($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -530,17 +531,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListTopicsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListTopicsRequest())->setProject($formattedProject);
         try {
             $gapicClient->listTopics($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -568,9 +571,7 @@ class PublisherClientTest extends GeneratedTest
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
         $messages = [];
-        $request = (new PublishRequest())
-            ->setTopic($formattedTopic)
-            ->setMessages($messages);
+        $request = (new PublishRequest())->setTopic($formattedTopic)->setMessages($messages);
         $response = $gapicClient->publish($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -596,19 +597,20 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
         $messages = [];
-        $request = (new PublishRequest())
-            ->setTopic($formattedTopic)
-            ->setMessages($messages);
+        $request = (new PublishRequest())->setTopic($formattedTopic)->setMessages($messages);
         try {
             $gapicClient->publish($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -644,9 +646,7 @@ class PublisherClientTest extends GeneratedTest
         $topicName = 'topicName388205658';
         $topic->setName($topicName);
         $updateMask = new FieldMask();
-        $request = (new UpdateTopicRequest())
-            ->setTopic($topic)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateTopicRequest())->setTopic($topic)->setUpdateMask($updateMask);
         $response = $gapicClient->updateTopic($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -672,21 +672,22 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $topic = new Topic();
         $topicName = 'topicName388205658';
         $topic->setName($topicName);
         $updateMask = new FieldMask();
-        $request = (new UpdateTopicRequest())
-            ->setTopic($topic)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateTopicRequest())->setTopic($topic)->setUpdateMask($updateMask);
         try {
             $gapicClient->updateTopic($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -717,8 +718,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         $response = $gapicClient->getIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -742,17 +742,19 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         try {
             $gapicClient->getIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -784,9 +786,7 @@ class PublisherClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         $response = $gapicClient->setIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -812,19 +812,20 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         try {
             $gapicClient->setIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -852,9 +853,7 @@ class PublisherClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         $response = $gapicClient->testIamPermissions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -880,19 +879,20 @@ class PublisherClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         try {
             $gapicClient->testIamPermissions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -925,8 +925,7 @@ class PublisherClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $name = 'name3373707';
-        $request = (new Topic())
-            ->setName($name);
+        $request = (new Topic())->setName($name);
         $response = $gapicClient->createTopicAsync($request)->wait();
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();

--- a/PubSub/tests/Unit/V1/Client/SchemaServiceClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/SchemaServiceClientTest.php
@@ -67,7 +67,9 @@ class SchemaServiceClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return SchemaServiceClient */
@@ -101,9 +103,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new CommitSchemaRequest())
-            ->setName($formattedName)
-            ->setSchema($schema);
+        $request = (new CommitSchemaRequest())->setName($formattedName)->setSchema($schema);
         $response = $gapicClient->commitSchema($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -129,21 +129,22 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new CommitSchemaRequest())
-            ->setName($formattedName)
-            ->setSchema($schema);
+        $request = (new CommitSchemaRequest())->setName($formattedName)->setSchema($schema);
         try {
             $gapicClient->commitSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -179,9 +180,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new CreateSchemaRequest())
-            ->setParent($formattedParent)
-            ->setSchema($schema);
+        $request = (new CreateSchemaRequest())->setParent($formattedParent)->setSchema($schema);
         $response = $gapicClient->createSchema($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -207,21 +206,22 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new CreateSchemaRequest())
-            ->setParent($formattedParent)
-            ->setSchema($schema);
+        $request = (new CreateSchemaRequest())->setParent($formattedParent)->setSchema($schema);
         try {
             $gapicClient->createSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -248,8 +248,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new DeleteSchemaRequest())
-            ->setName($formattedName);
+        $request = (new DeleteSchemaRequest())->setName($formattedName);
         $gapicClient->deleteSchema($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -272,17 +271,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new DeleteSchemaRequest())
-            ->setName($formattedName);
+        $request = (new DeleteSchemaRequest())->setName($formattedName);
         try {
             $gapicClient->deleteSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -316,9 +317,7 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
         $revisionId = 'revisionId513861631';
-        $request = (new DeleteSchemaRevisionRequest())
-            ->setName($formattedName)
-            ->setRevisionId($revisionId);
+        $request = (new DeleteSchemaRevisionRequest())->setName($formattedName)->setRevisionId($revisionId);
         $response = $gapicClient->deleteSchemaRevision($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -344,19 +343,20 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
         $revisionId = 'revisionId513861631';
-        $request = (new DeleteSchemaRevisionRequest())
-            ->setName($formattedName)
-            ->setRevisionId($revisionId);
+        $request = (new DeleteSchemaRevisionRequest())->setName($formattedName)->setRevisionId($revisionId);
         try {
             $gapicClient->deleteSchemaRevision($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -389,8 +389,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new GetSchemaRequest())
-            ->setName($formattedName);
+        $request = (new GetSchemaRequest())->setName($formattedName);
         $response = $gapicClient->getSchema($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -414,17 +413,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new GetSchemaRequest())
-            ->setName($formattedName);
+        $request = (new GetSchemaRequest())->setName($formattedName);
         try {
             $gapicClient->getSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -449,17 +450,14 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $schemasElement = new Schema();
-        $schemas = [
-            $schemasElement,
-        ];
+        $schemas = [$schemasElement];
         $expectedResponse = new ListSchemaRevisionsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSchemas($schemas);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new ListSchemaRevisionsRequest())
-            ->setName($formattedName);
+        $request = (new ListSchemaRevisionsRequest())->setName($formattedName);
         $response = $gapicClient->listSchemaRevisions($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -486,17 +484,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
-        $request = (new ListSchemaRevisionsRequest())
-            ->setName($formattedName);
+        $request = (new ListSchemaRevisionsRequest())->setName($formattedName);
         try {
             $gapicClient->listSchemaRevisions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -521,17 +521,14 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $schemasElement = new Schema();
-        $schemas = [
-            $schemasElement,
-        ];
+        $schemas = [$schemasElement];
         $expectedResponse = new ListSchemasResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSchemas($schemas);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSchemasRequest())
-            ->setParent($formattedParent);
+        $request = (new ListSchemasRequest())->setParent($formattedParent);
         $response = $gapicClient->listSchemas($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -558,17 +555,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSchemasRequest())
-            ->setParent($formattedParent);
+        $request = (new ListSchemasRequest())->setParent($formattedParent);
         try {
             $gapicClient->listSchemas($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -602,9 +601,7 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
         $revisionId = 'revisionId513861631';
-        $request = (new RollbackSchemaRequest())
-            ->setName($formattedName)
-            ->setRevisionId($revisionId);
+        $request = (new RollbackSchemaRequest())->setName($formattedName)->setRevisionId($revisionId);
         $response = $gapicClient->rollbackSchema($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -630,19 +627,20 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->schemaName('[PROJECT]', '[SCHEMA]');
         $revisionId = 'revisionId513861631';
-        $request = (new RollbackSchemaRequest())
-            ->setName($formattedName)
-            ->setRevisionId($revisionId);
+        $request = (new RollbackSchemaRequest())->setName($formattedName)->setRevisionId($revisionId);
         try {
             $gapicClient->rollbackSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -669,8 +667,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ValidateMessageRequest())
-            ->setParent($formattedParent);
+        $request = (new ValidateMessageRequest())->setParent($formattedParent);
         $response = $gapicClient->validateMessage($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -694,17 +691,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ValidateMessageRequest())
-            ->setParent($formattedParent);
+        $request = (new ValidateMessageRequest())->setParent($formattedParent);
         try {
             $gapicClient->validateMessage($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -734,9 +733,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new ValidateSchemaRequest())
-            ->setParent($formattedParent)
-            ->setSchema($schema);
+        $request = (new ValidateSchemaRequest())->setParent($formattedParent)->setSchema($schema);
         $response = $gapicClient->validateSchema($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -762,21 +759,22 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new ValidateSchemaRequest())
-            ->setParent($formattedParent)
-            ->setSchema($schema);
+        $request = (new ValidateSchemaRequest())->setParent($formattedParent)->setSchema($schema);
         try {
             $gapicClient->validateSchema($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -807,8 +805,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         $response = $gapicClient->getIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -832,17 +829,19 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         try {
             $gapicClient->getIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -874,9 +873,7 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         $response = $gapicClient->setIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -902,19 +899,20 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         try {
             $gapicClient->setIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -942,9 +940,7 @@ class SchemaServiceClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         $response = $gapicClient->testIamPermissions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -970,19 +966,20 @@ class SchemaServiceClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         try {
             $gapicClient->testIamPermissions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1018,9 +1015,7 @@ class SchemaServiceClientTest extends GeneratedTest
         $schema = new Schema();
         $schemaName = 'schemaName-448762932';
         $schema->setName($schemaName);
-        $request = (new CommitSchemaRequest())
-            ->setName($formattedName)
-            ->setSchema($schema);
+        $request = (new CommitSchemaRequest())->setName($formattedName)->setSchema($schema);
         $response = $gapicClient->commitSchemaAsync($request)->wait();
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();

--- a/PubSub/tests/Unit/V1/Client/SubscriberClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/SubscriberClientTest.php
@@ -77,7 +77,9 @@ class SubscriberClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return SubscriberClient */
@@ -103,9 +105,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $ackIds = [];
-        $request = (new AcknowledgeRequest())
-            ->setSubscription($formattedSubscription)
-            ->setAckIds($ackIds);
+        $request = (new AcknowledgeRequest())->setSubscription($formattedSubscription)->setAckIds($ackIds);
         $gapicClient->acknowledge($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -130,19 +130,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $ackIds = [];
-        $request = (new AcknowledgeRequest())
-            ->setSubscription($formattedSubscription)
-            ->setAckIds($ackIds);
+        $request = (new AcknowledgeRequest())->setSubscription($formattedSubscription)->setAckIds($ackIds);
         try {
             $gapicClient->acknowledge($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -174,9 +175,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new CreateSnapshotRequest())
-            ->setName($formattedName)
-            ->setSubscription($formattedSubscription);
+        $request = (new CreateSnapshotRequest())->setName($formattedName)->setSubscription($formattedSubscription);
         $response = $gapicClient->createSnapshot($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -202,19 +201,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new CreateSnapshotRequest())
-            ->setName($formattedName)
-            ->setSubscription($formattedSubscription);
+        $request = (new CreateSnapshotRequest())->setName($formattedName)->setSubscription($formattedSubscription);
         try {
             $gapicClient->createSnapshot($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -258,9 +258,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $name = 'name3373707';
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new Subscription())
-            ->setName($name)
-            ->setTopic($formattedTopic);
+        $request = (new Subscription())->setName($name)->setTopic($formattedTopic);
         $response = $gapicClient->createSubscription($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -286,19 +284,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $name = 'name3373707';
         $formattedTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
-        $request = (new Subscription())
-            ->setName($name)
-            ->setTopic($formattedTopic);
+        $request = (new Subscription())->setName($name)->setTopic($formattedTopic);
         try {
             $gapicClient->createSubscription($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -325,8 +324,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSnapshot = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
-        $request = (new DeleteSnapshotRequest())
-            ->setSnapshot($formattedSnapshot);
+        $request = (new DeleteSnapshotRequest())->setSnapshot($formattedSnapshot);
         $gapicClient->deleteSnapshot($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -349,17 +347,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSnapshot = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
-        $request = (new DeleteSnapshotRequest())
-            ->setSnapshot($formattedSnapshot);
+        $request = (new DeleteSnapshotRequest())->setSnapshot($formattedSnapshot);
         try {
             $gapicClient->deleteSnapshot($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -386,8 +386,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new DeleteSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new DeleteSubscriptionRequest())->setSubscription($formattedSubscription);
         $gapicClient->deleteSubscription($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -410,17 +409,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new DeleteSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new DeleteSubscriptionRequest())->setSubscription($formattedSubscription);
         try {
             $gapicClient->deleteSubscription($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -451,8 +452,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSnapshot = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
-        $request = (new GetSnapshotRequest())
-            ->setSnapshot($formattedSnapshot);
+        $request = (new GetSnapshotRequest())->setSnapshot($formattedSnapshot);
         $response = $gapicClient->getSnapshot($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -476,17 +476,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSnapshot = $gapicClient->snapshotName('[PROJECT]', '[SNAPSHOT]');
-        $request = (new GetSnapshotRequest())
-            ->setSnapshot($formattedSnapshot);
+        $request = (new GetSnapshotRequest())->setSnapshot($formattedSnapshot);
         try {
             $gapicClient->getSnapshot($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -529,8 +531,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new GetSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new GetSubscriptionRequest())->setSubscription($formattedSubscription);
         $response = $gapicClient->getSubscription($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -554,17 +555,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new GetSubscriptionRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new GetSubscriptionRequest())->setSubscription($formattedSubscription);
         try {
             $gapicClient->getSubscription($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -589,17 +592,14 @@ class SubscriberClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $snapshotsElement = new Snapshot();
-        $snapshots = [
-            $snapshotsElement,
-        ];
+        $snapshots = [$snapshotsElement];
         $expectedResponse = new ListSnapshotsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSnapshots($snapshots);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSnapshotsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListSnapshotsRequest())->setProject($formattedProject);
         $response = $gapicClient->listSnapshots($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -626,17 +626,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSnapshotsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListSnapshotsRequest())->setProject($formattedProject);
         try {
             $gapicClient->listSnapshots($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -661,17 +663,14 @@ class SubscriberClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $subscriptionsElement = new Subscription();
-        $subscriptions = [
-            $subscriptionsElement,
-        ];
+        $subscriptions = [$subscriptionsElement];
         $expectedResponse = new ListSubscriptionsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSubscriptions($subscriptions);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSubscriptionsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListSubscriptionsRequest())->setProject($formattedProject);
         $response = $gapicClient->listSubscriptions($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -698,17 +697,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedProject = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListSubscriptionsRequest())
-            ->setProject($formattedProject);
+        $request = (new ListSubscriptionsRequest())->setProject($formattedProject);
         try {
             $gapicClient->listSubscriptions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -767,12 +768,15 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
@@ -809,9 +813,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $pushConfig = new PushConfig();
-        $request = (new ModifyPushConfigRequest())
-            ->setSubscription($formattedSubscription)
-            ->setPushConfig($pushConfig);
+        $request = (new ModifyPushConfigRequest())->setSubscription($formattedSubscription)->setPushConfig($pushConfig);
         $gapicClient->modifyPushConfig($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -836,19 +838,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $pushConfig = new PushConfig();
-        $request = (new ModifyPushConfigRequest())
-            ->setSubscription($formattedSubscription)
-            ->setPushConfig($pushConfig);
+        $request = (new ModifyPushConfigRequest())->setSubscription($formattedSubscription)->setPushConfig($pushConfig);
         try {
             $gapicClient->modifyPushConfig($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -876,9 +879,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $maxMessages = 496131527;
-        $request = (new PullRequest())
-            ->setSubscription($formattedSubscription)
-            ->setMaxMessages($maxMessages);
+        $request = (new PullRequest())->setSubscription($formattedSubscription)->setMaxMessages($maxMessages);
         $response = $gapicClient->pull($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -904,19 +905,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $maxMessages = 496131527;
-        $request = (new PullRequest())
-            ->setSubscription($formattedSubscription)
-            ->setMaxMessages($maxMessages);
+        $request = (new PullRequest())->setSubscription($formattedSubscription)->setMaxMessages($maxMessages);
         try {
             $gapicClient->pull($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -943,8 +945,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new SeekRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new SeekRequest())->setSubscription($formattedSubscription);
         $response = $gapicClient->seek($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -968,17 +969,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
-        $request = (new SeekRequest())
-            ->setSubscription($formattedSubscription);
+        $request = (new SeekRequest())->setSubscription($formattedSubscription);
         try {
             $gapicClient->seek($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1028,10 +1031,7 @@ class SubscriberClientTest extends GeneratedTest
         $bidi->write($request);
         $responses = [];
         $responses[] = $bidi->read();
-        $bidi->writeAll([
-            $request2,
-            $request3,
-        ]);
+        $bidi->writeAll([$request2, $request3]);
         foreach ($bidi->closeWriteAndReadAll() as $response) {
             $responses[] = $response;
         }
@@ -1069,12 +1069,15 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->setStreamingStatus($status);
         $this->assertTrue($transport->isExhausted());
         $bidi = $gapicClient->streamingPull();
@@ -1110,9 +1113,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $snapshot = new Snapshot();
         $updateMask = new FieldMask();
-        $request = (new UpdateSnapshotRequest())
-            ->setSnapshot($snapshot)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateSnapshotRequest())->setSnapshot($snapshot)->setUpdateMask($updateMask);
         $response = $gapicClient->updateSnapshot($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1138,19 +1139,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $snapshot = new Snapshot();
         $updateMask = new FieldMask();
-        $request = (new UpdateSnapshotRequest())
-            ->setSnapshot($snapshot)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateSnapshotRequest())->setSnapshot($snapshot)->setUpdateMask($updateMask);
         try {
             $gapicClient->updateSnapshot($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1198,9 +1200,7 @@ class SubscriberClientTest extends GeneratedTest
         $subscriptionTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
         $subscription->setTopic($subscriptionTopic);
         $updateMask = new FieldMask();
-        $request = (new UpdateSubscriptionRequest())
-            ->setSubscription($subscription)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateSubscriptionRequest())->setSubscription($subscription)->setUpdateMask($updateMask);
         $response = $gapicClient->updateSubscription($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1226,12 +1226,15 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $subscription = new Subscription();
@@ -1240,9 +1243,7 @@ class SubscriberClientTest extends GeneratedTest
         $subscriptionTopic = $gapicClient->topicName('[PROJECT]', '[TOPIC]');
         $subscription->setTopic($subscriptionTopic);
         $updateMask = new FieldMask();
-        $request = (new UpdateSubscriptionRequest())
-            ->setSubscription($subscription)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateSubscriptionRequest())->setSubscription($subscription)->setUpdateMask($updateMask);
         try {
             $gapicClient->updateSubscription($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1273,8 +1274,7 @@ class SubscriberClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         $response = $gapicClient->getIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1298,17 +1298,19 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         try {
             $gapicClient->getIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1340,9 +1342,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         $response = $gapicClient->setIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1368,19 +1368,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         try {
             $gapicClient->setIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1408,9 +1409,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         $response = $gapicClient->testIamPermissions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1436,19 +1435,20 @@ class SubscriberClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         try {
             $gapicClient->testIamPermissions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1476,9 +1476,7 @@ class SubscriberClientTest extends GeneratedTest
         // Mock request
         $formattedSubscription = $gapicClient->subscriptionName('[PROJECT]', '[SUBSCRIPTION]');
         $ackIds = [];
-        $request = (new AcknowledgeRequest())
-            ->setSubscription($formattedSubscription)
-            ->setAckIds($ackIds);
+        $request = (new AcknowledgeRequest())->setSubscription($formattedSubscription)->setAckIds($ackIds);
         $gapicClient->acknowledgeAsync($request)->wait();
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));


### PR DESCRIPTION
Updates `PubSub/owlbot.py` to run `@prettier/plugin-php` post-generation formatting on generated clients and tests (`**/Client/*`), aligning PubSub with the repository code style standards.

Formatted files:
- Client classes:
  - `PubSub/src/V1/Client/PublisherClient.php`
  - `PubSub/src/V1/Client/SchemaServiceClient.php`
  - `PubSub/src/V1/Client/SubscriberClient.php`
- Unit tests:
  - `PubSub/tests/Unit/V1/Client/PublisherClientTest.php`
  - `PubSub/tests/Unit/V1/Client/SchemaServiceClientTest.php`
  - `PubSub/tests/Unit/V1/Client/SubscriberClientTest.php`

The change to PHP code is generated by running Owlbot copy:
```
docker run --rm --user $(id -u):$(id -g) -v .:/repo -w /repo -v ../googleapis-gen:/googleapis-gen --env HOME=/tmp gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-code  --source-repo=/googleapis-gen --config-file=PubSub/.OwlBot.yaml

docker run --rm --user $(id -u):$(id -g) -v $(pwd):/repo -w /repo   --env HOME=/tmp   gcr.io/cloud-devrel-public-resources/owlbot-php:latest
```
