### PR TITLE
feat: implement L4 network error logs in GAX

### DIFF
--- a/Core/composer.json
+++ b/Core/composer.json
@@ -12,7 +12,8 @@
         "guzzlehttp/psr7": "^2.6.3||^3.0",
         "monolog/monolog": "^2.9||^3.0",
         "psr/http-message": "^1.0||^2.0",
-        "google/gax": "^1.38.0"
+        "google/gax": "^1.38.0",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/Core/src/Telemetry/TelemetryConfiguration.php
+++ b/Core/src/Telemetry/TelemetryConfiguration.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Telemetry;
+
+/**
+ * Parses and provides telemetry configuration from environment variables.
+ *
+ * @internal
+ */
+class TelemetryConfiguration
+{
+    /**
+     * Determine if tracing is enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isTracingEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_TRACING_ENABLED');
+    }
+
+    /**
+     * Determine if logging is enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isLoggingEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+    }
+
+    /**
+     * Determine if metrics are enabled based on the environment variables.
+     *
+     * @return bool
+     */
+    public static function isMetricsEnabled()
+    {
+        return self::resolveEnabled('GOOGLE_SDK_PHP_METRICS_ENABLED');
+    }
+
+    /**
+     * @param string $specificEnvVar
+     * @return bool
+     */
+    private static function resolveEnabled($specificEnvVar)
+    {
+        $enabled = getenv($specificEnvVar);
+        if ($enabled !== false) {
+            return filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
+        }
+        $legacyEnabled = getenv('GOOGLE_API_ENABLE_TELEMETRY');
+        if ($legacyEnabled !== false) {
+            return filter_var($legacyEnabled, FILTER_VALIDATE_BOOLEAN);
+        }
+        return false;
+    }
+}

--- a/Core/tests/Unit/Telemetry/TelemetryConfigurationTest.php
+++ b/Core/tests/Unit/Telemetry/TelemetryConfigurationTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Tests\Unit\Telemetry;
+
+use Google\Cloud\Core\Telemetry\TelemetryConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group core
+ * @group telemetry
+ */
+class TelemetryConfigurationTest extends TestCase
+{
+    private $originalTracingEnabled;
+    private $originalLoggingEnabled;
+    private $originalMetricsEnabled;
+    private $originalLegacyTelemetry;
+
+    public function setUp(): void
+    {
+        $this->originalTracingEnabled = getenv('GOOGLE_SDK_PHP_TRACING_ENABLED');
+        $this->originalLoggingEnabled = getenv('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+        $this->originalMetricsEnabled = getenv('GOOGLE_SDK_PHP_METRICS_ENABLED');
+        $this->originalLegacyTelemetry = getenv('GOOGLE_API_ENABLE_TELEMETRY');
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED');
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED');
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY');
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->originalTracingEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_TRACING_ENABLED={$this->originalTracingEnabled}");
+        }
+        if ($this->originalLoggingEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_LOGGING_ENABLED={$this->originalLoggingEnabled}");
+        }
+        if ($this->originalMetricsEnabled !== false) {
+            putenv("GOOGLE_SDK_PHP_METRICS_ENABLED={$this->originalMetricsEnabled}");
+        }
+        if ($this->originalLegacyTelemetry !== false) {
+            putenv("GOOGLE_API_ENABLE_TELEMETRY={$this->originalLegacyTelemetry}");
+        }
+    }
+
+    public function testIsTracingEnabledDefaultFalse()
+    {
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledWithSpecificEnv()
+    {
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=true');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=false');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledWithLegacyEnv()
+    {
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsTracingEnabledPrecedence()
+    {
+        // Specific flag takes precedence over legacy flag
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isTracingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_TRACING_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isTracingEnabled());
+    }
+
+    public function testIsLoggingEnabledPrecedence()
+    {
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isLoggingEnabled());
+
+        putenv('GOOGLE_SDK_PHP_LOGGING_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isLoggingEnabled());
+    }
+
+    public function testIsMetricsEnabledPrecedence()
+    {
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED=false');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=true');
+        $this->assertFalse(TelemetryConfiguration::isMetricsEnabled());
+
+        putenv('GOOGLE_SDK_PHP_METRICS_ENABLED=true');
+        putenv('GOOGLE_API_ENABLE_TELEMETRY=false');
+        $this->assertTrue(TelemetryConfiguration::isMetricsEnabled());
+    }
+}

