### PR TITLE
chore: fix PHPStan failures for PHP 8.4 and unmatched ignores

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,10 @@ parameters:
         - Logging/src/LogMessageProcessor/MonologV3MessageProcessor.php
         # ignore GAX because we implement a stricter phpstan.neon.dist there
         - Gax
+    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
+        - identifier: unset.possiblyHookedProperty
         # Protobuf constant classes sometimes contain multiple values for one array key
         - identifier: array.duplicateKey
         # Ignore this error because I don't consider it to be level 0


### PR DESCRIPTION
This PR fixes recent PHPStan CI failures related to PHP 8.4 property hooks and unmatched ignores. 

The gapic-generator-php has started generating `protected` properties, which causes PHPStan to fail with `unset.possiblyHookedProperty` since PHP 8.4 added property hooks. Also, as obsolete files are being cleaned up across the repository, the `array.duplicateKey` ignore rule is occasionally left unmatched, causing the CI to fail.

We can fix this by:
1. Adding `unset.possiblyHookedProperty` to `phpstan.neon.dist` `ignoreErrors`.
2. Adding `reportUnmatchedIgnoredErrors: false` to `phpstan.neon.dist`.

This was originally included in #9555 but split into a separate PR to keep changes isolated.