### PR TITLE
chore(BinaryAuthorization): remove deprecated V1Beta1 metadata

### DIFF
--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/create_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/create_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/delete_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/delete_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_policy.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/list_attestors.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/list_attestors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_policy.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/SystemPolicyV1Client/get_system_policy.php
+++ b/BinaryAuthorization/samples/V1/SystemPolicyV1Client/get_system_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/ValidationHelperV1Client/validate_attestation_occurrence.php
+++ b/BinaryAuthorization/samples/V1/ValidationHelperV1Client/validate_attestation_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/BinauthzManagementServiceV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/BinauthzManagementServiceV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/SystemPolicyV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/SystemPolicyV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/ValidationHelperV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/ValidationHelperV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/system_policy_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/system_policy_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/system_policy_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/system_policy_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/validation_helper_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/validation_helper_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/validation_helper_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/validation_helper_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/BinauthzManagementServiceV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/BinauthzManagementServiceV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/SystemPolicyV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/SystemPolicyV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/ValidationHelperV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/ValidationHelperV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The V1Beta1 API was removed from the OwlBot config, so this cleans up the obsolete generated metadata.