### PR TITLE
chore(Firestore): update staging paths for Admin

### DIFF
--- a/Firestore/.OwlBot.yaml
+++ b/Firestore/.OwlBot.yaml
@@ -2,5 +2,5 @@ deep-copy-regex:
     - source: /google/firestore/(v1)/.*-php/(.*)
       dest: /owl-bot-staging/Firestore/$1/$2
     - source: /google/firestore/admin/(v1)/.*-php/(.*)
-      dest: /owl-bot-staging/Firestore/$1/Admin/$2
+      dest: /owl-bot-staging/Firestore/Admin/$1/$2
 api-name: Firestore

--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -44,7 +44,7 @@ php.owlbot_main(
 )
 
 # Firestore Admin also lives here
-admin_library = Path(f"../{php.STAGING_DIR}/Firestore/v1/Admin").resolve()
+admin_library = Path(f"../{php.STAGING_DIR}/Firestore/Admin/v1").resolve()
 
 # copy all src
 s.move(


### PR DESCRIPTION
Updates the staging destination paths in `Firestore/.OwlBot.yaml` and `Firestore/owlbot.py` so that Admin is staged as a sibling under `Admin/v1` rather than nested inside `v1/`.

This prevents post-processor path collisions and duplicate method generation.

Rerun Owlbot pipeline without any code change:
```
docker run --rm --user $(id -u):$(id -g) -v .:/repo -w /repo -v ../googleapis-gen:/googleapis-gen --env HOME=/tmp gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-code  --source-repo=/googleapis-gen --config-file=Firestore/.OwlBot.yaml

docker run --rm --user $(id -u):$(id -g) -v $(pwd):/repo -w /repo   --env HOME=/tmp   gcr.io/cloud-devrel-public-resources/owlbot-php:latest
```

For https://github.com/googleapis/librarian/issues/7391