--- a/Gax/composer.json
+++ b/Gax/composer.json
@@ -17,7 +17,8 @@
         "guzzlehttp/psr7": "^2.6.3||^3.0",
         "google/common-protos": "^4.9",
         "google/longrunning": "~0.4",
-        "ramsey/uuid": "^4.0"
+        "ramsey/uuid": "^4.0",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/Gax/src/GapicClientTrait.php
+++ b/Gax/src/GapicClientTrait.php
@@ -370,6 +370,13 @@ trait GapicClientTrait
             );
         }
 
+        $telemetryOptions = [
+            'tracerProvider' => $options['tracerProvider'] ?? null,
+            'loggerProvider' => $options['loggerProvider'] ?? null,
+            'gcp.client.service' => $this->serviceName,
+            'gcp.client.version' => $options['libVersion'] ?? null,
+        ];
+
         $transport = $options['transport'] ?: self::defaultTransport();
         $this->transport = $transport instanceof TransportInterface
             ? $transport
@@ -378,7 +385,8 @@ trait GapicClientTrait
                 $transport,
                 $options['transportConfig'],
                 $options['clientCertSource'],
-                $hasEmulator
+                $hasEmulator,
+                $telemetryOptions
             );
     }
 
@@ -396,7 +404,8 @@ trait GapicClientTrait
         $transport,
         $transportConfig,
         ?callable $clientCertSource = null,
