### PR TITLE
chore(Spanner): update prettier glob in owlbot.py and format clients

### DIFF
--- a/Spanner/owlbot.py
+++ b/Spanner/owlbot.py
@@ -85,7 +85,7 @@ subprocess.run([
     '--package=@prettier/plugin-php@^0.19',
     '--',
     'prettier',
-    '**/Gapic/*',
+    '**/Client/*',
     '--write',
     '--parser=php',
     '--single-quote',

--- a/Spanner/src/Admin/Database/V1/Client/DatabaseAdminClient.php
+++ b/Spanner/src/Admin/Database/V1/Client/DatabaseAdminClient.php
@@ -206,7 +206,10 @@ final class DatabaseAdminClient
      */
     public function resumeOperation($operationName, $methodName = null)
     {
-        $options = $methodName && isset($this->descriptors[$methodName]['longRunning']) ? $this->descriptors[$methodName]['longRunning'] : [];
+        $options =
+            $methodName && isset($this->descriptors[$methodName]['longRunning'])
+                ? $this->descriptors[$methodName]['longRunning']
+                : [];
         $operation = new OperationResponse($operationName, $this->getOperationsClient(), $options);
         $operation->reload();
         return $operation;
@@ -261,8 +264,12 @@ final class DatabaseAdminClient
      *
      * @return string The formatted backup_schedule resource.
      */
-    public static function backupScheduleName(string $project, string $instance, string $database, string $schedule): string
-    {
+    public static function backupScheduleName(
+        string $project,
+        string $instance,
+        string $database,
+        string $schedule
+    ): string {
         return self::getPathTemplate('backupSchedule')->render([
             'project' => $project,
             'instance' => $instance,
@@ -304,8 +311,13 @@ final class DatabaseAdminClient
      *
      * @return string The formatted crypto_key_version resource.
      */
-    public static function cryptoKeyVersionName(string $project, string $location, string $keyRing, string $cryptoKey, string $cryptoKeyVersion): string
-    {
+    public static function cryptoKeyVersionName(
+        string $project,
+        string $location,
+        string $keyRing,
+        string $cryptoKey,
+        string $cryptoKeyVersion
+    ): string {
         return self::getPathTemplate('cryptoKeyVersion')->render([
             'project' => $project,
             'location' => $location,
@@ -891,8 +903,10 @@ final class DatabaseAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function internalUpdateGraphOperation(InternalUpdateGraphOperationRequest $request, array $callOptions = []): InternalUpdateGraphOperationResponse
-    {
+    public function internalUpdateGraphOperation(
+        InternalUpdateGraphOperationRequest $request,
+        array $callOptions = []
+    ): InternalUpdateGraphOperationResponse {
         return $this->startApiCall('InternalUpdateGraphOperation', $request, $callOptions)->wait();
     }
 
@@ -926,8 +940,10 @@ final class DatabaseAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listBackupOperations(ListBackupOperationsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listBackupOperations(
+        ListBackupOperationsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListBackupOperations', $request, $callOptions);
     }
 
@@ -1013,8 +1029,10 @@ final class DatabaseAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listDatabaseOperations(ListDatabaseOperationsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listDatabaseOperations(
+        ListDatabaseOperationsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListDatabaseOperations', $request, $callOptions);
     }
 
@@ -1174,8 +1192,10 @@ final class DatabaseAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function testIamPermissions(TestIamPermissionsRequest $request, array $callOptions = []): TestIamPermissionsResponse
-    {
+    public function testIamPermissions(
+        TestIamPermissionsRequest $request,
+        array $callOptions = []
+    ): TestIamPermissionsResponse {
         return $this->startApiCall('TestIamPermissions', $request, $callOptions)->wait();
     }
 

--- a/Spanner/src/Admin/Instance/V1/Client/InstanceAdminClient.php
+++ b/Spanner/src/Admin/Instance/V1/Client/InstanceAdminClient.php
@@ -207,7 +207,10 @@ final class InstanceAdminClient
      */
     public function resumeOperation($operationName, $methodName = null)
     {
-        $options = $methodName && isset($this->descriptors[$methodName]['longRunning']) ? $this->descriptors[$methodName]['longRunning'] : [];
+        $options =
+            $methodName && isset($this->descriptors[$methodName]['longRunning'])
+                ? $this->descriptors[$methodName]['longRunning']
+                : [];
         $operation = new OperationResponse($operationName, $this->getOperationsClient(), $options);
         $operation->reload();
         return $operation;
@@ -538,8 +541,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function createInstanceConfig(CreateInstanceConfigRequest $request, array $callOptions = []): OperationResponse
-    {
+    public function createInstanceConfig(
+        CreateInstanceConfigRequest $request,
+        array $callOptions = []
+    ): OperationResponse {
         return $this->startApiCall('CreateInstanceConfig', $request, $callOptions)->wait();
     }
 
@@ -601,8 +606,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function createInstancePartition(CreateInstancePartitionRequest $request, array $callOptions = []): OperationResponse
-    {
+    public function createInstancePartition(
+        CreateInstancePartitionRequest $request,
+        array $callOptions = []
+    ): OperationResponse {
         return $this->startApiCall('CreateInstancePartition', $request, $callOptions)->wait();
     }
 
@@ -805,8 +812,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function getInstancePartition(GetInstancePartitionRequest $request, array $callOptions = []): InstancePartition
-    {
+    public function getInstancePartition(
+        GetInstancePartitionRequest $request,
+        array $callOptions = []
+    ): InstancePartition {
         return $this->startApiCall('GetInstancePartition', $request, $callOptions)->wait();
     }
 
@@ -842,8 +851,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listInstanceConfigOperations(ListInstanceConfigOperationsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listInstanceConfigOperations(
+        ListInstanceConfigOperationsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListInstanceConfigOperations', $request, $callOptions);
     }
 
@@ -911,8 +922,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listInstancePartitionOperations(ListInstancePartitionOperationsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listInstancePartitionOperations(
+        ListInstancePartitionOperationsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListInstancePartitionOperations', $request, $callOptions);
     }
 
@@ -937,8 +950,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function listInstancePartitions(ListInstancePartitionsRequest $request, array $callOptions = []): PagedListResponse
-    {
+    public function listInstancePartitions(
+        ListInstancePartitionsRequest $request,
+        array $callOptions = []
+    ): PagedListResponse {
         return $this->startApiCall('ListInstancePartitions', $request, $callOptions);
     }
 
@@ -1110,8 +1125,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function testIamPermissions(TestIamPermissionsRequest $request, array $callOptions = []): TestIamPermissionsResponse
-    {
+    public function testIamPermissions(
+        TestIamPermissionsRequest $request,
+        array $callOptions = []
+    ): TestIamPermissionsResponse {
         return $this->startApiCall('TestIamPermissions', $request, $callOptions)->wait();
     }
 
@@ -1243,8 +1260,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function updateInstanceConfig(UpdateInstanceConfigRequest $request, array $callOptions = []): OperationResponse
-    {
+    public function updateInstanceConfig(
+        UpdateInstanceConfigRequest $request,
+        array $callOptions = []
+    ): OperationResponse {
         return $this->startApiCall('UpdateInstanceConfig', $request, $callOptions)->wait();
     }
 
@@ -1312,8 +1331,10 @@ final class InstanceAdminClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function updateInstancePartition(UpdateInstancePartitionRequest $request, array $callOptions = []): OperationResponse
-    {
+    public function updateInstancePartition(
+        UpdateInstancePartitionRequest $request,
+        array $callOptions = []
+    ): OperationResponse {
         return $this->startApiCall('UpdateInstancePartition', $request, $callOptions)->wait();
     }
 

--- a/Spanner/src/V1/Client/SpannerClient.php
+++ b/Spanner/src/V1/Client/SpannerClient.php
@@ -327,8 +327,10 @@ final class SpannerClient
      *
      * @throws ApiException Thrown if the API call fails.
      */
-    public function batchCreateSessions(BatchCreateSessionsRequest $request, array $callOptions = []): BatchCreateSessionsResponse
-    {
+    public function batchCreateSessions(
+        BatchCreateSessionsRequest $request,
+        array $callOptions = []
+    ): BatchCreateSessionsResponse {
         return $this->startApiCall('BatchCreateSessions', $request, $callOptions)->wait();
     }
 

--- a/Spanner/tests/Unit/Admin/Database/V1/Client/DatabaseAdminClientTest.php
+++ b/Spanner/tests/Unit/Admin/Database/V1/Client/DatabaseAdminClientTest.php
@@ -95,7 +95,9 @@ class DatabaseAdminClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return DatabaseAdminClient */
@@ -121,9 +123,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $splitPoints = [];
-        $request = (new AddSplitPointsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSplitPoints($splitPoints);
+        $request = (new AddSplitPointsRequest())->setDatabase($formattedDatabase)->setSplitPoints($splitPoints);
         $response = $gapicClient->addSplitPoints($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -149,19 +149,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $splitPoints = [];
-        $request = (new AddSplitPointsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSplitPoints($splitPoints);
+        $request = (new AddSplitPointsRequest())->setDatabase($formattedDatabase)->setSplitPoints($splitPoints);
         try {
             $gapicClient->addSplitPoints($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -287,12 +288,15 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
@@ -434,12 +438,15 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
@@ -519,12 +526,15 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
@@ -589,9 +599,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $createStatement = 'createStatement552974828';
-        $request = (new CreateDatabaseRequest())
-            ->setParent($formattedParent)
-            ->setCreateStatement($createStatement);
+        $request = (new CreateDatabaseRequest())->setParent($formattedParent)->setCreateStatement($createStatement);
         $response = $gapicClient->createDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -649,19 +657,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $createStatement = 'createStatement552974828';
-        $request = (new CreateDatabaseRequest())
-            ->setParent($formattedParent)
-            ->setCreateStatement($createStatement);
+        $request = (new CreateDatabaseRequest())->setParent($formattedParent)->setCreateStatement($createStatement);
         $response = $gapicClient->createDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -697,8 +706,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->backupName('[PROJECT]', '[INSTANCE]', '[BACKUP]');
-        $request = (new DeleteBackupRequest())
-            ->setName($formattedName);
+        $request = (new DeleteBackupRequest())->setName($formattedName);
         $gapicClient->deleteBackup($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -721,17 +729,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->backupName('[PROJECT]', '[INSTANCE]', '[BACKUP]');
-        $request = (new DeleteBackupRequest())
-            ->setName($formattedName);
+        $request = (new DeleteBackupRequest())->setName($formattedName);
         try {
             $gapicClient->deleteBackup($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -758,8 +768,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->backupScheduleName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SCHEDULE]');
-        $request = (new DeleteBackupScheduleRequest())
-            ->setName($formattedName);
+        $request = (new DeleteBackupScheduleRequest())->setName($formattedName);
         $gapicClient->deleteBackupSchedule($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -782,17 +791,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->backupScheduleName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SCHEDULE]');
-        $request = (new DeleteBackupScheduleRequest())
-            ->setName($formattedName);
+        $request = (new DeleteBackupScheduleRequest())->setName($formattedName);
         try {
             $gapicClient->deleteBackupSchedule($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -819,8 +830,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new DropDatabaseRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new DropDatabaseRequest())->setDatabase($formattedDatabase);
         $gapicClient->dropDatabase($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -843,17 +853,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new DropDatabaseRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new DropDatabaseRequest())->setDatabase($formattedDatabase);
         try {
             $gapicClient->dropDatabase($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -892,8 +904,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->backupName('[PROJECT]', '[INSTANCE]', '[BACKUP]');
-        $request = (new GetBackupRequest())
-            ->setName($formattedName);
+        $request = (new GetBackupRequest())->setName($formattedName);
         $response = $gapicClient->getBackup($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -917,17 +928,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->backupName('[PROJECT]', '[INSTANCE]', '[BACKUP]');
-        $request = (new GetBackupRequest())
-            ->setName($formattedName);
+        $request = (new GetBackupRequest())->setName($formattedName);
         try {
             $gapicClient->getBackup($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -956,8 +969,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->backupScheduleName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SCHEDULE]');
-        $request = (new GetBackupScheduleRequest())
-            ->setName($formattedName);
+        $request = (new GetBackupScheduleRequest())->setName($formattedName);
         $response = $gapicClient->getBackupSchedule($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -981,17 +993,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->backupScheduleName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SCHEDULE]');
-        $request = (new GetBackupScheduleRequest())
-            ->setName($formattedName);
+        $request = (new GetBackupScheduleRequest())->setName($formattedName);
         try {
             $gapicClient->getBackupSchedule($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1028,8 +1042,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new GetDatabaseRequest())
-            ->setName($formattedName);
+        $request = (new GetDatabaseRequest())->setName($formattedName);
         $response = $gapicClient->getDatabase($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1053,17 +1066,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new GetDatabaseRequest())
-            ->setName($formattedName);
+        $request = (new GetDatabaseRequest())->setName($formattedName);
         try {
             $gapicClient->getDatabase($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1092,8 +1107,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new GetDatabaseDdlRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new GetDatabaseDdlRequest())->setDatabase($formattedDatabase);
         $response = $gapicClient->getDatabaseDdl($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1117,17 +1131,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new GetDatabaseDdlRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new GetDatabaseDdlRequest())->setDatabase($formattedDatabase);
         try {
             $gapicClient->getDatabaseDdl($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1158,8 +1174,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         $response = $gapicClient->getIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1183,17 +1198,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         try {
             $gapicClient->getIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1232,7 +1249,10 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertSame(1, count($actualRequests));
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
-        $this->assertSame('/google.spanner.admin.database.v1.DatabaseAdmin/InternalUpdateGraphOperation', $actualFuncCall);
+        $this->assertSame(
+            '/google.spanner.admin.database.v1.DatabaseAdmin/InternalUpdateGraphOperation',
+            $actualFuncCall
+        );
         $actualValue = $actualRequestObject->getDatabase();
         $this->assertProtobufEquals($formattedDatabase, $actualValue);
         $actualValue = $actualRequestObject->getOperationId();
@@ -1253,12 +1273,15 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
@@ -1292,17 +1315,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $operationsElement = new Operation();
-        $operations = [
-            $operationsElement,
-        ];
+        $operations = [$operationsElement];
         $expectedResponse = new ListBackupOperationsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setOperations($operations);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListBackupOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupOperationsRequest())->setParent($formattedParent);
         $response = $gapicClient->listBackupOperations($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1329,17 +1349,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListBackupOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupOperationsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listBackupOperations($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1364,17 +1386,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $backupSchedulesElement = new BackupSchedule();
-        $backupSchedules = [
-            $backupSchedulesElement,
-        ];
+        $backupSchedules = [$backupSchedulesElement];
         $expectedResponse = new ListBackupSchedulesResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setBackupSchedules($backupSchedules);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListBackupSchedulesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupSchedulesRequest())->setParent($formattedParent);
         $response = $gapicClient->listBackupSchedules($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1401,17 +1420,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListBackupSchedulesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupSchedulesRequest())->setParent($formattedParent);
         try {
             $gapicClient->listBackupSchedules($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1436,17 +1457,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $backupsElement = new Backup();
-        $backups = [
-            $backupsElement,
-        ];
+        $backups = [$backupsElement];
         $expectedResponse = new ListBackupsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setBackups($backups);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListBackupsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupsRequest())->setParent($formattedParent);
         $response = $gapicClient->listBackups($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1473,17 +1491,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListBackupsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListBackupsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listBackups($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1508,17 +1528,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $operationsElement = new Operation();
-        $operations = [
-            $operationsElement,
-        ];
+        $operations = [$operationsElement];
         $expectedResponse = new ListDatabaseOperationsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setOperations($operations);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListDatabaseOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabaseOperationsRequest())->setParent($formattedParent);
         $response = $gapicClient->listDatabaseOperations($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1545,17 +1562,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListDatabaseOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabaseOperationsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listDatabaseOperations($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1580,17 +1599,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $databaseRolesElement = new DatabaseRole();
-        $databaseRoles = [
-            $databaseRolesElement,
-        ];
+        $databaseRoles = [$databaseRolesElement];
         $expectedResponse = new ListDatabaseRolesResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setDatabaseRoles($databaseRoles);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListDatabaseRolesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabaseRolesRequest())->setParent($formattedParent);
         $response = $gapicClient->listDatabaseRoles($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1617,17 +1633,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListDatabaseRolesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabaseRolesRequest())->setParent($formattedParent);
         try {
             $gapicClient->listDatabaseRoles($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1652,17 +1670,14 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $databasesElement = new Database();
-        $databases = [
-            $databasesElement,
-        ];
+        $databases = [$databasesElement];
         $expectedResponse = new ListDatabasesResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setDatabases($databases);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListDatabasesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabasesRequest())->setParent($formattedParent);
         $response = $gapicClient->listDatabases($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1689,17 +1704,19 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListDatabasesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListDatabasesRequest())->setParent($formattedParent);
         try {
             $gapicClient->listDatabases($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1755,9 +1772,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $databaseId = 'databaseId816491103';
-        $request = (new RestoreDatabaseRequest())
-            ->setParent($formattedParent)
-            ->setDatabaseId($databaseId);
+        $request = (new RestoreDatabaseRequest())->setParent($formattedParent)->setDatabaseId($databaseId);
         $response = $gapicClient->restoreDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1815,19 +1830,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $databaseId = 'databaseId816491103';
-        $request = (new RestoreDatabaseRequest())
-            ->setParent($formattedParent)
-            ->setDatabaseId($databaseId);
+        $request = (new RestoreDatabaseRequest())->setParent($formattedParent)->setDatabaseId($databaseId);
         $response = $gapicClient->restoreDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1868,9 +1884,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         $response = $gapicClient->setIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1896,19 +1910,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         try {
             $gapicClient->setIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1936,9 +1951,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         $response = $gapicClient->testIamPermissions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1964,19 +1977,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         try {
             $gapicClient->testIamPermissions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -2016,9 +2030,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $backup = new Backup();
         $updateMask = new FieldMask();
-        $request = (new UpdateBackupRequest())
-            ->setBackup($backup)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateBackupRequest())->setBackup($backup)->setUpdateMask($updateMask);
         $response = $gapicClient->updateBackup($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -2044,19 +2056,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $backup = new Backup();
         $updateMask = new FieldMask();
-        $request = (new UpdateBackupRequest())
-            ->setBackup($backup)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateBackupRequest())->setBackup($backup)->setUpdateMask($updateMask);
         try {
             $gapicClient->updateBackup($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -2086,9 +2099,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $backupSchedule = new BackupSchedule();
         $updateMask = new FieldMask();
-        $request = (new UpdateBackupScheduleRequest())
-            ->setBackupSchedule($backupSchedule)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateBackupScheduleRequest())->setBackupSchedule($backupSchedule)->setUpdateMask($updateMask);
         $response = $gapicClient->updateBackupSchedule($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -2114,19 +2125,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $backupSchedule = new BackupSchedule();
         $updateMask = new FieldMask();
-        $request = (new UpdateBackupScheduleRequest())
-            ->setBackupSchedule($backupSchedule)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateBackupScheduleRequest())->setBackupSchedule($backupSchedule)->setUpdateMask($updateMask);
         try {
             $gapicClient->updateBackupSchedule($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -2184,9 +2196,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         $databaseName = 'databaseName-459093338';
         $database->setName($databaseName);
         $updateMask = new FieldMask();
-        $request = (new UpdateDatabaseRequest())
-            ->setDatabase($database)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateDatabaseRequest())->setDatabase($database)->setUpdateMask($updateMask);
         $response = $gapicClient->updateDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -2244,21 +2254,22 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $database = new Database();
         $databaseName = 'databaseName-459093338';
         $database->setName($databaseName);
         $updateMask = new FieldMask();
-        $request = (new UpdateDatabaseRequest())
-            ->setDatabase($database)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateDatabaseRequest())->setDatabase($database)->setUpdateMask($updateMask);
         $response = $gapicClient->updateDatabase($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -2313,9 +2324,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $statements = [];
-        $request = (new UpdateDatabaseDdlRequest())
-            ->setDatabase($formattedDatabase)
-            ->setStatements($statements);
+        $request = (new UpdateDatabaseDdlRequest())->setDatabase($formattedDatabase)->setStatements($statements);
         $response = $gapicClient->updateDatabaseDdl($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -2373,19 +2382,20 @@ class DatabaseAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $statements = [];
-        $request = (new UpdateDatabaseDdlRequest())
-            ->setDatabase($formattedDatabase)
-            ->setStatements($statements);
+        $request = (new UpdateDatabaseDdlRequest())->setDatabase($formattedDatabase)->setStatements($statements);
         $response = $gapicClient->updateDatabaseDdl($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -2422,9 +2432,7 @@ class DatabaseAdminClientTest extends GeneratedTest
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $splitPoints = [];
-        $request = (new AddSplitPointsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSplitPoints($splitPoints);
+        $request = (new AddSplitPointsRequest())->setDatabase($formattedDatabase)->setSplitPoints($splitPoints);
         $response = $gapicClient->addSplitPointsAsync($request)->wait();
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();

--- a/Spanner/tests/Unit/Admin/Instance/V1/Client/InstanceAdminClientTest.php
+++ b/Spanner/tests/Unit/Admin/Instance/V1/Client/InstanceAdminClientTest.php
@@ -84,7 +84,9 @@ class InstanceAdminClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return InstanceAdminClient */
@@ -208,12 +210,15 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
@@ -359,12 +364,15 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
@@ -458,7 +466,10 @@ class InstanceAdminClientTest extends GeneratedTest
         $this->assertSame(0, count($operationsRequestsEmpty));
         $actualApiFuncCall = $apiRequests[0]->getFuncCall();
         $actualApiRequestObject = $apiRequests[0]->getRequestObject();
-        $this->assertSame('/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstancePartition', $actualApiFuncCall);
+        $this->assertSame(
+            '/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstancePartition',
+            $actualApiFuncCall
+        );
         $actualValue = $actualApiRequestObject->getParent();
         $this->assertProtobufEquals($formattedParent, $actualValue);
         $actualValue = $actualApiRequestObject->getInstancePartitionId();
@@ -508,12 +519,15 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
@@ -564,8 +578,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new DeleteInstanceRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstanceRequest())->setName($formattedName);
         $gapicClient->deleteInstance($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -588,17 +601,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new DeleteInstanceRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstanceRequest())->setName($formattedName);
         try {
             $gapicClient->deleteInstance($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -625,8 +640,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new DeleteInstanceConfigRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstanceConfigRequest())->setName($formattedName);
         $gapicClient->deleteInstanceConfig($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -649,17 +663,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new DeleteInstanceConfigRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstanceConfigRequest())->setName($formattedName);
         try {
             $gapicClient->deleteInstanceConfig($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -686,8 +702,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instancePartitionName('[PROJECT]', '[INSTANCE]', '[INSTANCE_PARTITION]');
-        $request = (new DeleteInstancePartitionRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstancePartitionRequest())->setName($formattedName);
         $gapicClient->deleteInstancePartition($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -710,17 +725,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instancePartitionName('[PROJECT]', '[INSTANCE]', '[INSTANCE_PARTITION]');
-        $request = (new DeleteInstancePartitionRequest())
-            ->setName($formattedName);
+        $request = (new DeleteInstancePartitionRequest())->setName($formattedName);
         try {
             $gapicClient->deleteInstancePartition($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -751,8 +768,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         $response = $gapicClient->getIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -776,17 +792,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
-        $request = (new GetIamPolicyRequest())
-            ->setResource($resource);
+        $request = (new GetIamPolicyRequest())->setResource($resource);
         try {
             $gapicClient->getIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -823,8 +841,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new GetInstanceRequest())
-            ->setName($formattedName);
+        $request = (new GetInstanceRequest())->setName($formattedName);
         $response = $gapicClient->getInstance($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -848,17 +865,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new GetInstanceRequest())
-            ->setName($formattedName);
+        $request = (new GetInstanceRequest())->setName($formattedName);
         try {
             $gapicClient->getInstance($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -897,8 +916,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new GetInstanceConfigRequest())
-            ->setName($formattedName);
+        $request = (new GetInstanceConfigRequest())->setName($formattedName);
         $response = $gapicClient->getInstanceConfig($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -922,17 +940,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new GetInstanceConfigRequest())
-            ->setName($formattedName);
+        $request = (new GetInstanceConfigRequest())->setName($formattedName);
         try {
             $gapicClient->getInstanceConfig($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -969,8 +989,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->instancePartitionName('[PROJECT]', '[INSTANCE]', '[INSTANCE_PARTITION]');
-        $request = (new GetInstancePartitionRequest())
-            ->setName($formattedName);
+        $request = (new GetInstancePartitionRequest())->setName($formattedName);
         $response = $gapicClient->getInstancePartition($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -994,17 +1013,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instancePartitionName('[PROJECT]', '[INSTANCE]', '[INSTANCE_PARTITION]');
-        $request = (new GetInstancePartitionRequest())
-            ->setName($formattedName);
+        $request = (new GetInstancePartitionRequest())->setName($formattedName);
         try {
             $gapicClient->getInstancePartition($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1029,17 +1050,14 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $operationsElement = new Operation();
-        $operations = [
-            $operationsElement,
-        ];
+        $operations = [$operationsElement];
         $expectedResponse = new ListInstanceConfigOperationsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setOperations($operations);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstanceConfigOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstanceConfigOperationsRequest())->setParent($formattedParent);
         $response = $gapicClient->listInstanceConfigOperations($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1049,7 +1067,10 @@ class InstanceAdminClientTest extends GeneratedTest
         $this->assertSame(1, count($actualRequests));
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
-        $this->assertSame('/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations', $actualFuncCall);
+        $this->assertSame(
+            '/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations',
+            $actualFuncCall
+        );
         $actualValue = $actualRequestObject->getParent();
         $this->assertProtobufEquals($formattedParent, $actualValue);
         $this->assertTrue($transport->isExhausted());
@@ -1066,17 +1087,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstanceConfigOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstanceConfigOperationsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listInstanceConfigOperations($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1101,17 +1124,14 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $instanceConfigsElement = new InstanceConfig();
-        $instanceConfigs = [
-            $instanceConfigsElement,
-        ];
+        $instanceConfigs = [$instanceConfigsElement];
         $expectedResponse = new ListInstanceConfigsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setInstanceConfigs($instanceConfigs);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstanceConfigsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstanceConfigsRequest())->setParent($formattedParent);
         $response = $gapicClient->listInstanceConfigs($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1138,17 +1158,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstanceConfigsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstanceConfigsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listInstanceConfigs($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1173,17 +1195,14 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $operationsElement = new Operation();
-        $operations = [
-            $operationsElement,
-        ];
+        $operations = [$operationsElement];
         $expectedResponse = new ListInstancePartitionOperationsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setOperations($operations);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListInstancePartitionOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancePartitionOperationsRequest())->setParent($formattedParent);
         $response = $gapicClient->listInstancePartitionOperations($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1193,7 +1212,10 @@ class InstanceAdminClientTest extends GeneratedTest
         $this->assertSame(1, count($actualRequests));
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
-        $this->assertSame('/google.spanner.admin.instance.v1.InstanceAdmin/ListInstancePartitionOperations', $actualFuncCall);
+        $this->assertSame(
+            '/google.spanner.admin.instance.v1.InstanceAdmin/ListInstancePartitionOperations',
+            $actualFuncCall
+        );
         $actualValue = $actualRequestObject->getParent();
         $this->assertProtobufEquals($formattedParent, $actualValue);
         $this->assertTrue($transport->isExhausted());
@@ -1210,17 +1232,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListInstancePartitionOperationsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancePartitionOperationsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listInstancePartitionOperations($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1245,17 +1269,14 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $instancePartitionsElement = new InstancePartition();
-        $instancePartitions = [
-            $instancePartitionsElement,
-        ];
+        $instancePartitions = [$instancePartitionsElement];
         $expectedResponse = new ListInstancePartitionsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setInstancePartitions($instancePartitions);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListInstancePartitionsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancePartitionsRequest())->setParent($formattedParent);
         $response = $gapicClient->listInstancePartitions($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1282,17 +1303,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
-        $request = (new ListInstancePartitionsRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancePartitionsRequest())->setParent($formattedParent);
         try {
             $gapicClient->listInstancePartitions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1317,17 +1340,14 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $instancesElement = new Instance();
-        $instances = [
-            $instancesElement,
-        ];
+        $instances = [$instancesElement];
         $expectedResponse = new ListInstancesResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setInstances($instances);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstancesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancesRequest())->setParent($formattedParent);
         $response = $gapicClient->listInstances($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -1354,17 +1374,19 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedParent = $gapicClient->projectName('[PROJECT]');
-        $request = (new ListInstancesRequest())
-            ->setParent($formattedParent);
+        $request = (new ListInstancesRequest())->setParent($formattedParent);
         try {
             $gapicClient->listInstances($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1410,9 +1432,7 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $formattedTargetConfig = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new MoveInstanceRequest())
-            ->setName($formattedName)
-            ->setTargetConfig($formattedTargetConfig);
+        $request = (new MoveInstanceRequest())->setName($formattedName)->setTargetConfig($formattedTargetConfig);
         $response = $gapicClient->moveInstance($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1470,19 +1490,20 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->instanceName('[PROJECT]', '[INSTANCE]');
         $formattedTargetConfig = $gapicClient->instanceConfigName('[PROJECT]', '[INSTANCE_CONFIG]');
-        $request = (new MoveInstanceRequest())
-            ->setName($formattedName)
-            ->setTargetConfig($formattedTargetConfig);
+        $request = (new MoveInstanceRequest())->setName($formattedName)->setTargetConfig($formattedTargetConfig);
         $response = $gapicClient->moveInstance($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1523,9 +1544,7 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         $response = $gapicClient->setIamPolicy($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1551,19 +1570,20 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $policy = new Policy();
-        $request = (new SetIamPolicyRequest())
-            ->setResource($resource)
-            ->setPolicy($policy);
+        $request = (new SetIamPolicyRequest())->setResource($resource)->setPolicy($policy);
         try {
             $gapicClient->setIamPolicy($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1591,9 +1611,7 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         $response = $gapicClient->testIamPermissions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1619,19 +1637,20 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $resource = 'resource-341064690';
         $permissions = [];
-        $request = (new TestIamPermissionsRequest())
-            ->setResource($resource)
-            ->setPermissions($permissions);
+        $request = (new TestIamPermissionsRequest())->setResource($resource)->setPermissions($permissions);
         try {
             $gapicClient->testIamPermissions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1693,9 +1712,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $instanceDisplayName = 'instanceDisplayName1824500376';
         $instance->setDisplayName($instanceDisplayName);
         $fieldMask = new FieldMask();
-        $request = (new UpdateInstanceRequest())
-            ->setInstance($instance)
-            ->setFieldMask($fieldMask);
+        $request = (new UpdateInstanceRequest())->setInstance($instance)->setFieldMask($fieldMask);
         $response = $gapicClient->updateInstance($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1753,12 +1770,15 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $instance = new Instance();
@@ -1769,9 +1789,7 @@ class InstanceAdminClientTest extends GeneratedTest
         $instanceDisplayName = 'instanceDisplayName1824500376';
         $instance->setDisplayName($instanceDisplayName);
         $fieldMask = new FieldMask();
-        $request = (new UpdateInstanceRequest())
-            ->setInstance($instance)
-            ->setFieldMask($fieldMask);
+        $request = (new UpdateInstanceRequest())->setInstance($instance)->setFieldMask($fieldMask);
         $response = $gapicClient->updateInstance($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1838,9 +1856,7 @@ class InstanceAdminClientTest extends GeneratedTest
         // Mock request
         $instanceConfig = new InstanceConfig();
         $updateMask = new FieldMask();
-        $request = (new UpdateInstanceConfigRequest())
-            ->setInstanceConfig($instanceConfig)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateInstanceConfigRequest())->setInstanceConfig($instanceConfig)->setUpdateMask($updateMask);
         $response = $gapicClient->updateInstanceConfig($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1898,19 +1914,20 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $instanceConfig = new InstanceConfig();
         $updateMask = new FieldMask();
-        $request = (new UpdateInstanceConfigRequest())
-            ->setInstanceConfig($instanceConfig)
-            ->setUpdateMask($updateMask);
+        $request = (new UpdateInstanceConfigRequest())->setInstanceConfig($instanceConfig)->setUpdateMask($updateMask);
         $response = $gapicClient->updateInstanceConfig($request);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1993,7 +2010,10 @@ class InstanceAdminClientTest extends GeneratedTest
         $this->assertSame(0, count($operationsRequestsEmpty));
         $actualApiFuncCall = $apiRequests[0]->getFuncCall();
         $actualApiRequestObject = $apiRequests[0]->getRequestObject();
-        $this->assertSame('/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstancePartition', $actualApiFuncCall);
+        $this->assertSame(
+            '/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstancePartition',
+            $actualApiFuncCall
+        );
         $actualValue = $actualApiRequestObject->getInstancePartition();
         $this->assertProtobufEquals($instancePartition, $actualValue);
         $actualValue = $actualApiRequestObject->getFieldMask();
@@ -2041,12 +2061,15 @@ class InstanceAdminClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $instancePartition = new InstancePartition();

--- a/Spanner/tests/Unit/V1/Client/SpannerClientTest.php
+++ b/Spanner/tests/Unit/V1/Client/SpannerClientTest.php
@@ -77,7 +77,9 @@ class SpannerClientTest extends GeneratedTest
     /** @return CredentialsWrapper */
     private function createCredentials()
     {
-        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /** @return SpannerClient */
@@ -103,9 +105,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $sessionCount = 185691686;
-        $request = (new BatchCreateSessionsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSessionCount($sessionCount);
+        $request = (new BatchCreateSessionsRequest())->setDatabase($formattedDatabase)->setSessionCount($sessionCount);
         $response = $gapicClient->batchCreateSessions($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -131,19 +131,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $sessionCount = 185691686;
-        $request = (new BatchCreateSessionsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSessionCount($sessionCount);
+        $request = (new BatchCreateSessionsRequest())->setDatabase($formattedDatabase)->setSessionCount($sessionCount);
         try {
             $gapicClient->batchCreateSessions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -175,9 +176,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $mutationGroups = [];
-        $request = (new BatchWriteRequest())
-            ->setSession($formattedSession)
-            ->setMutationGroups($mutationGroups);
+        $request = (new BatchWriteRequest())->setSession($formattedSession)->setMutationGroups($mutationGroups);
         $serverStream = $gapicClient->batchWrite($request);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
         $responses = iterator_to_array($serverStream->readAll());
@@ -208,20 +207,21 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->setStreamingStatus($status);
         $this->assertTrue($transport->isExhausted());
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $mutationGroups = [];
-        $request = (new BatchWriteRequest())
-            ->setSession($formattedSession)
-            ->setMutationGroups($mutationGroups);
+        $request = (new BatchWriteRequest())->setSession($formattedSession)->setMutationGroups($mutationGroups);
         $serverStream = $gapicClient->batchWrite($request);
         $results = $serverStream->readAll();
         try {
@@ -253,9 +253,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $options = new TransactionOptions();
-        $request = (new BeginTransactionRequest())
-            ->setSession($formattedSession)
-            ->setOptions($options);
+        $request = (new BeginTransactionRequest())->setSession($formattedSession)->setOptions($options);
         $response = $gapicClient->beginTransaction($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -281,19 +279,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $options = new TransactionOptions();
-        $request = (new BeginTransactionRequest())
-            ->setSession($formattedSession)
-            ->setOptions($options);
+        $request = (new BeginTransactionRequest())->setSession($formattedSession)->setOptions($options);
         try {
             $gapicClient->beginTransaction($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -321,9 +320,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $mutations = [];
-        $request = (new CommitRequest())
-            ->setSession($formattedSession)
-            ->setMutations($mutations);
+        $request = (new CommitRequest())->setSession($formattedSession)->setMutations($mutations);
         $response = $gapicClient->commit($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -349,19 +346,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $mutations = [];
-        $request = (new CommitRequest())
-            ->setSession($formattedSession)
-            ->setMutations($mutations);
+        $request = (new CommitRequest())->setSession($formattedSession)->setMutations($mutations);
         try {
             $gapicClient->commit($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -394,8 +392,7 @@ class SpannerClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new CreateSessionRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new CreateSessionRequest())->setDatabase($formattedDatabase);
         $response = $gapicClient->createSession($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -419,17 +416,19 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new CreateSessionRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new CreateSessionRequest())->setDatabase($formattedDatabase);
         try {
             $gapicClient->createSession($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -456,8 +455,7 @@ class SpannerClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
-        $request = (new DeleteSessionRequest())
-            ->setName($formattedName);
+        $request = (new DeleteSessionRequest())->setName($formattedName);
         $gapicClient->deleteSession($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -480,17 +478,19 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
-        $request = (new DeleteSessionRequest())
-            ->setName($formattedName);
+        $request = (new DeleteSessionRequest())->setName($formattedName);
         try {
             $gapicClient->deleteSession($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -554,12 +554,15 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
@@ -598,9 +601,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new ExecuteSqlRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new ExecuteSqlRequest())->setSession($formattedSession)->setSql($sql);
         $response = $gapicClient->executeSql($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -626,19 +627,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new ExecuteSqlRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new ExecuteSqlRequest())->setSession($formattedSession)->setSql($sql);
         try {
             $gapicClient->executeSql($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -688,9 +690,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new ExecuteSqlRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new ExecuteSqlRequest())->setSession($formattedSession)->setSql($sql);
         $serverStream = $gapicClient->executeStreamingSql($request);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
         $responses = iterator_to_array($serverStream->readAll());
@@ -721,20 +721,21 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->setStreamingStatus($status);
         $this->assertTrue($transport->isExhausted());
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new ExecuteSqlRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new ExecuteSqlRequest())->setSession($formattedSession)->setSql($sql);
         $serverStream = $gapicClient->executeStreamingSql($request);
         $results = $serverStream->readAll();
         try {
@@ -773,8 +774,7 @@ class SpannerClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new FetchCacheUpdateRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new FetchCacheUpdateRequest())->setDatabase($formattedDatabase);
         $serverStream = $gapicClient->fetchCacheUpdate($request);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
         $responses = iterator_to_array($serverStream->readAll());
@@ -803,18 +803,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->setStreamingStatus($status);
         $this->assertTrue($transport->isExhausted());
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new FetchCacheUpdateRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new FetchCacheUpdateRequest())->setDatabase($formattedDatabase);
         $serverStream = $gapicClient->fetchCacheUpdate($request);
         $results = $serverStream->readAll();
         try {
@@ -849,8 +851,7 @@ class SpannerClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
-        $request = (new GetSessionRequest())
-            ->setName($formattedName);
+        $request = (new GetSessionRequest())->setName($formattedName);
         $response = $gapicClient->getSession($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -874,17 +875,19 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedName = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
-        $request = (new GetSessionRequest())
-            ->setName($formattedName);
+        $request = (new GetSessionRequest())->setName($formattedName);
         try {
             $gapicClient->getSession($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -909,17 +912,14 @@ class SpannerClientTest extends GeneratedTest
         // Mock response
         $nextPageToken = '';
         $sessionsElement = new Session();
-        $sessions = [
-            $sessionsElement,
-        ];
+        $sessions = [$sessionsElement];
         $expectedResponse = new ListSessionsResponse();
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setSessions($sessions);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListSessionsRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new ListSessionsRequest())->setDatabase($formattedDatabase);
         $response = $gapicClient->listSessions($request);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
@@ -946,17 +946,19 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
-        $request = (new ListSessionsRequest())
-            ->setDatabase($formattedDatabase);
+        $request = (new ListSessionsRequest())->setDatabase($formattedDatabase);
         try {
             $gapicClient->listSessions($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -984,9 +986,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new PartitionQueryRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new PartitionQueryRequest())->setSession($formattedSession)->setSql($sql);
         $response = $gapicClient->partitionQuery($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1012,19 +1012,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $sql = 'sql114126';
-        $request = (new PartitionQueryRequest())
-            ->setSession($formattedSession)
-            ->setSql($sql);
+        $request = (new PartitionQueryRequest())->setSession($formattedSession)->setSql($sql);
         try {
             $gapicClient->partitionQuery($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1084,12 +1085,15 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
@@ -1162,12 +1166,15 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
@@ -1206,9 +1213,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $transactionId = '28';
-        $request = (new RollbackRequest())
-            ->setSession($formattedSession)
-            ->setTransactionId($transactionId);
+        $request = (new RollbackRequest())->setSession($formattedSession)->setTransactionId($transactionId);
         $gapicClient->rollback($request);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -1233,19 +1238,20 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage  = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->addResponse(null, $status);
         // Mock request
         $formattedSession = $gapicClient->sessionName('[PROJECT]', '[INSTANCE]', '[DATABASE]', '[SESSION]');
         $transactionId = '28';
-        $request = (new RollbackRequest())
-            ->setSession($formattedSession)
-            ->setTransactionId($transactionId);
+        $request = (new RollbackRequest())->setSession($formattedSession)->setTransactionId($transactionId);
         try {
             $gapicClient->rollback($request);
             // If the $gapicClient method call did not throw, fail the test
@@ -1336,12 +1342,15 @@ class SpannerClientTest extends GeneratedTest
         $status = new stdClass();
         $status->code = Code::DATA_LOSS;
         $status->details = 'internal error';
-        $expectedExceptionMessage = json_encode([
-            'message' => 'internal error',
-            'code' => Code::DATA_LOSS,
-            'status' => 'DATA_LOSS',
-            'details' => [],
-        ], JSON_PRETTY_PRINT);
+        $expectedExceptionMessage = json_encode(
+            [
+                'message' => 'internal error',
+                'code' => Code::DATA_LOSS,
+                'status' => 'DATA_LOSS',
+                'details' => [],
+            ],
+            JSON_PRETTY_PRINT
+        );
         $transport->setStreamingStatus($status);
         $this->assertTrue($transport->isExhausted());
         // Mock request
@@ -1383,9 +1392,7 @@ class SpannerClientTest extends GeneratedTest
         // Mock request
         $formattedDatabase = $gapicClient->databaseName('[PROJECT]', '[INSTANCE]', '[DATABASE]');
         $sessionCount = 185691686;
-        $request = (new BatchCreateSessionsRequest())
-            ->setDatabase($formattedDatabase)
-            ->setSessionCount($sessionCount);
+        $request = (new BatchCreateSessionsRequest())->setDatabase($formattedDatabase)->setSessionCount($sessionCount);
         $response = $gapicClient->batchCreateSessionsAsync($request)->wait();
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();


### PR DESCRIPTION
Updates the prettier target pattern in `Spanner/owlbot.py` from `**/Gapic/*` to `**/Client/*` and formats generated client classes and tests to align Spanner with current repository style standards.

Formatted files:
- Client classes:
  - `Spanner/src/Admin/Database/V1/Client/DatabaseAdminClient.php`
  - `Spanner/src/Admin/Instance/V1/Client/InstanceAdminClient.php`
  - `Spanner/src/V1/Client/SpannerClient.php`
- Unit tests:
  - `Spanner/tests/Unit/Admin/Database/V1/Client/DatabaseAdminClientTest.php`
  - `Spanner/tests/Unit/Admin/Instance/V1/Client/InstanceAdminClientTest.php`
  - `Spanner/tests/Unit/V1/Client/SpannerClientTest.php`

The change to PHP code is generated by running Owlbot copy:
```
docker run --rm --user $(id -u):$(id -g) -v .:/repo -w /repo -v ../googleapis-gen:/googleapis-gen --env HOME=/tmp gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-code  --source-repo=/googleapis-gen --config-file=Spanner/.OwlBot.yaml

docker run --rm --user $(id -u):$(id -g) -v $(pwd):/repo -w /repo   --env HOME=/tmp   gcr.io/cloud-devrel-public-resources/owlbot-php:latest
```
