### PR TITLE
chore: update copyright years to 2026 for generated files (part 2: AlloyDb to ArtifactRegistry)

### DIFF
--- a/AlloyDb/owlbot.py
+++ b/AlloyDb/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/batch_create_instances.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/batch_create_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_backup.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_secondary_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_secondary_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_secondary_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_secondary_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/create_user.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/create_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/delete_backup.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/delete_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/delete_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/delete_user.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/delete_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/execute_sql.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/execute_sql.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/export_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/export_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/failover_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/failover_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/generate_client_certificate.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/generate_client_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_backup.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_connection_info.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_connection_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_location.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/get_user.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/get_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/import_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/import_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/inject_fault.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/inject_fault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_backups.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_clusters.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_databases.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_databases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_instances.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_locations.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_supported_database_flags.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_supported_database_flags.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/list_users.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/list_users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/promote_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/promote_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/restart_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/restart_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/restore_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/restore_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/switchover_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/switchover_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/update_backup.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/update_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/update_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/update_instance.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/update_user.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/update_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBAdminClient/upgrade_cluster.php
+++ b/AlloyDb/samples/V1/AlloyDBAdminClient/upgrade_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/get_location.php
+++ b/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/list_locations.php
+++ b/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/restore_from_cloud_sql.php
+++ b/AlloyDb/samples/V1/AlloyDBCSQLAdminClient/restore_from_cloud_sql.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/Client/AlloyDBAdminClient.php
+++ b/AlloyDb/src/V1/Client/AlloyDBAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/Client/AlloyDBCSQLAdminClient.php
+++ b/AlloyDb/src/V1/Client/AlloyDBCSQLAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/resources/alloy_db_admin_descriptor_config.php
+++ b/AlloyDb/src/V1/resources/alloy_db_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/resources/alloy_db_admin_rest_client_config.php
+++ b/AlloyDb/src/V1/resources/alloy_db_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/resources/alloy_dbcsql_admin_descriptor_config.php
+++ b/AlloyDb/src/V1/resources/alloy_dbcsql_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/src/V1/resources/alloy_dbcsql_admin_rest_client_config.php
+++ b/AlloyDb/src/V1/resources/alloy_dbcsql_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/tests/Unit/V1/Client/AlloyDBAdminClientTest.php
+++ b/AlloyDb/tests/Unit/V1/Client/AlloyDBAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AlloyDb/tests/Unit/V1/Client/AlloyDBCSQLAdminClientTest.php
+++ b/AlloyDb/tests/Unit/V1/Client/AlloyDBCSQLAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/owlbot.py
+++ b/AnalyticsAdmin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/acknowledge_user_data_collection.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/acknowledge_user_data_collection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/approve_display_video360_advertiser_link_proposal.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/approve_display_video360_advertiser_link_proposal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_audience.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_audience.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/archive_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_create_access_bindings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_create_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_delete_access_bindings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_delete_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_get_access_bindings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_get_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_update_access_bindings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/batch_update_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/cancel_display_video360_advertiser_link_proposal.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/cancel_display_video360_advertiser_link_proposal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_access_binding.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_ad_sense_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_ad_sense_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_audience.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_audience.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_big_query_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_big_query_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_calculated_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_calculated_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_channel_group.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_channel_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_data_stream.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_display_video360_advertiser_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_display_video360_advertiser_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_display_video360_advertiser_link_proposal.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_display_video360_advertiser_link_proposal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_event_create_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_event_create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_event_edit_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_event_edit_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_expanded_data_set.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_expanded_data_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_firebase_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_firebase_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_key_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_property.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_reporting_data_annotation.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_reporting_data_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_rollup_property.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_rollup_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_rollup_property_source_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_rollup_property_source_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_search_ads360_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_search_ads360_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_sk_ad_network_conversion_value_schema.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_sk_ad_network_conversion_value_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_subproperty_event_filter.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/create_subproperty_event_filter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_access_binding.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_account.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_ad_sense_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_ad_sense_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_big_query_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_big_query_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_calculated_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_calculated_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_channel_group.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_channel_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_data_stream.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_display_video360_advertiser_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_display_video360_advertiser_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_display_video360_advertiser_link_proposal.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_display_video360_advertiser_link_proposal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_event_create_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_event_create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_event_edit_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_event_edit_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_expanded_data_set.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_expanded_data_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_firebase_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_firebase_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_key_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_property.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_reporting_data_annotation.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_reporting_data_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_rollup_property_source_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_rollup_property_source_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_search_ads360_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_search_ads360_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_sk_ad_network_conversion_value_schema.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_sk_ad_network_conversion_value_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_subproperty_event_filter.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/delete_subproperty_event_filter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_access_binding.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_account.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_ad_sense_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_ad_sense_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_attribution_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_attribution_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_audience.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_audience.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_big_query_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_big_query_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_calculated_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_calculated_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_channel_group.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_channel_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_redaction_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_redaction_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_retention_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_retention_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_sharing_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_sharing_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_stream.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_display_video360_advertiser_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_display_video360_advertiser_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_display_video360_advertiser_link_proposal.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_display_video360_advertiser_link_proposal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_enhanced_measurement_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_enhanced_measurement_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_event_create_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_event_create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_event_edit_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_event_edit_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_expanded_data_set.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_expanded_data_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_global_site_tag.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_global_site_tag.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_google_signals_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_google_signals_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_key_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_property.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_reporting_data_annotation.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_reporting_data_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_reporting_identity_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_reporting_identity_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_rollup_property_source_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_rollup_property_source_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_search_ads360_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_search_ads360_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_sk_ad_network_conversion_value_schema.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_sk_ad_network_conversion_value_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_subproperty_event_filter.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_subproperty_event_filter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_subproperty_sync_config.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/get_subproperty_sync_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_access_bindings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_account_summaries.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_account_summaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_accounts.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_ad_sense_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_ad_sense_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_audiences.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_audiences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_big_query_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_big_query_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_calculated_metrics.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_calculated_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_channel_groups.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_channel_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_conversion_events.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_conversion_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_custom_dimensions.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_custom_dimensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_custom_metrics.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_custom_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_data_streams.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_data_streams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_display_video360_advertiser_link_proposals.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_display_video360_advertiser_link_proposals.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_display_video360_advertiser_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_display_video360_advertiser_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_event_create_rules.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_event_create_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_event_edit_rules.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_event_edit_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_expanded_data_sets.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_expanded_data_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_firebase_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_firebase_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_google_ads_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_google_ads_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_key_events.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_key_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_measurement_protocol_secrets.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_measurement_protocol_secrets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_properties.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_properties.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_reporting_data_annotations.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_reporting_data_annotations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_rollup_property_source_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_rollup_property_source_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_search_ads360_links.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_search_ads360_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_sk_ad_network_conversion_value_schemas.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_sk_ad_network_conversion_value_schemas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_subproperty_event_filters.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_subproperty_event_filters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_subproperty_sync_configs.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/list_subproperty_sync_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/provision_account_ticket.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/provision_account_ticket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/provision_subproperty.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/provision_subproperty.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/reorder_event_edit_rules.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/reorder_event_edit_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/run_access_report.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/run_access_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/search_change_history_events.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/search_change_history_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/submit_user_deletion.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/submit_user_deletion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_access_binding.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_account.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_attribution_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_attribution_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_audience.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_audience.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_big_query_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_big_query_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_calculated_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_calculated_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_channel_group.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_channel_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_redaction_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_redaction_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_retention_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_retention_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_stream.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_display_video360_advertiser_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_display_video360_advertiser_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_enhanced_measurement_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_enhanced_measurement_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_event_create_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_event_create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_event_edit_rule.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_event_edit_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_expanded_data_set.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_expanded_data_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_google_signals_settings.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_google_signals_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_key_event.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_property.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_reporting_data_annotation.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_reporting_data_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_search_ads360_link.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_search_ads360_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_sk_ad_network_conversion_value_schema.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_sk_ad_network_conversion_value_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_subproperty_event_filter.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_subproperty_event_filter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_subproperty_sync_config.php
+++ b/AnalyticsAdmin/samples/V1alpha/AnalyticsAdminServiceClient/update_subproperty_sync_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/acknowledge_user_data_collection.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/acknowledge_user_data_collection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/archive_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/archive_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/archive_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/archive_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_data_stream.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_firebase_link.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_firebase_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_key_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_property.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/create_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_account.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_data_stream.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_firebase_link.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_firebase_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_key_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_property.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/delete_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_account.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_retention_settings.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_retention_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_sharing_settings.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_sharing_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_stream.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_key_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_property.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/get_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_account_summaries.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_account_summaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_accounts.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_conversion_events.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_conversion_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_custom_dimensions.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_custom_dimensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_custom_metrics.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_custom_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_data_streams.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_data_streams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_firebase_links.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_firebase_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_google_ads_links.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_google_ads_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_key_events.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_key_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_measurement_protocol_secrets.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_measurement_protocol_secrets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_properties.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/list_properties.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/provision_account_ticket.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/provision_account_ticket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/run_access_report.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/run_access_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/search_change_history_events.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/search_change_history_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_account.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_conversion_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_conversion_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_custom_dimension.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_custom_dimension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_custom_metric.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_custom_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_data_retention_settings.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_data_retention_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_data_stream.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_data_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_google_ads_link.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_google_ads_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_key_event.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_key_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_measurement_protocol_secret.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_measurement_protocol_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_property.php
+++ b/AnalyticsAdmin/samples/V1beta/AnalyticsAdminServiceClient/update_property.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1alpha/Client/AnalyticsAdminServiceClient.php
+++ b/AnalyticsAdmin/src/V1alpha/Client/AnalyticsAdminServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1alpha/resources/analytics_admin_service_descriptor_config.php
+++ b/AnalyticsAdmin/src/V1alpha/resources/analytics_admin_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1alpha/resources/analytics_admin_service_rest_client_config.php
+++ b/AnalyticsAdmin/src/V1alpha/resources/analytics_admin_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1beta/Client/AnalyticsAdminServiceClient.php
+++ b/AnalyticsAdmin/src/V1beta/Client/AnalyticsAdminServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1beta/resources/analytics_admin_service_descriptor_config.php
+++ b/AnalyticsAdmin/src/V1beta/resources/analytics_admin_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/src/V1beta/resources/analytics_admin_service_rest_client_config.php
+++ b/AnalyticsAdmin/src/V1beta/resources/analytics_admin_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/tests/Unit/V1alpha/Client/AnalyticsAdminServiceClientTest.php
+++ b/AnalyticsAdmin/tests/Unit/V1alpha/Client/AnalyticsAdminServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsAdmin/tests/Unit/V1beta/Client/AnalyticsAdminServiceClientTest.php
+++ b/AnalyticsAdmin/tests/Unit/V1beta/Client/AnalyticsAdminServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/owlbot.py
+++ b/AnalyticsData/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_audience_list.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_audience_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_recurring_audience_list.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_recurring_audience_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_report_task.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/create_report_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_audience_list.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_audience_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_property_quotas_snapshot.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_property_quotas_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_recurring_audience_list.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_recurring_audience_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_report_task.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/get_report_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_audience_lists.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_audience_lists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_recurring_audience_lists.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_recurring_audience_lists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_report_tasks.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/list_report_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/query_audience_list.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/query_audience_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/query_report_task.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/query_report_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/run_funnel_report.php
+++ b/AnalyticsData/samples/V1alpha/AlphaAnalyticsDataClient/run_funnel_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/batch_run_pivot_reports.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/batch_run_pivot_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/batch_run_reports.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/batch_run_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/check_compatibility.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/check_compatibility.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/create_audience_export.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/create_audience_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/get_audience_export.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/get_audience_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/get_metadata.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/get_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/list_audience_exports.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/list_audience_exports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/query_audience_export.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/query_audience_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_pivot_report.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_pivot_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_realtime_report.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_realtime_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_report.php
+++ b/AnalyticsData/samples/V1beta/BetaAnalyticsDataClient/run_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1alpha/Client/AlphaAnalyticsDataClient.php
+++ b/AnalyticsData/src/V1alpha/Client/AlphaAnalyticsDataClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1alpha/resources/alpha_analytics_data_descriptor_config.php
+++ b/AnalyticsData/src/V1alpha/resources/alpha_analytics_data_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1alpha/resources/alpha_analytics_data_rest_client_config.php
+++ b/AnalyticsData/src/V1alpha/resources/alpha_analytics_data_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1beta/Client/BetaAnalyticsDataClient.php
+++ b/AnalyticsData/src/V1beta/Client/BetaAnalyticsDataClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1beta/resources/beta_analytics_data_descriptor_config.php
+++ b/AnalyticsData/src/V1beta/resources/beta_analytics_data_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/src/V1beta/resources/beta_analytics_data_rest_client_config.php
+++ b/AnalyticsData/src/V1beta/resources/beta_analytics_data_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/tests/Unit/V1alpha/Client/AlphaAnalyticsDataClientTest.php
+++ b/AnalyticsData/tests/Unit/V1alpha/Client/AlphaAnalyticsDataClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnalyticsData/tests/Unit/V1beta/Client/BetaAnalyticsDataClientTest.php
+++ b/AnalyticsData/tests/Unit/V1beta/Client/BetaAnalyticsDataClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/owlbot.py
+++ b/ApiGateway/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/create_api.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/create_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/create_api_config.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/create_api_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/create_gateway.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/create_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_api.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_api_config.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_api_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_gateway.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/delete_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/get_api.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/get_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/get_api_config.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/get_api_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/get_gateway.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/get_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/list_api_configs.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/list_api_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/list_apis.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/list_apis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/list_gateways.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/list_gateways.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/update_api.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/update_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/update_api_config.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/update_api_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/samples/V1/ApiGatewayServiceClient/update_gateway.php
+++ b/ApiGateway/samples/V1/ApiGatewayServiceClient/update_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/src/V1/Client/ApiGatewayServiceClient.php
+++ b/ApiGateway/src/V1/Client/ApiGatewayServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/src/V1/resources/api_gateway_service_descriptor_config.php
+++ b/ApiGateway/src/V1/resources/api_gateway_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/src/V1/resources/api_gateway_service_rest_client_config.php
+++ b/ApiGateway/src/V1/resources/api_gateway_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiGateway/tests/Unit/V1/Client/ApiGatewayServiceClientTest.php
+++ b/ApiGateway/tests/Unit/V1/Client/ApiGatewayServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/owlbot.py
+++ b/ApiHub/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_api_operation.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_api_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_attribute.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_deployment.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_external_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_external_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_spec.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/create_version.php
+++ b/ApiHub/samples/V1/ApiHubClient/create_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_api_operation.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_api_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_attribute.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_deployment.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_external_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_external_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_spec.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/delete_version.php
+++ b/ApiHub/samples/V1/ApiHubClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_api_operation.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_api_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_attribute.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_definition.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_definition.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_deployment.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_external_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_external_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_spec.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_spec_contents.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_spec_contents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/get_version.php
+++ b/ApiHub/samples/V1/ApiHubClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_api_operations.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_api_operations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_apis.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_apis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_attributes.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_attributes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_deployments.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_external_apis.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_external_apis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_specs.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_specs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/list_versions.php
+++ b/ApiHub/samples/V1/ApiHubClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/search_resources.php
+++ b/ApiHub/samples/V1/ApiHubClient/search_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_api_operation.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_api_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_attribute.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_deployment.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_external_api.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_external_api.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_spec.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubClient/update_version.php
+++ b/ApiHub/samples/V1/ApiHubClient/update_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCollectClient/collect_api_data.php
+++ b/ApiHub/samples/V1/ApiHubCollectClient/collect_api_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCollectClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubCollectClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCollectClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubCollectClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/create_curation.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/create_curation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/delete_curation.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/delete_curation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/get_curation.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/get_curation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/list_curations.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/list_curations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubCurateClient/update_curation.php
+++ b/ApiHub/samples/V1/ApiHubCurateClient/update_curation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/create_dependency.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/create_dependency.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/delete_dependency.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/delete_dependency.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/get_dependency.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/get_dependency.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/list_dependencies.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/list_dependencies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDependenciesClient/update_dependency.php
+++ b/ApiHub/samples/V1/ApiHubDependenciesClient/update_dependency.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/get_discovered_api_observation.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/get_discovered_api_observation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/get_discovered_api_operation.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/get_discovered_api_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/list_discovered_api_observations.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/list_discovered_api_observations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/list_discovered_api_operations.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/list_discovered_api_operations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubDiscoveryClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubDiscoveryClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/create_plugin.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/create_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/create_plugin_instance.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/create_plugin_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/delete_plugin.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/delete_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/delete_plugin_instance.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/delete_plugin_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/disable_plugin.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/disable_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/disable_plugin_instance_action.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/disable_plugin_instance_action.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/enable_plugin.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/enable_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/enable_plugin_instance_action.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/enable_plugin_instance_action.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/execute_plugin_instance_action.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/execute_plugin_instance_action.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/get_location.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/get_plugin.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/get_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/get_plugin_instance.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/get_plugin_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/list_locations.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/list_plugin_instances.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/list_plugin_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/list_plugins.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/list_plugins.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ApiHubPluginClient/update_plugin_instance.php
+++ b/ApiHub/samples/V1/ApiHubPluginClient/update_plugin_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/HostProjectRegistrationServiceClient/create_host_project_registration.php
+++ b/ApiHub/samples/V1/HostProjectRegistrationServiceClient/create_host_project_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/HostProjectRegistrationServiceClient/get_host_project_registration.php
+++ b/ApiHub/samples/V1/HostProjectRegistrationServiceClient/get_host_project_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/HostProjectRegistrationServiceClient/get_location.php
+++ b/ApiHub/samples/V1/HostProjectRegistrationServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/HostProjectRegistrationServiceClient/list_host_project_registrations.php
+++ b/ApiHub/samples/V1/HostProjectRegistrationServiceClient/list_host_project_registrations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/HostProjectRegistrationServiceClient/list_locations.php
+++ b/ApiHub/samples/V1/HostProjectRegistrationServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/get_location.php
+++ b/ApiHub/samples/V1/LintingServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/get_style_guide.php
+++ b/ApiHub/samples/V1/LintingServiceClient/get_style_guide.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/get_style_guide_contents.php
+++ b/ApiHub/samples/V1/LintingServiceClient/get_style_guide_contents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/lint_spec.php
+++ b/ApiHub/samples/V1/LintingServiceClient/lint_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/list_locations.php
+++ b/ApiHub/samples/V1/LintingServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/LintingServiceClient/update_style_guide.php
+++ b/ApiHub/samples/V1/LintingServiceClient/update_style_guide.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/create_api_hub_instance.php
+++ b/ApiHub/samples/V1/ProvisioningClient/create_api_hub_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/delete_api_hub_instance.php
+++ b/ApiHub/samples/V1/ProvisioningClient/delete_api_hub_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/get_api_hub_instance.php
+++ b/ApiHub/samples/V1/ProvisioningClient/get_api_hub_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/get_location.php
+++ b/ApiHub/samples/V1/ProvisioningClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/list_locations.php
+++ b/ApiHub/samples/V1/ProvisioningClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/ProvisioningClient/lookup_api_hub_instance.php
+++ b/ApiHub/samples/V1/ProvisioningClient/lookup_api_hub_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/create_runtime_project_attachment.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/create_runtime_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/delete_runtime_project_attachment.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/delete_runtime_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/get_location.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/get_runtime_project_attachment.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/get_runtime_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/list_locations.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/list_runtime_project_attachments.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/list_runtime_project_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/lookup_runtime_project_attachment.php
+++ b/ApiHub/samples/V1/RuntimeProjectAttachmentServiceClient/lookup_runtime_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubClient.php
+++ b/ApiHub/src/V1/Client/ApiHubClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubCollectClient.php
+++ b/ApiHub/src/V1/Client/ApiHubCollectClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubCurateClient.php
+++ b/ApiHub/src/V1/Client/ApiHubCurateClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubDependenciesClient.php
+++ b/ApiHub/src/V1/Client/ApiHubDependenciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubDiscoveryClient.php
+++ b/ApiHub/src/V1/Client/ApiHubDiscoveryClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ApiHubPluginClient.php
+++ b/ApiHub/src/V1/Client/ApiHubPluginClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/HostProjectRegistrationServiceClient.php
+++ b/ApiHub/src/V1/Client/HostProjectRegistrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/LintingServiceClient.php
+++ b/ApiHub/src/V1/Client/LintingServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/ProvisioningClient.php
+++ b/ApiHub/src/V1/Client/ProvisioningClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/Client/RuntimeProjectAttachmentServiceClient.php
+++ b/ApiHub/src/V1/Client/RuntimeProjectAttachmentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_collect_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_collect_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_collect_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_collect_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_curate_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_curate_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_curate_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_curate_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_dependencies_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_dependencies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_dependencies_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_dependencies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_discovery_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_discovery_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_discovery_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_discovery_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_plugin_descriptor_config.php
+++ b/ApiHub/src/V1/resources/api_hub_plugin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_plugin_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_plugin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/api_hub_rest_client_config.php
+++ b/ApiHub/src/V1/resources/api_hub_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/host_project_registration_service_descriptor_config.php
+++ b/ApiHub/src/V1/resources/host_project_registration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/host_project_registration_service_rest_client_config.php
+++ b/ApiHub/src/V1/resources/host_project_registration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/linting_service_descriptor_config.php
+++ b/ApiHub/src/V1/resources/linting_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/linting_service_rest_client_config.php
+++ b/ApiHub/src/V1/resources/linting_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/provisioning_descriptor_config.php
+++ b/ApiHub/src/V1/resources/provisioning_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/provisioning_rest_client_config.php
+++ b/ApiHub/src/V1/resources/provisioning_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/runtime_project_attachment_service_descriptor_config.php
+++ b/ApiHub/src/V1/resources/runtime_project_attachment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/src/V1/resources/runtime_project_attachment_service_rest_client_config.php
+++ b/ApiHub/src/V1/resources/runtime_project_attachment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubCollectClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubCollectClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubCurateClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubCurateClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubDependenciesClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubDependenciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubDiscoveryClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubDiscoveryClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ApiHubPluginClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ApiHubPluginClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/HostProjectRegistrationServiceClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/HostProjectRegistrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/LintingServiceClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/LintingServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/ProvisioningClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/ProvisioningClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiHub/tests/Unit/V1/Client/RuntimeProjectAttachmentServiceClientTest.php
+++ b/ApiHub/tests/Unit/V1/Client/RuntimeProjectAttachmentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/owlbot.py
+++ b/ApiKeys/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/create_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/create_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/delete_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/delete_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/get_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/get_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/get_key_string.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/get_key_string.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/list_keys.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/list_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/lookup_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/lookup_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/undelete_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/undelete_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/samples/V2/ApiKeysClient/update_key.php
+++ b/ApiKeys/samples/V2/ApiKeysClient/update_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/src/V2/Client/ApiKeysClient.php
+++ b/ApiKeys/src/V2/Client/ApiKeysClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/src/V2/resources/api_keys_descriptor_config.php
+++ b/ApiKeys/src/V2/resources/api_keys_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/src/V2/resources/api_keys_rest_client_config.php
+++ b/ApiKeys/src/V2/resources/api_keys_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiKeys/tests/Unit/V2/Client/ApiKeysClientTest.php
+++ b/ApiKeys/tests/Unit/V2/Client/ApiKeysClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApiRegistry/owlbot.py
+++ b/ApiRegistry/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ApigeeConnect/owlbot.py
+++ b/ApigeeConnect/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ApigeeConnect/samples/V1/ConnectionServiceClient/list_connections.php
+++ b/ApigeeConnect/samples/V1/ConnectionServiceClient/list_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/samples/V1/TetherClient/egress.php
+++ b/ApigeeConnect/samples/V1/TetherClient/egress.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/Client/ConnectionServiceClient.php
+++ b/ApigeeConnect/src/V1/Client/ConnectionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/Client/TetherClient.php
+++ b/ApigeeConnect/src/V1/Client/TetherClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/resources/connection_service_descriptor_config.php
+++ b/ApigeeConnect/src/V1/resources/connection_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/resources/connection_service_rest_client_config.php
+++ b/ApigeeConnect/src/V1/resources/connection_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/resources/tether_descriptor_config.php
+++ b/ApigeeConnect/src/V1/resources/tether_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/src/V1/resources/tether_rest_client_config.php
+++ b/ApigeeConnect/src/V1/resources/tether_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/tests/Unit/V1/Client/ConnectionServiceClientTest.php
+++ b/ApigeeConnect/tests/Unit/V1/Client/ConnectionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ApigeeConnect/tests/Unit/V1/Client/TetherClientTest.php
+++ b/ApigeeConnect/tests/Unit/V1/Client/TetherClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/owlbot.py
+++ b/AppEngineAdmin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ApplicationsClient/create_application.php
+++ b/AppEngineAdmin/samples/V1/ApplicationsClient/create_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ApplicationsClient/get_application.php
+++ b/AppEngineAdmin/samples/V1/ApplicationsClient/get_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ApplicationsClient/repair_application.php
+++ b/AppEngineAdmin/samples/V1/ApplicationsClient/repair_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ApplicationsClient/update_application.php
+++ b/AppEngineAdmin/samples/V1/ApplicationsClient/update_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/create_authorized_certificate.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/create_authorized_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/delete_authorized_certificate.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/delete_authorized_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/get_authorized_certificate.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/get_authorized_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/list_authorized_certificates.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/list_authorized_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/update_authorized_certificate.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedCertificatesClient/update_authorized_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/AuthorizedDomainsClient/list_authorized_domains.php
+++ b/AppEngineAdmin/samples/V1/AuthorizedDomainsClient/list_authorized_domains.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/DomainMappingsClient/create_domain_mapping.php
+++ b/AppEngineAdmin/samples/V1/DomainMappingsClient/create_domain_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/DomainMappingsClient/delete_domain_mapping.php
+++ b/AppEngineAdmin/samples/V1/DomainMappingsClient/delete_domain_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/DomainMappingsClient/get_domain_mapping.php
+++ b/AppEngineAdmin/samples/V1/DomainMappingsClient/get_domain_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/DomainMappingsClient/list_domain_mappings.php
+++ b/AppEngineAdmin/samples/V1/DomainMappingsClient/list_domain_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/DomainMappingsClient/update_domain_mapping.php
+++ b/AppEngineAdmin/samples/V1/DomainMappingsClient/update_domain_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/batch_update_ingress_rules.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/batch_update_ingress_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/create_ingress_rule.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/create_ingress_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/delete_ingress_rule.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/delete_ingress_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/get_ingress_rule.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/get_ingress_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/list_ingress_rules.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/list_ingress_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/FirewallClient/update_ingress_rule.php
+++ b/AppEngineAdmin/samples/V1/FirewallClient/update_ingress_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/InstancesClient/debug_instance.php
+++ b/AppEngineAdmin/samples/V1/InstancesClient/debug_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/InstancesClient/delete_instance.php
+++ b/AppEngineAdmin/samples/V1/InstancesClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/InstancesClient/get_instance.php
+++ b/AppEngineAdmin/samples/V1/InstancesClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/InstancesClient/list_instances.php
+++ b/AppEngineAdmin/samples/V1/InstancesClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ServicesClient/delete_service.php
+++ b/AppEngineAdmin/samples/V1/ServicesClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ServicesClient/get_service.php
+++ b/AppEngineAdmin/samples/V1/ServicesClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ServicesClient/list_services.php
+++ b/AppEngineAdmin/samples/V1/ServicesClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/ServicesClient/update_service.php
+++ b/AppEngineAdmin/samples/V1/ServicesClient/update_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/VersionsClient/create_version.php
+++ b/AppEngineAdmin/samples/V1/VersionsClient/create_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/VersionsClient/delete_version.php
+++ b/AppEngineAdmin/samples/V1/VersionsClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/VersionsClient/get_version.php
+++ b/AppEngineAdmin/samples/V1/VersionsClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/VersionsClient/list_versions.php
+++ b/AppEngineAdmin/samples/V1/VersionsClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/samples/V1/VersionsClient/update_version.php
+++ b/AppEngineAdmin/samples/V1/VersionsClient/update_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/ApplicationsClient.php
+++ b/AppEngineAdmin/src/V1/Client/ApplicationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/AuthorizedCertificatesClient.php
+++ b/AppEngineAdmin/src/V1/Client/AuthorizedCertificatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/AuthorizedDomainsClient.php
+++ b/AppEngineAdmin/src/V1/Client/AuthorizedDomainsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/DomainMappingsClient.php
+++ b/AppEngineAdmin/src/V1/Client/DomainMappingsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/FirewallClient.php
+++ b/AppEngineAdmin/src/V1/Client/FirewallClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/InstancesClient.php
+++ b/AppEngineAdmin/src/V1/Client/InstancesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/ServicesClient.php
+++ b/AppEngineAdmin/src/V1/Client/ServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/Client/VersionsClient.php
+++ b/AppEngineAdmin/src/V1/Client/VersionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/applications_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/applications_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/applications_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/applications_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/authorized_certificates_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/authorized_certificates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/authorized_certificates_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/authorized_certificates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/authorized_domains_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/authorized_domains_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/authorized_domains_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/authorized_domains_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/domain_mappings_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/domain_mappings_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/domain_mappings_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/domain_mappings_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/firewall_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/firewall_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/firewall_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/firewall_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/instances_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/instances_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/instances_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/instances_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/services_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/services_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/versions_descriptor_config.php
+++ b/AppEngineAdmin/src/V1/resources/versions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/src/V1/resources/versions_rest_client_config.php
+++ b/AppEngineAdmin/src/V1/resources/versions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/ApplicationsClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/ApplicationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/AuthorizedCertificatesClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/AuthorizedCertificatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/AuthorizedDomainsClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/AuthorizedDomainsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/DomainMappingsClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/DomainMappingsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/FirewallClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/FirewallClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/InstancesClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/InstancesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/ServicesClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/ServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppEngineAdmin/tests/Unit/V1/Client/VersionsClientTest.php
+++ b/AppEngineAdmin/tests/Unit/V1/Client/VersionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/owlbot.py
+++ b/AppHub/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/create_application.php
+++ b/AppHub/samples/V1/AppHubClient/create_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/create_service.php
+++ b/AppHub/samples/V1/AppHubClient/create_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/create_service_project_attachment.php
+++ b/AppHub/samples/V1/AppHubClient/create_service_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/create_workload.php
+++ b/AppHub/samples/V1/AppHubClient/create_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/delete_application.php
+++ b/AppHub/samples/V1/AppHubClient/delete_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/delete_service.php
+++ b/AppHub/samples/V1/AppHubClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/delete_service_project_attachment.php
+++ b/AppHub/samples/V1/AppHubClient/delete_service_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/delete_workload.php
+++ b/AppHub/samples/V1/AppHubClient/delete_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/detach_service_project_attachment.php
+++ b/AppHub/samples/V1/AppHubClient/detach_service_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_application.php
+++ b/AppHub/samples/V1/AppHubClient/get_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_discovered_service.php
+++ b/AppHub/samples/V1/AppHubClient/get_discovered_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_discovered_workload.php
+++ b/AppHub/samples/V1/AppHubClient/get_discovered_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_iam_policy.php
+++ b/AppHub/samples/V1/AppHubClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_location.php
+++ b/AppHub/samples/V1/AppHubClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_service.php
+++ b/AppHub/samples/V1/AppHubClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_service_project_attachment.php
+++ b/AppHub/samples/V1/AppHubClient/get_service_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/get_workload.php
+++ b/AppHub/samples/V1/AppHubClient/get_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_applications.php
+++ b/AppHub/samples/V1/AppHubClient/list_applications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_discovered_services.php
+++ b/AppHub/samples/V1/AppHubClient/list_discovered_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_discovered_workloads.php
+++ b/AppHub/samples/V1/AppHubClient/list_discovered_workloads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_locations.php
+++ b/AppHub/samples/V1/AppHubClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_service_project_attachments.php
+++ b/AppHub/samples/V1/AppHubClient/list_service_project_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_services.php
+++ b/AppHub/samples/V1/AppHubClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/list_workloads.php
+++ b/AppHub/samples/V1/AppHubClient/list_workloads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/lookup_discovered_service.php
+++ b/AppHub/samples/V1/AppHubClient/lookup_discovered_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/lookup_discovered_workload.php
+++ b/AppHub/samples/V1/AppHubClient/lookup_discovered_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/lookup_service_project_attachment.php
+++ b/AppHub/samples/V1/AppHubClient/lookup_service_project_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/set_iam_policy.php
+++ b/AppHub/samples/V1/AppHubClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/test_iam_permissions.php
+++ b/AppHub/samples/V1/AppHubClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/update_application.php
+++ b/AppHub/samples/V1/AppHubClient/update_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/update_service.php
+++ b/AppHub/samples/V1/AppHubClient/update_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/samples/V1/AppHubClient/update_workload.php
+++ b/AppHub/samples/V1/AppHubClient/update_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/src/V1/Client/AppHubClient.php
+++ b/AppHub/src/V1/Client/AppHubClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/src/V1/resources/app_hub_descriptor_config.php
+++ b/AppHub/src/V1/resources/app_hub_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/src/V1/resources/app_hub_rest_client_config.php
+++ b/AppHub/src/V1/resources/app_hub_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppHub/tests/Unit/V1/Client/AppHubClientTest.php
+++ b/AppHub/tests/Unit/V1/Client/AppHubClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppOptimize/owlbot.py
+++ b/AppOptimize/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppsChat/owlbot.py
+++ b/AppsChat/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/complete_import_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/complete_import_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/create_custom_emoji.php
+++ b/AppsChat/samples/V1/ChatServiceClient/create_custom_emoji.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/create_membership.php
+++ b/AppsChat/samples/V1/ChatServiceClient/create_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/create_message.php
+++ b/AppsChat/samples/V1/ChatServiceClient/create_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/create_reaction.php
+++ b/AppsChat/samples/V1/ChatServiceClient/create_reaction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/create_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/create_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/delete_custom_emoji.php
+++ b/AppsChat/samples/V1/ChatServiceClient/delete_custom_emoji.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/delete_membership.php
+++ b/AppsChat/samples/V1/ChatServiceClient/delete_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/delete_message.php
+++ b/AppsChat/samples/V1/ChatServiceClient/delete_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/delete_reaction.php
+++ b/AppsChat/samples/V1/ChatServiceClient/delete_reaction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/delete_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/delete_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/find_direct_message.php
+++ b/AppsChat/samples/V1/ChatServiceClient/find_direct_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_attachment.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_custom_emoji.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_custom_emoji.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_membership.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_message.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_space_event.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_space_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_space_notification_setting.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_space_notification_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_space_read_state.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_space_read_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/get_thread_read_state.php
+++ b/AppsChat/samples/V1/ChatServiceClient/get_thread_read_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_custom_emojis.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_custom_emojis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_memberships.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_memberships.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_messages.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_messages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_reactions.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_reactions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_space_events.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_space_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/list_spaces.php
+++ b/AppsChat/samples/V1/ChatServiceClient/list_spaces.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/search_spaces.php
+++ b/AppsChat/samples/V1/ChatServiceClient/search_spaces.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/set_up_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/set_up_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/update_membership.php
+++ b/AppsChat/samples/V1/ChatServiceClient/update_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/update_message.php
+++ b/AppsChat/samples/V1/ChatServiceClient/update_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/update_space.php
+++ b/AppsChat/samples/V1/ChatServiceClient/update_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/update_space_notification_setting.php
+++ b/AppsChat/samples/V1/ChatServiceClient/update_space_notification_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/update_space_read_state.php
+++ b/AppsChat/samples/V1/ChatServiceClient/update_space_read_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/samples/V1/ChatServiceClient/upload_attachment.php
+++ b/AppsChat/samples/V1/ChatServiceClient/upload_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/src/Chat/V1/Client/ChatServiceClient.php
+++ b/AppsChat/src/Chat/V1/Client/ChatServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/src/Chat/V1/resources/chat_service_descriptor_config.php
+++ b/AppsChat/src/Chat/V1/resources/chat_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/src/Chat/V1/resources/chat_service_rest_client_config.php
+++ b/AppsChat/src/Chat/V1/resources/chat_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsChat/tests/Unit/V1/Client/ChatServiceClientTest.php
+++ b/AppsChat/tests/Unit/V1/Client/ChatServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/owlbot.py
+++ b/AppsEventsSubscriptions/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/create_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/create_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/delete_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/delete_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/get_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/get_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/list_subscriptions.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/list_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/reactivate_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/reactivate_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/update_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1/SubscriptionsServiceClient/update_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/create_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/create_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/delete_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/delete_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/get_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/get_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/list_subscriptions.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/list_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/reactivate_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/reactivate_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/update_subscription.php
+++ b/AppsEventsSubscriptions/samples/V1beta/SubscriptionsServiceClient/update_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1/Client/SubscriptionsServiceClient.php
+++ b/AppsEventsSubscriptions/src/V1/Client/SubscriptionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1/resources/subscriptions_service_descriptor_config.php
+++ b/AppsEventsSubscriptions/src/V1/resources/subscriptions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1/resources/subscriptions_service_rest_client_config.php
+++ b/AppsEventsSubscriptions/src/V1/resources/subscriptions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1beta/Client/SubscriptionsServiceClient.php
+++ b/AppsEventsSubscriptions/src/V1beta/Client/SubscriptionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1beta/resources/subscriptions_service_descriptor_config.php
+++ b/AppsEventsSubscriptions/src/V1beta/resources/subscriptions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/src/V1beta/resources/subscriptions_service_rest_client_config.php
+++ b/AppsEventsSubscriptions/src/V1beta/resources/subscriptions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/tests/Unit/V1/Client/SubscriptionsServiceClientTest.php
+++ b/AppsEventsSubscriptions/tests/Unit/V1/Client/SubscriptionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsEventsSubscriptions/tests/Unit/V1beta/Client/SubscriptionsServiceClientTest.php
+++ b/AppsEventsSubscriptions/tests/Unit/V1beta/Client/SubscriptionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/owlbot.py
+++ b/AppsMeet/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_conference_record.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_conference_record.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_participant.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_participant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_participant_session.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_participant_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_recording.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_recording.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_transcript.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_transcript.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_transcript_entry.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/get_transcript_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_conference_records.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_conference_records.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_participant_sessions.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_participant_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_participants.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_participants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_recordings.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_recordings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_transcript_entries.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_transcript_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_transcripts.php
+++ b/AppsMeet/samples/V2/ConferenceRecordsServiceClient/list_transcripts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/SpacesServiceClient/create_space.php
+++ b/AppsMeet/samples/V2/SpacesServiceClient/create_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/SpacesServiceClient/end_active_conference.php
+++ b/AppsMeet/samples/V2/SpacesServiceClient/end_active_conference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/SpacesServiceClient/get_space.php
+++ b/AppsMeet/samples/V2/SpacesServiceClient/get_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2/SpacesServiceClient/update_space.php
+++ b/AppsMeet/samples/V2/SpacesServiceClient/update_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_conference_record.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_conference_record.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_participant.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_participant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_participant_session.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_participant_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_recording.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_recording.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_transcript.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_transcript.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_transcript_entry.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/get_transcript_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_conference_records.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_conference_records.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_participant_sessions.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_participant_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_participants.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_participants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_recordings.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_recordings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_transcript_entries.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_transcript_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_transcripts.php
+++ b/AppsMeet/samples/V2beta/ConferenceRecordsServiceClient/list_transcripts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/connect_active_conference.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/connect_active_conference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/create_member.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/create_member.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/create_space.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/create_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/delete_member.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/delete_member.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/end_active_conference.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/end_active_conference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/get_member.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/get_member.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/get_space.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/get_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/list_members.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/list_members.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/samples/V2beta/SpacesServiceClient/update_space.php
+++ b/AppsMeet/samples/V2beta/SpacesServiceClient/update_space.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/Client/ConferenceRecordsServiceClient.php
+++ b/AppsMeet/src/V2/Client/ConferenceRecordsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/Client/SpacesServiceClient.php
+++ b/AppsMeet/src/V2/Client/SpacesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/resources/conference_records_service_descriptor_config.php
+++ b/AppsMeet/src/V2/resources/conference_records_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/resources/conference_records_service_rest_client_config.php
+++ b/AppsMeet/src/V2/resources/conference_records_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/resources/spaces_service_descriptor_config.php
+++ b/AppsMeet/src/V2/resources/spaces_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2/resources/spaces_service_rest_client_config.php
+++ b/AppsMeet/src/V2/resources/spaces_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/Client/ConferenceRecordsServiceClient.php
+++ b/AppsMeet/src/V2beta/Client/ConferenceRecordsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/Client/SpacesServiceClient.php
+++ b/AppsMeet/src/V2beta/Client/SpacesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/resources/conference_records_service_descriptor_config.php
+++ b/AppsMeet/src/V2beta/resources/conference_records_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/resources/conference_records_service_rest_client_config.php
+++ b/AppsMeet/src/V2beta/resources/conference_records_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/resources/spaces_service_descriptor_config.php
+++ b/AppsMeet/src/V2beta/resources/spaces_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/src/V2beta/resources/spaces_service_rest_client_config.php
+++ b/AppsMeet/src/V2beta/resources/spaces_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/tests/Unit/V2/Client/ConferenceRecordsServiceClientTest.php
+++ b/AppsMeet/tests/Unit/V2/Client/ConferenceRecordsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/tests/Unit/V2/Client/SpacesServiceClientTest.php
+++ b/AppsMeet/tests/Unit/V2/Client/SpacesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/tests/Unit/V2beta/Client/ConferenceRecordsServiceClientTest.php
+++ b/AppsMeet/tests/Unit/V2beta/Client/ConferenceRecordsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AppsMeet/tests/Unit/V2beta/Client/SpacesServiceClientTest.php
+++ b/AppsMeet/tests/Unit/V2beta/Client/SpacesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/owlbot.py
+++ b/ArtifactRegistry/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/batch_delete_versions.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/batch_delete_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_attachment.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_repository.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_rule.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_tag.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/create_tag.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_attachment.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_file.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_package.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_package.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_repository.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_rule.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_tag.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_tag.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_version.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/export_artifact.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/export_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_attachment.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_docker_image.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_docker_image.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_file.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_iam_policy.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_location.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_maven_artifact.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_maven_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_npm_package.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_npm_package.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_package.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_package.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_project_settings.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_project_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_python_package.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_python_package.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_repository.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_rule.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_tag.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_tag.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_version.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_vpcsc_config.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/get_vpcsc_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/import_apt_artifacts.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/import_apt_artifacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/import_yum_artifacts.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/import_yum_artifacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_attachments.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_docker_images.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_docker_images.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_files.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_locations.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_maven_artifacts.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_maven_artifacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_npm_packages.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_npm_packages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_packages.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_packages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_python_packages.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_python_packages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_repositories.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_rules.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_tags.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_tags.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_versions.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/set_iam_policy.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/test_iam_permissions.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_file.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_package.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_package.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_project_settings.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_project_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_repository.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_rule.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_tag.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_tag.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_version.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_vpcsc_config.php
+++ b/ArtifactRegistry/samples/V1/ArtifactRegistryClient/update_vpcsc_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/src/V1/Client/ArtifactRegistryClient.php
+++ b/ArtifactRegistry/src/V1/Client/ArtifactRegistryClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/src/V1/resources/artifact_registry_descriptor_config.php
+++ b/ArtifactRegistry/src/V1/resources/artifact_registry_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/src/V1/resources/artifact_registry_rest_client_config.php
+++ b/ArtifactRegistry/src/V1/resources/artifact_registry_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ArtifactRegistry/tests/Unit/V1/Client/ArtifactRegistryClientTest.php
+++ b/ArtifactRegistry/tests/Unit/V1/Client/ArtifactRegistryClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **767 generated files** in **15 in-scope packages** (AlloyDb through ArtifactRegistry).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`AlloyDb`, `AnalyticsAdmin`, `AnalyticsData`, `ApiGateway`, `ApiHub`, `ApiKeys`, `ApiRegistry`, `ApigeeConnect`, `AppEngineAdmin`, `AppHub`, `AppOptimize`, `AppsChat`, `AppsEventsSubscriptions`, `AppsMeet`, `ArtifactRegistry`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-2
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 2 of 10 in the 2026 copyright update series.