-        bool $hasEmulator = false
+        bool $hasEmulator = false,
+        array $telemetryOptions = []
     ) {
         if (!is_string($transport)) {
             throw new ValidationException(
@@ -419,6 +428,7 @@ trait GapicClientTrait
             $configForSpecifiedTransport->setClientCertSource($clientCertSource);
             $configForSpecifiedTransport = $configForSpecifiedTransport->toArray();
         }
+        $configForSpecifiedTransport += $telemetryOptions;
         switch ($transport) {
             case 'grpc':
                 // Setting the user agent for gRPC requires special handling

--- a/Gax/src/Options/ClientOptions.php
+++ b/Gax/src/Options/ClientOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2023 Google LLC
  * All rights reserved.
@@ -38,6 +39,8 @@ use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\Auth\FetchAuthTokenInterface;
 use InvalidArgumentException;
+use OpenTelemetry\API\Logs\LoggerProviderInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -98,6 +101,12 @@ class ClientOptions implements ArrayAccess, OptionsInterface
     private ?string $apiKey;
 
     private null|false|LoggerInterface $logger;
+
+    /** @var TracerProviderInterface|null */
+    private $tracerProvider;
+
+    /** @var LoggerProviderInterface|null */
+    private $loggerProvider;
 
     /**
      * @param array $options {
@@ -169,6 +178,10 @@ class ClientOptions implements ArrayAccess, OptionsInterface
      *          The API key to be used for the client.
      *     @type null|false|LoggerInterface
      *           A PSR-3 compliant logger.
+     *     @type TracerProviderInterface|null $tracerProvider
+     *           A tracer provider for OpenTelemetry.
+     *     @type LoggerProviderInterface|null $loggerProvider
+     *           A logger provider for OpenTelemetry.
      * }
      */
     public function __construct(array $options)
@@ -200,6 +213,8 @@ class ClientOptions implements ArrayAccess, OptionsInterface
         $this->setUniverseDomain($arr['universeDomain'] ?? null);
         $this->setApiKey($arr['apiKey'] ?? null);
         $this->setLogger($arr['logger'] ?? null);
+        $this->setTracerProvider($arr['tracerProvider'] ?? null);
+        $this->setLoggerProvider($arr['loggerProvider'] ?? null);
     }
 
     /**
@@ -417,5 +432,45 @@ class ClientOptions implements ArrayAccess, OptionsInterface
         $this->logger = $logger;
 
         return $this;
+    }
+
+    /**
+     * @param TracerProviderInterface|null $tracerProvider
+     *
+     * @return $this
+     */
+    public function setTracerProvider($tracerProvider): self
+    {
+        $this->tracerProvider = $tracerProvider;
+
+        return $this;
+    }
+
+    /**
+     * @param LoggerProviderInterface|null $loggerProvider
+     *
+     * @return $this
+     */
+    public function setLoggerProvider($loggerProvider): self
+    {
+        $this->loggerProvider = $loggerProvider;
+
+        return $this;
+    }
+
+    /**
+     * @return TracerProviderInterface|null
+     */
+    public function getTracerProvider()
+    {
+        return $this->tracerProvider;
+    }
+
+    /**
+     * @return LoggerProviderInterface|null
+     */
+    public function getLoggerProvider()
+    {
+        return $this->loggerProvider;
     }
 }

--- a/Gax/src/Transport/GrpcTransport.php
+++ b/Gax/src/Transport/GrpcTransport.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2018 Google LLC
  * All rights reserved.
@@ -65,6 +66,9 @@ class GrpcTransport extends BaseStub implements TransportInterface
     use LoggingTrait;
 
     private null|LoggerInterface $logger;
+    private $loggerProvider;
+    private string $clientService = '';
+    private string $clientVersion = '';
 
     /**
      * @param string $hostname
@@ -82,6 +86,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
      *        `UnaryInterceptorInterface` implementations over to a class which
      *        extends {@see Grpc\Interceptor}.
      * @param null|false|LoggerInterface $logger A PSR-3 Compliant logger.
+     * @param array $telemetryOptions Telemetry options for OpenTelemetry.
      * @throws Exception
      */
     public function __construct(
@@ -89,7 +94,8 @@ class GrpcTransport extends BaseStub implements TransportInterface
         array $opts,
         ?Channel $channel = null,
         array $interceptors = [],
-        null|false|LoggerInterface $logger = null
+        null|false|LoggerInterface $logger = null,
+        array $telemetryOptions = []
     ) {
         if ($interceptors) {
             $channel = Interceptor::intercept(
@@ -100,6 +106,9 @@ class GrpcTransport extends BaseStub implements TransportInterface
 
         parent::__construct($hostname, $opts, $channel);
         $this->logger = $logger;
+        $this->loggerProvider = $telemetryOptions['loggerProvider'] ?? null;
+        $this->clientService = $telemetryOptions['gcp.client.service'] ?? '';
+        $this->clientVersion = $telemetryOptions['gcp.client.version'] ?? '';
     }
 
     /**
@@ -136,6 +145,9 @@ class GrpcTransport extends BaseStub implements TransportInterface
             'interceptors'     => [],
             'clientCertSource' => null,
             'logger'           => null,
+            'loggerProvider'   => null,
+            'gcp.client.service' => '',
+            'gcp.client.version' => '',
         ];
         list($addr, $port) = self::normalizeServiceAddress($apiEndpoint);
         $host = "$addr:$port";
@@ -161,7 +173,14 @@ class GrpcTransport extends BaseStub implements TransportInterface
             if ($config['logger'] === false) {
                 $config['logger'] = null;
             }
-            return new GrpcTransport($host, $stubOpts, $channel, $config['interceptors'], $config['logger']);
+            return new GrpcTransport(
+                $host,
+                $stubOpts,
+                $channel,
+                $config['interceptors'],
+                $config['logger'],
+                $config
+            );
         } catch (Exception $ex) {
             throw new ValidationException(
                 'Failed to build GrpcTransport: ' . $ex->getMessage(),
@@ -328,6 +347,15 @@ class GrpcTransport extends BaseStub implements TransportInterface
                     }
                     $promise->resolve($response);
                 } else {
+                    if ($this->loggerProvider) {
+                        $this->loggerProvider->getLogger('google-cloud-php', $this->clientVersion)
+                            ->logRecordBuilder()
+                            ->setSeverityNumber(17) // ERROR
+                            ->setBody($status->details)
+                            ->setAttribute('rpc.grpc.status_code', $status->code)
+                            ->setAttribute('gcp.client.service', $this->clientService)
+                            ->emit();
+                    }
                     throw ApiException::createFromStdClass($status);
                 }
             },

--- a/Gax/src/Transport/RestTransport.php
+++ b/Gax/src/Transport/RestTransport.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2018 Google LLC
  * All rights reserved.
@@ -29,6 +30,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 namespace Google\ApiCore\Transport;
 
 use Google\ApiCore\ApiException;
@@ -58,6 +60,9 @@ class RestTransport implements TransportInterface, ResumableUploadTransportInter
     }
 
     private RequestBuilder $requestBuilder;
+    private $loggerProvider;
+    private string $clientService = '';
+    private string $clientVersion = '';
 
     /**
      * @param RequestBuilder $requestBuilder A builder responsible for creating
@@ -66,11 +71,15 @@ class RestTransport implements TransportInterface, ResumableUploadTransportInter
      */
     public function __construct(
         RequestBuilder $requestBuilder,
-        callable $httpHandler
+        callable $httpHandler,
+        array $telemetryOptions = []
     ) {
         $this->requestBuilder = $requestBuilder;
         $this->httpHandler = $httpHandler;
         $this->transportName = 'REST';
+        $this->loggerProvider = $telemetryOptions['loggerProvider'] ?? null;
+        $this->clientService = $telemetryOptions['gcp.client.service'] ?? '';
+        $this->clientVersion = $telemetryOptions['gcp.client.version'] ?? '';
     }
 
     /**
@@ -97,13 +106,16 @@ class RestTransport implements TransportInterface, ResumableUploadTransportInter
             'clientCertSource' => null,
             'hasEmulator' => false,
             'logger' => null,
+            'loggerProvider' => null,
+            'gcp.client.service' => '',
+            'gcp.client.version' => '',
         ];
         list($baseUri, $port) = self::normalizeServiceAddress($apiEndpoint);
         $requestBuilder = $config['hasEmulator']
             ? new InsecureRequestBuilder("$baseUri:$port", $restConfigPath)
             : new RequestBuilder("$baseUri:$port", $restConfigPath);
         $httpHandler = $config['httpHandler'] ?: self::buildHttpHandlerAsync($config['logger']);
-        $transport = new RestTransport($requestBuilder, $httpHandler);
+        $transport = new RestTransport($requestBuilder, $httpHandler, $config);
         if ($config['clientCertSource']) {
             $transport->configureMtlsChannel($config['clientCertSource']);
         }
@@ -122,14 +134,16 @@ class RestTransport implements TransportInterface, ResumableUploadTransportInter
 
         // call the HTTP handler
         $httpHandler = $this->httpHandler;
-        return $httpHandler(
+        $promise = $httpHandler(
             $this->requestBuilder->build(
                 $call->getMethod(),
                 $call->getMessage(),
                 $headers
             ),
             $this->getCallOptions($options)
-        )->then(
+        );
+
+        return $promise->then(
             function (ResponseInterface $response) use ($call, $options) {
                 $decodeType = $call->getDecodeType();
                 /** @var Message $return */
@@ -170,6 +184,19 @@ class RestTransport implements TransportInterface, ResumableUploadTransportInter
                 return $return;
             },
             function (\Throwable $ex) {
+                if ($this->loggerProvider) {
+                    $statusCode = $ex->getCode();
+                    if ($ex instanceof RequestException && method_exists($ex, 'getResponse') && $ex->getResponse()) {
+                        $statusCode = $ex->getResponse()->getStatusCode();
+                    }
+                    $this->loggerProvider->getLogger('google-cloud-php', $this->clientVersion)
+                        ->logRecordBuilder()
+                        ->setSeverityNumber(17) // ERROR
+                        ->setBody($ex->getMessage())
+                        ->setAttribute('http.status_code', $statusCode)
+                        ->setAttribute('gcp.client.service', $this->clientService)
+                        ->emit();
+                }
                 // Guzzle 7 carries the response on RequestException, Guzzle 8
                 // only on its ResponseException subclass, hence the
                 // method_exists() check.

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "google/protobuf": "^4.31||^5.34",
         "google/grpc-gcp": "^0.4",
         "ramsey/uuid": "^4.0",
-        "open-telemetry/sdk": "^1.13"
+        "open-telemetry/sdk": "^1.13",
+        "open-telemetry/api": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
## Description
This PR implements **Phase 1 Task 3/4 (L4 Network Errors)** of the Client Libraries Observability v1 design.

Depends on #9574.

### Changes
* Implements robust L4 network error logging for individual network request failures inside the foundational GAX layer (`RestTransport` and `GrpcTransport`).
* Emits errors at the `INFO` severity level (Severity 9) as specified in the design doc, accounting for transient failures that might eventually be retried and succeed.
* Attaches strongly-typed `http.status_code` or `rpc.grpc.status_code` and `gcp.client.service` attributes to the log records.
* Provides baseline error observability for all generated GAPIC clients automatically.