### PR TITLE
build: Add open-telemetry/api dependency to Core and Gax

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,8 @@
         "guzzlehttp/psr7": "^2.6.3||^3.0",
         "monolog/monolog": "^2.9||^3.0",
         "psr/http-message": "^1.0||^2.0",
-        "google/gax": "^1.38.0"
+        "google/gax": "^1.38.0",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Core/src/Telemetry/TelemetryConfiguration.php
+++ b/Core/src/Telemetry/TelemetryConfiguration.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Telemetry;
+
+/**
+ * Parses and provides telemetry configuration from environment variables.
+ *
+ * @internal
+ */
+class TelemetryConfiguration
+{
+    /**
+     * Determine if tracing is enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isTracingEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_TRACING_ENABLED');
+    }
+
+    /**
+     * Determine if logging is enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isLoggingEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+    }
+
+    /**
+     * Determine if metrics are enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isMetricsEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_METRICS_ENABLED');
+    }
+
+    /**
+     * @param string $specificEnvVar
+     * @return bool
+     */
+    private static function resolveEnabled($specificEnvVar)
+    {
+        $enabled = getenv($specificEnvVar);
+        if ($enabled !== false) {
+            return filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
+        }
+        $legacyEnabled = getenv('GOOGLE_API_ENABLE_TELEMETRY');
+        if ($legacyEnabled !== false) {
+            return filter_var($legacyEnabled, FILTER_VALIDATE_BOOLEAN);
+        }
+        return false;
+    }
+}

--- a/Core/tests/Unit/Telemetry/TelemetryConfigurationTest.php
+++ b/Core/tests/Unit/Telemetry/TelemetryConfigurationTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Tests\Unit\Telemetry;
+
+use Google\Cloud\Core\Telemetry\TelemetryConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group core
+ * @group telemetry
+ */
+class TelemetryConfigurationTest extends TestCase
+{
+    private $originalTracingEnabled;
+    private $originalLoggingEnabled;
+    private $originalMetricsEnabled;
+    private $originalLegacyTelemetry;
+
+    public function setUp(): void
+    {
+        $this->originalTracingEnabled = getenv('GOOGLE_SDK_PHP_TRACING_ENABLED');
+        $this->originalLoggingEnabled = getenv('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+        $this->originalMetricsEnabled = getenv('GOOGLE_SDK_PHP_METRICS_ENABLED');
+        $this->originalLegacyTelemetry = getenv('GOOGLE_API_ENABLE_TELEMETRY');
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED');
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY');
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->originalTracingEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_TRACING_ENABLED={$this->originalTracingEnabled}");
+        }
+        if ($this->originalLoggingEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_LOGGING_ENABLED={$this->originalLoggingEnabled}");
+        }
+        if ($this->originalMetricsEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_METRICS_ENABLED={$this->originalMetricsEnabled}");
+        }
+        if ($this->originalLegacyTelemetry !== false) {
+            putenv("GOOGLE_API_ENABLE_TELEMETRY={$this->originalLegacyTelemetry}");
+        }
+    }
+
+    public function testIsTracingEnabledDefaultFalse()
+    {
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledWithSpecificEnv()
+    {
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=true');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=false');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledWithLegacyEnv()
+    {
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledPrecedence()
+    {
+        // Specific flag takes precedence over legacy flag
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsLoggingEnabledPrecedence()
+    {
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isLoggingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isLoggingEnabled());
+    }
+
+    public function testIsMetricsEnabledPrecedence()
+    {
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isMetricsEnabled());
+
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isMetricsEnabled());
+    }
+}

--- a/Gax/composer.json
+++ b/Gax/composer.json
@@ -17,7 +17,8 @@
         "guzzlehttp/psr7": "^2.6.3||^3.0",
         "google/common-protos": "^4.9",
         "google/longrunning": "~0.4",
-        "ramsey/uuid": "^4.0"
+        "ramsey/uuid": "^4.0",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/Gax/src/Options/ClientOptions.php
+++ b/Gax/src/Options/ClientOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2023 Google LLC
  * All rights reserved.
@@ -38,6 +39,8 @@ use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\Auth\FetchAuthTokenInterface;
 use InvalidArgumentException;
+use OpenTelemetry\API\Logs\LoggerProviderInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -98,6 +101,12 @@ class ClientOptions implements ArrayAccess, OptionsInterface
     private ?string $apiKey;
 
     private null|false|LoggerInterface $logger;
