### PR TITLE
chore: update copyright years to 2026 for generated files (part 6: DatastoreAdmin to EssentialContacts)

### DIFF
--- a/DatastoreAdmin/owlbot.py
+++ b/DatastoreAdmin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/create_index.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/create_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/delete_index.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/delete_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/export_entities.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/export_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/get_index.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/get_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/import_entities.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/import_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/samples/V1/DatastoreAdminClient/list_indexes.php
+++ b/DatastoreAdmin/samples/V1/DatastoreAdminClient/list_indexes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/src/V1/Client/DatastoreAdminClient.php
+++ b/DatastoreAdmin/src/V1/Client/DatastoreAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/src/V1/resources/datastore_admin_descriptor_config.php
+++ b/DatastoreAdmin/src/V1/resources/datastore_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/src/V1/resources/datastore_admin_rest_client_config.php
+++ b/DatastoreAdmin/src/V1/resources/datastore_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DatastoreAdmin/tests/Unit/V1/Client/DatastoreAdminClientTest.php
+++ b/DatastoreAdmin/tests/Unit/V1/Client/DatastoreAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/owlbot.py
+++ b/Datastream/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/create_connection_profile.php
+++ b/Datastream/samples/V1/DatastreamClient/create_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/create_private_connection.php
+++ b/Datastream/samples/V1/DatastreamClient/create_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/create_route.php
+++ b/Datastream/samples/V1/DatastreamClient/create_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/create_stream.php
+++ b/Datastream/samples/V1/DatastreamClient/create_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/delete_connection_profile.php
+++ b/Datastream/samples/V1/DatastreamClient/delete_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/delete_private_connection.php
+++ b/Datastream/samples/V1/DatastreamClient/delete_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/delete_route.php
+++ b/Datastream/samples/V1/DatastreamClient/delete_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/delete_stream.php
+++ b/Datastream/samples/V1/DatastreamClient/delete_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/discover_connection_profile.php
+++ b/Datastream/samples/V1/DatastreamClient/discover_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/fetch_static_ips.php
+++ b/Datastream/samples/V1/DatastreamClient/fetch_static_ips.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_connection_profile.php
+++ b/Datastream/samples/V1/DatastreamClient/get_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_location.php
+++ b/Datastream/samples/V1/DatastreamClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_private_connection.php
+++ b/Datastream/samples/V1/DatastreamClient/get_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_route.php
+++ b/Datastream/samples/V1/DatastreamClient/get_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_stream.php
+++ b/Datastream/samples/V1/DatastreamClient/get_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/get_stream_object.php
+++ b/Datastream/samples/V1/DatastreamClient/get_stream_object.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_connection_profiles.php
+++ b/Datastream/samples/V1/DatastreamClient/list_connection_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_locations.php
+++ b/Datastream/samples/V1/DatastreamClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_private_connections.php
+++ b/Datastream/samples/V1/DatastreamClient/list_private_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_routes.php
+++ b/Datastream/samples/V1/DatastreamClient/list_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_stream_objects.php
+++ b/Datastream/samples/V1/DatastreamClient/list_stream_objects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/list_streams.php
+++ b/Datastream/samples/V1/DatastreamClient/list_streams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/lookup_stream_object.php
+++ b/Datastream/samples/V1/DatastreamClient/lookup_stream_object.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/run_stream.php
+++ b/Datastream/samples/V1/DatastreamClient/run_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/start_backfill_job.php
+++ b/Datastream/samples/V1/DatastreamClient/start_backfill_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/stop_backfill_job.php
+++ b/Datastream/samples/V1/DatastreamClient/stop_backfill_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/update_connection_profile.php
+++ b/Datastream/samples/V1/DatastreamClient/update_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/samples/V1/DatastreamClient/update_stream.php
+++ b/Datastream/samples/V1/DatastreamClient/update_stream.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/src/V1/Client/DatastreamClient.php
+++ b/Datastream/src/V1/Client/DatastreamClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/src/V1/resources/datastream_descriptor_config.php
+++ b/Datastream/src/V1/resources/datastream_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/src/V1/resources/datastream_rest_client_config.php
+++ b/Datastream/src/V1/resources/datastream_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Datastream/tests/Unit/V1/Client/DatastreamClientTest.php
+++ b/Datastream/tests/Unit/V1/Client/DatastreamClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/owlbot.py
+++ b/Deploy/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/abandon_release.php
+++ b/Deploy/samples/V1/CloudDeployClient/abandon_release.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/advance_rollout.php
+++ b/Deploy/samples/V1/CloudDeployClient/advance_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/approve_rollout.php
+++ b/Deploy/samples/V1/CloudDeployClient/approve_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/cancel_automation_run.php
+++ b/Deploy/samples/V1/CloudDeployClient/cancel_automation_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/cancel_rollout.php
+++ b/Deploy/samples/V1/CloudDeployClient/cancel_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_automation.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_automation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_custom_target_type.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_custom_target_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_delivery_pipeline.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_delivery_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_deploy_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_deploy_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_release.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_release.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_rollout.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/create_target.php
+++ b/Deploy/samples/V1/CloudDeployClient/create_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/delete_automation.php
+++ b/Deploy/samples/V1/CloudDeployClient/delete_automation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/delete_custom_target_type.php
+++ b/Deploy/samples/V1/CloudDeployClient/delete_custom_target_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/delete_delivery_pipeline.php
+++ b/Deploy/samples/V1/CloudDeployClient/delete_delivery_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/delete_deploy_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/delete_deploy_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/delete_target.php
+++ b/Deploy/samples/V1/CloudDeployClient/delete_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_automation.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_automation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_automation_run.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_automation_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_config.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_custom_target_type.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_custom_target_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_delivery_pipeline.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_delivery_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_deploy_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_deploy_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_iam_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_job_run.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_job_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_location.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_release.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_release.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_rollout.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/get_target.php
+++ b/Deploy/samples/V1/CloudDeployClient/get_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/ignore_job.php
+++ b/Deploy/samples/V1/CloudDeployClient/ignore_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_automation_runs.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_automation_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_automations.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_automations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_custom_target_types.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_custom_target_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_delivery_pipelines.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_delivery_pipelines.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_deploy_policies.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_deploy_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_job_runs.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_job_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_locations.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_releases.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_releases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_rollouts.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_rollouts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/list_targets.php
+++ b/Deploy/samples/V1/CloudDeployClient/list_targets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/retry_job.php
+++ b/Deploy/samples/V1/CloudDeployClient/retry_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/rollback_target.php
+++ b/Deploy/samples/V1/CloudDeployClient/rollback_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/set_iam_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/terminate_job_run.php
+++ b/Deploy/samples/V1/CloudDeployClient/terminate_job_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/test_iam_permissions.php
+++ b/Deploy/samples/V1/CloudDeployClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/update_automation.php
+++ b/Deploy/samples/V1/CloudDeployClient/update_automation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/update_custom_target_type.php
+++ b/Deploy/samples/V1/CloudDeployClient/update_custom_target_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/update_delivery_pipeline.php
+++ b/Deploy/samples/V1/CloudDeployClient/update_delivery_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/update_deploy_policy.php
+++ b/Deploy/samples/V1/CloudDeployClient/update_deploy_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/samples/V1/CloudDeployClient/update_target.php
+++ b/Deploy/samples/V1/CloudDeployClient/update_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/src/V1/Client/CloudDeployClient.php
+++ b/Deploy/src/V1/Client/CloudDeployClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/src/V1/resources/cloud_deploy_descriptor_config.php
+++ b/Deploy/src/V1/resources/cloud_deploy_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/src/V1/resources/cloud_deploy_rest_client_config.php
+++ b/Deploy/src/V1/resources/cloud_deploy_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Deploy/tests/Unit/V1/Client/CloudDeployClientTest.php
+++ b/Deploy/tests/Unit/V1/Client/CloudDeployClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/owlbot.py
+++ b/DeveloperConnect/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/create_account_connector.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/create_account_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/create_connection.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/create_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/create_git_repository_link.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/create_git_repository_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_account_connector.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_account_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_connection.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_git_repository_link.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_git_repository_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_self.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_self.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_user.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/delete_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_access_token.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_access_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_git_hub_installations.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_git_hub_installations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_git_refs.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_git_refs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_linkable_git_repositories.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_linkable_git_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_read_token.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_read_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_read_write_token.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_read_write_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_self.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/fetch_self.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/get_account_connector.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/get_account_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/get_connection.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/get_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/get_git_repository_link.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/get_git_repository_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/get_location.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/list_account_connectors.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/list_account_connectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/list_connections.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/list_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/list_git_repository_links.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/list_git_repository_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/list_locations.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/list_users.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/list_users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/update_account_connector.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/update_account_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/DeveloperConnectClient/update_connection.php
+++ b/DeveloperConnect/samples/V1/DeveloperConnectClient/update_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/create_insights_config.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/create_insights_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/delete_insights_config.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/delete_insights_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/get_insights_config.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/get_insights_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/get_location.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/list_insights_configs.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/list_insights_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/list_locations.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/samples/V1/InsightsConfigServiceClient/update_insights_config.php
+++ b/DeveloperConnect/samples/V1/InsightsConfigServiceClient/update_insights_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/Client/DeveloperConnectClient.php
+++ b/DeveloperConnect/src/V1/Client/DeveloperConnectClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/Client/InsightsConfigServiceClient.php
+++ b/DeveloperConnect/src/V1/Client/InsightsConfigServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/resources/developer_connect_descriptor_config.php
+++ b/DeveloperConnect/src/V1/resources/developer_connect_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/resources/developer_connect_rest_client_config.php
+++ b/DeveloperConnect/src/V1/resources/developer_connect_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/resources/insights_config_service_descriptor_config.php
+++ b/DeveloperConnect/src/V1/resources/insights_config_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/src/V1/resources/insights_config_service_rest_client_config.php
+++ b/DeveloperConnect/src/V1/resources/insights_config_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/tests/Unit/V1/Client/DeveloperConnectClientTest.php
+++ b/DeveloperConnect/tests/Unit/V1/Client/DeveloperConnectClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperConnect/tests/Unit/V1/Client/InsightsConfigServiceClientTest.php
+++ b/DeveloperConnect/tests/Unit/V1/Client/InsightsConfigServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeveloperKnowledge/owlbot.py
+++ b/DeveloperKnowledge/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DeviceStreaming/owlbot.py
+++ b/DeviceStreaming/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/adb_connect.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/adb_connect.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/cancel_device_session.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/cancel_device_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/create_device_session.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/create_device_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/get_device_session.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/get_device_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/list_device_sessions.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/list_device_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/samples/V1/DirectAccessServiceClient/update_device_session.php
+++ b/DeviceStreaming/samples/V1/DirectAccessServiceClient/update_device_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/src/V1/Client/DirectAccessServiceClient.php
+++ b/DeviceStreaming/src/V1/Client/DirectAccessServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/src/V1/resources/direct_access_service_descriptor_config.php
+++ b/DeviceStreaming/src/V1/resources/direct_access_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/src/V1/resources/direct_access_service_rest_client_config.php
+++ b/DeviceStreaming/src/V1/resources/direct_access_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DeviceStreaming/tests/Unit/V1/Client/DirectAccessServiceClientTest.php
+++ b/DeviceStreaming/tests/Unit/V1/Client/DirectAccessServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/owlbot.py
+++ b/Dialogflow/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/delete_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/delete_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/export_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/export_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/get_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/get_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/get_location.php
+++ b/Dialogflow/samples/V2/AgentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/get_validation_result.php
+++ b/Dialogflow/samples/V2/AgentsClient/get_validation_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/import_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/import_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/list_locations.php
+++ b/Dialogflow/samples/V2/AgentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/restore_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/restore_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/search_agents.php
+++ b/Dialogflow/samples/V2/AgentsClient/search_agents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/set_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/set_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AgentsClient/train_agent.php
+++ b/Dialogflow/samples/V2/AgentsClient/train_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AnswerRecordsClient/get_location.php
+++ b/Dialogflow/samples/V2/AnswerRecordsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AnswerRecordsClient/list_answer_records.php
+++ b/Dialogflow/samples/V2/AnswerRecordsClient/list_answer_records.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AnswerRecordsClient/list_locations.php
+++ b/Dialogflow/samples/V2/AnswerRecordsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/AnswerRecordsClient/update_answer_record.php
+++ b/Dialogflow/samples/V2/AnswerRecordsClient/update_answer_record.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/create_context.php
+++ b/Dialogflow/samples/V2/ContextsClient/create_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/delete_all_contexts.php
+++ b/Dialogflow/samples/V2/ContextsClient/delete_all_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/delete_context.php
+++ b/Dialogflow/samples/V2/ContextsClient/delete_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/get_context.php
+++ b/Dialogflow/samples/V2/ContextsClient/get_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/get_location.php
+++ b/Dialogflow/samples/V2/ContextsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/list_contexts.php
+++ b/Dialogflow/samples/V2/ContextsClient/list_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ContextsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ContextsClient/update_context.php
+++ b/Dialogflow/samples/V2/ContextsClient/update_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/create_conversation_dataset.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/create_conversation_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/delete_conversation_dataset.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/delete_conversation_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/get_conversation_dataset.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/get_conversation_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/get_location.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/import_conversation_data.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/import_conversation_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/list_conversation_datasets.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/list_conversation_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationDatasetsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ConversationDatasetsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/create_conversation_model.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/create_conversation_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/create_conversation_model_evaluation.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/create_conversation_model_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/delete_conversation_model.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/delete_conversation_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/deploy_conversation_model.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/deploy_conversation_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/get_conversation_model.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/get_conversation_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/get_conversation_model_evaluation.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/get_conversation_model_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/get_location.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/list_conversation_model_evaluations.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/list_conversation_model_evaluations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/list_conversation_models.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/list_conversation_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationModelsClient/undeploy_conversation_model.php
+++ b/Dialogflow/samples/V2/ConversationModelsClient/undeploy_conversation_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/clear_suggestion_feature_config.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/clear_suggestion_feature_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/create_conversation_profile.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/create_conversation_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/delete_conversation_profile.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/delete_conversation_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/get_conversation_profile.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/get_conversation_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/get_location.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/list_conversation_profiles.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/list_conversation_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/list_locations.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/set_suggestion_feature_config.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/set_suggestion_feature_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationProfilesClient/update_conversation_profile.php
+++ b/Dialogflow/samples/V2/ConversationProfilesClient/update_conversation_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/complete_conversation.php
+++ b/Dialogflow/samples/V2/ConversationsClient/complete_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/create_conversation.php
+++ b/Dialogflow/samples/V2/ConversationsClient/create_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/generate_stateless_suggestion.php
+++ b/Dialogflow/samples/V2/ConversationsClient/generate_stateless_suggestion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/generate_stateless_summary.php
+++ b/Dialogflow/samples/V2/ConversationsClient/generate_stateless_summary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/generate_suggestions.php
+++ b/Dialogflow/samples/V2/ConversationsClient/generate_suggestions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/get_conversation.php
+++ b/Dialogflow/samples/V2/ConversationsClient/get_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/get_location.php
+++ b/Dialogflow/samples/V2/ConversationsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/ingest_context_references.php
+++ b/Dialogflow/samples/V2/ConversationsClient/ingest_context_references.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/list_conversations.php
+++ b/Dialogflow/samples/V2/ConversationsClient/list_conversations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ConversationsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/list_messages.php
+++ b/Dialogflow/samples/V2/ConversationsClient/list_messages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/search_knowledge.php
+++ b/Dialogflow/samples/V2/ConversationsClient/search_knowledge.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ConversationsClient/suggest_conversation_summary.php
+++ b/Dialogflow/samples/V2/ConversationsClient/suggest_conversation_summary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/create_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/create_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/delete_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/delete_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/export_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/export_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/get_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/get_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/get_location.php
+++ b/Dialogflow/samples/V2/DocumentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/import_documents.php
+++ b/Dialogflow/samples/V2/DocumentsClient/import_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/list_documents.php
+++ b/Dialogflow/samples/V2/DocumentsClient/list_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/list_locations.php
+++ b/Dialogflow/samples/V2/DocumentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/reload_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/reload_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/DocumentsClient/update_document.php
+++ b/Dialogflow/samples/V2/DocumentsClient/update_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EncryptionSpecServiceClient/get_encryption_spec.php
+++ b/Dialogflow/samples/V2/EncryptionSpecServiceClient/get_encryption_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EncryptionSpecServiceClient/get_location.php
+++ b/Dialogflow/samples/V2/EncryptionSpecServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EncryptionSpecServiceClient/initialize_encryption_spec.php
+++ b/Dialogflow/samples/V2/EncryptionSpecServiceClient/initialize_encryption_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EncryptionSpecServiceClient/list_locations.php
+++ b/Dialogflow/samples/V2/EncryptionSpecServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/batch_create_entities.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/batch_create_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/batch_delete_entities.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/batch_delete_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/batch_delete_entity_types.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/batch_delete_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/batch_update_entities.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/batch_update_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/batch_update_entity_types.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/batch_update_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/create_entity_type.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/create_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/delete_entity_type.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/delete_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/get_entity_type.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/get_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/get_location.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/list_entity_types.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/list_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/list_locations.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EntityTypesClient/update_entity_type.php
+++ b/Dialogflow/samples/V2/EntityTypesClient/update_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/create_environment.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/create_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/delete_environment.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/delete_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/get_environment.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/get_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/get_environment_history.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/get_environment_history.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/get_location.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/list_environments.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/list_environments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/list_locations.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/EnvironmentsClient/update_environment.php
+++ b/Dialogflow/samples/V2/EnvironmentsClient/update_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/FulfillmentsClient/get_fulfillment.php
+++ b/Dialogflow/samples/V2/FulfillmentsClient/get_fulfillment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/FulfillmentsClient/get_location.php
+++ b/Dialogflow/samples/V2/FulfillmentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/FulfillmentsClient/list_locations.php
+++ b/Dialogflow/samples/V2/FulfillmentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/FulfillmentsClient/update_fulfillment.php
+++ b/Dialogflow/samples/V2/FulfillmentsClient/update_fulfillment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/create_generator_evaluation.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/create_generator_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/delete_generator_evaluation.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/delete_generator_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/get_generator_evaluation.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/get_generator_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/get_location.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/list_generator_evaluations.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/list_generator_evaluations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorEvaluationsClient/list_locations.php
+++ b/Dialogflow/samples/V2/GeneratorEvaluationsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/create_generator.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/create_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/delete_generator.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/delete_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/get_generator.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/get_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/get_location.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/list_generators.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/list_generators.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/list_locations.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/GeneratorsClient/update_generator.php
+++ b/Dialogflow/samples/V2/GeneratorsClient/update_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/batch_delete_intents.php
+++ b/Dialogflow/samples/V2/IntentsClient/batch_delete_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/batch_update_intents.php
+++ b/Dialogflow/samples/V2/IntentsClient/batch_update_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/create_intent.php
+++ b/Dialogflow/samples/V2/IntentsClient/create_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/delete_intent.php
+++ b/Dialogflow/samples/V2/IntentsClient/delete_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/get_intent.php
+++ b/Dialogflow/samples/V2/IntentsClient/get_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/get_location.php
+++ b/Dialogflow/samples/V2/IntentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/list_intents.php
+++ b/Dialogflow/samples/V2/IntentsClient/list_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/list_locations.php
+++ b/Dialogflow/samples/V2/IntentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/IntentsClient/update_intent.php
+++ b/Dialogflow/samples/V2/IntentsClient/update_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/create_knowledge_base.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/create_knowledge_base.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/delete_knowledge_base.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/delete_knowledge_base.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/get_knowledge_base.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/get_knowledge_base.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/get_location.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/list_knowledge_bases.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/list_knowledge_bases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/list_locations.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/KnowledgeBasesClient/update_knowledge_base.php
+++ b/Dialogflow/samples/V2/KnowledgeBasesClient/update_knowledge_base.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/analyze_content.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/analyze_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/create_participant.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/create_participant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/get_location.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/get_participant.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/get_participant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/list_participants.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/list_participants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/streaming_analyze_content.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/streaming_analyze_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/suggest_articles.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/suggest_articles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/suggest_faq_answers.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/suggest_faq_answers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/suggest_knowledge_assist.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/suggest_knowledge_assist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/suggest_smart_replies.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/suggest_smart_replies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ParticipantsClient/update_participant.php
+++ b/Dialogflow/samples/V2/ParticipantsClient/update_participant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/create_session_entity_type.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/create_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/delete_session_entity_type.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/delete_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/get_location.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/get_session_entity_type.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/get_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/list_locations.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/list_session_entity_types.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/list_session_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionEntityTypesClient/update_session_entity_type.php
+++ b/Dialogflow/samples/V2/SessionEntityTypesClient/update_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionsClient/detect_intent.php
+++ b/Dialogflow/samples/V2/SessionsClient/detect_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionsClient/get_location.php
+++ b/Dialogflow/samples/V2/SessionsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionsClient/list_locations.php
+++ b/Dialogflow/samples/V2/SessionsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SessionsClient/streaming_detect_intent.php
+++ b/Dialogflow/samples/V2/SessionsClient/streaming_detect_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/create_sip_trunk.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/create_sip_trunk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/delete_sip_trunk.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/delete_sip_trunk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/get_location.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/get_sip_trunk.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/get_sip_trunk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/list_locations.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/list_sip_trunks.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/list_sip_trunks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/SipTrunksClient/update_sip_trunk.php
+++ b/Dialogflow/samples/V2/SipTrunksClient/update_sip_trunk.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/create_tool.php
+++ b/Dialogflow/samples/V2/ToolsClient/create_tool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/delete_tool.php
+++ b/Dialogflow/samples/V2/ToolsClient/delete_tool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/get_location.php
+++ b/Dialogflow/samples/V2/ToolsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/get_tool.php
+++ b/Dialogflow/samples/V2/ToolsClient/get_tool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/list_locations.php
+++ b/Dialogflow/samples/V2/ToolsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/list_tools.php
+++ b/Dialogflow/samples/V2/ToolsClient/list_tools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/ToolsClient/update_tool.php
+++ b/Dialogflow/samples/V2/ToolsClient/update_tool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/create_version.php
+++ b/Dialogflow/samples/V2/VersionsClient/create_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/delete_version.php
+++ b/Dialogflow/samples/V2/VersionsClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/get_location.php
+++ b/Dialogflow/samples/V2/VersionsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/get_version.php
+++ b/Dialogflow/samples/V2/VersionsClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/list_locations.php
+++ b/Dialogflow/samples/V2/VersionsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/list_versions.php
+++ b/Dialogflow/samples/V2/VersionsClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/samples/V2/VersionsClient/update_version.php
+++ b/Dialogflow/samples/V2/VersionsClient/update_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/AgentsClient.php
+++ b/Dialogflow/src/V2/Client/AgentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/AnswerRecordsClient.php
+++ b/Dialogflow/src/V2/Client/AnswerRecordsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ContextsClient.php
+++ b/Dialogflow/src/V2/Client/ContextsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ConversationDatasetsClient.php
+++ b/Dialogflow/src/V2/Client/ConversationDatasetsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ConversationModelsClient.php
+++ b/Dialogflow/src/V2/Client/ConversationModelsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ConversationProfilesClient.php
+++ b/Dialogflow/src/V2/Client/ConversationProfilesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ConversationsClient.php
+++ b/Dialogflow/src/V2/Client/ConversationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/DocumentsClient.php
+++ b/Dialogflow/src/V2/Client/DocumentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/EncryptionSpecServiceClient.php
+++ b/Dialogflow/src/V2/Client/EncryptionSpecServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/EntityTypesClient.php
+++ b/Dialogflow/src/V2/Client/EntityTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/EnvironmentsClient.php
+++ b/Dialogflow/src/V2/Client/EnvironmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/FulfillmentsClient.php
+++ b/Dialogflow/src/V2/Client/FulfillmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/GeneratorEvaluationsClient.php
+++ b/Dialogflow/src/V2/Client/GeneratorEvaluationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/GeneratorsClient.php
+++ b/Dialogflow/src/V2/Client/GeneratorsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/IntentsClient.php
+++ b/Dialogflow/src/V2/Client/IntentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/KnowledgeBasesClient.php
+++ b/Dialogflow/src/V2/Client/KnowledgeBasesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ParticipantsClient.php
+++ b/Dialogflow/src/V2/Client/ParticipantsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/SessionEntityTypesClient.php
+++ b/Dialogflow/src/V2/Client/SessionEntityTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/SessionsClient.php
+++ b/Dialogflow/src/V2/Client/SessionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/SipTrunksClient.php
+++ b/Dialogflow/src/V2/Client/SipTrunksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/ToolsClient.php
+++ b/Dialogflow/src/V2/Client/ToolsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/Client/VersionsClient.php
+++ b/Dialogflow/src/V2/Client/VersionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/agents_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/agents_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/agents_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/agents_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/answer_records_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/answer_records_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/answer_records_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/answer_records_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/contexts_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/contexts_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/contexts_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/contexts_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_datasets_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/conversation_datasets_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_datasets_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/conversation_datasets_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_models_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/conversation_models_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_models_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/conversation_models_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_profiles_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/conversation_profiles_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversation_profiles_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/conversation_profiles_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversations_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/conversations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/conversations_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/conversations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/documents_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/documents_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/documents_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/documents_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/encryption_spec_service_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/encryption_spec_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/encryption_spec_service_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/encryption_spec_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/entity_types_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/entity_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/entity_types_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/entity_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/environments_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/environments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/environments_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/environments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/fulfillments_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/fulfillments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/fulfillments_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/fulfillments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/generator_evaluations_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/generator_evaluations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/generator_evaluations_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/generator_evaluations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/generators_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/generators_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/generators_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/generators_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/intents_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/intents_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/intents_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/intents_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/knowledge_bases_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/knowledge_bases_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/knowledge_bases_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/knowledge_bases_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/participants_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/participants_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/participants_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/participants_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/session_entity_types_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/session_entity_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/session_entity_types_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/session_entity_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/sessions_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/sessions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/sessions_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/sessions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/sip_trunks_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/sip_trunks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/sip_trunks_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/sip_trunks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/tools_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/tools_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/tools_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/tools_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/versions_descriptor_config.php
+++ b/Dialogflow/src/V2/resources/versions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/src/V2/resources/versions_rest_client_config.php
+++ b/Dialogflow/src/V2/resources/versions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/AgentsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/AgentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/AnswerRecordsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/AnswerRecordsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ContextsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ContextsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ConversationDatasetsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ConversationDatasetsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ConversationModelsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ConversationModelsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ConversationProfilesClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ConversationProfilesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ConversationsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ConversationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/DocumentsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/DocumentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/EncryptionSpecServiceClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/EncryptionSpecServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/EntityTypesClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/EntityTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/EnvironmentsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/EnvironmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/FulfillmentsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/FulfillmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/GeneratorEvaluationsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/GeneratorEvaluationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/GeneratorsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/GeneratorsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/IntentsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/IntentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/KnowledgeBasesClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/KnowledgeBasesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ParticipantsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ParticipantsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/SessionEntityTypesClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/SessionEntityTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/SessionsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/SessionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/SipTrunksClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/SipTrunksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/ToolsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/ToolsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dialogflow/tests/Unit/V2/Client/VersionsClientTest.php
+++ b/Dialogflow/tests/Unit/V2/Client/VersionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/owlbot.py
+++ b/DialogflowCx/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/create_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/create_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/delete_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/delete_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/export_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/export_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/get_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/get_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/get_agent_validation_result.php
+++ b/DialogflowCx/samples/V3/AgentsClient/get_agent_validation_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/get_generative_settings.php
+++ b/DialogflowCx/samples/V3/AgentsClient/get_generative_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/get_location.php
+++ b/DialogflowCx/samples/V3/AgentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/list_agents.php
+++ b/DialogflowCx/samples/V3/AgentsClient/list_agents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/AgentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/restore_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/restore_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/update_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/update_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/update_generative_settings.php
+++ b/DialogflowCx/samples/V3/AgentsClient/update_generative_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/AgentsClient/validate_agent.php
+++ b/DialogflowCx/samples/V3/AgentsClient/validate_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ChangelogsClient/get_changelog.php
+++ b/DialogflowCx/samples/V3/ChangelogsClient/get_changelog.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ChangelogsClient/get_location.php
+++ b/DialogflowCx/samples/V3/ChangelogsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ChangelogsClient/list_changelogs.php
+++ b/DialogflowCx/samples/V3/ChangelogsClient/list_changelogs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ChangelogsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/ChangelogsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/DeploymentsClient/get_deployment.php
+++ b/DialogflowCx/samples/V3/DeploymentsClient/get_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/DeploymentsClient/get_location.php
+++ b/DialogflowCx/samples/V3/DeploymentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/DeploymentsClient/list_deployments.php
+++ b/DialogflowCx/samples/V3/DeploymentsClient/list_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/DeploymentsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/DeploymentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/create_entity_type.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/create_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/delete_entity_type.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/delete_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/export_entity_types.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/export_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/get_entity_type.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/get_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/get_location.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/import_entity_types.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/import_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/list_entity_types.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/list_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/list_locations.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EntityTypesClient/update_entity_type.php
+++ b/DialogflowCx/samples/V3/EntityTypesClient/update_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/create_environment.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/create_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/delete_environment.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/delete_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/deploy_flow.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/deploy_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/get_environment.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/get_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/get_location.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/list_continuous_test_results.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/list_continuous_test_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/list_environments.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/list_environments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/lookup_environment_history.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/lookup_environment_history.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/run_continuous_test.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/run_continuous_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/EnvironmentsClient/update_environment.php
+++ b/DialogflowCx/samples/V3/EnvironmentsClient/update_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/create_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/create_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/delete_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/delete_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/get_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/get_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/get_location.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/list_experiments.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/list_experiments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/start_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/start_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/stop_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/stop_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/ExperimentsClient/update_experiment.php
+++ b/DialogflowCx/samples/V3/ExperimentsClient/update_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/create_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/create_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/delete_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/delete_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/export_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/export_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/get_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/get_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/get_flow_validation_result.php
+++ b/DialogflowCx/samples/V3/FlowsClient/get_flow_validation_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/get_location.php
+++ b/DialogflowCx/samples/V3/FlowsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/import_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/import_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/list_flows.php
+++ b/DialogflowCx/samples/V3/FlowsClient/list_flows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/FlowsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/train_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/train_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/update_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/update_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/FlowsClient/validate_flow.php
+++ b/DialogflowCx/samples/V3/FlowsClient/validate_flow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/create_generator.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/create_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/delete_generator.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/delete_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/get_generator.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/get_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/get_location.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/list_generators.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/list_generators.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/GeneratorsClient/update_generator.php
+++ b/DialogflowCx/samples/V3/GeneratorsClient/update_generator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/create_intent.php
+++ b/DialogflowCx/samples/V3/IntentsClient/create_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/delete_intent.php
+++ b/DialogflowCx/samples/V3/IntentsClient/delete_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/export_intents.php
+++ b/DialogflowCx/samples/V3/IntentsClient/export_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/get_intent.php
+++ b/DialogflowCx/samples/V3/IntentsClient/get_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/get_location.php
+++ b/DialogflowCx/samples/V3/IntentsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/import_intents.php
+++ b/DialogflowCx/samples/V3/IntentsClient/import_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/list_intents.php
+++ b/DialogflowCx/samples/V3/IntentsClient/list_intents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/IntentsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/IntentsClient/update_intent.php
+++ b/DialogflowCx/samples/V3/IntentsClient/update_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/create_page.php
+++ b/DialogflowCx/samples/V3/PagesClient/create_page.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/delete_page.php
+++ b/DialogflowCx/samples/V3/PagesClient/delete_page.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/get_location.php
+++ b/DialogflowCx/samples/V3/PagesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/get_page.php
+++ b/DialogflowCx/samples/V3/PagesClient/get_page.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/list_locations.php
+++ b/DialogflowCx/samples/V3/PagesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/list_pages.php
+++ b/DialogflowCx/samples/V3/PagesClient/list_pages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/PagesClient/update_page.php
+++ b/DialogflowCx/samples/V3/PagesClient/update_page.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/create_security_settings.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/create_security_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/delete_security_settings.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/delete_security_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/get_location.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/get_security_settings.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/get_security_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/list_locations.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/list_security_settings.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/list_security_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SecuritySettingsServiceClient/update_security_settings.php
+++ b/DialogflowCx/samples/V3/SecuritySettingsServiceClient/update_security_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/create_session_entity_type.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/create_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/delete_session_entity_type.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/delete_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/get_location.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/get_session_entity_type.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/get_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/list_locations.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/list_session_entity_types.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/list_session_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionEntityTypesClient/update_session_entity_type.php
+++ b/DialogflowCx/samples/V3/SessionEntityTypesClient/update_session_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/detect_intent.php
+++ b/DialogflowCx/samples/V3/SessionsClient/detect_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/fulfill_intent.php
+++ b/DialogflowCx/samples/V3/SessionsClient/fulfill_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/get_location.php
+++ b/DialogflowCx/samples/V3/SessionsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/SessionsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/match_intent.php
+++ b/DialogflowCx/samples/V3/SessionsClient/match_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/server_streaming_detect_intent.php
+++ b/DialogflowCx/samples/V3/SessionsClient/server_streaming_detect_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/streaming_detect_intent.php
+++ b/DialogflowCx/samples/V3/SessionsClient/streaming_detect_intent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/SessionsClient/submit_answer_feedback.php
+++ b/DialogflowCx/samples/V3/SessionsClient/submit_answer_feedback.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/batch_delete_test_cases.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/batch_delete_test_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/batch_run_test_cases.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/batch_run_test_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/calculate_coverage.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/calculate_coverage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/create_test_case.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/create_test_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/export_test_cases.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/export_test_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/get_location.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/get_test_case.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/get_test_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/get_test_case_result.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/get_test_case_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/import_test_cases.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/import_test_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/list_locations.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/list_test_case_results.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/list_test_case_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/list_test_cases.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/list_test_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/run_test_case.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/run_test_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TestCasesClient/update_test_case.php
+++ b/DialogflowCx/samples/V3/TestCasesClient/update_test_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/create_transition_route_group.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/create_transition_route_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/delete_transition_route_group.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/delete_transition_route_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/get_location.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/get_transition_route_group.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/get_transition_route_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/list_transition_route_groups.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/list_transition_route_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/TransitionRouteGroupsClient/update_transition_route_group.php
+++ b/DialogflowCx/samples/V3/TransitionRouteGroupsClient/update_transition_route_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/compare_versions.php
+++ b/DialogflowCx/samples/V3/VersionsClient/compare_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/create_version.php
+++ b/DialogflowCx/samples/V3/VersionsClient/create_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/delete_version.php
+++ b/DialogflowCx/samples/V3/VersionsClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/get_location.php
+++ b/DialogflowCx/samples/V3/VersionsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/get_version.php
+++ b/DialogflowCx/samples/V3/VersionsClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/list_locations.php
+++ b/DialogflowCx/samples/V3/VersionsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/list_versions.php
+++ b/DialogflowCx/samples/V3/VersionsClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/load_version.php
+++ b/DialogflowCx/samples/V3/VersionsClient/load_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/VersionsClient/update_version.php
+++ b/DialogflowCx/samples/V3/VersionsClient/update_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/create_webhook.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/create_webhook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/delete_webhook.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/delete_webhook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/get_location.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/get_webhook.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/get_webhook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/list_locations.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/list_webhooks.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/list_webhooks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/samples/V3/WebhooksClient/update_webhook.php
+++ b/DialogflowCx/samples/V3/WebhooksClient/update_webhook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/AgentsClient.php
+++ b/DialogflowCx/src/V3/Client/AgentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/ChangelogsClient.php
+++ b/DialogflowCx/src/V3/Client/ChangelogsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/DeploymentsClient.php
+++ b/DialogflowCx/src/V3/Client/DeploymentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/EntityTypesClient.php
+++ b/DialogflowCx/src/V3/Client/EntityTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/EnvironmentsClient.php
+++ b/DialogflowCx/src/V3/Client/EnvironmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/ExperimentsClient.php
+++ b/DialogflowCx/src/V3/Client/ExperimentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/FlowsClient.php
+++ b/DialogflowCx/src/V3/Client/FlowsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/GeneratorsClient.php
+++ b/DialogflowCx/src/V3/Client/GeneratorsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/IntentsClient.php
+++ b/DialogflowCx/src/V3/Client/IntentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/PagesClient.php
+++ b/DialogflowCx/src/V3/Client/PagesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/SecuritySettingsServiceClient.php
+++ b/DialogflowCx/src/V3/Client/SecuritySettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/SessionEntityTypesClient.php
+++ b/DialogflowCx/src/V3/Client/SessionEntityTypesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/SessionsClient.php
+++ b/DialogflowCx/src/V3/Client/SessionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/TestCasesClient.php
+++ b/DialogflowCx/src/V3/Client/TestCasesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/TransitionRouteGroupsClient.php
+++ b/DialogflowCx/src/V3/Client/TransitionRouteGroupsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/VersionsClient.php
+++ b/DialogflowCx/src/V3/Client/VersionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/Client/WebhooksClient.php
+++ b/DialogflowCx/src/V3/Client/WebhooksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/agents_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/agents_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/agents_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/agents_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/changelogs_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/changelogs_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/changelogs_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/changelogs_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/deployments_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/deployments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/deployments_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/deployments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/entity_types_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/entity_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/entity_types_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/entity_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/environments_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/environments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/environments_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/environments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/experiments_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/experiments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/experiments_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/experiments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/flows_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/flows_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/flows_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/flows_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/generators_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/generators_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/generators_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/generators_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/intents_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/intents_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/intents_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/intents_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/pages_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/pages_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/pages_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/pages_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/security_settings_service_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/security_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/security_settings_service_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/security_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/session_entity_types_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/session_entity_types_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/session_entity_types_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/session_entity_types_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/sessions_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/sessions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/sessions_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/sessions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/test_cases_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/test_cases_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/test_cases_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/test_cases_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/transition_route_groups_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/transition_route_groups_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/transition_route_groups_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/transition_route_groups_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/versions_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/versions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/versions_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/versions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/webhooks_descriptor_config.php
+++ b/DialogflowCx/src/V3/resources/webhooks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/src/V3/resources/webhooks_rest_client_config.php
+++ b/DialogflowCx/src/V3/resources/webhooks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/AgentsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/AgentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/ChangelogsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/ChangelogsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/DeploymentsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/DeploymentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/EntityTypesClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/EntityTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/EnvironmentsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/EnvironmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/ExperimentsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/ExperimentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/FlowsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/FlowsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/GeneratorsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/GeneratorsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/IntentsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/IntentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/PagesClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/PagesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/SecuritySettingsServiceClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/SecuritySettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/SessionEntityTypesClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/SessionEntityTypesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/SessionsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/SessionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/TestCasesClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/TestCasesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/TransitionRouteGroupsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/TransitionRouteGroupsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/VersionsClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/VersionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DialogflowCx/tests/Unit/V3/Client/WebhooksClientTest.php
+++ b/DialogflowCx/tests/Unit/V3/Client/WebhooksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/owlbot.py
+++ b/DiscoveryEngine/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/AssistantServiceClient/stream_assist.php
+++ b/DiscoveryEngine/samples/V1/AssistantServiceClient/stream_assist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CmekConfigServiceClient/delete_cmek_config.php
+++ b/DiscoveryEngine/samples/V1/CmekConfigServiceClient/delete_cmek_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CmekConfigServiceClient/get_cmek_config.php
+++ b/DiscoveryEngine/samples/V1/CmekConfigServiceClient/get_cmek_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CmekConfigServiceClient/list_cmek_configs.php
+++ b/DiscoveryEngine/samples/V1/CmekConfigServiceClient/list_cmek_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CmekConfigServiceClient/update_cmek_config.php
+++ b/DiscoveryEngine/samples/V1/CmekConfigServiceClient/update_cmek_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CompletionServiceClient/complete_query.php
+++ b/DiscoveryEngine/samples/V1/CompletionServiceClient/complete_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CompletionServiceClient/import_completion_suggestions.php
+++ b/DiscoveryEngine/samples/V1/CompletionServiceClient/import_completion_suggestions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CompletionServiceClient/import_suggestion_deny_list_entries.php
+++ b/DiscoveryEngine/samples/V1/CompletionServiceClient/import_suggestion_deny_list_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CompletionServiceClient/purge_completion_suggestions.php
+++ b/DiscoveryEngine/samples/V1/CompletionServiceClient/purge_completion_suggestions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/CompletionServiceClient/purge_suggestion_deny_list_entries.php
+++ b/DiscoveryEngine/samples/V1/CompletionServiceClient/purge_suggestion_deny_list_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ControlServiceClient/create_control.php
+++ b/DiscoveryEngine/samples/V1/ControlServiceClient/create_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ControlServiceClient/delete_control.php
+++ b/DiscoveryEngine/samples/V1/ControlServiceClient/delete_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ControlServiceClient/get_control.php
+++ b/DiscoveryEngine/samples/V1/ControlServiceClient/get_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ControlServiceClient/list_controls.php
+++ b/DiscoveryEngine/samples/V1/ControlServiceClient/list_controls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ControlServiceClient/update_control.php
+++ b/DiscoveryEngine/samples/V1/ControlServiceClient/update_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/answer_query.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/answer_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/converse_conversation.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/converse_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/create_conversation.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/create_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/create_session.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/create_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/delete_conversation.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/delete_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/delete_session.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/delete_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_answer.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_answer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_conversation.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_session.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/get_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/list_conversations.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/list_conversations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/list_sessions.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/list_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/stream_answer_query.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/stream_answer_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/update_conversation.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/update_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/update_session.php
+++ b/DiscoveryEngine/samples/V1/ConversationalSearchServiceClient/update_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DataStoreServiceClient/create_data_store.php
+++ b/DiscoveryEngine/samples/V1/DataStoreServiceClient/create_data_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DataStoreServiceClient/delete_data_store.php
+++ b/DiscoveryEngine/samples/V1/DataStoreServiceClient/delete_data_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DataStoreServiceClient/get_data_store.php
+++ b/DiscoveryEngine/samples/V1/DataStoreServiceClient/get_data_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DataStoreServiceClient/list_data_stores.php
+++ b/DiscoveryEngine/samples/V1/DataStoreServiceClient/list_data_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DataStoreServiceClient/update_data_store.php
+++ b/DiscoveryEngine/samples/V1/DataStoreServiceClient/update_data_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/batch_get_documents_metadata.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/batch_get_documents_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/create_document.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/create_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/delete_document.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/delete_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/get_document.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/get_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/import_documents.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/import_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/list_documents.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/list_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/purge_documents.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/purge_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/DocumentServiceClient/update_document.php
+++ b/DiscoveryEngine/samples/V1/DocumentServiceClient/update_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/EngineServiceClient/create_engine.php
+++ b/DiscoveryEngine/samples/V1/EngineServiceClient/create_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/EngineServiceClient/delete_engine.php
+++ b/DiscoveryEngine/samples/V1/EngineServiceClient/delete_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/EngineServiceClient/get_engine.php
+++ b/DiscoveryEngine/samples/V1/EngineServiceClient/get_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/EngineServiceClient/list_engines.php
+++ b/DiscoveryEngine/samples/V1/EngineServiceClient/list_engines.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/EngineServiceClient/update_engine.php
+++ b/DiscoveryEngine/samples/V1/EngineServiceClient/update_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/check_grounding.php
+++ b/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/check_grounding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/generate_grounded_content.php
+++ b/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/generate_grounded_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/stream_generate_grounded_content.php
+++ b/DiscoveryEngine/samples/V1/GroundedGenerationServiceClient/stream_generate_grounded_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/create_identity_mapping_store.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/create_identity_mapping_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/delete_identity_mapping_store.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/delete_identity_mapping_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/get_identity_mapping_store.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/get_identity_mapping_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/import_identity_mappings.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/import_identity_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/list_identity_mapping_stores.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/list_identity_mapping_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/list_identity_mappings.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/list_identity_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/purge_identity_mappings.php
+++ b/DiscoveryEngine/samples/V1/IdentityMappingStoreServiceClient/purge_identity_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ProjectServiceClient/provision_project.php
+++ b/DiscoveryEngine/samples/V1/ProjectServiceClient/provision_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/RankServiceClient/rank.php
+++ b/DiscoveryEngine/samples/V1/RankServiceClient/rank.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/RecommendationServiceClient/recommend.php
+++ b/DiscoveryEngine/samples/V1/RecommendationServiceClient/recommend.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SchemaServiceClient/create_schema.php
+++ b/DiscoveryEngine/samples/V1/SchemaServiceClient/create_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SchemaServiceClient/delete_schema.php
+++ b/DiscoveryEngine/samples/V1/SchemaServiceClient/delete_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SchemaServiceClient/get_schema.php
+++ b/DiscoveryEngine/samples/V1/SchemaServiceClient/get_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SchemaServiceClient/list_schemas.php
+++ b/DiscoveryEngine/samples/V1/SchemaServiceClient/list_schemas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SchemaServiceClient/update_schema.php
+++ b/DiscoveryEngine/samples/V1/SchemaServiceClient/update_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SearchServiceClient/search.php
+++ b/DiscoveryEngine/samples/V1/SearchServiceClient/search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SearchServiceClient/search_lite.php
+++ b/DiscoveryEngine/samples/V1/SearchServiceClient/search_lite.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SearchTuningServiceClient/list_custom_models.php
+++ b/DiscoveryEngine/samples/V1/SearchTuningServiceClient/list_custom_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SearchTuningServiceClient/train_custom_model.php
+++ b/DiscoveryEngine/samples/V1/SearchTuningServiceClient/train_custom_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/ServingConfigServiceClient/update_serving_config.php
+++ b/DiscoveryEngine/samples/V1/ServingConfigServiceClient/update_serving_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SessionServiceClient/create_session.php
+++ b/DiscoveryEngine/samples/V1/SessionServiceClient/create_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SessionServiceClient/delete_session.php
+++ b/DiscoveryEngine/samples/V1/SessionServiceClient/delete_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SessionServiceClient/get_session.php
+++ b/DiscoveryEngine/samples/V1/SessionServiceClient/get_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SessionServiceClient/list_sessions.php
+++ b/DiscoveryEngine/samples/V1/SessionServiceClient/list_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SessionServiceClient/update_session.php
+++ b/DiscoveryEngine/samples/V1/SessionServiceClient/update_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/batch_create_target_sites.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/batch_create_target_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/batch_verify_target_sites.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/batch_verify_target_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/create_sitemap.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/create_sitemap.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/create_target_site.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/create_target_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/delete_sitemap.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/delete_sitemap.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/delete_target_site.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/delete_target_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/disable_advanced_site_search.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/disable_advanced_site_search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/enable_advanced_site_search.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/enable_advanced_site_search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/fetch_domain_verification_status.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/fetch_domain_verification_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/fetch_sitemaps.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/fetch_sitemaps.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/get_site_search_engine.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/get_site_search_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/get_target_site.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/get_target_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/list_target_sites.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/list_target_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/recrawl_uris.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/recrawl_uris.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/update_target_site.php
+++ b/DiscoveryEngine/samples/V1/SiteSearchEngineServiceClient/update_target_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserEventServiceClient/collect_user_event.php
+++ b/DiscoveryEngine/samples/V1/UserEventServiceClient/collect_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserEventServiceClient/import_user_events.php
+++ b/DiscoveryEngine/samples/V1/UserEventServiceClient/import_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserEventServiceClient/purge_user_events.php
+++ b/DiscoveryEngine/samples/V1/UserEventServiceClient/purge_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserEventServiceClient/write_user_event.php
+++ b/DiscoveryEngine/samples/V1/UserEventServiceClient/write_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserLicenseServiceClient/batch_update_user_licenses.php
+++ b/DiscoveryEngine/samples/V1/UserLicenseServiceClient/batch_update_user_licenses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/samples/V1/UserLicenseServiceClient/list_user_licenses.php
+++ b/DiscoveryEngine/samples/V1/UserLicenseServiceClient/list_user_licenses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/AssistantServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/AssistantServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/CmekConfigServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/CmekConfigServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/CompletionServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/CompletionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/ControlServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/ControlServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/ConversationalSearchServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/ConversationalSearchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/DataStoreServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/DataStoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/DocumentServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/DocumentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/EngineServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/EngineServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/GroundedGenerationServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/GroundedGenerationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/IdentityMappingStoreServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/IdentityMappingStoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/ProjectServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/ProjectServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/RankServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/RankServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/RecommendationServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/RecommendationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/SchemaServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/SchemaServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/SearchServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/SearchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/SearchTuningServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/SearchTuningServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/ServingConfigServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/ServingConfigServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/SessionServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/SessionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/SiteSearchEngineServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/SiteSearchEngineServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/UserEventServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/UserEventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/Client/UserLicenseServiceClient.php
+++ b/DiscoveryEngine/src/V1/Client/UserLicenseServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/assistant_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/assistant_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/assistant_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/assistant_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/cmek_config_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/cmek_config_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/cmek_config_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/cmek_config_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/completion_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/completion_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/completion_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/completion_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/control_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/control_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/control_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/control_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/conversational_search_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/conversational_search_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/conversational_search_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/conversational_search_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/data_store_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/data_store_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/data_store_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/data_store_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/document_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/document_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/document_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/document_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/engine_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/engine_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/engine_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/engine_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/grounded_generation_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/grounded_generation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/grounded_generation_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/grounded_generation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/identity_mapping_store_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/identity_mapping_store_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/identity_mapping_store_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/identity_mapping_store_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/project_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/project_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/project_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/project_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/rank_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/rank_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/rank_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/rank_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/recommendation_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/recommendation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/recommendation_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/recommendation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/schema_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/schema_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/schema_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/schema_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/search_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/search_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/search_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/search_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/search_tuning_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/search_tuning_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/search_tuning_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/search_tuning_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/serving_config_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/serving_config_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/serving_config_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/serving_config_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/session_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/session_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/session_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/session_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/site_search_engine_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/site_search_engine_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/site_search_engine_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/site_search_engine_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/user_event_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/user_event_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/user_event_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/user_event_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/user_license_service_descriptor_config.php
+++ b/DiscoveryEngine/src/V1/resources/user_license_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/src/V1/resources/user_license_service_rest_client_config.php
+++ b/DiscoveryEngine/src/V1/resources/user_license_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/AssistantServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/AssistantServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/CmekConfigServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/CmekConfigServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/CompletionServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/CompletionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/ControlServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/ControlServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/ConversationalSearchServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/ConversationalSearchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/DataStoreServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/DataStoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/DocumentServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/DocumentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/EngineServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/EngineServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/GroundedGenerationServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/GroundedGenerationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/IdentityMappingStoreServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/IdentityMappingStoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/ProjectServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/ProjectServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/RankServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/RankServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/RecommendationServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/RecommendationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/SchemaServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/SchemaServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/SearchServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/SearchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/SearchTuningServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/SearchTuningServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/ServingConfigServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/ServingConfigServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/SessionServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/SessionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/SiteSearchEngineServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/SiteSearchEngineServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/UserEventServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/UserEventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DiscoveryEngine/tests/Unit/V1/Client/UserLicenseServiceClientTest.php
+++ b/DiscoveryEngine/tests/Unit/V1/Client/UserLicenseServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/owlbot.py
+++ b/Dlp/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/activate_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/activate_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/cancel_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/cancel_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_connection.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_deidentify_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_deidentify_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_discovery_config.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_discovery_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_inspect_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_inspect_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/create_stored_info_type.php
+++ b/Dlp/samples/V2/DlpServiceClient/create_stored_info_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/deidentify_content.php
+++ b/Dlp/samples/V2/DlpServiceClient/deidentify_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_connection.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_deidentify_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_deidentify_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_discovery_config.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_discovery_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_file_store_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_file_store_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_inspect_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_inspect_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_stored_info_type.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_stored_info_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/delete_table_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/delete_table_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/finish_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/finish_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_column_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_column_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_connection.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_deidentify_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_deidentify_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_discovery_config.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_discovery_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_file_store_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_file_store_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_inspect_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_inspect_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_project_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_project_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_stored_info_type.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_stored_info_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/get_table_data_profile.php
+++ b/Dlp/samples/V2/DlpServiceClient/get_table_data_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/hybrid_inspect_dlp_job.php
+++ b/Dlp/samples/V2/DlpServiceClient/hybrid_inspect_dlp_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/hybrid_inspect_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/hybrid_inspect_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/inspect_content.php
+++ b/Dlp/samples/V2/DlpServiceClient/inspect_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_column_data_profiles.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_column_data_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_connections.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_deidentify_templates.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_deidentify_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_discovery_configs.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_discovery_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_dlp_jobs.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_dlp_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_file_store_data_profiles.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_file_store_data_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_info_types.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_info_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_inspect_templates.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_inspect_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_job_triggers.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_job_triggers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_project_data_profiles.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_project_data_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_stored_info_types.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_stored_info_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/list_table_data_profiles.php
+++ b/Dlp/samples/V2/DlpServiceClient/list_table_data_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/redact_image.php
+++ b/Dlp/samples/V2/DlpServiceClient/redact_image.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/reidentify_content.php
+++ b/Dlp/samples/V2/DlpServiceClient/reidentify_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/search_connections.php
+++ b/Dlp/samples/V2/DlpServiceClient/search_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_connection.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_deidentify_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_deidentify_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_discovery_config.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_discovery_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_inspect_template.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_inspect_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_job_trigger.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_job_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/samples/V2/DlpServiceClient/update_stored_info_type.php
+++ b/Dlp/samples/V2/DlpServiceClient/update_stored_info_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/src/V2/Client/DlpServiceClient.php
+++ b/Dlp/src/V2/Client/DlpServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/src/V2/resources/dlp_service_descriptor_config.php
+++ b/Dlp/src/V2/resources/dlp_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/src/V2/resources/dlp_service_rest_client_config.php
+++ b/Dlp/src/V2/resources/dlp_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dlp/tests/Unit/V2/Client/DlpServiceClientTest.php
+++ b/Dlp/tests/Unit/V2/Client/DlpServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/owlbot.py
+++ b/Dms/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/apply_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/apply_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/commit_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/commit_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/convert_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/convert_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/create_connection_profile.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/create_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/create_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/create_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/create_mapping_rule.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/create_mapping_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/create_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/create_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/create_private_connection.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/create_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/delete_connection_profile.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/delete_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/delete_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/delete_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/delete_mapping_rule.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/delete_mapping_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/delete_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/delete_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/delete_private_connection.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/delete_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/describe_conversion_workspace_revisions.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/describe_conversion_workspace_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/describe_database_entities.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/describe_database_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/fetch_static_ips.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/fetch_static_ips.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/generate_ssh_script.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/generate_ssh_script.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/generate_tcp_proxy_script.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/generate_tcp_proxy_script.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/get_connection_profile.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/get_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/get_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/get_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/get_mapping_rule.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/get_mapping_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/get_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/get_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/get_private_connection.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/get_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/import_mapping_rules.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/import_mapping_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/list_connection_profiles.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/list_connection_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/list_conversion_workspaces.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/list_conversion_workspaces.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/list_mapping_rules.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/list_mapping_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/list_migration_jobs.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/list_migration_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/list_private_connections.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/list_private_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/promote_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/promote_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/restart_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/restart_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/resume_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/resume_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/rollback_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/rollback_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/search_background_jobs.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/search_background_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/seed_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/seed_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/start_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/start_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/stop_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/stop_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/update_connection_profile.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/update_connection_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/update_conversion_workspace.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/update_conversion_workspace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/update_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/update_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/samples/V1/DataMigrationServiceClient/verify_migration_job.php
+++ b/Dms/samples/V1/DataMigrationServiceClient/verify_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/src/V1/Client/DataMigrationServiceClient.php
+++ b/Dms/src/V1/Client/DataMigrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/src/V1/resources/data_migration_service_descriptor_config.php
+++ b/Dms/src/V1/resources/data_migration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/src/V1/resources/data_migration_service_rest_client_config.php
+++ b/Dms/src/V1/resources/data_migration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Dms/tests/Unit/V1/Client/DataMigrationServiceClientTest.php
+++ b/Dms/tests/Unit/V1/Client/DataMigrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/owlbot.py
+++ b/DocumentAi/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/batch_process_documents.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/batch_process_documents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/create_processor.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/create_processor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/delete_processor.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/delete_processor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/delete_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/delete_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/deploy_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/deploy_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/disable_processor.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/disable_processor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/enable_processor.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/enable_processor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/evaluate_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/evaluate_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/fetch_processor_types.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/fetch_processor_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_evaluation.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_location.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor_type.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/get_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_evaluations.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_evaluations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_locations.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processor_types.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processor_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processor_versions.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processor_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processors.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/list_processors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/process_document.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/process_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/review_document.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/review_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/set_default_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/set_default_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/train_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/train_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/samples/V1/DocumentProcessorServiceClient/undeploy_processor_version.php
+++ b/DocumentAi/samples/V1/DocumentProcessorServiceClient/undeploy_processor_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/src/V1/Client/DocumentProcessorServiceClient.php
+++ b/DocumentAi/src/V1/Client/DocumentProcessorServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/src/V1/resources/document_processor_service_descriptor_config.php
+++ b/DocumentAi/src/V1/resources/document_processor_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/src/V1/resources/document_processor_service_rest_client_config.php
+++ b/DocumentAi/src/V1/resources/document_processor_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/DocumentAi/tests/Unit/V1/Client/DocumentProcessorServiceClientTest.php
+++ b/DocumentAi/tests/Unit/V1/Client/DocumentProcessorServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/owlbot.py
+++ b/Domains/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/configure_contact_settings.php
+++ b/Domains/samples/V1/DomainsClient/configure_contact_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/configure_dns_settings.php
+++ b/Domains/samples/V1/DomainsClient/configure_dns_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/configure_management_settings.php
+++ b/Domains/samples/V1/DomainsClient/configure_management_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/delete_registration.php
+++ b/Domains/samples/V1/DomainsClient/delete_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/export_registration.php
+++ b/Domains/samples/V1/DomainsClient/export_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/get_registration.php
+++ b/Domains/samples/V1/DomainsClient/get_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/list_registrations.php
+++ b/Domains/samples/V1/DomainsClient/list_registrations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/register_domain.php
+++ b/Domains/samples/V1/DomainsClient/register_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/reset_authorization_code.php
+++ b/Domains/samples/V1/DomainsClient/reset_authorization_code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/retrieve_authorization_code.php
+++ b/Domains/samples/V1/DomainsClient/retrieve_authorization_code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/retrieve_register_parameters.php
+++ b/Domains/samples/V1/DomainsClient/retrieve_register_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/retrieve_transfer_parameters.php
+++ b/Domains/samples/V1/DomainsClient/retrieve_transfer_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/search_domains.php
+++ b/Domains/samples/V1/DomainsClient/search_domains.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/transfer_domain.php
+++ b/Domains/samples/V1/DomainsClient/transfer_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/samples/V1/DomainsClient/update_registration.php
+++ b/Domains/samples/V1/DomainsClient/update_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/src/V1/Client/DomainsClient.php
+++ b/Domains/src/V1/Client/DomainsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/src/V1/resources/domains_descriptor_config.php
+++ b/Domains/src/V1/resources/domains_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/src/V1/resources/domains_rest_client_config.php
+++ b/Domains/src/V1/resources/domains_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Domains/tests/Unit/V1/Client/DomainsClientTest.php
+++ b/Domains/tests/Unit/V1/Client/DomainsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/owlbot.py
+++ b/EdgeNetwork/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/create_interconnect_attachment.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/create_interconnect_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/create_network.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/create_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/create_router.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/create_router.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/create_subnet.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/create_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_interconnect_attachment.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_interconnect_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_network.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_router.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_router.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_subnet.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/delete_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_interconnect.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_interconnect.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_network.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_router.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/diagnose_router.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_interconnect.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_interconnect.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_interconnect_attachment.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_interconnect_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_location.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_network.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_router.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_router.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_subnet.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/get_zone.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/get_zone.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/initialize_zone.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/initialize_zone.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_interconnect_attachments.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_interconnect_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_interconnects.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_interconnects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_locations.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_networks.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_networks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_routers.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_routers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_subnets.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_subnets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/list_zones.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/list_zones.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/update_router.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/update_router.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/samples/V1/EdgeNetworkClient/update_subnet.php
+++ b/EdgeNetwork/samples/V1/EdgeNetworkClient/update_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/src/V1/Client/EdgeNetworkClient.php
+++ b/EdgeNetwork/src/V1/Client/EdgeNetworkClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/src/V1/resources/edge_network_descriptor_config.php
+++ b/EdgeNetwork/src/V1/resources/edge_network_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/src/V1/resources/edge_network_rest_client_config.php
+++ b/EdgeNetwork/src/V1/resources/edge_network_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EdgeNetwork/tests/Unit/V1/Client/EdgeNetworkClientTest.php
+++ b/EdgeNetwork/tests/Unit/V1/Client/EdgeNetworkClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ErrorReporting/tests/System/V1beta1/ReportErrorsServiceSmokeTest.php
+++ b/ErrorReporting/tests/System/V1beta1/ReportErrorsServiceSmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/owlbot.py
+++ b/EssentialContacts/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/compute_contacts.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/compute_contacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/create_contact.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/create_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/delete_contact.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/delete_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/get_contact.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/get_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/list_contacts.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/list_contacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/send_test_message.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/send_test_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/samples/V1/EssentialContactsServiceClient/update_contact.php
+++ b/EssentialContacts/samples/V1/EssentialContactsServiceClient/update_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/src/V1/Client/EssentialContactsServiceClient.php
+++ b/EssentialContacts/src/V1/Client/EssentialContactsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/src/V1/resources/essential_contacts_service_descriptor_config.php
+++ b/EssentialContacts/src/V1/resources/essential_contacts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/src/V1/resources/essential_contacts_service_rest_client_config.php
+++ b/EssentialContacts/src/V1/resources/essential_contacts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EssentialContacts/tests/Unit/V1/Client/EssentialContactsServiceClientTest.php
+++ b/EssentialContacts/tests/Unit/V1/Client/EssentialContactsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1011 generated files** in **16 in-scope packages** (DatastoreAdmin through EssentialContacts).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`DatastoreAdmin`, `Datastream`, `Deploy`, `DeveloperConnect`, `DeveloperKnowledge`, `DeviceStreaming`, `Dialogflow`, `DialogflowCx`, `DiscoveryEngine`, `Dlp`, `Dms`, `DocumentAi`, `Domains`, `EdgeNetwork`, `ErrorReporting`, `EssentialContacts`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-6
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 6 of 10 in the 2026 copyright update series.
