### PR TITLE
chore: update copyright years to 2026 for generated files (part 3: Asset to CommonProtos)

### DIFF
--- a/Asset/owlbot.py
+++ b/Asset/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_move.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_org_policies.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_org_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_assets.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_containers.php
+++ b/Asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_containers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
+++ b/Asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/batch_get_effective_iam_policies.php
+++ b/Asset/samples/V1/AssetServiceClient/batch_get_effective_iam_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/create_feed.php
+++ b/Asset/samples/V1/AssetServiceClient/create_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/create_saved_query.php
+++ b/Asset/samples/V1/AssetServiceClient/create_saved_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/delete_feed.php
+++ b/Asset/samples/V1/AssetServiceClient/delete_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/delete_saved_query.php
+++ b/Asset/samples/V1/AssetServiceClient/delete_saved_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/export_assets.php
+++ b/Asset/samples/V1/AssetServiceClient/export_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/get_feed.php
+++ b/Asset/samples/V1/AssetServiceClient/get_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/get_saved_query.php
+++ b/Asset/samples/V1/AssetServiceClient/get_saved_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/list_assets.php
+++ b/Asset/samples/V1/AssetServiceClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/list_feeds.php
+++ b/Asset/samples/V1/AssetServiceClient/list_feeds.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/list_saved_queries.php
+++ b/Asset/samples/V1/AssetServiceClient/list_saved_queries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/query_assets.php
+++ b/Asset/samples/V1/AssetServiceClient/query_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
+++ b/Asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/search_all_resources.php
+++ b/Asset/samples/V1/AssetServiceClient/search_all_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/update_feed.php
+++ b/Asset/samples/V1/AssetServiceClient/update_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/samples/V1/AssetServiceClient/update_saved_query.php
+++ b/Asset/samples/V1/AssetServiceClient/update_saved_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/src/V1/Client/AssetServiceClient.php
+++ b/Asset/src/V1/Client/AssetServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/src/V1/resources/asset_service_descriptor_config.php
+++ b/Asset/src/V1/resources/asset_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/src/V1/resources/asset_service_rest_client_config.php
+++ b/Asset/src/V1/resources/asset_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/tests/System/V1/AssetServiceSmokeTest.php
+++ b/Asset/tests/System/V1/AssetServiceSmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Asset/tests/Unit/V1/Client/AssetServiceClientTest.php
+++ b/Asset/tests/Unit/V1/Client/AssetServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/owlbot.py
+++ b/AssuredWorkloads/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/acknowledge_violation.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/acknowledge_violation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/create_workload.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/create_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/delete_workload.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/delete_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/get_violation.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/get_violation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/get_workload.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/get_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/list_violations.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/list_violations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/list_workloads.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/list_workloads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/restrict_allowed_resources.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/restrict_allowed_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/update_workload.php
+++ b/AssuredWorkloads/samples/V1/AssuredWorkloadsServiceClient/update_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/analyze_workload_move.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/analyze_workload_move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/create_workload.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/create_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/delete_workload.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/delete_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/get_workload.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/get_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/list_workloads.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/list_workloads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/restrict_allowed_resources.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/restrict_allowed_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/update_workload.php
+++ b/AssuredWorkloads/samples/V1beta1/AssuredWorkloadsServiceClient/update_workload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1/Client/AssuredWorkloadsServiceClient.php
+++ b/AssuredWorkloads/src/V1/Client/AssuredWorkloadsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1/resources/assured_workloads_service_descriptor_config.php
+++ b/AssuredWorkloads/src/V1/resources/assured_workloads_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1/resources/assured_workloads_service_rest_client_config.php
+++ b/AssuredWorkloads/src/V1/resources/assured_workloads_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1beta1/Client/AssuredWorkloadsServiceClient.php
+++ b/AssuredWorkloads/src/V1beta1/Client/AssuredWorkloadsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1beta1/resources/assured_workloads_service_descriptor_config.php
+++ b/AssuredWorkloads/src/V1beta1/resources/assured_workloads_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/src/V1beta1/resources/assured_workloads_service_rest_client_config.php
+++ b/AssuredWorkloads/src/V1beta1/resources/assured_workloads_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/tests/Unit/V1/Client/AssuredWorkloadsServiceClientTest.php
+++ b/AssuredWorkloads/tests/Unit/V1/Client/AssuredWorkloadsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AssuredWorkloads/tests/Unit/V1beta1/Client/AssuredWorkloadsServiceClientTest.php
+++ b/AssuredWorkloads/tests/Unit/V1beta1/Client/AssuredWorkloadsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AuditManager/owlbot.py
+++ b/AuditManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AutoMl/owlbot.py
+++ b/AutoMl/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/create_dataset.php
+++ b/AutoMl/samples/V1/AutoMlClient/create_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/create_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/create_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/delete_dataset.php
+++ b/AutoMl/samples/V1/AutoMlClient/delete_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/delete_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/delete_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/deploy_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/deploy_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/export_data.php
+++ b/AutoMl/samples/V1/AutoMlClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/export_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/export_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/get_annotation_spec.php
+++ b/AutoMl/samples/V1/AutoMlClient/get_annotation_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/get_dataset.php
+++ b/AutoMl/samples/V1/AutoMlClient/get_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/get_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/get_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/get_model_evaluation.php
+++ b/AutoMl/samples/V1/AutoMlClient/get_model_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/import_data.php
+++ b/AutoMl/samples/V1/AutoMlClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/list_datasets.php
+++ b/AutoMl/samples/V1/AutoMlClient/list_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/list_model_evaluations.php
+++ b/AutoMl/samples/V1/AutoMlClient/list_model_evaluations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/list_models.php
+++ b/AutoMl/samples/V1/AutoMlClient/list_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/undeploy_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/undeploy_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/update_dataset.php
+++ b/AutoMl/samples/V1/AutoMlClient/update_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/AutoMlClient/update_model.php
+++ b/AutoMl/samples/V1/AutoMlClient/update_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/PredictionServiceClient/batch_predict.php
+++ b/AutoMl/samples/V1/PredictionServiceClient/batch_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/samples/V1/PredictionServiceClient/predict.php
+++ b/AutoMl/samples/V1/PredictionServiceClient/predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/Client/AutoMlClient.php
+++ b/AutoMl/src/V1/Client/AutoMlClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/Client/PredictionServiceClient.php
+++ b/AutoMl/src/V1/Client/PredictionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/resources/auto_ml_descriptor_config.php
+++ b/AutoMl/src/V1/resources/auto_ml_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/resources/auto_ml_rest_client_config.php
+++ b/AutoMl/src/V1/resources/auto_ml_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/resources/prediction_service_descriptor_config.php
+++ b/AutoMl/src/V1/resources/prediction_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/src/V1/resources/prediction_service_rest_client_config.php
+++ b/AutoMl/src/V1/resources/prediction_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/tests/Unit/V1/Client/AutoMlClientTest.php
+++ b/AutoMl/tests/Unit/V1/Client/AutoMlClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AutoMl/tests/Unit/V1/Client/PredictionServiceClientTest.php
+++ b/AutoMl/tests/Unit/V1/Client/PredictionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/owlbot.py
+++ b/BackupDr/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/create_backup_plan.php
+++ b/BackupDr/samples/V1/BackupDRClient/create_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/create_backup_plan_association.php
+++ b/BackupDr/samples/V1/BackupDRClient/create_backup_plan_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/create_backup_vault.php
+++ b/BackupDr/samples/V1/BackupDRClient/create_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/create_management_server.php
+++ b/BackupDr/samples/V1/BackupDRClient/create_management_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/delete_backup.php
+++ b/BackupDr/samples/V1/BackupDRClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/delete_backup_plan.php
+++ b/BackupDr/samples/V1/BackupDRClient/delete_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/delete_backup_plan_association.php
+++ b/BackupDr/samples/V1/BackupDRClient/delete_backup_plan_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/delete_backup_vault.php
+++ b/BackupDr/samples/V1/BackupDRClient/delete_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/delete_management_server.php
+++ b/BackupDr/samples/V1/BackupDRClient/delete_management_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/fetch_backup_plan_associations_for_resource_type.php
+++ b/BackupDr/samples/V1/BackupDRClient/fetch_backup_plan_associations_for_resource_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/fetch_backups_for_resource_type.php
+++ b/BackupDr/samples/V1/BackupDRClient/fetch_backups_for_resource_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/fetch_data_source_references_for_resource_type.php
+++ b/BackupDr/samples/V1/BackupDRClient/fetch_data_source_references_for_resource_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/fetch_usable_backup_vaults.php
+++ b/BackupDr/samples/V1/BackupDRClient/fetch_usable_backup_vaults.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_backup.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_backup_plan.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_backup_plan_association.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_backup_plan_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_backup_plan_revision.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_backup_plan_revision.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_backup_vault.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_data_source.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_data_source_reference.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_data_source_reference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_iam_policy.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_location.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/get_management_server.php
+++ b/BackupDr/samples/V1/BackupDRClient/get_management_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/initialize_service.php
+++ b/BackupDr/samples/V1/BackupDRClient/initialize_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_backup_plan_associations.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_backup_plan_associations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_backup_plan_revisions.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_backup_plan_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_backup_plans.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_backup_plans.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_backup_vaults.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_backup_vaults.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_backups.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_data_source_references.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_data_source_references.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_data_sources.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_locations.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/list_management_servers.php
+++ b/BackupDr/samples/V1/BackupDRClient/list_management_servers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/restore_backup.php
+++ b/BackupDr/samples/V1/BackupDRClient/restore_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/set_iam_policy.php
+++ b/BackupDr/samples/V1/BackupDRClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/test_iam_permissions.php
+++ b/BackupDr/samples/V1/BackupDRClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/trigger_backup.php
+++ b/BackupDr/samples/V1/BackupDRClient/trigger_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/update_backup.php
+++ b/BackupDr/samples/V1/BackupDRClient/update_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/update_backup_plan.php
+++ b/BackupDr/samples/V1/BackupDRClient/update_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/update_backup_plan_association.php
+++ b/BackupDr/samples/V1/BackupDRClient/update_backup_plan_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/update_backup_vault.php
+++ b/BackupDr/samples/V1/BackupDRClient/update_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/samples/V1/BackupDRClient/update_data_source.php
+++ b/BackupDr/samples/V1/BackupDRClient/update_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/src/V1/Client/BackupDRClient.php
+++ b/BackupDr/src/V1/Client/BackupDRClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/src/V1/resources/backup_dr_descriptor_config.php
+++ b/BackupDr/src/V1/resources/backup_dr_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/src/V1/resources/backup_dr_rest_client_config.php
+++ b/BackupDr/src/V1/resources/backup_dr_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BackupDr/tests/Unit/V1/Client/BackupDRClientTest.php
+++ b/BackupDr/tests/Unit/V1/Client/BackupDRClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/owlbot.py
+++ b/BareMetalSolution/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_nfs_share.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_nfs_share.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_provisioning_config.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_provisioning_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_ssh_key.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_ssh_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_volume_snapshot.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/create_volume_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_nfs_share.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_nfs_share.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_ssh_key.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_ssh_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_volume_snapshot.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/delete_volume_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/detach_lun.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/detach_lun.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/disable_interactive_serial_console.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/disable_interactive_serial_console.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/enable_interactive_serial_console.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/enable_interactive_serial_console.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/evict_lun.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/evict_lun.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/evict_volume.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/evict_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_location.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_lun.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_lun.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_network.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_nfs_share.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_nfs_share.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_provisioning_config.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_provisioning_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_volume.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_volume_snapshot.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/get_volume_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_instances.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_locations.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_luns.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_luns.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_network_usage.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_network_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_networks.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_networks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_nfs_shares.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_nfs_shares.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_os_images.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_os_images.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_provisioning_quotas.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_provisioning_quotas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_ssh_keys.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_ssh_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_volume_snapshots.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_volume_snapshots.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_volumes.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/list_volumes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_network.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_nfs_share.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_nfs_share.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_volume.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/rename_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/reset_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/reset_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/resize_volume.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/resize_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/restore_volume_snapshot.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/restore_volume_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/start_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/start_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/stop_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/stop_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/submit_provisioning_config.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/submit_provisioning_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_instance.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_network.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_nfs_share.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_nfs_share.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_provisioning_config.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_provisioning_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_volume.php
+++ b/BareMetalSolution/samples/V2/BareMetalSolutionClient/update_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/src/V2/Client/BareMetalSolutionClient.php
+++ b/BareMetalSolution/src/V2/Client/BareMetalSolutionClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/src/V2/resources/bare_metal_solution_descriptor_config.php
+++ b/BareMetalSolution/src/V2/resources/bare_metal_solution_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/src/V2/resources/bare_metal_solution_rest_client_config.php
+++ b/BareMetalSolution/src/V2/resources/bare_metal_solution_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BareMetalSolution/tests/Unit/V2/Client/BareMetalSolutionClientTest.php
+++ b/BareMetalSolution/tests/Unit/V2/Client/BareMetalSolutionClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/owlbot.py
+++ b/Batch/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/cancel_job.php
+++ b/Batch/samples/V1/BatchServiceClient/cancel_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/create_job.php
+++ b/Batch/samples/V1/BatchServiceClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/delete_job.php
+++ b/Batch/samples/V1/BatchServiceClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/get_job.php
+++ b/Batch/samples/V1/BatchServiceClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/get_location.php
+++ b/Batch/samples/V1/BatchServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/get_task.php
+++ b/Batch/samples/V1/BatchServiceClient/get_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/list_jobs.php
+++ b/Batch/samples/V1/BatchServiceClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/list_locations.php
+++ b/Batch/samples/V1/BatchServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/samples/V1/BatchServiceClient/list_tasks.php
+++ b/Batch/samples/V1/BatchServiceClient/list_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/src/V1/Client/BatchServiceClient.php
+++ b/Batch/src/V1/Client/BatchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/src/V1/resources/batch_service_descriptor_config.php
+++ b/Batch/src/V1/resources/batch_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/src/V1/resources/batch_service_rest_client_config.php
+++ b/Batch/src/V1/resources/batch_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Batch/tests/Unit/V1/Client/BatchServiceClientTest.php
+++ b/Batch/tests/Unit/V1/Client/BatchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/owlbot.py
+++ b/BeyondCorpAppConnections/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/create_app_connection.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/create_app_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/delete_app_connection.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/delete_app_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_app_connection.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_app_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_iam_policy.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_location.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/list_app_connections.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/list_app_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/list_locations.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/resolve_app_connections.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/resolve_app_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/set_iam_policy.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/test_iam_permissions.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/update_app_connection.php
+++ b/BeyondCorpAppConnections/samples/V1/AppConnectionsServiceClient/update_app_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/src/V1/Client/AppConnectionsServiceClient.php
+++ b/BeyondCorpAppConnections/src/V1/Client/AppConnectionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/src/V1/resources/app_connections_service_descriptor_config.php
+++ b/BeyondCorpAppConnections/src/V1/resources/app_connections_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/src/V1/resources/app_connections_service_rest_client_config.php
+++ b/BeyondCorpAppConnections/src/V1/resources/app_connections_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnections/tests/Unit/V1/Client/AppConnectionsServiceClientTest.php
+++ b/BeyondCorpAppConnections/tests/Unit/V1/Client/AppConnectionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/owlbot.py
+++ b/BeyondCorpAppConnectors/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/create_app_connector.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/create_app_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/delete_app_connector.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/delete_app_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_app_connector.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_app_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_iam_policy.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_location.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/list_app_connectors.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/list_app_connectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/list_locations.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/report_status.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/report_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/set_iam_policy.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/test_iam_permissions.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/update_app_connector.php
+++ b/BeyondCorpAppConnectors/samples/V1/AppConnectorsServiceClient/update_app_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/src/V1/Client/AppConnectorsServiceClient.php
+++ b/BeyondCorpAppConnectors/src/V1/Client/AppConnectorsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/src/V1/resources/app_connectors_service_descriptor_config.php
+++ b/BeyondCorpAppConnectors/src/V1/resources/app_connectors_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/src/V1/resources/app_connectors_service_rest_client_config.php
+++ b/BeyondCorpAppConnectors/src/V1/resources/app_connectors_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppConnectors/tests/Unit/V1/Client/AppConnectorsServiceClientTest.php
+++ b/BeyondCorpAppConnectors/tests/Unit/V1/Client/AppConnectorsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/owlbot.py
+++ b/BeyondCorpAppGateways/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/create_app_gateway.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/create_app_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/delete_app_gateway.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/delete_app_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_app_gateway.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_app_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_iam_policy.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_location.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/list_app_gateways.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/list_app_gateways.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/list_locations.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/set_iam_policy.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/test_iam_permissions.php
+++ b/BeyondCorpAppGateways/samples/V1/AppGatewaysServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/src/V1/Client/AppGatewaysServiceClient.php
+++ b/BeyondCorpAppGateways/src/V1/Client/AppGatewaysServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/src/V1/resources/app_gateways_service_descriptor_config.php
+++ b/BeyondCorpAppGateways/src/V1/resources/app_gateways_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/src/V1/resources/app_gateways_service_rest_client_config.php
+++ b/BeyondCorpAppGateways/src/V1/resources/app_gateways_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpAppGateways/tests/Unit/V1/Client/AppGatewaysServiceClientTest.php
+++ b/BeyondCorpAppGateways/tests/Unit/V1/Client/AppGatewaysServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/owlbot.py
+++ b/BeyondCorpClientConnectorServices/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/create_client_connector_service.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/create_client_connector_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/delete_client_connector_service.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/delete_client_connector_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_client_connector_service.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_client_connector_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_iam_policy.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_location.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/list_client_connector_services.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/list_client_connector_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/list_locations.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/set_iam_policy.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/test_iam_permissions.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/update_client_connector_service.php
+++ b/BeyondCorpClientConnectorServices/samples/V1/ClientConnectorServicesServiceClient/update_client_connector_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/src/V1/Client/ClientConnectorServicesServiceClient.php
+++ b/BeyondCorpClientConnectorServices/src/V1/Client/ClientConnectorServicesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/src/V1/resources/client_connector_services_service_descriptor_config.php
+++ b/BeyondCorpClientConnectorServices/src/V1/resources/client_connector_services_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/src/V1/resources/client_connector_services_service_rest_client_config.php
+++ b/BeyondCorpClientConnectorServices/src/V1/resources/client_connector_services_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientConnectorServices/tests/Unit/V1/Client/ClientConnectorServicesServiceClientTest.php
+++ b/BeyondCorpClientConnectorServices/tests/Unit/V1/Client/ClientConnectorServicesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/owlbot.py
+++ b/BeyondCorpClientGateways/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/create_client_gateway.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/create_client_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/delete_client_gateway.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/delete_client_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_client_gateway.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_client_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_iam_policy.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_location.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/list_client_gateways.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/list_client_gateways.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/list_locations.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/set_iam_policy.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/test_iam_permissions.php
+++ b/BeyondCorpClientGateways/samples/V1/ClientGatewaysServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/src/V1/Client/ClientGatewaysServiceClient.php
+++ b/BeyondCorpClientGateways/src/V1/Client/ClientGatewaysServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/src/V1/resources/client_gateways_service_descriptor_config.php
+++ b/BeyondCorpClientGateways/src/V1/resources/client_gateways_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/src/V1/resources/client_gateways_service_rest_client_config.php
+++ b/BeyondCorpClientGateways/src/V1/resources/client_gateways_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BeyondCorpClientGateways/tests/Unit/V1/Client/ClientGatewaysServiceClientTest.php
+++ b/BeyondCorpClientGateways/tests/Unit/V1/Client/ClientGatewaysServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/owlbot.py
+++ b/BigQueryAnalyticsHub/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/approve_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/approve_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_data_exchange.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_listing.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/create_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_data_exchange.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_listing.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_subscription.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/delete_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_data_exchange.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_iam_policy.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_listing.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_subscription.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/get_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_data_exchanges.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_data_exchanges.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_listings.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_listings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_org_data_exchanges.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_org_data_exchanges.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_query_templates.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_query_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_shared_resource_subscriptions.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_shared_resource_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_subscriptions.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/list_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/refresh_subscription.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/refresh_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/revoke_subscription.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/revoke_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/set_iam_policy.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/submit_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/submit_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/subscribe_data_exchange.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/subscribe_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/subscribe_listing.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/subscribe_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/test_iam_permissions.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_data_exchange.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_listing.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_query_template.php
+++ b/BigQueryAnalyticsHub/samples/V1/AnalyticsHubServiceClient/update_query_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/src/V1/Client/AnalyticsHubServiceClient.php
+++ b/BigQueryAnalyticsHub/src/V1/Client/AnalyticsHubServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/src/V1/resources/analytics_hub_service_descriptor_config.php
+++ b/BigQueryAnalyticsHub/src/V1/resources/analytics_hub_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/src/V1/resources/analytics_hub_service_rest_client_config.php
+++ b/BigQueryAnalyticsHub/src/V1/resources/analytics_hub_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryAnalyticsHub/tests/Unit/V1/Client/AnalyticsHubServiceClientTest.php
+++ b/BigQueryAnalyticsHub/tests/Unit/V1/Client/AnalyticsHubServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/owlbot.py
+++ b/BigQueryConnection/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/create_connection.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/create_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/delete_connection.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/delete_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/get_connection.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/get_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/get_iam_policy.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/list_connections.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/list_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/set_iam_policy.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/test_iam_permissions.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/samples/V1/ConnectionServiceClient/update_connection.php
+++ b/BigQueryConnection/samples/V1/ConnectionServiceClient/update_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/src/V1/Client/ConnectionServiceClient.php
+++ b/BigQueryConnection/src/V1/Client/ConnectionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/src/V1/resources/connection_service_descriptor_config.php
+++ b/BigQueryConnection/src/V1/resources/connection_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/src/V1/resources/connection_service_rest_client_config.php
+++ b/BigQueryConnection/src/V1/resources/connection_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryConnection/tests/Unit/V1/Client/ConnectionServiceClientTest.php
+++ b/BigQueryConnection/tests/Unit/V1/Client/ConnectionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/owlbot.py
+++ b/BigQueryDataExchange/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/create_data_exchange.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/create_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/create_listing.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/create_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/delete_data_exchange.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/delete_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/delete_listing.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/delete_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_data_exchange.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_iam_policy.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_listing.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_location.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_data_exchanges.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_data_exchanges.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_listings.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_listings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_locations.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_org_data_exchanges.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/list_org_data_exchanges.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/set_iam_policy.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/subscribe_listing.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/subscribe_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/test_iam_permissions.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/update_data_exchange.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/update_data_exchange.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/update_listing.php
+++ b/BigQueryDataExchange/samples/V1beta1/AnalyticsHubServiceClient/update_listing.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/src/V1beta1/Client/AnalyticsHubServiceClient.php
+++ b/BigQueryDataExchange/src/V1beta1/Client/AnalyticsHubServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/src/V1beta1/resources/analytics_hub_service_descriptor_config.php
+++ b/BigQueryDataExchange/src/V1beta1/resources/analytics_hub_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/src/V1beta1/resources/analytics_hub_service_rest_client_config.php
+++ b/BigQueryDataExchange/src/V1beta1/resources/analytics_hub_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataExchange/tests/Unit/V1beta1/Client/AnalyticsHubServiceClientTest.php
+++ b/BigQueryDataExchange/tests/Unit/V1beta1/Client/AnalyticsHubServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/owlbot.py
+++ b/BigQueryDataPolicies/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/create_data_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/create_data_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/delete_data_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/delete_data_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/get_data_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/get_data_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/get_iam_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/list_data_policies.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/list_data_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/rename_data_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/rename_data_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/set_iam_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/test_iam_permissions.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/update_data_policy.php
+++ b/BigQueryDataPolicies/samples/V1/DataPolicyServiceClient/update_data_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/src/V1/Client/DataPolicyServiceClient.php
+++ b/BigQueryDataPolicies/src/V1/Client/DataPolicyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/src/V1/resources/data_policy_service_descriptor_config.php
+++ b/BigQueryDataPolicies/src/V1/resources/data_policy_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/src/V1/resources/data_policy_service_rest_client_config.php
+++ b/BigQueryDataPolicies/src/V1/resources/data_policy_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataPolicies/tests/Unit/V1/Client/DataPolicyServiceClientTest.php
+++ b/BigQueryDataPolicies/tests/Unit/V1/Client/DataPolicyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/owlbot.py
+++ b/BigQueryDataTransfer/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/check_valid_creds.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/check_valid_creds.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/create_transfer_config.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/create_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/delete_transfer_config.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/delete_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/delete_transfer_run.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/delete_transfer_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/enroll_data_sources.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/enroll_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_data_source.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_location.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_transfer_config.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_transfer_run.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/get_transfer_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_data_sources.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_locations.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_configs.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_logs.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_logs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_runs.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/list_transfer_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/schedule_transfer_runs.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/schedule_transfer_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/start_manual_transfer_runs.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/start_manual_transfer_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/unenroll_data_sources.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/unenroll_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/update_transfer_config.php
+++ b/BigQueryDataTransfer/samples/V1/DataTransferServiceClient/update_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/src/V1/Client/DataTransferServiceClient.php
+++ b/BigQueryDataTransfer/src/V1/Client/DataTransferServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/src/V1/resources/data_transfer_service_descriptor_config.php
+++ b/BigQueryDataTransfer/src/V1/resources/data_transfer_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/src/V1/resources/data_transfer_service_rest_client_config.php
+++ b/BigQueryDataTransfer/src/V1/resources/data_transfer_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryDataTransfer/tests/Unit/V1/Client/DataTransferServiceClientTest.php
+++ b/BigQueryDataTransfer/tests/Unit/V1/Client/DataTransferServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/owlbot.py
+++ b/BigQueryMigration/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/create_migration_workflow.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/create_migration_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/delete_migration_workflow.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/delete_migration_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/get_migration_subtask.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/get_migration_subtask.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/get_migration_workflow.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/get_migration_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/list_migration_subtasks.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/list_migration_subtasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/list_migration_workflows.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/list_migration_workflows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/samples/V2/MigrationServiceClient/start_migration_workflow.php
+++ b/BigQueryMigration/samples/V2/MigrationServiceClient/start_migration_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/src/V2/Client/MigrationServiceClient.php
+++ b/BigQueryMigration/src/V2/Client/MigrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/src/V2/resources/migration_service_descriptor_config.php
+++ b/BigQueryMigration/src/V2/resources/migration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/src/V2/resources/migration_service_rest_client_config.php
+++ b/BigQueryMigration/src/V2/resources/migration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryMigration/tests/Unit/V2/Client/MigrationServiceClientTest.php
+++ b/BigQueryMigration/tests/Unit/V2/Client/MigrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/owlbot.py
+++ b/BigQueryReservation/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/create_assignment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/create_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/create_capacity_commitment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/create_capacity_commitment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/create_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/create_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/create_reservation_group.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/create_reservation_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/delete_assignment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/delete_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/delete_capacity_commitment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/delete_capacity_commitment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/delete_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/delete_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/delete_reservation_group.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/delete_reservation_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/failover_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/failover_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/get_bi_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/get_bi_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/get_capacity_commitment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/get_capacity_commitment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/get_iam_policy.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/get_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/get_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/get_reservation_group.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/get_reservation_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/list_assignments.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/list_assignments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/list_capacity_commitments.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/list_capacity_commitments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/list_reservation_groups.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/list_reservation_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/list_reservations.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/list_reservations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/merge_capacity_commitments.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/merge_capacity_commitments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/move_assignment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/move_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/search_all_assignments.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/search_all_assignments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/search_assignments.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/search_assignments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/set_iam_policy.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/split_capacity_commitment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/split_capacity_commitment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/test_iam_permissions.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/update_assignment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/update_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/update_bi_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/update_bi_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/update_capacity_commitment.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/update_capacity_commitment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/samples/V1/ReservationServiceClient/update_reservation.php
+++ b/BigQueryReservation/samples/V1/ReservationServiceClient/update_reservation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/src/V1/Client/ReservationServiceClient.php
+++ b/BigQueryReservation/src/V1/Client/ReservationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/src/V1/resources/reservation_service_descriptor_config.php
+++ b/BigQueryReservation/src/V1/resources/reservation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/src/V1/resources/reservation_service_rest_client_config.php
+++ b/BigQueryReservation/src/V1/resources/reservation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryReservation/tests/Unit/V1/Client/ReservationServiceClientTest.php
+++ b/BigQueryReservation/tests/Unit/V1/Client/ReservationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/metadata/descriptor_fix.php
+++ b/BigQueryStorage/metadata/descriptor_fix.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/owlbot.py
+++ b/BigQueryStorage/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryReadClient/create_read_session.php
+++ b/BigQueryStorage/samples/V1/BigQueryReadClient/create_read_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryReadClient/read_rows.php
+++ b/BigQueryStorage/samples/V1/BigQueryReadClient/read_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryReadClient/split_read_stream.php
+++ b/BigQueryStorage/samples/V1/BigQueryReadClient/split_read_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/append_rows.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/append_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/batch_commit_write_streams.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/batch_commit_write_streams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/create_write_stream.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/create_write_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/finalize_write_stream.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/finalize_write_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/flush_rows.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/flush_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/samples/V1/BigQueryWriteClient/get_write_stream.php
+++ b/BigQueryStorage/samples/V1/BigQueryWriteClient/get_write_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/Client/BigQueryReadClient.php
+++ b/BigQueryStorage/src/V1/Client/BigQueryReadClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/Client/BigQueryWriteClient.php
+++ b/BigQueryStorage/src/V1/Client/BigQueryWriteClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/resources/big_query_read_descriptor_config.php
+++ b/BigQueryStorage/src/V1/resources/big_query_read_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/resources/big_query_read_rest_client_config.php
+++ b/BigQueryStorage/src/V1/resources/big_query_read_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/resources/big_query_write_descriptor_config.php
+++ b/BigQueryStorage/src/V1/resources/big_query_write_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/src/V1/resources/big_query_write_rest_client_config.php
+++ b/BigQueryStorage/src/V1/resources/big_query_write_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/tests/Unit/V1/Client/BigQueryReadClientTest.php
+++ b/BigQueryStorage/tests/Unit/V1/Client/BigQueryReadClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BigQueryStorage/tests/Unit/V1/Client/BigQueryWriteClientTest.php
+++ b/BigQueryStorage/tests/Unit/V1/Client/BigQueryWriteClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/check_and_mutate_row.php
+++ b/Bigtable/samples/V2/BigtableClient/check_and_mutate_row.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/execute_query.php
+++ b/Bigtable/samples/V2/BigtableClient/execute_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/generate_initial_change_stream_partitions.php
+++ b/Bigtable/samples/V2/BigtableClient/generate_initial_change_stream_partitions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/mutate_row.php
+++ b/Bigtable/samples/V2/BigtableClient/mutate_row.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/mutate_rows.php
+++ b/Bigtable/samples/V2/BigtableClient/mutate_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/ping_and_warm.php
+++ b/Bigtable/samples/V2/BigtableClient/ping_and_warm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/prepare_query.php
+++ b/Bigtable/samples/V2/BigtableClient/prepare_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/read_change_stream.php
+++ b/Bigtable/samples/V2/BigtableClient/read_change_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/read_modify_write_row.php
+++ b/Bigtable/samples/V2/BigtableClient/read_modify_write_row.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/read_rows.php
+++ b/Bigtable/samples/V2/BigtableClient/read_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/samples/V2/BigtableClient/sample_row_keys.php
+++ b/Bigtable/samples/V2/BigtableClient/sample_row_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/Client/BigtableInstanceAdminClient.php
+++ b/Bigtable/src/Admin/V2/Client/BigtableInstanceAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/Client/BigtableTableAdminClient.php
+++ b/Bigtable/src/Admin/V2/Client/BigtableTableAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/resources/bigtable_instance_admin_descriptor_config.php
+++ b/Bigtable/src/Admin/V2/resources/bigtable_instance_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/resources/bigtable_instance_admin_rest_client_config.php
+++ b/Bigtable/src/Admin/V2/resources/bigtable_instance_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/resources/bigtable_table_admin_descriptor_config.php
+++ b/Bigtable/src/Admin/V2/resources/bigtable_table_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/Admin/V2/resources/bigtable_table_admin_rest_client_config.php
+++ b/Bigtable/src/Admin/V2/resources/bigtable_table_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/V2/Client/BigtableClient.php
+++ b/Bigtable/src/V2/Client/BigtableClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/V2/resources/bigtable_descriptor_config.php
+++ b/Bigtable/src/V2/resources/bigtable_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/src/V2/resources/bigtable_rest_client_config.php
+++ b/Bigtable/src/V2/resources/bigtable_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/tests/Unit/Admin/V2/Client/BigtableInstanceAdminClientTest.php
+++ b/Bigtable/tests/Unit/Admin/V2/Client/BigtableInstanceAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/tests/Unit/Admin/V2/Client/BigtableTableAdminClientTest.php
+++ b/Bigtable/tests/Unit/Admin/V2/Client/BigtableTableAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Bigtable/tests/Unit/V2/Client/BigtableClientTest.php
+++ b/Bigtable/tests/Unit/V2/Client/BigtableClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/owlbot.py
+++ b/Billing/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/create_billing_account.php
+++ b/Billing/samples/V1/CloudBillingClient/create_billing_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/get_billing_account.php
+++ b/Billing/samples/V1/CloudBillingClient/get_billing_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/get_iam_policy.php
+++ b/Billing/samples/V1/CloudBillingClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/get_project_billing_info.php
+++ b/Billing/samples/V1/CloudBillingClient/get_project_billing_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/list_billing_accounts.php
+++ b/Billing/samples/V1/CloudBillingClient/list_billing_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/list_project_billing_info.php
+++ b/Billing/samples/V1/CloudBillingClient/list_project_billing_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/move_billing_account.php
+++ b/Billing/samples/V1/CloudBillingClient/move_billing_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/set_iam_policy.php
+++ b/Billing/samples/V1/CloudBillingClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/test_iam_permissions.php
+++ b/Billing/samples/V1/CloudBillingClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/update_billing_account.php
+++ b/Billing/samples/V1/CloudBillingClient/update_billing_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudBillingClient/update_project_billing_info.php
+++ b/Billing/samples/V1/CloudBillingClient/update_project_billing_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudCatalogClient/list_services.php
+++ b/Billing/samples/V1/CloudCatalogClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/samples/V1/CloudCatalogClient/list_skus.php
+++ b/Billing/samples/V1/CloudCatalogClient/list_skus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/Client/CloudBillingClient.php
+++ b/Billing/src/V1/Client/CloudBillingClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/Client/CloudCatalogClient.php
+++ b/Billing/src/V1/Client/CloudCatalogClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/resources/cloud_billing_descriptor_config.php
+++ b/Billing/src/V1/resources/cloud_billing_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/resources/cloud_billing_rest_client_config.php
+++ b/Billing/src/V1/resources/cloud_billing_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/resources/cloud_catalog_descriptor_config.php
+++ b/Billing/src/V1/resources/cloud_catalog_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/src/V1/resources/cloud_catalog_rest_client_config.php
+++ b/Billing/src/V1/resources/cloud_catalog_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/tests/Unit/V1/Client/CloudBillingClientTest.php
+++ b/Billing/tests/Unit/V1/Client/CloudBillingClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Billing/tests/Unit/V1/Client/CloudCatalogClientTest.php
+++ b/Billing/tests/Unit/V1/Client/CloudCatalogClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/owlbot.py
+++ b/BillingBudgets/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BillingBudgets/samples/V1/BudgetServiceClient/create_budget.php
+++ b/BillingBudgets/samples/V1/BudgetServiceClient/create_budget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/samples/V1/BudgetServiceClient/delete_budget.php
+++ b/BillingBudgets/samples/V1/BudgetServiceClient/delete_budget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/samples/V1/BudgetServiceClient/get_budget.php
+++ b/BillingBudgets/samples/V1/BudgetServiceClient/get_budget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/samples/V1/BudgetServiceClient/list_budgets.php
+++ b/BillingBudgets/samples/V1/BudgetServiceClient/list_budgets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/samples/V1/BudgetServiceClient/update_budget.php
+++ b/BillingBudgets/samples/V1/BudgetServiceClient/update_budget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/src/V1/Client/BudgetServiceClient.php
+++ b/BillingBudgets/src/V1/Client/BudgetServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/src/V1/resources/budget_service_descriptor_config.php
+++ b/BillingBudgets/src/V1/resources/budget_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/src/V1/resources/budget_service_rest_client_config.php
+++ b/BillingBudgets/src/V1/resources/budget_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BillingBudgets/tests/Unit/V1/Client/BudgetServiceClientTest.php
+++ b/BillingBudgets/tests/Unit/V1/Client/BudgetServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/owlbot.py
+++ b/BinaryAuthorization/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/create_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/create_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/delete_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/delete_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_policy.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/get_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/list_attestors.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/list_attestors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_attestor.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_attestor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_policy.php
+++ b/BinaryAuthorization/samples/V1/BinauthzManagementServiceV1Client/update_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/SystemPolicyV1Client/get_system_policy.php
+++ b/BinaryAuthorization/samples/V1/SystemPolicyV1Client/get_system_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/samples/V1/ValidationHelperV1Client/validate_attestation_occurrence.php
+++ b/BinaryAuthorization/samples/V1/ValidationHelperV1Client/validate_attestation_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/BinauthzManagementServiceV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/BinauthzManagementServiceV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/SystemPolicyV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/SystemPolicyV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/Client/ValidationHelperV1Client.php
+++ b/BinaryAuthorization/src/V1/Client/ValidationHelperV1Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/binauthz_management_service_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/system_policy_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/system_policy_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/system_policy_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/system_policy_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/validation_helper_v1_descriptor_config.php
+++ b/BinaryAuthorization/src/V1/resources/validation_helper_v1_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/src/V1/resources/validation_helper_v1_rest_client_config.php
+++ b/BinaryAuthorization/src/V1/resources/validation_helper_v1_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/BinauthzManagementServiceV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/BinauthzManagementServiceV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/SystemPolicyV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/SystemPolicyV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/BinaryAuthorization/tests/Unit/V1/Client/ValidationHelperV1ClientTest.php
+++ b/BinaryAuthorization/tests/Unit/V1/Client/ValidationHelperV1ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/owlbot.py
+++ b/Build/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/batch_create_repositories.php
+++ b/Build/samples/V2/RepositoryManagerClient/batch_create_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/create_connection.php
+++ b/Build/samples/V2/RepositoryManagerClient/create_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/create_repository.php
+++ b/Build/samples/V2/RepositoryManagerClient/create_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/delete_connection.php
+++ b/Build/samples/V2/RepositoryManagerClient/delete_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/delete_repository.php
+++ b/Build/samples/V2/RepositoryManagerClient/delete_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/fetch_git_refs.php
+++ b/Build/samples/V2/RepositoryManagerClient/fetch_git_refs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/fetch_linkable_repositories.php
+++ b/Build/samples/V2/RepositoryManagerClient/fetch_linkable_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/fetch_read_token.php
+++ b/Build/samples/V2/RepositoryManagerClient/fetch_read_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/fetch_read_write_token.php
+++ b/Build/samples/V2/RepositoryManagerClient/fetch_read_write_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/get_connection.php
+++ b/Build/samples/V2/RepositoryManagerClient/get_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/get_iam_policy.php
+++ b/Build/samples/V2/RepositoryManagerClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/get_repository.php
+++ b/Build/samples/V2/RepositoryManagerClient/get_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/list_connections.php
+++ b/Build/samples/V2/RepositoryManagerClient/list_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/list_repositories.php
+++ b/Build/samples/V2/RepositoryManagerClient/list_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/set_iam_policy.php
+++ b/Build/samples/V2/RepositoryManagerClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/test_iam_permissions.php
+++ b/Build/samples/V2/RepositoryManagerClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/samples/V2/RepositoryManagerClient/update_connection.php
+++ b/Build/samples/V2/RepositoryManagerClient/update_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/src/V2/Client/RepositoryManagerClient.php
+++ b/Build/src/V2/Client/RepositoryManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/src/V2/resources/repository_manager_descriptor_config.php
+++ b/Build/src/V2/resources/repository_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/src/V2/resources/repository_manager_rest_client_config.php
+++ b/Build/src/V2/resources/repository_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Build/tests/Unit/V2/Client/RepositoryManagerClientTest.php
+++ b/Build/tests/Unit/V2/Client/RepositoryManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/owlbot.py
+++ b/CapacityPlanner/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/export_forecasts.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/export_forecasts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/export_reservations_usage.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/export_reservations_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/export_usage_histories.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/export_usage_histories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/query_forecasts.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/query_forecasts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/query_reservations.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/query_reservations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/samples/V1beta/UsageServiceClient/query_usage_histories.php
+++ b/CapacityPlanner/samples/V1beta/UsageServiceClient/query_usage_histories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/src/V1beta/Client/UsageServiceClient.php
+++ b/CapacityPlanner/src/V1beta/Client/UsageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/src/V1beta/resources/usage_service_descriptor_config.php
+++ b/CapacityPlanner/src/V1beta/resources/usage_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/src/V1beta/resources/usage_service_rest_client_config.php
+++ b/CapacityPlanner/src/V1beta/resources/usage_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CapacityPlanner/tests/Unit/V1beta/Client/UsageServiceClientTest.php
+++ b/CapacityPlanner/tests/Unit/V1beta/Client/UsageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/owlbot.py
+++ b/CertificateManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_certificate.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_issuance_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_issuance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_map.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_map_entry.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_certificate_map_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_dns_authorization.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_dns_authorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/create_trust_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/create_trust_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_issuance_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_issuance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_map.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_map_entry.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_certificate_map_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_dns_authorization.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_dns_authorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/delete_trust_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/delete_trust_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_certificate.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_issuance_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_issuance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_map.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_map_entry.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_certificate_map_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_dns_authorization.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_dns_authorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_location.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/get_trust_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/get_trust_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_issuance_configs.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_issuance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_map_entries.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_map_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_maps.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_certificate_maps.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_certificates.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_dns_authorizations.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_dns_authorizations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_locations.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/list_trust_configs.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/list_trust_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/update_certificate.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/update_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/update_certificate_map.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/update_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/update_certificate_map_entry.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/update_certificate_map_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/update_dns_authorization.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/update_dns_authorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/samples/V1/CertificateManagerClient/update_trust_config.php
+++ b/CertificateManager/samples/V1/CertificateManagerClient/update_trust_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/src/V1/Client/CertificateManagerClient.php
+++ b/CertificateManager/src/V1/Client/CertificateManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/src/V1/resources/certificate_manager_descriptor_config.php
+++ b/CertificateManager/src/V1/resources/certificate_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/src/V1/resources/certificate_manager_rest_client_config.php
+++ b/CertificateManager/src/V1/resources/certificate_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CertificateManager/tests/Unit/V1/Client/CertificateManagerClientTest.php
+++ b/CertificateManager/tests/Unit/V1/Client/CertificateManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ces/owlbot.py
+++ b/Ces/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Channel/owlbot.py
+++ b/Channel/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelReportsServiceClient/fetch_report_results.php
+++ b/Channel/samples/V1/CloudChannelReportsServiceClient/fetch_report_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelReportsServiceClient/list_reports.php
+++ b/Channel/samples/V1/CloudChannelReportsServiceClient/list_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelReportsServiceClient/run_report_job.php
+++ b/Channel/samples/V1/CloudChannelReportsServiceClient/run_report_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/activate_entitlement.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/activate_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/cancel_entitlement.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/cancel_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/change_offer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/change_offer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/change_parameters.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/change_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/change_renewal_settings.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/change_renewal_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/check_cloud_identity_accounts_exist.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/check_cloud_identity_accounts_exist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/create_channel_partner_link.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/create_channel_partner_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/create_channel_partner_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/create_channel_partner_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/create_customer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/create_customer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/create_customer_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/create_customer_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/create_entitlement.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/create_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/delete_channel_partner_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/delete_channel_partner_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/delete_customer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/delete_customer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/delete_customer_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/delete_customer_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/get_channel_partner_link.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/get_channel_partner_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/get_channel_partner_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/get_channel_partner_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/get_customer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/get_customer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/get_customer_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/get_customer_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/get_entitlement.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/get_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/import_customer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/import_customer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_channel_partner_links.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_channel_partner_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_channel_partner_repricing_configs.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_channel_partner_repricing_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_customer_repricing_configs.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_customer_repricing_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_customers.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_customers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_entitlement_changes.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_entitlement_changes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_entitlements.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_entitlements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_offers.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_offers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_products.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_purchasable_offers.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_purchasable_offers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_purchasable_skus.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_purchasable_skus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_sku_group_billable_skus.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_sku_group_billable_skus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_sku_groups.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_sku_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_skus.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_skus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_subscribers.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_subscribers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_transferable_offers.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_transferable_offers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/list_transferable_skus.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/list_transferable_skus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/lookup_offer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/lookup_offer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/provision_cloud_identity.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/provision_cloud_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/query_eligible_billing_accounts.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/query_eligible_billing_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/register_subscriber.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/register_subscriber.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/start_paid_service.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/start_paid_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/suspend_entitlement.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/suspend_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/transfer_entitlements.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/transfer_entitlements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/transfer_entitlements_to_google.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/transfer_entitlements_to_google.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/unregister_subscriber.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/unregister_subscriber.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/update_channel_partner_link.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/update_channel_partner_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/update_channel_partner_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/update_channel_partner_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/update_customer.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/update_customer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/samples/V1/CloudChannelServiceClient/update_customer_repricing_config.php
+++ b/Channel/samples/V1/CloudChannelServiceClient/update_customer_repricing_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/Client/CloudChannelReportsServiceClient.php
+++ b/Channel/src/V1/Client/CloudChannelReportsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/Client/CloudChannelServiceClient.php
+++ b/Channel/src/V1/Client/CloudChannelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/resources/cloud_channel_reports_service_descriptor_config.php
+++ b/Channel/src/V1/resources/cloud_channel_reports_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/resources/cloud_channel_reports_service_rest_client_config.php
+++ b/Channel/src/V1/resources/cloud_channel_reports_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/resources/cloud_channel_service_descriptor_config.php
+++ b/Channel/src/V1/resources/cloud_channel_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/src/V1/resources/cloud_channel_service_rest_client_config.php
+++ b/Channel/src/V1/resources/cloud_channel_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/tests/Unit/V1/Client/CloudChannelReportsServiceClientTest.php
+++ b/Channel/tests/Unit/V1/Client/CloudChannelReportsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Channel/tests/Unit/V1/Client/CloudChannelServiceClientTest.php
+++ b/Channel/tests/Unit/V1/Client/CloudChannelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/owlbot.py
+++ b/Chronicle/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/create_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/delete_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/get_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_labels.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_scopes.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/list_data_access_scopes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_label.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_scope.php
+++ b/Chronicle/samples/V1/DataAccessControlServiceClient/update_data_access_scope.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/create_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/create_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/delete_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/delete_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/get_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/get_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/list_watchlists.php
+++ b/Chronicle/samples/V1/EntityServiceClient/list_watchlists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/EntityServiceClient/update_watchlist.php
+++ b/Chronicle/samples/V1/EntityServiceClient/update_watchlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/InstanceServiceClient/get_instance.php
+++ b/Chronicle/samples/V1/InstanceServiceClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/create_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/create_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/get_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/get_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/list_reference_lists.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/list_reference_lists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/ReferenceListServiceClient/update_reference_list.php
+++ b/Chronicle/samples/V1/ReferenceListServiceClient/update_reference_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/create_retrohunt.php
+++ b/Chronicle/samples/V1/RuleServiceClient/create_retrohunt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/create_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/create_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/delete_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/delete_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_retrohunt.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_retrohunt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/get_rule_deployment.php
+++ b/Chronicle/samples/V1/RuleServiceClient/get_rule_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_retrohunts.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_retrohunts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rule_deployments.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rule_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rule_revisions.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rule_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/list_rules.php
+++ b/Chronicle/samples/V1/RuleServiceClient/list_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/update_rule.php
+++ b/Chronicle/samples/V1/RuleServiceClient/update_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/samples/V1/RuleServiceClient/update_rule_deployment.php
+++ b/Chronicle/samples/V1/RuleServiceClient/update_rule_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/DataAccessControlServiceClient.php
+++ b/Chronicle/src/V1/Client/DataAccessControlServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/EntityServiceClient.php
+++ b/Chronicle/src/V1/Client/EntityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/InstanceServiceClient.php
+++ b/Chronicle/src/V1/Client/InstanceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/ReferenceListServiceClient.php
+++ b/Chronicle/src/V1/Client/ReferenceListServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/Client/RuleServiceClient.php
+++ b/Chronicle/src/V1/Client/RuleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/data_access_control_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/data_access_control_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/data_access_control_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/data_access_control_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/entity_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/entity_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/entity_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/entity_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/instance_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/instance_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/instance_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/instance_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/reference_list_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/reference_list_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/reference_list_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/reference_list_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/rule_service_descriptor_config.php
+++ b/Chronicle/src/V1/resources/rule_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/src/V1/resources/rule_service_rest_client_config.php
+++ b/Chronicle/src/V1/resources/rule_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/DataAccessControlServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/DataAccessControlServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/EntityServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/EntityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/InstanceServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/InstanceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/ReferenceListServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/ReferenceListServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Chronicle/tests/Unit/V1/Client/RuleServiceClientTest.php
+++ b/Chronicle/tests/Unit/V1/Client/RuleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CloudCommonProtos/owlbot.py
+++ b/CloudCommonProtos/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CloudCommonProtos/tests/Unit/InstantiateClassesTest.php
+++ b/CloudCommonProtos/tests/Unit/InstantiateClassesTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/owlbot.py
+++ b/CommerceConsumerProcurement/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/cancel_order.php
+++ b/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/cancel_order.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/get_order.php
+++ b/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/get_order.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/list_orders.php
+++ b/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/list_orders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/modify_order.php
+++ b/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/modify_order.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/place_order.php
+++ b/CommerceConsumerProcurement/samples/V1/ConsumerProcurementServiceClient/place_order.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/assign.php
+++ b/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/assign.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/enumerate_licensed_users.php
+++ b/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/enumerate_licensed_users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/get_license_pool.php
+++ b/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/get_license_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/unassign.php
+++ b/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/unassign.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/update_license_pool.php
+++ b/CommerceConsumerProcurement/samples/V1/LicenseManagementServiceClient/update_license_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/Client/ConsumerProcurementServiceClient.php
+++ b/CommerceConsumerProcurement/src/V1/Client/ConsumerProcurementServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/Client/LicenseManagementServiceClient.php
+++ b/CommerceConsumerProcurement/src/V1/Client/LicenseManagementServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/resources/consumer_procurement_service_descriptor_config.php
+++ b/CommerceConsumerProcurement/src/V1/resources/consumer_procurement_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/resources/consumer_procurement_service_rest_client_config.php
+++ b/CommerceConsumerProcurement/src/V1/resources/consumer_procurement_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/resources/license_management_service_descriptor_config.php
+++ b/CommerceConsumerProcurement/src/V1/resources/license_management_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/src/V1/resources/license_management_service_rest_client_config.php
+++ b/CommerceConsumerProcurement/src/V1/resources/license_management_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/tests/Unit/V1/Client/ConsumerProcurementServiceClientTest.php
+++ b/CommerceConsumerProcurement/tests/Unit/V1/Client/ConsumerProcurementServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceConsumerProcurement/tests/Unit/V1/Client/LicenseManagementServiceClientTest.php
+++ b/CommerceConsumerProcurement/tests/Unit/V1/Client/LicenseManagementServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CommerceProducer/owlbot.py
+++ b/CommerceProducer/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CommonProtos/owlbot.py
+++ b/CommonProtos/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **726 generated files** in **34 in-scope packages** (Asset through CommonProtos).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`Asset`, `AssuredWorkloads`, `AuditManager`, `AutoMl`, `BackupDr`, `BareMetalSolution`, `Batch`, `BeyondCorpAppConnections`, `BeyondCorpAppConnectors`, `BeyondCorpAppGateways`, `BeyondCorpClientConnectorServices`, `BeyondCorpClientGateways`, `BigQueryAnalyticsHub`, `BigQueryConnection`, `BigQueryDataExchange`, `BigQueryDataPolicies`, `BigQueryDataTransfer`, `BigQueryMigration`, `BigQueryReservation`, `BigQueryStorage`, `Bigtable`, `Billing`, `BillingBudgets`, `BinaryAuthorization`, `Build`, `CapacityPlanner`, `CertificateManager`, `Ces`, `Channel`, `Chronicle`, `CloudCommonProtos`, `CommerceConsumerProcurement`, `CommerceProducer`, `CommonProtos`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-3
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 3 of 10 in the 2026 copyright update series.
