### PR TITLE
chore(Spanner): update staging paths for Database and Instance Admin

### DIFF
--- a/Spanner/.OwlBot.yaml
+++ b/Spanner/.OwlBot.yaml
@@ -2,7 +2,7 @@ deep-copy-regex:
     - source: /google/spanner/(v1)/.*-php/(.*)
       dest: /owl-bot-staging/Spanner/$1/$2
     - source: /google/spanner/admin/database/(v1)/.*-php/(.*)
-      dest: /owl-bot-staging/Spanner/$1/Admin/Database/$1/$2
+      dest: /owl-bot-staging/Spanner/Admin/Database/$1/$2
     - source: /google/spanner/admin/instance/(v1)/.*-php/(.*)
-      dest: /owl-bot-staging/Spanner/$1/Admin/Instance/$1/$2
+      dest: /owl-bot-staging/Spanner/Admin/Instance/$1/$2
 api-name: Spanner

--- a/Spanner/owlbot.py
+++ b/Spanner/owlbot.py
@@ -41,7 +41,7 @@ php.owlbot_main(
 )
 
 # Spanner Database Admin also lives here
-admin_library = Path(f"../{php.STAGING_DIR}/Spanner/v1/Admin/Database/v1").resolve()
+admin_library = Path(f"../{php.STAGING_DIR}/Spanner/Admin/Database/v1").resolve()
 
 # copy all src except handwritten partial veneers
 s.move(admin_library / f'src/V1/Gapic', 'src/Admin/Database/V1/Gapic', merge=php._merge)
@@ -56,7 +56,7 @@ s.move(admin_library / f'tests/Unit', 'tests/Unit/Admin/Database', merge=php._me
 s.move(admin_library / f'proto/src/GPBMetadata/Google/Spanner', f'metadata/', merge=php._merge)
 
 # Spanner Instance Admin also lives here
-admin_library = Path(f"../{php.STAGING_DIR}/Spanner/v1/Admin/Instance/v1").resolve()
+admin_library = Path(f"../{php.STAGING_DIR}/Spanner/Admin/Instance/v1").resolve()
 
 # copy all src except handwritten partial veneers
 s.move(admin_library / f'src/V1/Gapic', 'src/Admin/Instance/V1/Gapic', merge=php._merge)


### PR DESCRIPTION
Updates the staging destination paths in `Spanner/.OwlBot.yaml` and `Spanner/owlbot.py` so that Database Admin and Instance Admin are staged as siblings under `Admin/` (`Admin/Database/v1` and `Admin/Instance/v1`) rather than nested inside `v1/`.

This prevents post-processor path collisions and duplicate method generation.

Rerun Owlbot pipeline without any code change:
```
docker run --rm --user $(id -u):$(id -g) -v .:/repo -w /repo -v ../googleapis-gen:/googleapis-gen --env HOME=/tmp gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-code  --source-repo=/googleapis-gen --config-file=Spanner/.OwlBot.yaml

docker run --rm --user $(id -u):$(id -g) -v $(pwd):/repo -w /repo   --env HOME=/tmp   gcr.io/cloud-devrel-public-resources/owlbot-php:latest
```

Fixes https://github.com/googleapis/librarian/issues/7391