+
+    /** @var TracerProviderInterface|null */
+    private $tracerProvider;
+
+    /** @var LoggerProviderInterface|null */
+    private $loggerProvider;
 
     /**
      * @param array $options {
@@ -169,6 +178,10 @@ class ClientOptions implements ArrayAccess, OptionsInterface
      *          The API key to be used for the client.
      *     @type null|false|LoggerInterface
      *           A PSR-3 compliant logger.
+     *     @type TracerProviderInterface|null $tracerProvider
+     *           A tracer provider for OpenTelemetry.
+     *     @type LoggerProviderInterface|null $loggerProvider
+     *           A logger provider for OpenTelemetry.
      * }
      */
     public function __construct(array $options)
@@ -200,6 +213,8 @@ class ClientOptions implements ArrayAccess, OptionsInterface
         $this->setUniverseDomain($arr['universeDomain'] ?? null);
         $this->setApiKey($arr['apiKey'] ?? null);
         $this->setLogger($arr['logger'] ?? null);
+        $this->setTracerProvider($arr['tracerProvider'] ?? null);
+        $this->setLoggerProvider($arr['loggerProvider'] ?? null);
     }
 
     /**
@@ -417,5 +432,45 @@ class ClientOptions implements ArrayAccess, OptionsInterface
         $this->logger = $logger;
 
         return $this;
+    }
+
+    /**
+     * @param TracerProviderInterface|null $tracerProvider
+     *
+     * @return $this
+     */
+    public function setTracerProvider($tracerProvider): self
+    {
+        $this->tracerProvider = $tracerProvider;
+
+        return $this;
+    }
+
+    /**
+     * @param LoggerProviderInterface|null $loggerProvider
+     *
+     * @return $this
+     */
+    public function setLoggerProvider($loggerProvider): self
+    {
+        $this->loggerProvider = $loggerProvider;
+
+        return $this;
+    }
+
+    /**
+     * @return TracerProviderInterface|null
+     */
+    public function getTracerProvider()
+    {
+        return $this->tracerProvider;
+    }
+
+    /**
+     * @return LoggerProviderInterface|null
+     */
+    public function getLoggerProvider()
+    {
+        return $this->loggerProvider;
     }
 }

--- a/Gax/tests/Unit/Options/ClientOptionsTest.php
+++ b/Gax/tests/Unit/Options/ClientOptionsTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\ApiCore\Tests\Unit\Options;
+
+use Google\ApiCore\Options\ClientOptions;
+use PHPUnit\Framework\TestCase;
+use OpenTelemetry\API\Logs\LoggerProviderInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+
+class ClientOptionsTest extends TestCase
+{
+    public function testSetAndGetTracerProvider()
+    {
+        $tracerProvider = $this->createMock(TracerProviderInterface::class);
+        $options = new ClientOptions([]);
+        $options->setTracerProvider($tracerProvider);
+        $this->assertSame($tracerProvider, $options->getTracerProvider());
+    }
+
+    public function testSetAndGetLoggerProvider()
+    {
+        $loggerProvider = $this->createMock(LoggerProviderInterface::class);
+        $options = new ClientOptions([]);
+        $options->setLoggerProvider($loggerProvider);
+        $this->assertSame($loggerProvider, $options->getLoggerProvider());
+    }
+    
+    public function testConstructorInjection()
+    {
+        $tracerProvider = $this->createMock(TracerProviderInterface::class);
+        $loggerProvider = $this->createMock(LoggerProviderInterface::class);
+        
+        $options = new ClientOptions([
+            'tracerProvider' => $tracerProvider,
+            'loggerProvider' => $loggerProvider,
+        ]);
+        
+        $this->assertSame($tracerProvider, $options->getTracerProvider());
+        $this->assertSame($loggerProvider, $options->getLoggerProvider());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "google/protobuf": "^4.31||^5.34",
         "google/grpc-gcp": "^0.4",
         "ramsey/uuid": "^4.0",
-        "open-telemetry/sdk": "^1.13"
+        "open-telemetry/sdk": "^1.13",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
## Description
This PR implements **Phase 1 Task 2** of the Client Libraries Observability v1 design.

Depends on #9573.

### Changes
* Adds the `open-telemetry/api` dependency to both `Core` and `Gax` `composer.json` files.
* Relying directly on the community standard OpenTelemetry API avoids the maintenance burden of building and supporting custom abstraction wrappers. The OTel API is designed to safely no-op if an SDK is not present in the user's environment.