### PR TITLE
chore: update copyright years to 2026 for generated files (part 4: Compute to Compute)

### DIFF
--- a/Compute/owlbot.py
+++ b/Compute/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AcceleratorTypesClient/aggregated_list.php
+++ b/Compute/samples/V1/AcceleratorTypesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AcceleratorTypesClient/get.php
+++ b/Compute/samples/V1/AcceleratorTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AcceleratorTypesClient/list.php
+++ b/Compute/samples/V1/AcceleratorTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/aggregated_list.php
+++ b/Compute/samples/V1/AddressesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/delete.php
+++ b/Compute/samples/V1/AddressesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/get.php
+++ b/Compute/samples/V1/AddressesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/insert.php
+++ b/Compute/samples/V1/AddressesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/list.php
+++ b/Compute/samples/V1/AddressesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/move.php
+++ b/Compute/samples/V1/AddressesClient/move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/set_labels.php
+++ b/Compute/samples/V1/AddressesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AddressesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/AddressesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AdviceClient/calendar_mode.php
+++ b/Compute/samples/V1/AdviceClient/calendar_mode.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/aggregated_list.php
+++ b/Compute/samples/V1/AutoscalersClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/delete.php
+++ b/Compute/samples/V1/AutoscalersClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/get.php
+++ b/Compute/samples/V1/AutoscalersClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/insert.php
+++ b/Compute/samples/V1/AutoscalersClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/list.php
+++ b/Compute/samples/V1/AutoscalersClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/patch.php
+++ b/Compute/samples/V1/AutoscalersClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/AutoscalersClient/update.php
+++ b/Compute/samples/V1/AutoscalersClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/add_signed_url_key.php
+++ b/Compute/samples/V1/BackendBucketsClient/add_signed_url_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/delete.php
+++ b/Compute/samples/V1/BackendBucketsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/delete_signed_url_key.php
+++ b/Compute/samples/V1/BackendBucketsClient/delete_signed_url_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/get.php
+++ b/Compute/samples/V1/BackendBucketsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/get_iam_policy.php
+++ b/Compute/samples/V1/BackendBucketsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/insert.php
+++ b/Compute/samples/V1/BackendBucketsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/list.php
+++ b/Compute/samples/V1/BackendBucketsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/patch.php
+++ b/Compute/samples/V1/BackendBucketsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/set_edge_security_policy.php
+++ b/Compute/samples/V1/BackendBucketsClient/set_edge_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/set_iam_policy.php
+++ b/Compute/samples/V1/BackendBucketsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/BackendBucketsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendBucketsClient/update.php
+++ b/Compute/samples/V1/BackendBucketsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/add_signed_url_key.php
+++ b/Compute/samples/V1/BackendServicesClient/add_signed_url_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/aggregated_list.php
+++ b/Compute/samples/V1/BackendServicesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/delete.php
+++ b/Compute/samples/V1/BackendServicesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/delete_signed_url_key.php
+++ b/Compute/samples/V1/BackendServicesClient/delete_signed_url_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/get.php
+++ b/Compute/samples/V1/BackendServicesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/get_effective_security_policies.php
+++ b/Compute/samples/V1/BackendServicesClient/get_effective_security_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/get_health.php
+++ b/Compute/samples/V1/BackendServicesClient/get_health.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/get_iam_policy.php
+++ b/Compute/samples/V1/BackendServicesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/insert.php
+++ b/Compute/samples/V1/BackendServicesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/list.php
+++ b/Compute/samples/V1/BackendServicesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/list_usable.php
+++ b/Compute/samples/V1/BackendServicesClient/list_usable.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/patch.php
+++ b/Compute/samples/V1/BackendServicesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/set_edge_security_policy.php
+++ b/Compute/samples/V1/BackendServicesClient/set_edge_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/set_iam_policy.php
+++ b/Compute/samples/V1/BackendServicesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/set_security_policy.php
+++ b/Compute/samples/V1/BackendServicesClient/set_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/BackendServicesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/BackendServicesClient/update.php
+++ b/Compute/samples/V1/BackendServicesClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/CrossSiteNetworksClient/delete.php
+++ b/Compute/samples/V1/CrossSiteNetworksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/CrossSiteNetworksClient/get.php
+++ b/Compute/samples/V1/CrossSiteNetworksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/CrossSiteNetworksClient/insert.php
+++ b/Compute/samples/V1/CrossSiteNetworksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/CrossSiteNetworksClient/list.php
+++ b/Compute/samples/V1/CrossSiteNetworksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/CrossSiteNetworksClient/patch.php
+++ b/Compute/samples/V1/CrossSiteNetworksClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DiskTypesClient/aggregated_list.php
+++ b/Compute/samples/V1/DiskTypesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DiskTypesClient/get.php
+++ b/Compute/samples/V1/DiskTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DiskTypesClient/list.php
+++ b/Compute/samples/V1/DiskTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/add_resource_policies.php
+++ b/Compute/samples/V1/DisksClient/add_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/aggregated_list.php
+++ b/Compute/samples/V1/DisksClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/bulk_insert.php
+++ b/Compute/samples/V1/DisksClient/bulk_insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/bulk_set_labels.php
+++ b/Compute/samples/V1/DisksClient/bulk_set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/create_snapshot.php
+++ b/Compute/samples/V1/DisksClient/create_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/delete.php
+++ b/Compute/samples/V1/DisksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/get.php
+++ b/Compute/samples/V1/DisksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/get_iam_policy.php
+++ b/Compute/samples/V1/DisksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/insert.php
+++ b/Compute/samples/V1/DisksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/list.php
+++ b/Compute/samples/V1/DisksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/remove_resource_policies.php
+++ b/Compute/samples/V1/DisksClient/remove_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/resize.php
+++ b/Compute/samples/V1/DisksClient/resize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/set_iam_policy.php
+++ b/Compute/samples/V1/DisksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/set_labels.php
+++ b/Compute/samples/V1/DisksClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/start_async_replication.php
+++ b/Compute/samples/V1/DisksClient/start_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/stop_async_replication.php
+++ b/Compute/samples/V1/DisksClient/stop_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/stop_group_async_replication.php
+++ b/Compute/samples/V1/DisksClient/stop_group_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/test_iam_permissions.php
+++ b/Compute/samples/V1/DisksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/DisksClient/update.php
+++ b/Compute/samples/V1/DisksClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/delete.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/get.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/insert.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/list.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/set_labels.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ExternalVpnGatewaysClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ExternalVpnGatewaysClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/add_association.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/add_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/clone_rules.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/clone_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/delete.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/get.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/get_association.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/get_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/get_iam_policy.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/insert.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/list.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/list_associations.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/list_associations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/move.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/patch.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/remove_association.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/remove_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/set_iam_policy.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallPoliciesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/FirewallPoliciesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/delete.php
+++ b/Compute/samples/V1/FirewallsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/get.php
+++ b/Compute/samples/V1/FirewallsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/insert.php
+++ b/Compute/samples/V1/FirewallsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/list.php
+++ b/Compute/samples/V1/FirewallsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/patch.php
+++ b/Compute/samples/V1/FirewallsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/FirewallsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FirewallsClient/update.php
+++ b/Compute/samples/V1/FirewallsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/aggregated_list.php
+++ b/Compute/samples/V1/ForwardingRulesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/delete.php
+++ b/Compute/samples/V1/ForwardingRulesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/get.php
+++ b/Compute/samples/V1/ForwardingRulesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/insert.php
+++ b/Compute/samples/V1/ForwardingRulesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/list.php
+++ b/Compute/samples/V1/ForwardingRulesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/patch.php
+++ b/Compute/samples/V1/ForwardingRulesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/set_labels.php
+++ b/Compute/samples/V1/ForwardingRulesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ForwardingRulesClient/set_target.php
+++ b/Compute/samples/V1/ForwardingRulesClient/set_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/aggregated_list.php
+++ b/Compute/samples/V1/FutureReservationsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/cancel.php
+++ b/Compute/samples/V1/FutureReservationsClient/cancel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/delete.php
+++ b/Compute/samples/V1/FutureReservationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/get.php
+++ b/Compute/samples/V1/FutureReservationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/insert.php
+++ b/Compute/samples/V1/FutureReservationsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/list.php
+++ b/Compute/samples/V1/FutureReservationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/FutureReservationsClient/update.php
+++ b/Compute/samples/V1/FutureReservationsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/delete.php
+++ b/Compute/samples/V1/GlobalAddressesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/get.php
+++ b/Compute/samples/V1/GlobalAddressesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/insert.php
+++ b/Compute/samples/V1/GlobalAddressesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/list.php
+++ b/Compute/samples/V1/GlobalAddressesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/move.php
+++ b/Compute/samples/V1/GlobalAddressesClient/move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/set_labels.php
+++ b/Compute/samples/V1/GlobalAddressesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalAddressesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/GlobalAddressesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/delete.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/get.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/insert.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/list.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/patch.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/set_labels.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalForwardingRulesClient/set_target.php
+++ b/Compute/samples/V1/GlobalForwardingRulesClient/set_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/attach_network_endpoints.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/attach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/delete.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/detach_network_endpoints.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/detach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/get.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/insert.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/list.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/list_network_endpoints.php
+++ b/Compute/samples/V1/GlobalNetworkEndpointGroupsClient/list_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOperationsClient/aggregated_list.php
+++ b/Compute/samples/V1/GlobalOperationsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOperationsClient/delete.php
+++ b/Compute/samples/V1/GlobalOperationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOperationsClient/get.php
+++ b/Compute/samples/V1/GlobalOperationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOperationsClient/list.php
+++ b/Compute/samples/V1/GlobalOperationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOperationsClient/wait.php
+++ b/Compute/samples/V1/GlobalOperationsClient/wait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOrganizationOperationsClient/delete.php
+++ b/Compute/samples/V1/GlobalOrganizationOperationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOrganizationOperationsClient/get.php
+++ b/Compute/samples/V1/GlobalOrganizationOperationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalOrganizationOperationsClient/list.php
+++ b/Compute/samples/V1/GlobalOrganizationOperationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/delete.php
+++ b/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/get.php
+++ b/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/insert.php
+++ b/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/list.php
+++ b/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/patch.php
+++ b/Compute/samples/V1/GlobalPublicDelegatedPrefixesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/aggregated_list.php
+++ b/Compute/samples/V1/HealthChecksClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/delete.php
+++ b/Compute/samples/V1/HealthChecksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/get.php
+++ b/Compute/samples/V1/HealthChecksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/insert.php
+++ b/Compute/samples/V1/HealthChecksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/list.php
+++ b/Compute/samples/V1/HealthChecksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/patch.php
+++ b/Compute/samples/V1/HealthChecksClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/HealthChecksClient/update.php
+++ b/Compute/samples/V1/HealthChecksClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImageFamilyViewsClient/get.php
+++ b/Compute/samples/V1/ImageFamilyViewsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/delete.php
+++ b/Compute/samples/V1/ImagesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/deprecate.php
+++ b/Compute/samples/V1/ImagesClient/deprecate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/get.php
+++ b/Compute/samples/V1/ImagesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/get_from_family.php
+++ b/Compute/samples/V1/ImagesClient/get_from_family.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/get_iam_policy.php
+++ b/Compute/samples/V1/ImagesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/insert.php
+++ b/Compute/samples/V1/ImagesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/list.php
+++ b/Compute/samples/V1/ImagesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/patch.php
+++ b/Compute/samples/V1/ImagesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/set_iam_policy.php
+++ b/Compute/samples/V1/ImagesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/set_labels.php
+++ b/Compute/samples/V1/ImagesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ImagesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ImagesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/cancel.php
+++ b/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/cancel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/delete.php
+++ b/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/get.php
+++ b/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/insert.php
+++ b/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/list.php
+++ b/Compute/samples/V1/InstanceGroupManagerResizeRequestsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/abandon_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/abandon_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/aggregated_list.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/apply_updates_to_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/apply_updates_to_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/create_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/create_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/delete.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/delete_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/delete_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/delete_per_instance_configs.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/delete_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/get.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/insert.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/list.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/list_errors.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/list_errors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/list_managed_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/list_managed_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/list_per_instance_configs.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/list_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/patch.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/patch_per_instance_configs.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/patch_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/recreate_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/recreate_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/resize.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/resize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/resume_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/resume_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/set_instance_template.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/set_instance_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/set_target_pools.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/set_target_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/start_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/start_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/stop_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/stop_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/suspend_instances.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/suspend_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupManagersClient/update_per_instance_configs.php
+++ b/Compute/samples/V1/InstanceGroupManagersClient/update_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/add_instances.php
+++ b/Compute/samples/V1/InstanceGroupsClient/add_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/aggregated_list.php
+++ b/Compute/samples/V1/InstanceGroupsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/delete.php
+++ b/Compute/samples/V1/InstanceGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/get.php
+++ b/Compute/samples/V1/InstanceGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/insert.php
+++ b/Compute/samples/V1/InstanceGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/list.php
+++ b/Compute/samples/V1/InstanceGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/list_instances.php
+++ b/Compute/samples/V1/InstanceGroupsClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/remove_instances.php
+++ b/Compute/samples/V1/InstanceGroupsClient/remove_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/set_named_ports.php
+++ b/Compute/samples/V1/InstanceGroupsClient/set_named_ports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InstanceGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceSettingsServiceClient/get.php
+++ b/Compute/samples/V1/InstanceSettingsServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceSettingsServiceClient/patch.php
+++ b/Compute/samples/V1/InstanceSettingsServiceClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/aggregated_list.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/delete.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/get.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/get_iam_policy.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/insert.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/list.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/set_iam_policy.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstanceTemplatesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InstanceTemplatesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/add_access_config.php
+++ b/Compute/samples/V1/InstancesClient/add_access_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/add_network_interface.php
+++ b/Compute/samples/V1/InstancesClient/add_network_interface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/add_resource_policies.php
+++ b/Compute/samples/V1/InstancesClient/add_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/aggregated_list.php
+++ b/Compute/samples/V1/InstancesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/attach_disk.php
+++ b/Compute/samples/V1/InstancesClient/attach_disk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/bulk_insert.php
+++ b/Compute/samples/V1/InstancesClient/bulk_insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/delete.php
+++ b/Compute/samples/V1/InstancesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/delete_access_config.php
+++ b/Compute/samples/V1/InstancesClient/delete_access_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/delete_network_interface.php
+++ b/Compute/samples/V1/InstancesClient/delete_network_interface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/detach_disk.php
+++ b/Compute/samples/V1/InstancesClient/detach_disk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get.php
+++ b/Compute/samples/V1/InstancesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_effective_firewalls.php
+++ b/Compute/samples/V1/InstancesClient/get_effective_firewalls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_guest_attributes.php
+++ b/Compute/samples/V1/InstancesClient/get_guest_attributes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_iam_policy.php
+++ b/Compute/samples/V1/InstancesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_screenshot.php
+++ b/Compute/samples/V1/InstancesClient/get_screenshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_serial_port_output.php
+++ b/Compute/samples/V1/InstancesClient/get_serial_port_output.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/get_shielded_instance_identity.php
+++ b/Compute/samples/V1/InstancesClient/get_shielded_instance_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/insert.php
+++ b/Compute/samples/V1/InstancesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/list.php
+++ b/Compute/samples/V1/InstancesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/list_referrers.php
+++ b/Compute/samples/V1/InstancesClient/list_referrers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/perform_maintenance.php
+++ b/Compute/samples/V1/InstancesClient/perform_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/remove_resource_policies.php
+++ b/Compute/samples/V1/InstancesClient/remove_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/report_host_as_faulty.php
+++ b/Compute/samples/V1/InstancesClient/report_host_as_faulty.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/reset.php
+++ b/Compute/samples/V1/InstancesClient/reset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/resume.php
+++ b/Compute/samples/V1/InstancesClient/resume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/send_diagnostic_interrupt.php
+++ b/Compute/samples/V1/InstancesClient/send_diagnostic_interrupt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_deletion_protection.php
+++ b/Compute/samples/V1/InstancesClient/set_deletion_protection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_disk_auto_delete.php
+++ b/Compute/samples/V1/InstancesClient/set_disk_auto_delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_iam_policy.php
+++ b/Compute/samples/V1/InstancesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_labels.php
+++ b/Compute/samples/V1/InstancesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_machine_resources.php
+++ b/Compute/samples/V1/InstancesClient/set_machine_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_machine_type.php
+++ b/Compute/samples/V1/InstancesClient/set_machine_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_metadata.php
+++ b/Compute/samples/V1/InstancesClient/set_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_min_cpu_platform.php
+++ b/Compute/samples/V1/InstancesClient/set_min_cpu_platform.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_name.php
+++ b/Compute/samples/V1/InstancesClient/set_name.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_scheduling.php
+++ b/Compute/samples/V1/InstancesClient/set_scheduling.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_security_policy.php
+++ b/Compute/samples/V1/InstancesClient/set_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_service_account.php
+++ b/Compute/samples/V1/InstancesClient/set_service_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_shielded_instance_integrity_policy.php
+++ b/Compute/samples/V1/InstancesClient/set_shielded_instance_integrity_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/set_tags.php
+++ b/Compute/samples/V1/InstancesClient/set_tags.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/simulate_maintenance_event.php
+++ b/Compute/samples/V1/InstancesClient/simulate_maintenance_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/start.php
+++ b/Compute/samples/V1/InstancesClient/start.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/start_with_encryption_key.php
+++ b/Compute/samples/V1/InstancesClient/start_with_encryption_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/stop.php
+++ b/Compute/samples/V1/InstancesClient/stop.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/suspend.php
+++ b/Compute/samples/V1/InstancesClient/suspend.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InstancesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/update.php
+++ b/Compute/samples/V1/InstancesClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/update_access_config.php
+++ b/Compute/samples/V1/InstancesClient/update_access_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/update_display_device.php
+++ b/Compute/samples/V1/InstancesClient/update_display_device.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/update_network_interface.php
+++ b/Compute/samples/V1/InstancesClient/update_network_interface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstancesClient/update_shielded_instance_config.php
+++ b/Compute/samples/V1/InstancesClient/update_shielded_instance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/aggregated_list.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/delete.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/get.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/get_iam_policy.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/insert.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/list.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/set_iam_policy.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/set_labels.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InstantSnapshotsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InstantSnapshotsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/delete.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/get.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/get_iam_policy.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/get_operational_status.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/get_operational_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/insert.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/list.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/patch.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/set_iam_policy.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InterconnectAttachmentGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/aggregated_list.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/delete.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/get.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/insert.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/list.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/patch.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectAttachmentsClient/set_labels.php
+++ b/Compute/samples/V1/InterconnectAttachmentsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/create_members.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/create_members.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/delete.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/get.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/get_iam_policy.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/get_operational_status.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/get_operational_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/insert.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/list.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/patch.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/set_iam_policy.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/InterconnectGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectLocationsClient/get.php
+++ b/Compute/samples/V1/InterconnectLocationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectLocationsClient/list.php
+++ b/Compute/samples/V1/InterconnectLocationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectRemoteLocationsClient/get.php
+++ b/Compute/samples/V1/InterconnectRemoteLocationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectRemoteLocationsClient/list.php
+++ b/Compute/samples/V1/InterconnectRemoteLocationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/delete.php
+++ b/Compute/samples/V1/InterconnectsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/get.php
+++ b/Compute/samples/V1/InterconnectsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/get_diagnostics.php
+++ b/Compute/samples/V1/InterconnectsClient/get_diagnostics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/get_macsec_config.php
+++ b/Compute/samples/V1/InterconnectsClient/get_macsec_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/insert.php
+++ b/Compute/samples/V1/InterconnectsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/list.php
+++ b/Compute/samples/V1/InterconnectsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/patch.php
+++ b/Compute/samples/V1/InterconnectsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/InterconnectsClient/set_labels.php
+++ b/Compute/samples/V1/InterconnectsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicenseCodesClient/get.php
+++ b/Compute/samples/V1/LicenseCodesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicenseCodesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/LicenseCodesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/delete.php
+++ b/Compute/samples/V1/LicensesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/get.php
+++ b/Compute/samples/V1/LicensesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/get_iam_policy.php
+++ b/Compute/samples/V1/LicensesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/insert.php
+++ b/Compute/samples/V1/LicensesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/list.php
+++ b/Compute/samples/V1/LicensesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/set_iam_policy.php
+++ b/Compute/samples/V1/LicensesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/LicensesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/LicensesClient/update.php
+++ b/Compute/samples/V1/LicensesClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/delete.php
+++ b/Compute/samples/V1/MachineImagesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/get.php
+++ b/Compute/samples/V1/MachineImagesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/get_iam_policy.php
+++ b/Compute/samples/V1/MachineImagesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/insert.php
+++ b/Compute/samples/V1/MachineImagesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/list.php
+++ b/Compute/samples/V1/MachineImagesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/set_iam_policy.php
+++ b/Compute/samples/V1/MachineImagesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/set_labels.php
+++ b/Compute/samples/V1/MachineImagesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineImagesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/MachineImagesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineTypesClient/aggregated_list.php
+++ b/Compute/samples/V1/MachineTypesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineTypesClient/get.php
+++ b/Compute/samples/V1/MachineTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/MachineTypesClient/list.php
+++ b/Compute/samples/V1/MachineTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/aggregated_list.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/delete.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/get.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/get_iam_policy.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/insert.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/list.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/patch.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/set_iam_policy.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkAttachmentsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/NetworkAttachmentsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEdgeSecurityServicesClient/aggregated_list.php
+++ b/Compute/samples/V1/NetworkEdgeSecurityServicesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEdgeSecurityServicesClient/delete.php
+++ b/Compute/samples/V1/NetworkEdgeSecurityServicesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEdgeSecurityServicesClient/get.php
+++ b/Compute/samples/V1/NetworkEdgeSecurityServicesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEdgeSecurityServicesClient/insert.php
+++ b/Compute/samples/V1/NetworkEdgeSecurityServicesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEdgeSecurityServicesClient/patch.php
+++ b/Compute/samples/V1/NetworkEdgeSecurityServicesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/aggregated_list.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/attach_network_endpoints.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/attach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/delete.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/detach_network_endpoints.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/detach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/get.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/insert.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/list.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/list_network_endpoints.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/list_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkEndpointGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/NetworkEndpointGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/add_association.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/add_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/add_packet_mirroring_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/add_packet_mirroring_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/aggregated_list.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/clone_rules.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/clone_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/delete.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/get.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/get_association.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/get_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/get_iam_policy.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/get_packet_mirroring_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/get_packet_mirroring_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/insert.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/list.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/patch.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/patch_packet_mirroring_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/patch_packet_mirroring_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_association.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_packet_mirroring_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_packet_mirroring_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/set_iam_policy.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkFirewallPoliciesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/NetworkFirewallPoliciesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkProfilesClient/get.php
+++ b/Compute/samples/V1/NetworkProfilesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworkProfilesClient/list.php
+++ b/Compute/samples/V1/NetworkProfilesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/add_peering.php
+++ b/Compute/samples/V1/NetworksClient/add_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/delete.php
+++ b/Compute/samples/V1/NetworksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/get.php
+++ b/Compute/samples/V1/NetworksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/get_effective_firewalls.php
+++ b/Compute/samples/V1/NetworksClient/get_effective_firewalls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/insert.php
+++ b/Compute/samples/V1/NetworksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/list.php
+++ b/Compute/samples/V1/NetworksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/list_peering_routes.php
+++ b/Compute/samples/V1/NetworksClient/list_peering_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/patch.php
+++ b/Compute/samples/V1/NetworksClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/remove_peering.php
+++ b/Compute/samples/V1/NetworksClient/remove_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/request_remove_peering.php
+++ b/Compute/samples/V1/NetworksClient/request_remove_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/switch_to_custom_mode.php
+++ b/Compute/samples/V1/NetworksClient/switch_to_custom_mode.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NetworksClient/update_peering.php
+++ b/Compute/samples/V1/NetworksClient/update_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/add_nodes.php
+++ b/Compute/samples/V1/NodeGroupsClient/add_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/aggregated_list.php
+++ b/Compute/samples/V1/NodeGroupsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/delete.php
+++ b/Compute/samples/V1/NodeGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/delete_nodes.php
+++ b/Compute/samples/V1/NodeGroupsClient/delete_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/get.php
+++ b/Compute/samples/V1/NodeGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/get_iam_policy.php
+++ b/Compute/samples/V1/NodeGroupsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/insert.php
+++ b/Compute/samples/V1/NodeGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/list.php
+++ b/Compute/samples/V1/NodeGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/list_nodes.php
+++ b/Compute/samples/V1/NodeGroupsClient/list_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/patch.php
+++ b/Compute/samples/V1/NodeGroupsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/perform_maintenance.php
+++ b/Compute/samples/V1/NodeGroupsClient/perform_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/set_iam_policy.php
+++ b/Compute/samples/V1/NodeGroupsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/set_node_template.php
+++ b/Compute/samples/V1/NodeGroupsClient/set_node_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/simulate_maintenance_event.php
+++ b/Compute/samples/V1/NodeGroupsClient/simulate_maintenance_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/NodeGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/aggregated_list.php
+++ b/Compute/samples/V1/NodeTemplatesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/delete.php
+++ b/Compute/samples/V1/NodeTemplatesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/get.php
+++ b/Compute/samples/V1/NodeTemplatesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/get_iam_policy.php
+++ b/Compute/samples/V1/NodeTemplatesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/insert.php
+++ b/Compute/samples/V1/NodeTemplatesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/list.php
+++ b/Compute/samples/V1/NodeTemplatesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/set_iam_policy.php
+++ b/Compute/samples/V1/NodeTemplatesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTemplatesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/NodeTemplatesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTypesClient/aggregated_list.php
+++ b/Compute/samples/V1/NodeTypesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTypesClient/get.php
+++ b/Compute/samples/V1/NodeTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/NodeTypesClient/list.php
+++ b/Compute/samples/V1/NodeTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/add_association.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/add_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/copy_rules.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/copy_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/delete.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/get.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/get_association.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/get_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/insert.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/list.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/list_associations.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/list_associations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/list_preconfigured_expression_sets.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/list_preconfigured_expression_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/move.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/patch.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/remove_association.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/remove_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/OrganizationSecurityPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/OrganizationSecurityPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/aggregated_list.php
+++ b/Compute/samples/V1/PacketMirroringsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/delete.php
+++ b/Compute/samples/V1/PacketMirroringsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/get.php
+++ b/Compute/samples/V1/PacketMirroringsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/insert.php
+++ b/Compute/samples/V1/PacketMirroringsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/list.php
+++ b/Compute/samples/V1/PacketMirroringsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/patch.php
+++ b/Compute/samples/V1/PacketMirroringsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PacketMirroringsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/PacketMirroringsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PreviewFeaturesClient/get.php
+++ b/Compute/samples/V1/PreviewFeaturesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PreviewFeaturesClient/list.php
+++ b/Compute/samples/V1/PreviewFeaturesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PreviewFeaturesClient/update.php
+++ b/Compute/samples/V1/PreviewFeaturesClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/disable_xpn_host.php
+++ b/Compute/samples/V1/ProjectsClient/disable_xpn_host.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/disable_xpn_resource.php
+++ b/Compute/samples/V1/ProjectsClient/disable_xpn_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/enable_xpn_host.php
+++ b/Compute/samples/V1/ProjectsClient/enable_xpn_host.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/enable_xpn_resource.php
+++ b/Compute/samples/V1/ProjectsClient/enable_xpn_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/get.php
+++ b/Compute/samples/V1/ProjectsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/get_xpn_host.php
+++ b/Compute/samples/V1/ProjectsClient/get_xpn_host.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/get_xpn_resources.php
+++ b/Compute/samples/V1/ProjectsClient/get_xpn_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/list_xpn_hosts.php
+++ b/Compute/samples/V1/ProjectsClient/list_xpn_hosts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/move_disk.php
+++ b/Compute/samples/V1/ProjectsClient/move_disk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/move_instance.php
+++ b/Compute/samples/V1/ProjectsClient/move_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/set_cloud_armor_tier.php
+++ b/Compute/samples/V1/ProjectsClient/set_cloud_armor_tier.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/set_common_instance_metadata.php
+++ b/Compute/samples/V1/ProjectsClient/set_common_instance_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/set_default_network_tier.php
+++ b/Compute/samples/V1/ProjectsClient/set_default_network_tier.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ProjectsClient/set_usage_export_bucket.php
+++ b/Compute/samples/V1/ProjectsClient/set_usage_export_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/announce.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/announce.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/delete.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/get.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/insert.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/list.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/patch.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicAdvertisedPrefixesClient/withdraw.php
+++ b/Compute/samples/V1/PublicAdvertisedPrefixesClient/withdraw.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/aggregated_list.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/announce.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/announce.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/delete.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/get.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/insert.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/list.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/patch.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/PublicDelegatedPrefixesClient/withdraw.php
+++ b/Compute/samples/V1/PublicDelegatedPrefixesClient/withdraw.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/delete.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/get.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/insert.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/list.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/patch.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionAutoscalersClient/update.php
+++ b/Compute/samples/V1/RegionAutoscalersClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/delete.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/get.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/get_health.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/get_health.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/get_iam_policy.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/insert.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/list.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/list_usable.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/list_usable.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/patch.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/set_iam_policy.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/set_security_policy.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/set_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionBackendServicesClient/update.php
+++ b/Compute/samples/V1/RegionBackendServicesClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionCommitmentsClient/aggregated_list.php
+++ b/Compute/samples/V1/RegionCommitmentsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionCommitmentsClient/get.php
+++ b/Compute/samples/V1/RegionCommitmentsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionCommitmentsClient/insert.php
+++ b/Compute/samples/V1/RegionCommitmentsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionCommitmentsClient/list.php
+++ b/Compute/samples/V1/RegionCommitmentsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionCommitmentsClient/update.php
+++ b/Compute/samples/V1/RegionCommitmentsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDiskTypesClient/get.php
+++ b/Compute/samples/V1/RegionDiskTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDiskTypesClient/list.php
+++ b/Compute/samples/V1/RegionDiskTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/add_resource_policies.php
+++ b/Compute/samples/V1/RegionDisksClient/add_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/bulk_insert.php
+++ b/Compute/samples/V1/RegionDisksClient/bulk_insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/create_snapshot.php
+++ b/Compute/samples/V1/RegionDisksClient/create_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/delete.php
+++ b/Compute/samples/V1/RegionDisksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/get.php
+++ b/Compute/samples/V1/RegionDisksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/get_iam_policy.php
+++ b/Compute/samples/V1/RegionDisksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/insert.php
+++ b/Compute/samples/V1/RegionDisksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/list.php
+++ b/Compute/samples/V1/RegionDisksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/remove_resource_policies.php
+++ b/Compute/samples/V1/RegionDisksClient/remove_resource_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/resize.php
+++ b/Compute/samples/V1/RegionDisksClient/resize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/set_iam_policy.php
+++ b/Compute/samples/V1/RegionDisksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/set_labels.php
+++ b/Compute/samples/V1/RegionDisksClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/start_async_replication.php
+++ b/Compute/samples/V1/RegionDisksClient/start_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/stop_async_replication.php
+++ b/Compute/samples/V1/RegionDisksClient/stop_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/stop_group_async_replication.php
+++ b/Compute/samples/V1/RegionDisksClient/stop_group_async_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/test_iam_permissions.php
+++ b/Compute/samples/V1/RegionDisksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionDisksClient/update.php
+++ b/Compute/samples/V1/RegionDisksClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthCheckServicesClient/delete.php
+++ b/Compute/samples/V1/RegionHealthCheckServicesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthCheckServicesClient/get.php
+++ b/Compute/samples/V1/RegionHealthCheckServicesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthCheckServicesClient/insert.php
+++ b/Compute/samples/V1/RegionHealthCheckServicesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthCheckServicesClient/list.php
+++ b/Compute/samples/V1/RegionHealthCheckServicesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthCheckServicesClient/patch.php
+++ b/Compute/samples/V1/RegionHealthCheckServicesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/delete.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/get.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/insert.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/list.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/patch.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionHealthChecksClient/update.php
+++ b/Compute/samples/V1/RegionHealthChecksClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/abandon_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/abandon_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/apply_updates_to_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/apply_updates_to_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/create_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/create_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/delete.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/delete_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/delete_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/delete_per_instance_configs.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/delete_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/get.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/insert.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/list.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/list_errors.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/list_errors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/list_managed_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/list_managed_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/list_per_instance_configs.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/list_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/patch.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/patch_per_instance_configs.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/patch_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/recreate_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/recreate_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/resize.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/resize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/resume_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/resume_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/set_instance_template.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/set_instance_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/set_target_pools.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/set_target_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/start_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/start_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/stop_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/stop_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/suspend_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/suspend_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupManagersClient/update_per_instance_configs.php
+++ b/Compute/samples/V1/RegionInstanceGroupManagersClient/update_per_instance_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupsClient/get.php
+++ b/Compute/samples/V1/RegionInstanceGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupsClient/list.php
+++ b/Compute/samples/V1/RegionInstanceGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupsClient/list_instances.php
+++ b/Compute/samples/V1/RegionInstanceGroupsClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupsClient/set_named_ports.php
+++ b/Compute/samples/V1/RegionInstanceGroupsClient/set_named_ports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceGroupsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/RegionInstanceGroupsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceTemplatesClient/delete.php
+++ b/Compute/samples/V1/RegionInstanceTemplatesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceTemplatesClient/get.php
+++ b/Compute/samples/V1/RegionInstanceTemplatesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceTemplatesClient/insert.php
+++ b/Compute/samples/V1/RegionInstanceTemplatesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstanceTemplatesClient/list.php
+++ b/Compute/samples/V1/RegionInstanceTemplatesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstancesClient/bulk_insert.php
+++ b/Compute/samples/V1/RegionInstancesClient/bulk_insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/delete.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/get.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/get_iam_policy.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/insert.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/list.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/set_iam_policy.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/set_labels.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionInstantSnapshotsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/RegionInstantSnapshotsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/attach_network_endpoints.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/attach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/delete.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/detach_network_endpoints.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/detach_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/get.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/insert.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/list.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkEndpointGroupsClient/list_network_endpoints.php
+++ b/Compute/samples/V1/RegionNetworkEndpointGroupsClient/list_network_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/add_association.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/add_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/clone_rules.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/clone_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/delete.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_association.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_effective_firewalls.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_effective_firewalls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_iam_policy.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/insert.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/list.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/patch.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/remove_association.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/remove_association.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/set_iam_policy.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/RegionNetworkFirewallPoliciesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNotificationEndpointsClient/delete.php
+++ b/Compute/samples/V1/RegionNotificationEndpointsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNotificationEndpointsClient/get.php
+++ b/Compute/samples/V1/RegionNotificationEndpointsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNotificationEndpointsClient/insert.php
+++ b/Compute/samples/V1/RegionNotificationEndpointsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionNotificationEndpointsClient/list.php
+++ b/Compute/samples/V1/RegionNotificationEndpointsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionOperationsClient/delete.php
+++ b/Compute/samples/V1/RegionOperationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionOperationsClient/get.php
+++ b/Compute/samples/V1/RegionOperationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionOperationsClient/list.php
+++ b/Compute/samples/V1/RegionOperationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionOperationsClient/wait.php
+++ b/Compute/samples/V1/RegionOperationsClient/wait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/delete.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/get.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/insert.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/list.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/patch.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSecurityPoliciesClient/set_labels.php
+++ b/Compute/samples/V1/RegionSecurityPoliciesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslCertificatesClient/delete.php
+++ b/Compute/samples/V1/RegionSslCertificatesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslCertificatesClient/get.php
+++ b/Compute/samples/V1/RegionSslCertificatesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslCertificatesClient/insert.php
+++ b/Compute/samples/V1/RegionSslCertificatesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslCertificatesClient/list.php
+++ b/Compute/samples/V1/RegionSslCertificatesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/delete.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/get.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/insert.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/list.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/list_available_features.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/list_available_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionSslPoliciesClient/patch.php
+++ b/Compute/samples/V1/RegionSslPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpProxiesClient/delete.php
+++ b/Compute/samples/V1/RegionTargetHttpProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpProxiesClient/get.php
+++ b/Compute/samples/V1/RegionTargetHttpProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpProxiesClient/insert.php
+++ b/Compute/samples/V1/RegionTargetHttpProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpProxiesClient/list.php
+++ b/Compute/samples/V1/RegionTargetHttpProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpProxiesClient/set_url_map.php
+++ b/Compute/samples/V1/RegionTargetHttpProxiesClient/set_url_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/delete.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/get.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/insert.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/list.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/patch.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/set_ssl_certificates.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/set_ssl_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetHttpsProxiesClient/set_url_map.php
+++ b/Compute/samples/V1/RegionTargetHttpsProxiesClient/set_url_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetTcpProxiesClient/delete.php
+++ b/Compute/samples/V1/RegionTargetTcpProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetTcpProxiesClient/get.php
+++ b/Compute/samples/V1/RegionTargetTcpProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetTcpProxiesClient/insert.php
+++ b/Compute/samples/V1/RegionTargetTcpProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionTargetTcpProxiesClient/list.php
+++ b/Compute/samples/V1/RegionTargetTcpProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/delete.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/get.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/insert.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/list.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/patch.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/update.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionUrlMapsClient/validate.php
+++ b/Compute/samples/V1/RegionUrlMapsClient/validate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionZonesClient/list.php
+++ b/Compute/samples/V1/RegionZonesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionsClient/get.php
+++ b/Compute/samples/V1/RegionsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RegionsClient/list.php
+++ b/Compute/samples/V1/RegionsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/get.php
+++ b/Compute/samples/V1/ReservationBlocksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/get_iam_policy.php
+++ b/Compute/samples/V1/ReservationBlocksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/list.php
+++ b/Compute/samples/V1/ReservationBlocksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/perform_maintenance.php
+++ b/Compute/samples/V1/ReservationBlocksClient/perform_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/set_iam_policy.php
+++ b/Compute/samples/V1/ReservationBlocksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationBlocksClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ReservationBlocksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/get.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/get_iam_policy.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/list.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/perform_maintenance.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/perform_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/report_faulty.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/report_faulty.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/set_iam_policy.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationSubBlocksClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ReservationSubBlocksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/aggregated_list.php
+++ b/Compute/samples/V1/ReservationsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/delete.php
+++ b/Compute/samples/V1/ReservationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/get.php
+++ b/Compute/samples/V1/ReservationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/get_iam_policy.php
+++ b/Compute/samples/V1/ReservationsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/insert.php
+++ b/Compute/samples/V1/ReservationsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/list.php
+++ b/Compute/samples/V1/ReservationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/perform_maintenance.php
+++ b/Compute/samples/V1/ReservationsClient/perform_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/resize.php
+++ b/Compute/samples/V1/ReservationsClient/resize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/set_iam_policy.php
+++ b/Compute/samples/V1/ReservationsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ReservationsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ReservationsClient/update.php
+++ b/Compute/samples/V1/ReservationsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/aggregated_list.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/delete.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/get.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/get_iam_policy.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/insert.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/list.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/patch.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/set_iam_policy.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ResourcePoliciesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ResourcePoliciesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/aggregated_list.php
+++ b/Compute/samples/V1/RoutersClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/delete.php
+++ b/Compute/samples/V1/RoutersClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/delete_route_policy.php
+++ b/Compute/samples/V1/RoutersClient/delete_route_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/get.php
+++ b/Compute/samples/V1/RoutersClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/get_nat_ip_info.php
+++ b/Compute/samples/V1/RoutersClient/get_nat_ip_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/get_nat_mapping_info.php
+++ b/Compute/samples/V1/RoutersClient/get_nat_mapping_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/get_route_policy.php
+++ b/Compute/samples/V1/RoutersClient/get_route_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/get_router_status.php
+++ b/Compute/samples/V1/RoutersClient/get_router_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/insert.php
+++ b/Compute/samples/V1/RoutersClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/list.php
+++ b/Compute/samples/V1/RoutersClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/list_bgp_routes.php
+++ b/Compute/samples/V1/RoutersClient/list_bgp_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/list_route_policies.php
+++ b/Compute/samples/V1/RoutersClient/list_route_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/patch.php
+++ b/Compute/samples/V1/RoutersClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/patch_route_policy.php
+++ b/Compute/samples/V1/RoutersClient/patch_route_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/preview.php
+++ b/Compute/samples/V1/RoutersClient/preview.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/update.php
+++ b/Compute/samples/V1/RoutersClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutersClient/update_route_policy.php
+++ b/Compute/samples/V1/RoutersClient/update_route_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutesClient/delete.php
+++ b/Compute/samples/V1/RoutesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutesClient/get.php
+++ b/Compute/samples/V1/RoutesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutesClient/insert.php
+++ b/Compute/samples/V1/RoutesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/RoutesClient/list.php
+++ b/Compute/samples/V1/RoutesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/add_rule.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/add_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/aggregated_list.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/delete.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/get.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/get_rule.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/get_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/insert.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/list.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/list_preconfigured_expression_sets.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/list_preconfigured_expression_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/patch.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/patch_rule.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/patch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/remove_rule.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/remove_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SecurityPoliciesClient/set_labels.php
+++ b/Compute/samples/V1/SecurityPoliciesClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/aggregated_list.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/delete.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/get.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/get_iam_policy.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/insert.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/list.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/patch.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/set_iam_policy.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ServiceAttachmentsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/ServiceAttachmentsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotSettingsServiceClient/get.php
+++ b/Compute/samples/V1/SnapshotSettingsServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotSettingsServiceClient/patch.php
+++ b/Compute/samples/V1/SnapshotSettingsServiceClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/delete.php
+++ b/Compute/samples/V1/SnapshotsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/get.php
+++ b/Compute/samples/V1/SnapshotsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/get_iam_policy.php
+++ b/Compute/samples/V1/SnapshotsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/insert.php
+++ b/Compute/samples/V1/SnapshotsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/list.php
+++ b/Compute/samples/V1/SnapshotsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/set_iam_policy.php
+++ b/Compute/samples/V1/SnapshotsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/set_labels.php
+++ b/Compute/samples/V1/SnapshotsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SnapshotsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/SnapshotsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslCertificatesClient/aggregated_list.php
+++ b/Compute/samples/V1/SslCertificatesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslCertificatesClient/delete.php
+++ b/Compute/samples/V1/SslCertificatesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslCertificatesClient/get.php
+++ b/Compute/samples/V1/SslCertificatesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslCertificatesClient/insert.php
+++ b/Compute/samples/V1/SslCertificatesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslCertificatesClient/list.php
+++ b/Compute/samples/V1/SslCertificatesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/aggregated_list.php
+++ b/Compute/samples/V1/SslPoliciesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/delete.php
+++ b/Compute/samples/V1/SslPoliciesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/get.php
+++ b/Compute/samples/V1/SslPoliciesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/insert.php
+++ b/Compute/samples/V1/SslPoliciesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/list.php
+++ b/Compute/samples/V1/SslPoliciesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/list_available_features.php
+++ b/Compute/samples/V1/SslPoliciesClient/list_available_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SslPoliciesClient/patch.php
+++ b/Compute/samples/V1/SslPoliciesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolTypesClient/aggregated_list.php
+++ b/Compute/samples/V1/StoragePoolTypesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolTypesClient/get.php
+++ b/Compute/samples/V1/StoragePoolTypesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolTypesClient/list.php
+++ b/Compute/samples/V1/StoragePoolTypesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/aggregated_list.php
+++ b/Compute/samples/V1/StoragePoolsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/delete.php
+++ b/Compute/samples/V1/StoragePoolsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/get.php
+++ b/Compute/samples/V1/StoragePoolsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/get_iam_policy.php
+++ b/Compute/samples/V1/StoragePoolsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/insert.php
+++ b/Compute/samples/V1/StoragePoolsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/list.php
+++ b/Compute/samples/V1/StoragePoolsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/list_disks.php
+++ b/Compute/samples/V1/StoragePoolsClient/list_disks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/set_iam_policy.php
+++ b/Compute/samples/V1/StoragePoolsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/StoragePoolsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/StoragePoolsClient/update.php
+++ b/Compute/samples/V1/StoragePoolsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/aggregated_list.php
+++ b/Compute/samples/V1/SubnetworksClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/delete.php
+++ b/Compute/samples/V1/SubnetworksClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/expand_ip_cidr_range.php
+++ b/Compute/samples/V1/SubnetworksClient/expand_ip_cidr_range.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/get.php
+++ b/Compute/samples/V1/SubnetworksClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/get_iam_policy.php
+++ b/Compute/samples/V1/SubnetworksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/insert.php
+++ b/Compute/samples/V1/SubnetworksClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/list.php
+++ b/Compute/samples/V1/SubnetworksClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/list_usable.php
+++ b/Compute/samples/V1/SubnetworksClient/list_usable.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/patch.php
+++ b/Compute/samples/V1/SubnetworksClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/set_iam_policy.php
+++ b/Compute/samples/V1/SubnetworksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/set_private_ip_google_access.php
+++ b/Compute/samples/V1/SubnetworksClient/set_private_ip_google_access.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/SubnetworksClient/test_iam_permissions.php
+++ b/Compute/samples/V1/SubnetworksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetGrpcProxiesClient/delete.php
+++ b/Compute/samples/V1/TargetGrpcProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetGrpcProxiesClient/get.php
+++ b/Compute/samples/V1/TargetGrpcProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetGrpcProxiesClient/insert.php
+++ b/Compute/samples/V1/TargetGrpcProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetGrpcProxiesClient/list.php
+++ b/Compute/samples/V1/TargetGrpcProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetGrpcProxiesClient/patch.php
+++ b/Compute/samples/V1/TargetGrpcProxiesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/delete.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/get.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/insert.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/list.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/patch.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpProxiesClient/set_url_map.php
+++ b/Compute/samples/V1/TargetHttpProxiesClient/set_url_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/delete.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/get.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/insert.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/list.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/patch.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/set_certificate_map.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/set_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/set_quic_override.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/set_quic_override.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/set_ssl_certificates.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/set_ssl_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/set_ssl_policy.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/set_ssl_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetHttpsProxiesClient/set_url_map.php
+++ b/Compute/samples/V1/TargetHttpsProxiesClient/set_url_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetInstancesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/delete.php
+++ b/Compute/samples/V1/TargetInstancesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/get.php
+++ b/Compute/samples/V1/TargetInstancesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/insert.php
+++ b/Compute/samples/V1/TargetInstancesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/list.php
+++ b/Compute/samples/V1/TargetInstancesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/set_security_policy.php
+++ b/Compute/samples/V1/TargetInstancesClient/set_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetInstancesClient/test_iam_permissions.php
+++ b/Compute/samples/V1/TargetInstancesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/add_health_check.php
+++ b/Compute/samples/V1/TargetPoolsClient/add_health_check.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/add_instance.php
+++ b/Compute/samples/V1/TargetPoolsClient/add_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetPoolsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/delete.php
+++ b/Compute/samples/V1/TargetPoolsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/get.php
+++ b/Compute/samples/V1/TargetPoolsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/get_health.php
+++ b/Compute/samples/V1/TargetPoolsClient/get_health.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/insert.php
+++ b/Compute/samples/V1/TargetPoolsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/list.php
+++ b/Compute/samples/V1/TargetPoolsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/remove_health_check.php
+++ b/Compute/samples/V1/TargetPoolsClient/remove_health_check.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/remove_instance.php
+++ b/Compute/samples/V1/TargetPoolsClient/remove_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/set_backup.php
+++ b/Compute/samples/V1/TargetPoolsClient/set_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/set_security_policy.php
+++ b/Compute/samples/V1/TargetPoolsClient/set_security_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetPoolsClient/test_iam_permissions.php
+++ b/Compute/samples/V1/TargetPoolsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/delete.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/get.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/insert.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/list.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/set_backend_service.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/set_backend_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/set_certificate_map.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/set_certificate_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/set_proxy_header.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/set_proxy_header.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/set_ssl_certificates.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/set_ssl_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetSslProxiesClient/set_ssl_policy.php
+++ b/Compute/samples/V1/TargetSslProxiesClient/set_ssl_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/delete.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/get.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/insert.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/list.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/set_backend_service.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/set_backend_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetTcpProxiesClient/set_proxy_header.php
+++ b/Compute/samples/V1/TargetTcpProxiesClient/set_proxy_header.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/aggregated_list.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/delete.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/get.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/insert.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/list.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/TargetVpnGatewaysClient/set_labels.php
+++ b/Compute/samples/V1/TargetVpnGatewaysClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/aggregated_list.php
+++ b/Compute/samples/V1/UrlMapsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/delete.php
+++ b/Compute/samples/V1/UrlMapsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/get.php
+++ b/Compute/samples/V1/UrlMapsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/insert.php
+++ b/Compute/samples/V1/UrlMapsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/invalidate_cache.php
+++ b/Compute/samples/V1/UrlMapsClient/invalidate_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/list.php
+++ b/Compute/samples/V1/UrlMapsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/patch.php
+++ b/Compute/samples/V1/UrlMapsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/update.php
+++ b/Compute/samples/V1/UrlMapsClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/UrlMapsClient/validate.php
+++ b/Compute/samples/V1/UrlMapsClient/validate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/aggregated_list.php
+++ b/Compute/samples/V1/VpnGatewaysClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/delete.php
+++ b/Compute/samples/V1/VpnGatewaysClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/get.php
+++ b/Compute/samples/V1/VpnGatewaysClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/get_status.php
+++ b/Compute/samples/V1/VpnGatewaysClient/get_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/insert.php
+++ b/Compute/samples/V1/VpnGatewaysClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/list.php
+++ b/Compute/samples/V1/VpnGatewaysClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/set_labels.php
+++ b/Compute/samples/V1/VpnGatewaysClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnGatewaysClient/test_iam_permissions.php
+++ b/Compute/samples/V1/VpnGatewaysClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/aggregated_list.php
+++ b/Compute/samples/V1/VpnTunnelsClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/delete.php
+++ b/Compute/samples/V1/VpnTunnelsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/get.php
+++ b/Compute/samples/V1/VpnTunnelsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/insert.php
+++ b/Compute/samples/V1/VpnTunnelsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/list.php
+++ b/Compute/samples/V1/VpnTunnelsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/VpnTunnelsClient/set_labels.php
+++ b/Compute/samples/V1/VpnTunnelsClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/WireGroupsClient/delete.php
+++ b/Compute/samples/V1/WireGroupsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/WireGroupsClient/get.php
+++ b/Compute/samples/V1/WireGroupsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/WireGroupsClient/insert.php
+++ b/Compute/samples/V1/WireGroupsClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/WireGroupsClient/list.php
+++ b/Compute/samples/V1/WireGroupsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/WireGroupsClient/patch.php
+++ b/Compute/samples/V1/WireGroupsClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZoneOperationsClient/delete.php
+++ b/Compute/samples/V1/ZoneOperationsClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZoneOperationsClient/get.php
+++ b/Compute/samples/V1/ZoneOperationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZoneOperationsClient/list.php
+++ b/Compute/samples/V1/ZoneOperationsClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZoneOperationsClient/wait.php
+++ b/Compute/samples/V1/ZoneOperationsClient/wait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZonesClient/get.php
+++ b/Compute/samples/V1/ZonesClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/samples/V1/ZonesClient/list.php
+++ b/Compute/samples/V1/ZonesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/AcceleratorTypesClient.php
+++ b/Compute/src/V1/Client/AcceleratorTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/AddressesClient.php
+++ b/Compute/src/V1/Client/AddressesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/AdviceClient.php
+++ b/Compute/src/V1/Client/AdviceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/AutoscalersClient.php
+++ b/Compute/src/V1/Client/AutoscalersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/BackendBucketsClient.php
+++ b/Compute/src/V1/Client/BackendBucketsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/BackendServicesClient.php
+++ b/Compute/src/V1/Client/BackendServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/CrossSiteNetworksClient.php
+++ b/Compute/src/V1/Client/CrossSiteNetworksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/DiskTypesClient.php
+++ b/Compute/src/V1/Client/DiskTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/DisksClient.php
+++ b/Compute/src/V1/Client/DisksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ExternalVpnGatewaysClient.php
+++ b/Compute/src/V1/Client/ExternalVpnGatewaysClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/FirewallPoliciesClient.php
+++ b/Compute/src/V1/Client/FirewallPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/FirewallsClient.php
+++ b/Compute/src/V1/Client/FirewallsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ForwardingRulesClient.php
+++ b/Compute/src/V1/Client/ForwardingRulesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/FutureReservationsClient.php
+++ b/Compute/src/V1/Client/FutureReservationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalAddressesClient.php
+++ b/Compute/src/V1/Client/GlobalAddressesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalForwardingRulesClient.php
+++ b/Compute/src/V1/Client/GlobalForwardingRulesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalNetworkEndpointGroupsClient.php
+++ b/Compute/src/V1/Client/GlobalNetworkEndpointGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalOperationsClient.php
+++ b/Compute/src/V1/Client/GlobalOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalOrganizationOperationsClient.php
+++ b/Compute/src/V1/Client/GlobalOrganizationOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/GlobalPublicDelegatedPrefixesClient.php
+++ b/Compute/src/V1/Client/GlobalPublicDelegatedPrefixesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/HealthChecksClient.php
+++ b/Compute/src/V1/Client/HealthChecksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ImageFamilyViewsClient.php
+++ b/Compute/src/V1/Client/ImageFamilyViewsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ImagesClient.php
+++ b/Compute/src/V1/Client/ImagesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstanceGroupManagerResizeRequestsClient.php
+++ b/Compute/src/V1/Client/InstanceGroupManagerResizeRequestsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstanceGroupManagersClient.php
+++ b/Compute/src/V1/Client/InstanceGroupManagersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstanceGroupsClient.php
+++ b/Compute/src/V1/Client/InstanceGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstanceSettingsServiceClient.php
+++ b/Compute/src/V1/Client/InstanceSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstanceTemplatesClient.php
+++ b/Compute/src/V1/Client/InstanceTemplatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstancesClient.php
+++ b/Compute/src/V1/Client/InstancesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InstantSnapshotsClient.php
+++ b/Compute/src/V1/Client/InstantSnapshotsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectAttachmentGroupsClient.php
+++ b/Compute/src/V1/Client/InterconnectAttachmentGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectAttachmentsClient.php
+++ b/Compute/src/V1/Client/InterconnectAttachmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectGroupsClient.php
+++ b/Compute/src/V1/Client/InterconnectGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectLocationsClient.php
+++ b/Compute/src/V1/Client/InterconnectLocationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectRemoteLocationsClient.php
+++ b/Compute/src/V1/Client/InterconnectRemoteLocationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/InterconnectsClient.php
+++ b/Compute/src/V1/Client/InterconnectsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/LicenseCodesClient.php
+++ b/Compute/src/V1/Client/LicenseCodesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/LicensesClient.php
+++ b/Compute/src/V1/Client/LicensesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/MachineImagesClient.php
+++ b/Compute/src/V1/Client/MachineImagesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/MachineTypesClient.php
+++ b/Compute/src/V1/Client/MachineTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworkAttachmentsClient.php
+++ b/Compute/src/V1/Client/NetworkAttachmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworkEdgeSecurityServicesClient.php
+++ b/Compute/src/V1/Client/NetworkEdgeSecurityServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworkEndpointGroupsClient.php
+++ b/Compute/src/V1/Client/NetworkEndpointGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworkFirewallPoliciesClient.php
+++ b/Compute/src/V1/Client/NetworkFirewallPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworkProfilesClient.php
+++ b/Compute/src/V1/Client/NetworkProfilesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NetworksClient.php
+++ b/Compute/src/V1/Client/NetworksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NodeGroupsClient.php
+++ b/Compute/src/V1/Client/NodeGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NodeTemplatesClient.php
+++ b/Compute/src/V1/Client/NodeTemplatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/NodeTypesClient.php
+++ b/Compute/src/V1/Client/NodeTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/OrganizationSecurityPoliciesClient.php
+++ b/Compute/src/V1/Client/OrganizationSecurityPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/PacketMirroringsClient.php
+++ b/Compute/src/V1/Client/PacketMirroringsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/PreviewFeaturesClient.php
+++ b/Compute/src/V1/Client/PreviewFeaturesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ProjectsClient.php
+++ b/Compute/src/V1/Client/ProjectsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/PublicAdvertisedPrefixesClient.php
+++ b/Compute/src/V1/Client/PublicAdvertisedPrefixesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/PublicDelegatedPrefixesClient.php
+++ b/Compute/src/V1/Client/PublicDelegatedPrefixesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionAutoscalersClient.php
+++ b/Compute/src/V1/Client/RegionAutoscalersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionBackendServicesClient.php
+++ b/Compute/src/V1/Client/RegionBackendServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionCommitmentsClient.php
+++ b/Compute/src/V1/Client/RegionCommitmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionDiskTypesClient.php
+++ b/Compute/src/V1/Client/RegionDiskTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionDisksClient.php
+++ b/Compute/src/V1/Client/RegionDisksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionHealthCheckServicesClient.php
+++ b/Compute/src/V1/Client/RegionHealthCheckServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionHealthChecksClient.php
+++ b/Compute/src/V1/Client/RegionHealthChecksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionInstanceGroupManagersClient.php
+++ b/Compute/src/V1/Client/RegionInstanceGroupManagersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionInstanceGroupsClient.php
+++ b/Compute/src/V1/Client/RegionInstanceGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionInstanceTemplatesClient.php
+++ b/Compute/src/V1/Client/RegionInstanceTemplatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionInstancesClient.php
+++ b/Compute/src/V1/Client/RegionInstancesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionInstantSnapshotsClient.php
+++ b/Compute/src/V1/Client/RegionInstantSnapshotsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionNetworkEndpointGroupsClient.php
+++ b/Compute/src/V1/Client/RegionNetworkEndpointGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionNetworkFirewallPoliciesClient.php
+++ b/Compute/src/V1/Client/RegionNetworkFirewallPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionNotificationEndpointsClient.php
+++ b/Compute/src/V1/Client/RegionNotificationEndpointsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionOperationsClient.php
+++ b/Compute/src/V1/Client/RegionOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionSecurityPoliciesClient.php
+++ b/Compute/src/V1/Client/RegionSecurityPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionSslCertificatesClient.php
+++ b/Compute/src/V1/Client/RegionSslCertificatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionSslPoliciesClient.php
+++ b/Compute/src/V1/Client/RegionSslPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionTargetHttpProxiesClient.php
+++ b/Compute/src/V1/Client/RegionTargetHttpProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionTargetHttpsProxiesClient.php
+++ b/Compute/src/V1/Client/RegionTargetHttpsProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionTargetTcpProxiesClient.php
+++ b/Compute/src/V1/Client/RegionTargetTcpProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionUrlMapsClient.php
+++ b/Compute/src/V1/Client/RegionUrlMapsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionZonesClient.php
+++ b/Compute/src/V1/Client/RegionZonesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RegionsClient.php
+++ b/Compute/src/V1/Client/RegionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ReservationBlocksClient.php
+++ b/Compute/src/V1/Client/ReservationBlocksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ReservationSubBlocksClient.php
+++ b/Compute/src/V1/Client/ReservationSubBlocksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ReservationsClient.php
+++ b/Compute/src/V1/Client/ReservationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ResourcePoliciesClient.php
+++ b/Compute/src/V1/Client/ResourcePoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RoutersClient.php
+++ b/Compute/src/V1/Client/RoutersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/RoutesClient.php
+++ b/Compute/src/V1/Client/RoutesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SecurityPoliciesClient.php
+++ b/Compute/src/V1/Client/SecurityPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ServiceAttachmentsClient.php
+++ b/Compute/src/V1/Client/ServiceAttachmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SnapshotSettingsServiceClient.php
+++ b/Compute/src/V1/Client/SnapshotSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SnapshotsClient.php
+++ b/Compute/src/V1/Client/SnapshotsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SslCertificatesClient.php
+++ b/Compute/src/V1/Client/SslCertificatesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SslPoliciesClient.php
+++ b/Compute/src/V1/Client/SslPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/StoragePoolTypesClient.php
+++ b/Compute/src/V1/Client/StoragePoolTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/StoragePoolsClient.php
+++ b/Compute/src/V1/Client/StoragePoolsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/SubnetworksClient.php
+++ b/Compute/src/V1/Client/SubnetworksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetGrpcProxiesClient.php
+++ b/Compute/src/V1/Client/TargetGrpcProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetHttpProxiesClient.php
+++ b/Compute/src/V1/Client/TargetHttpProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetHttpsProxiesClient.php
+++ b/Compute/src/V1/Client/TargetHttpsProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetInstancesClient.php
+++ b/Compute/src/V1/Client/TargetInstancesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetPoolsClient.php
+++ b/Compute/src/V1/Client/TargetPoolsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetSslProxiesClient.php
+++ b/Compute/src/V1/Client/TargetSslProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetTcpProxiesClient.php
+++ b/Compute/src/V1/Client/TargetTcpProxiesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/TargetVpnGatewaysClient.php
+++ b/Compute/src/V1/Client/TargetVpnGatewaysClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/UrlMapsClient.php
+++ b/Compute/src/V1/Client/UrlMapsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/VpnGatewaysClient.php
+++ b/Compute/src/V1/Client/VpnGatewaysClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/VpnTunnelsClient.php
+++ b/Compute/src/V1/Client/VpnTunnelsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/WireGroupsClient.php
+++ b/Compute/src/V1/Client/WireGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ZoneOperationsClient.php
+++ b/Compute/src/V1/Client/ZoneOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/Client/ZonesClient.php
+++ b/Compute/src/V1/Client/ZonesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/accelerator_types_descriptor_config.php
+++ b/Compute/src/V1/resources/accelerator_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/accelerator_types_rest_client_config.php
+++ b/Compute/src/V1/resources/accelerator_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/addresses_descriptor_config.php
+++ b/Compute/src/V1/resources/addresses_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/addresses_rest_client_config.php
+++ b/Compute/src/V1/resources/addresses_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/advice_descriptor_config.php
+++ b/Compute/src/V1/resources/advice_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/advice_rest_client_config.php
+++ b/Compute/src/V1/resources/advice_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/autoscalers_descriptor_config.php
+++ b/Compute/src/V1/resources/autoscalers_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/autoscalers_rest_client_config.php
+++ b/Compute/src/V1/resources/autoscalers_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/backend_buckets_descriptor_config.php
+++ b/Compute/src/V1/resources/backend_buckets_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/backend_buckets_rest_client_config.php
+++ b/Compute/src/V1/resources/backend_buckets_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/backend_services_descriptor_config.php
+++ b/Compute/src/V1/resources/backend_services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/backend_services_rest_client_config.php
+++ b/Compute/src/V1/resources/backend_services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/cross_site_networks_descriptor_config.php
+++ b/Compute/src/V1/resources/cross_site_networks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/cross_site_networks_rest_client_config.php
+++ b/Compute/src/V1/resources/cross_site_networks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/disk_types_descriptor_config.php
+++ b/Compute/src/V1/resources/disk_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/disk_types_rest_client_config.php
+++ b/Compute/src/V1/resources/disk_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/disks_descriptor_config.php
+++ b/Compute/src/V1/resources/disks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/disks_rest_client_config.php
+++ b/Compute/src/V1/resources/disks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/external_vpn_gateways_descriptor_config.php
+++ b/Compute/src/V1/resources/external_vpn_gateways_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/external_vpn_gateways_rest_client_config.php
+++ b/Compute/src/V1/resources/external_vpn_gateways_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/firewall_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/firewall_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/firewall_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/firewall_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/firewalls_descriptor_config.php
+++ b/Compute/src/V1/resources/firewalls_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/firewalls_rest_client_config.php
+++ b/Compute/src/V1/resources/firewalls_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/forwarding_rules_descriptor_config.php
+++ b/Compute/src/V1/resources/forwarding_rules_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/forwarding_rules_rest_client_config.php
+++ b/Compute/src/V1/resources/forwarding_rules_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/future_reservations_descriptor_config.php
+++ b/Compute/src/V1/resources/future_reservations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/future_reservations_rest_client_config.php
+++ b/Compute/src/V1/resources/future_reservations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_addresses_descriptor_config.php
+++ b/Compute/src/V1/resources/global_addresses_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_addresses_rest_client_config.php
+++ b/Compute/src/V1/resources/global_addresses_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_forwarding_rules_descriptor_config.php
+++ b/Compute/src/V1/resources/global_forwarding_rules_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_forwarding_rules_rest_client_config.php
+++ b/Compute/src/V1/resources/global_forwarding_rules_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_network_endpoint_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/global_network_endpoint_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_network_endpoint_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/global_network_endpoint_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_operations_descriptor_config.php
+++ b/Compute/src/V1/resources/global_operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_operations_rest_client_config.php
+++ b/Compute/src/V1/resources/global_operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_organization_operations_descriptor_config.php
+++ b/Compute/src/V1/resources/global_organization_operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_organization_operations_rest_client_config.php
+++ b/Compute/src/V1/resources/global_organization_operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_public_delegated_prefixes_descriptor_config.php
+++ b/Compute/src/V1/resources/global_public_delegated_prefixes_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/global_public_delegated_prefixes_rest_client_config.php
+++ b/Compute/src/V1/resources/global_public_delegated_prefixes_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/health_checks_descriptor_config.php
+++ b/Compute/src/V1/resources/health_checks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/health_checks_rest_client_config.php
+++ b/Compute/src/V1/resources/health_checks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/image_family_views_descriptor_config.php
+++ b/Compute/src/V1/resources/image_family_views_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/image_family_views_rest_client_config.php
+++ b/Compute/src/V1/resources/image_family_views_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/images_descriptor_config.php
+++ b/Compute/src/V1/resources/images_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/images_rest_client_config.php
+++ b/Compute/src/V1/resources/images_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_group_manager_resize_requests_descriptor_config.php
+++ b/Compute/src/V1/resources/instance_group_manager_resize_requests_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_group_manager_resize_requests_rest_client_config.php
+++ b/Compute/src/V1/resources/instance_group_manager_resize_requests_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_group_managers_descriptor_config.php
+++ b/Compute/src/V1/resources/instance_group_managers_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_group_managers_rest_client_config.php
+++ b/Compute/src/V1/resources/instance_group_managers_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/instance_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/instance_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_settings_service_descriptor_config.php
+++ b/Compute/src/V1/resources/instance_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_settings_service_rest_client_config.php
+++ b/Compute/src/V1/resources/instance_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_templates_descriptor_config.php
+++ b/Compute/src/V1/resources/instance_templates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instance_templates_rest_client_config.php
+++ b/Compute/src/V1/resources/instance_templates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instances_descriptor_config.php
+++ b/Compute/src/V1/resources/instances_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instances_rest_client_config.php
+++ b/Compute/src/V1/resources/instances_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instant_snapshots_descriptor_config.php
+++ b/Compute/src/V1/resources/instant_snapshots_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/instant_snapshots_rest_client_config.php
+++ b/Compute/src/V1/resources/instant_snapshots_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_attachment_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnect_attachment_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_attachment_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnect_attachment_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_attachments_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnect_attachments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_attachments_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnect_attachments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnect_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnect_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_locations_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnect_locations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_locations_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnect_locations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_remote_locations_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnect_remote_locations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnect_remote_locations_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnect_remote_locations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnects_descriptor_config.php
+++ b/Compute/src/V1/resources/interconnects_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/interconnects_rest_client_config.php
+++ b/Compute/src/V1/resources/interconnects_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/license_codes_descriptor_config.php
+++ b/Compute/src/V1/resources/license_codes_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/license_codes_rest_client_config.php
+++ b/Compute/src/V1/resources/license_codes_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/licenses_descriptor_config.php
+++ b/Compute/src/V1/resources/licenses_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/licenses_rest_client_config.php
+++ b/Compute/src/V1/resources/licenses_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/machine_images_descriptor_config.php
+++ b/Compute/src/V1/resources/machine_images_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/machine_images_rest_client_config.php
+++ b/Compute/src/V1/resources/machine_images_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/machine_types_descriptor_config.php
+++ b/Compute/src/V1/resources/machine_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/machine_types_rest_client_config.php
+++ b/Compute/src/V1/resources/machine_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_attachments_descriptor_config.php
+++ b/Compute/src/V1/resources/network_attachments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_attachments_rest_client_config.php
+++ b/Compute/src/V1/resources/network_attachments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_edge_security_services_descriptor_config.php
+++ b/Compute/src/V1/resources/network_edge_security_services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_edge_security_services_rest_client_config.php
+++ b/Compute/src/V1/resources/network_edge_security_services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_endpoint_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/network_endpoint_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_endpoint_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/network_endpoint_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_firewall_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/network_firewall_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_firewall_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/network_firewall_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_profiles_descriptor_config.php
+++ b/Compute/src/V1/resources/network_profiles_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/network_profiles_rest_client_config.php
+++ b/Compute/src/V1/resources/network_profiles_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/networks_descriptor_config.php
+++ b/Compute/src/V1/resources/networks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/networks_rest_client_config.php
+++ b/Compute/src/V1/resources/networks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/node_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/node_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_templates_descriptor_config.php
+++ b/Compute/src/V1/resources/node_templates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_templates_rest_client_config.php
+++ b/Compute/src/V1/resources/node_templates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_types_descriptor_config.php
+++ b/Compute/src/V1/resources/node_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/node_types_rest_client_config.php
+++ b/Compute/src/V1/resources/node_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/organization_security_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/organization_security_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/organization_security_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/organization_security_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/packet_mirrorings_descriptor_config.php
+++ b/Compute/src/V1/resources/packet_mirrorings_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/packet_mirrorings_rest_client_config.php
+++ b/Compute/src/V1/resources/packet_mirrorings_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/preview_features_descriptor_config.php
+++ b/Compute/src/V1/resources/preview_features_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/preview_features_rest_client_config.php
+++ b/Compute/src/V1/resources/preview_features_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/projects_descriptor_config.php
+++ b/Compute/src/V1/resources/projects_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/projects_rest_client_config.php
+++ b/Compute/src/V1/resources/projects_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/public_advertised_prefixes_descriptor_config.php
+++ b/Compute/src/V1/resources/public_advertised_prefixes_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/public_advertised_prefixes_rest_client_config.php
+++ b/Compute/src/V1/resources/public_advertised_prefixes_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/public_delegated_prefixes_descriptor_config.php
+++ b/Compute/src/V1/resources/public_delegated_prefixes_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/public_delegated_prefixes_rest_client_config.php
+++ b/Compute/src/V1/resources/public_delegated_prefixes_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_autoscalers_descriptor_config.php
+++ b/Compute/src/V1/resources/region_autoscalers_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_autoscalers_rest_client_config.php
+++ b/Compute/src/V1/resources/region_autoscalers_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_backend_services_descriptor_config.php
+++ b/Compute/src/V1/resources/region_backend_services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_backend_services_rest_client_config.php
+++ b/Compute/src/V1/resources/region_backend_services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_commitments_descriptor_config.php
+++ b/Compute/src/V1/resources/region_commitments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_commitments_rest_client_config.php
+++ b/Compute/src/V1/resources/region_commitments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_disk_types_descriptor_config.php
+++ b/Compute/src/V1/resources/region_disk_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_disk_types_rest_client_config.php
+++ b/Compute/src/V1/resources/region_disk_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_disks_descriptor_config.php
+++ b/Compute/src/V1/resources/region_disks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_disks_rest_client_config.php
+++ b/Compute/src/V1/resources/region_disks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_health_check_services_descriptor_config.php
+++ b/Compute/src/V1/resources/region_health_check_services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_health_check_services_rest_client_config.php
+++ b/Compute/src/V1/resources/region_health_check_services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_health_checks_descriptor_config.php
+++ b/Compute/src/V1/resources/region_health_checks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_health_checks_rest_client_config.php
+++ b/Compute/src/V1/resources/region_health_checks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_group_managers_descriptor_config.php
+++ b/Compute/src/V1/resources/region_instance_group_managers_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_group_managers_rest_client_config.php
+++ b/Compute/src/V1/resources/region_instance_group_managers_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/region_instance_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/region_instance_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_templates_descriptor_config.php
+++ b/Compute/src/V1/resources/region_instance_templates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instance_templates_rest_client_config.php
+++ b/Compute/src/V1/resources/region_instance_templates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instances_descriptor_config.php
+++ b/Compute/src/V1/resources/region_instances_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instances_rest_client_config.php
+++ b/Compute/src/V1/resources/region_instances_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instant_snapshots_descriptor_config.php
+++ b/Compute/src/V1/resources/region_instant_snapshots_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_instant_snapshots_rest_client_config.php
+++ b/Compute/src/V1/resources/region_instant_snapshots_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_network_endpoint_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/region_network_endpoint_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_network_endpoint_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/region_network_endpoint_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_network_firewall_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_network_firewall_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_network_firewall_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_network_firewall_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_notification_endpoints_descriptor_config.php
+++ b/Compute/src/V1/resources/region_notification_endpoints_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_notification_endpoints_rest_client_config.php
+++ b/Compute/src/V1/resources/region_notification_endpoints_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_operations_descriptor_config.php
+++ b/Compute/src/V1/resources/region_operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_operations_rest_client_config.php
+++ b/Compute/src/V1/resources/region_operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_security_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_security_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_security_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_security_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_ssl_certificates_descriptor_config.php
+++ b/Compute/src/V1/resources/region_ssl_certificates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_ssl_certificates_rest_client_config.php
+++ b/Compute/src/V1/resources/region_ssl_certificates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_ssl_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_ssl_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_ssl_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_ssl_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_http_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_target_http_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_http_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_target_http_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_https_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_target_https_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_https_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_target_https_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_tcp_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/region_target_tcp_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_target_tcp_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/region_target_tcp_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_url_maps_descriptor_config.php
+++ b/Compute/src/V1/resources/region_url_maps_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_url_maps_rest_client_config.php
+++ b/Compute/src/V1/resources/region_url_maps_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_zones_descriptor_config.php
+++ b/Compute/src/V1/resources/region_zones_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/region_zones_rest_client_config.php
+++ b/Compute/src/V1/resources/region_zones_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/regions_descriptor_config.php
+++ b/Compute/src/V1/resources/regions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/regions_rest_client_config.php
+++ b/Compute/src/V1/resources/regions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservation_blocks_descriptor_config.php
+++ b/Compute/src/V1/resources/reservation_blocks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservation_blocks_rest_client_config.php
+++ b/Compute/src/V1/resources/reservation_blocks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservation_sub_blocks_descriptor_config.php
+++ b/Compute/src/V1/resources/reservation_sub_blocks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservation_sub_blocks_rest_client_config.php
+++ b/Compute/src/V1/resources/reservation_sub_blocks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservations_descriptor_config.php
+++ b/Compute/src/V1/resources/reservations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/reservations_rest_client_config.php
+++ b/Compute/src/V1/resources/reservations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/resource_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/resource_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/resource_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/resource_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/routers_descriptor_config.php
+++ b/Compute/src/V1/resources/routers_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/routers_rest_client_config.php
+++ b/Compute/src/V1/resources/routers_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/routes_descriptor_config.php
+++ b/Compute/src/V1/resources/routes_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/routes_rest_client_config.php
+++ b/Compute/src/V1/resources/routes_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/security_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/security_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/security_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/security_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/service_attachments_descriptor_config.php
+++ b/Compute/src/V1/resources/service_attachments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/service_attachments_rest_client_config.php
+++ b/Compute/src/V1/resources/service_attachments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/snapshot_settings_service_descriptor_config.php
+++ b/Compute/src/V1/resources/snapshot_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/snapshot_settings_service_rest_client_config.php
+++ b/Compute/src/V1/resources/snapshot_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/snapshots_descriptor_config.php
+++ b/Compute/src/V1/resources/snapshots_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/snapshots_rest_client_config.php
+++ b/Compute/src/V1/resources/snapshots_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/ssl_certificates_descriptor_config.php
+++ b/Compute/src/V1/resources/ssl_certificates_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/ssl_certificates_rest_client_config.php
+++ b/Compute/src/V1/resources/ssl_certificates_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/ssl_policies_descriptor_config.php
+++ b/Compute/src/V1/resources/ssl_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/ssl_policies_rest_client_config.php
+++ b/Compute/src/V1/resources/ssl_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/storage_pool_types_descriptor_config.php
+++ b/Compute/src/V1/resources/storage_pool_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/storage_pool_types_rest_client_config.php
+++ b/Compute/src/V1/resources/storage_pool_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/storage_pools_descriptor_config.php
+++ b/Compute/src/V1/resources/storage_pools_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/storage_pools_rest_client_config.php
+++ b/Compute/src/V1/resources/storage_pools_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/subnetworks_descriptor_config.php
+++ b/Compute/src/V1/resources/subnetworks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/subnetworks_rest_client_config.php
+++ b/Compute/src/V1/resources/subnetworks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_grpc_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/target_grpc_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_grpc_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/target_grpc_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_http_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/target_http_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_http_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/target_http_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_https_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/target_https_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_https_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/target_https_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_instances_descriptor_config.php
+++ b/Compute/src/V1/resources/target_instances_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_instances_rest_client_config.php
+++ b/Compute/src/V1/resources/target_instances_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_pools_descriptor_config.php
+++ b/Compute/src/V1/resources/target_pools_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_pools_rest_client_config.php
+++ b/Compute/src/V1/resources/target_pools_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_ssl_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/target_ssl_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_ssl_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/target_ssl_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_tcp_proxies_descriptor_config.php
+++ b/Compute/src/V1/resources/target_tcp_proxies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_tcp_proxies_rest_client_config.php
+++ b/Compute/src/V1/resources/target_tcp_proxies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_vpn_gateways_descriptor_config.php
+++ b/Compute/src/V1/resources/target_vpn_gateways_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/target_vpn_gateways_rest_client_config.php
+++ b/Compute/src/V1/resources/target_vpn_gateways_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/url_maps_descriptor_config.php
+++ b/Compute/src/V1/resources/url_maps_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/url_maps_rest_client_config.php
+++ b/Compute/src/V1/resources/url_maps_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/vpn_gateways_descriptor_config.php
+++ b/Compute/src/V1/resources/vpn_gateways_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/vpn_gateways_rest_client_config.php
+++ b/Compute/src/V1/resources/vpn_gateways_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/vpn_tunnels_descriptor_config.php
+++ b/Compute/src/V1/resources/vpn_tunnels_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/vpn_tunnels_rest_client_config.php
+++ b/Compute/src/V1/resources/vpn_tunnels_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/wire_groups_descriptor_config.php
+++ b/Compute/src/V1/resources/wire_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/wire_groups_rest_client_config.php
+++ b/Compute/src/V1/resources/wire_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/zone_operations_descriptor_config.php
+++ b/Compute/src/V1/resources/zone_operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/zone_operations_rest_client_config.php
+++ b/Compute/src/V1/resources/zone_operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/zones_descriptor_config.php
+++ b/Compute/src/V1/resources/zones_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/src/V1/resources/zones_rest_client_config.php
+++ b/Compute/src/V1/resources/zones_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/AcceleratorTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/AcceleratorTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/AddressesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/AddressesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/AdviceClientTest.php
+++ b/Compute/tests/Unit/V1/Client/AdviceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/AutoscalersClientTest.php
+++ b/Compute/tests/Unit/V1/Client/AutoscalersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/BackendBucketsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/BackendBucketsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/BackendServicesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/BackendServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/CrossSiteNetworksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/CrossSiteNetworksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/DiskTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/DiskTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/DisksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/DisksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ExternalVpnGatewaysClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ExternalVpnGatewaysClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/FirewallPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/FirewallPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/FirewallsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/FirewallsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ForwardingRulesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ForwardingRulesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/FutureReservationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/FutureReservationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalAddressesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalAddressesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalForwardingRulesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalForwardingRulesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalNetworkEndpointGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalNetworkEndpointGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalOperationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalOrganizationOperationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalOrganizationOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/GlobalPublicDelegatedPrefixesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/GlobalPublicDelegatedPrefixesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/HealthChecksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/HealthChecksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ImageFamilyViewsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ImageFamilyViewsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ImagesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ImagesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstanceGroupManagerResizeRequestsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstanceGroupManagerResizeRequestsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstanceGroupManagersClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstanceGroupManagersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstanceGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstanceGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstanceSettingsServiceClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstanceSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstanceTemplatesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstanceTemplatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstancesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstancesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InstantSnapshotsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InstantSnapshotsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectAttachmentGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectAttachmentGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectAttachmentsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectAttachmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectLocationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectLocationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectRemoteLocationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectRemoteLocationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/InterconnectsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/InterconnectsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/LicenseCodesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/LicenseCodesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/LicensesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/LicensesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/MachineImagesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/MachineImagesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/MachineTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/MachineTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworkAttachmentsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworkAttachmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworkEdgeSecurityServicesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworkEdgeSecurityServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworkEndpointGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworkEndpointGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworkFirewallPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworkFirewallPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworkProfilesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworkProfilesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NetworksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NetworksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NodeGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NodeGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NodeTemplatesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NodeTemplatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/NodeTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/NodeTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/OrganizationSecurityPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/OrganizationSecurityPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/PacketMirroringsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/PacketMirroringsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/PreviewFeaturesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/PreviewFeaturesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ProjectsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ProjectsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/PublicAdvertisedPrefixesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/PublicAdvertisedPrefixesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/PublicDelegatedPrefixesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/PublicDelegatedPrefixesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionAutoscalersClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionAutoscalersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionBackendServicesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionBackendServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionCommitmentsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionCommitmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionDiskTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionDiskTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionDisksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionDisksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionHealthCheckServicesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionHealthCheckServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionHealthChecksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionHealthChecksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionInstanceGroupManagersClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionInstanceGroupManagersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionInstanceGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionInstanceGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionInstanceTemplatesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionInstanceTemplatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionInstancesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionInstancesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionInstantSnapshotsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionInstantSnapshotsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionNetworkEndpointGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionNetworkEndpointGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionNetworkFirewallPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionNetworkFirewallPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionNotificationEndpointsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionNotificationEndpointsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionOperationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionSecurityPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionSecurityPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionSslCertificatesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionSslCertificatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionSslPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionSslPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionTargetHttpProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionTargetHttpProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionTargetHttpsProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionTargetHttpsProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionTargetTcpProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionTargetTcpProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionUrlMapsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionUrlMapsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionZonesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionZonesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RegionsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RegionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ReservationBlocksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ReservationBlocksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ReservationSubBlocksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ReservationSubBlocksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ReservationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ReservationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ResourcePoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ResourcePoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RoutersClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RoutersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/RoutesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/RoutesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SecurityPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SecurityPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ServiceAttachmentsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ServiceAttachmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SnapshotSettingsServiceClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SnapshotSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SnapshotsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SnapshotsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SslCertificatesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SslCertificatesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SslPoliciesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SslPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/StoragePoolTypesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/StoragePoolTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/StoragePoolsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/StoragePoolsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/SubnetworksClientTest.php
+++ b/Compute/tests/Unit/V1/Client/SubnetworksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetGrpcProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetGrpcProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetHttpProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetHttpProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetHttpsProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetHttpsProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetInstancesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetInstancesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetPoolsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetPoolsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetSslProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetSslProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetTcpProxiesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetTcpProxiesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/TargetVpnGatewaysClientTest.php
+++ b/Compute/tests/Unit/V1/Client/TargetVpnGatewaysClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/UrlMapsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/UrlMapsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/VpnGatewaysClientTest.php
+++ b/Compute/tests/Unit/V1/Client/VpnGatewaysClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/VpnTunnelsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/VpnTunnelsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/WireGroupsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/WireGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ZoneOperationsClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ZoneOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Compute/tests/Unit/V1/Client/ZonesClientTest.php
+++ b/Compute/tests/Unit/V1/Client/ZonesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1311 generated files** in **1 in-scope packages** (Compute through Compute).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`Compute`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-4
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 4 of 10 in the 2026 copyright update series.
