### PR TITLE
chore: update copyright years to 2026 for generated files (part 7: Eventarc to Monitoring)

### DIFF
--- a/Eventarc/owlbot.py
+++ b/Eventarc/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_channel.php
+++ b/Eventarc/samples/V1/EventarcClient/create_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_channel_connection.php
+++ b/Eventarc/samples/V1/EventarcClient/create_channel_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_enrollment.php
+++ b/Eventarc/samples/V1/EventarcClient/create_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_google_api_source.php
+++ b/Eventarc/samples/V1/EventarcClient/create_google_api_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_message_bus.php
+++ b/Eventarc/samples/V1/EventarcClient/create_message_bus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_pipeline.php
+++ b/Eventarc/samples/V1/EventarcClient/create_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/create_trigger.php
+++ b/Eventarc/samples/V1/EventarcClient/create_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_channel.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_channel_connection.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_channel_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_enrollment.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_google_api_source.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_google_api_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_message_bus.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_message_bus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_pipeline.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/delete_trigger.php
+++ b/Eventarc/samples/V1/EventarcClient/delete_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_channel.php
+++ b/Eventarc/samples/V1/EventarcClient/get_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_channel_connection.php
+++ b/Eventarc/samples/V1/EventarcClient/get_channel_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_enrollment.php
+++ b/Eventarc/samples/V1/EventarcClient/get_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_google_api_source.php
+++ b/Eventarc/samples/V1/EventarcClient/get_google_api_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_google_channel_config.php
+++ b/Eventarc/samples/V1/EventarcClient/get_google_channel_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_iam_policy.php
+++ b/Eventarc/samples/V1/EventarcClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_location.php
+++ b/Eventarc/samples/V1/EventarcClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_message_bus.php
+++ b/Eventarc/samples/V1/EventarcClient/get_message_bus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_pipeline.php
+++ b/Eventarc/samples/V1/EventarcClient/get_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_provider.php
+++ b/Eventarc/samples/V1/EventarcClient/get_provider.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/get_trigger.php
+++ b/Eventarc/samples/V1/EventarcClient/get_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_channel_connections.php
+++ b/Eventarc/samples/V1/EventarcClient/list_channel_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_channels.php
+++ b/Eventarc/samples/V1/EventarcClient/list_channels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_enrollments.php
+++ b/Eventarc/samples/V1/EventarcClient/list_enrollments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_google_api_sources.php
+++ b/Eventarc/samples/V1/EventarcClient/list_google_api_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_locations.php
+++ b/Eventarc/samples/V1/EventarcClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_message_bus_enrollments.php
+++ b/Eventarc/samples/V1/EventarcClient/list_message_bus_enrollments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_message_buses.php
+++ b/Eventarc/samples/V1/EventarcClient/list_message_buses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_pipelines.php
+++ b/Eventarc/samples/V1/EventarcClient/list_pipelines.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_providers.php
+++ b/Eventarc/samples/V1/EventarcClient/list_providers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/list_triggers.php
+++ b/Eventarc/samples/V1/EventarcClient/list_triggers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/set_iam_policy.php
+++ b/Eventarc/samples/V1/EventarcClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/test_iam_permissions.php
+++ b/Eventarc/samples/V1/EventarcClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_channel.php
+++ b/Eventarc/samples/V1/EventarcClient/update_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_enrollment.php
+++ b/Eventarc/samples/V1/EventarcClient/update_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_google_api_source.php
+++ b/Eventarc/samples/V1/EventarcClient/update_google_api_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_google_channel_config.php
+++ b/Eventarc/samples/V1/EventarcClient/update_google_channel_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_message_bus.php
+++ b/Eventarc/samples/V1/EventarcClient/update_message_bus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_pipeline.php
+++ b/Eventarc/samples/V1/EventarcClient/update_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/samples/V1/EventarcClient/update_trigger.php
+++ b/Eventarc/samples/V1/EventarcClient/update_trigger.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/src/V1/Client/EventarcClient.php
+++ b/Eventarc/src/V1/Client/EventarcClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/src/V1/resources/eventarc_descriptor_config.php
+++ b/Eventarc/src/V1/resources/eventarc_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/src/V1/resources/eventarc_rest_client_config.php
+++ b/Eventarc/src/V1/resources/eventarc_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Eventarc/tests/Unit/V1/Client/EventarcClientTest.php
+++ b/Eventarc/tests/Unit/V1/Client/EventarcClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/owlbot.py
+++ b/EventarcPublishing/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/EventarcPublishing/samples/V1/PublisherClient/publish.php
+++ b/EventarcPublishing/samples/V1/PublisherClient/publish.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/samples/V1/PublisherClient/publish_channel_connection_events.php
+++ b/EventarcPublishing/samples/V1/PublisherClient/publish_channel_connection_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/samples/V1/PublisherClient/publish_events.php
+++ b/EventarcPublishing/samples/V1/PublisherClient/publish_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/src/V1/Client/PublisherClient.php
+++ b/EventarcPublishing/src/V1/Client/PublisherClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/src/V1/resources/publisher_descriptor_config.php
+++ b/EventarcPublishing/src/V1/resources/publisher_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/src/V1/resources/publisher_rest_client_config.php
+++ b/EventarcPublishing/src/V1/resources/publisher_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/EventarcPublishing/tests/Unit/V1/Client/PublisherClientTest.php
+++ b/EventarcPublishing/tests/Unit/V1/Client/PublisherClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/owlbot.py
+++ b/Filestore/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/create_backup.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/create_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/create_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/create_snapshot.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/create_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/delete_backup.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/delete_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/delete_snapshot.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/delete_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/get_backup.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/get_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/get_snapshot.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/get_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/list_backups.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/list_instances.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/list_snapshots.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/list_snapshots.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/promote_replica.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/promote_replica.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/restore_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/restore_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/revert_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/revert_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/update_backup.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/update_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/update_instance.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/samples/V1/CloudFilestoreManagerClient/update_snapshot.php
+++ b/Filestore/samples/V1/CloudFilestoreManagerClient/update_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/src/V1/Client/CloudFilestoreManagerClient.php
+++ b/Filestore/src/V1/Client/CloudFilestoreManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/src/V1/resources/cloud_filestore_manager_descriptor_config.php
+++ b/Filestore/src/V1/resources/cloud_filestore_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/src/V1/resources/cloud_filestore_manager_rest_client_config.php
+++ b/Filestore/src/V1/resources/cloud_filestore_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Filestore/tests/Unit/V1/Client/CloudFilestoreManagerClientTest.php
+++ b/Filestore/tests/Unit/V1/Client/CloudFilestoreManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/owlbot.py
+++ b/FinancialServices/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_backtest_result.php
+++ b/FinancialServices/samples/V1/AMLClient/create_backtest_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_dataset.php
+++ b/FinancialServices/samples/V1/AMLClient/create_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_engine_config.php
+++ b/FinancialServices/samples/V1/AMLClient/create_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_instance.php
+++ b/FinancialServices/samples/V1/AMLClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_model.php
+++ b/FinancialServices/samples/V1/AMLClient/create_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/create_prediction_result.php
+++ b/FinancialServices/samples/V1/AMLClient/create_prediction_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_backtest_result.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_backtest_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_dataset.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_engine_config.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_instance.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_model.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/delete_prediction_result.php
+++ b/FinancialServices/samples/V1/AMLClient/delete_prediction_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/export_backtest_result_metadata.php
+++ b/FinancialServices/samples/V1/AMLClient/export_backtest_result_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/export_engine_config_metadata.php
+++ b/FinancialServices/samples/V1/AMLClient/export_engine_config_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/export_model_metadata.php
+++ b/FinancialServices/samples/V1/AMLClient/export_model_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/export_prediction_result_metadata.php
+++ b/FinancialServices/samples/V1/AMLClient/export_prediction_result_metadata.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/export_registered_parties.php
+++ b/FinancialServices/samples/V1/AMLClient/export_registered_parties.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_backtest_result.php
+++ b/FinancialServices/samples/V1/AMLClient/get_backtest_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_dataset.php
+++ b/FinancialServices/samples/V1/AMLClient/get_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_engine_config.php
+++ b/FinancialServices/samples/V1/AMLClient/get_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_engine_version.php
+++ b/FinancialServices/samples/V1/AMLClient/get_engine_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_instance.php
+++ b/FinancialServices/samples/V1/AMLClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_location.php
+++ b/FinancialServices/samples/V1/AMLClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_model.php
+++ b/FinancialServices/samples/V1/AMLClient/get_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/get_prediction_result.php
+++ b/FinancialServices/samples/V1/AMLClient/get_prediction_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/import_registered_parties.php
+++ b/FinancialServices/samples/V1/AMLClient/import_registered_parties.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_backtest_results.php
+++ b/FinancialServices/samples/V1/AMLClient/list_backtest_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_datasets.php
+++ b/FinancialServices/samples/V1/AMLClient/list_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_engine_configs.php
+++ b/FinancialServices/samples/V1/AMLClient/list_engine_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_engine_versions.php
+++ b/FinancialServices/samples/V1/AMLClient/list_engine_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_instances.php
+++ b/FinancialServices/samples/V1/AMLClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_locations.php
+++ b/FinancialServices/samples/V1/AMLClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_models.php
+++ b/FinancialServices/samples/V1/AMLClient/list_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/list_prediction_results.php
+++ b/FinancialServices/samples/V1/AMLClient/list_prediction_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_backtest_result.php
+++ b/FinancialServices/samples/V1/AMLClient/update_backtest_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_dataset.php
+++ b/FinancialServices/samples/V1/AMLClient/update_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_engine_config.php
+++ b/FinancialServices/samples/V1/AMLClient/update_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_instance.php
+++ b/FinancialServices/samples/V1/AMLClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_model.php
+++ b/FinancialServices/samples/V1/AMLClient/update_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/samples/V1/AMLClient/update_prediction_result.php
+++ b/FinancialServices/samples/V1/AMLClient/update_prediction_result.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/src/V1/Client/AMLClient.php
+++ b/FinancialServices/src/V1/Client/AMLClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/src/V1/resources/aml_descriptor_config.php
+++ b/FinancialServices/src/V1/resources/aml_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/src/V1/resources/aml_rest_client_config.php
+++ b/FinancialServices/src/V1/resources/aml_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FinancialServices/tests/Unit/V1/Client/AMLClientTest.php
+++ b/FinancialServices/tests/Unit/V1/Client/AMLClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/tests/System/Admin/V1/FirestoreAdminClientSmokeTest.php
+++ b/Firestore/tests/System/Admin/V1/FirestoreAdminClientSmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019 Google LLC.
+ * Copyright 2026 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/owlbot.py
+++ b/Functions/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/create_function.php
+++ b/Functions/samples/V2/FunctionServiceClient/create_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/delete_function.php
+++ b/Functions/samples/V2/FunctionServiceClient/delete_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/generate_download_url.php
+++ b/Functions/samples/V2/FunctionServiceClient/generate_download_url.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/generate_upload_url.php
+++ b/Functions/samples/V2/FunctionServiceClient/generate_upload_url.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/get_function.php
+++ b/Functions/samples/V2/FunctionServiceClient/get_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/get_iam_policy.php
+++ b/Functions/samples/V2/FunctionServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/list_functions.php
+++ b/Functions/samples/V2/FunctionServiceClient/list_functions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/list_locations.php
+++ b/Functions/samples/V2/FunctionServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/list_runtimes.php
+++ b/Functions/samples/V2/FunctionServiceClient/list_runtimes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/set_iam_policy.php
+++ b/Functions/samples/V2/FunctionServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/test_iam_permissions.php
+++ b/Functions/samples/V2/FunctionServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/samples/V2/FunctionServiceClient/update_function.php
+++ b/Functions/samples/V2/FunctionServiceClient/update_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/src/V2/Client/FunctionServiceClient.php
+++ b/Functions/src/V2/Client/FunctionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/src/V2/resources/function_service_descriptor_config.php
+++ b/Functions/src/V2/resources/function_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/src/V2/resources/function_service_rest_client_config.php
+++ b/Functions/src/V2/resources/function_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Functions/tests/Unit/V2/Client/FunctionServiceClientTest.php
+++ b/Functions/tests/Unit/V2/Client/FunctionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/owlbot.py
+++ b/GSuiteAddOns/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/create_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/create_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/delete_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/delete_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_authorization.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_authorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_install_status.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/get_install_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/install_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/install_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/list_deployments.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/list_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/replace_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/replace_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/uninstall_deployment.php
+++ b/GSuiteAddOns/samples/V1/GSuiteAddOnsClient/uninstall_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/src/V1/Client/GSuiteAddOnsClient.php
+++ b/GSuiteAddOns/src/V1/Client/GSuiteAddOnsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/src/V1/resources/g_suite_add_ons_descriptor_config.php
+++ b/GSuiteAddOns/src/V1/resources/g_suite_add_ons_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/src/V1/resources/g_suite_add_ons_rest_client_config.php
+++ b/GSuiteAddOns/src/V1/resources/g_suite_add_ons_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GSuiteAddOns/tests/Unit/V1/Client/GSuiteAddOnsClientTest.php
+++ b/GSuiteAddOns/tests/Unit/V1/Client/GSuiteAddOnsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/owlbot.py
+++ b/GeminiDataAnalytics/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/create_data_agent.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/create_data_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/delete_data_agent.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/delete_data_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_data_agent.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_data_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_iam_policy.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_location.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_accessible_data_agents.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_accessible_data_agents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_data_agents.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_data_agents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_locations.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/set_iam_policy.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/update_data_agent.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataAgentServiceClient/update_data_agent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/chat.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/chat.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/create_conversation.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/create_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/delete_conversation.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/delete_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/get_conversation.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/get_conversation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/get_location.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_conversations.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_conversations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_locations.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_messages.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/list_messages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/query_data.php
+++ b/GeminiDataAnalytics/samples/V1beta/DataChatServiceClient/query_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/Client/DataAgentServiceClient.php
+++ b/GeminiDataAnalytics/src/V1beta/Client/DataAgentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/Client/DataChatServiceClient.php
+++ b/GeminiDataAnalytics/src/V1beta/Client/DataChatServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/resources/data_agent_service_descriptor_config.php
+++ b/GeminiDataAnalytics/src/V1beta/resources/data_agent_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/resources/data_agent_service_rest_client_config.php
+++ b/GeminiDataAnalytics/src/V1beta/resources/data_agent_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/resources/data_chat_service_descriptor_config.php
+++ b/GeminiDataAnalytics/src/V1beta/resources/data_chat_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/src/V1beta/resources/data_chat_service_rest_client_config.php
+++ b/GeminiDataAnalytics/src/V1beta/resources/data_chat_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/tests/Unit/V1beta/Client/DataAgentServiceClientTest.php
+++ b/GeminiDataAnalytics/tests/Unit/V1beta/Client/DataAgentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeminiDataAnalytics/tests/Unit/V1beta/Client/DataChatServiceClientTest.php
+++ b/GeminiDataAnalytics/tests/Unit/V1beta/Client/DataChatServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GeoCommonProtos/owlbot.py
+++ b/GeoCommonProtos/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GeoCommonProtos/tests/Unit/InstantiateClassesTest.php
+++ b/GeoCommonProtos/tests/Unit/InstantiateClassesTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/owlbot.py
+++ b/GkeBackup/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_backup.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_backup_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_backup_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_backup_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_restore.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_restore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_restore_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_restore_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/create_restore_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/create_restore_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_backup.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_backup_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_backup_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_backup_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_restore.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_restore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_restore_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_restore_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/delete_restore_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/delete_restore_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_backup.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_backup_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_backup_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_backup_index_download_url.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_backup_index_download_url.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_backup_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_backup_plan_binding.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_backup_plan_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_iam_policy.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_location.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_restore.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_restore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_restore_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_restore_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_restore_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_restore_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_restore_plan_binding.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_restore_plan_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_volume_backup.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_volume_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/get_volume_restore.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/get_volume_restore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_backup_channels.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_backup_channels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_backup_plan_bindings.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_backup_plan_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_backup_plans.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_backup_plans.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_backups.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_locations.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_restore_channels.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_restore_channels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_restore_plan_bindings.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_restore_plan_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_restore_plans.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_restore_plans.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_restores.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_restores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_volume_backups.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_volume_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/list_volume_restores.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/list_volume_restores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/set_iam_policy.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/test_iam_permissions.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_backup.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_backup_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_backup_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_backup_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_backup_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_restore.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_restore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_restore_channel.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_restore_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/samples/V1/BackupForGKEClient/update_restore_plan.php
+++ b/GkeBackup/samples/V1/BackupForGKEClient/update_restore_plan.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/src/V1/Client/BackupForGKEClient.php
+++ b/GkeBackup/src/V1/Client/BackupForGKEClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/src/V1/resources/backup_for_gke_descriptor_config.php
+++ b/GkeBackup/src/V1/resources/backup_for_gke_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/src/V1/resources/backup_for_gke_rest_client_config.php
+++ b/GkeBackup/src/V1/resources/backup_for_gke_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeBackup/tests/Unit/V1/Client/BackupForGKEClientTest.php
+++ b/GkeBackup/tests/Unit/V1/Client/BackupForGKEClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/owlbot.py
+++ b/GkeConnectGateway/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/samples/V1/GatewayControlClient/generate_credentials.php
+++ b/GkeConnectGateway/samples/V1/GatewayControlClient/generate_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/samples/V1beta1/GatewayControlClient/generate_credentials.php
+++ b/GkeConnectGateway/samples/V1beta1/GatewayControlClient/generate_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1/Client/GatewayControlClient.php
+++ b/GkeConnectGateway/src/V1/Client/GatewayControlClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1/resources/gateway_control_descriptor_config.php
+++ b/GkeConnectGateway/src/V1/resources/gateway_control_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1/resources/gateway_control_rest_client_config.php
+++ b/GkeConnectGateway/src/V1/resources/gateway_control_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1beta1/Client/GatewayControlClient.php
+++ b/GkeConnectGateway/src/V1beta1/Client/GatewayControlClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1beta1/resources/gateway_control_descriptor_config.php
+++ b/GkeConnectGateway/src/V1beta1/resources/gateway_control_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/src/V1beta1/resources/gateway_control_rest_client_config.php
+++ b/GkeConnectGateway/src/V1beta1/resources/gateway_control_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/tests/Unit/V1/Client/GatewayControlClientTest.php
+++ b/GkeConnectGateway/tests/Unit/V1/Client/GatewayControlClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeConnectGateway/tests/Unit/V1beta1/Client/GatewayControlClientTest.php
+++ b/GkeConnectGateway/tests/Unit/V1beta1/Client/GatewayControlClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/owlbot.py
+++ b/GkeHub/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/create_feature.php
+++ b/GkeHub/samples/V1/GkeHubClient/create_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/create_membership.php
+++ b/GkeHub/samples/V1/GkeHubClient/create_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/delete_feature.php
+++ b/GkeHub/samples/V1/GkeHubClient/delete_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/delete_membership.php
+++ b/GkeHub/samples/V1/GkeHubClient/delete_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/generate_connect_manifest.php
+++ b/GkeHub/samples/V1/GkeHubClient/generate_connect_manifest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/get_feature.php
+++ b/GkeHub/samples/V1/GkeHubClient/get_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/get_membership.php
+++ b/GkeHub/samples/V1/GkeHubClient/get_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/list_features.php
+++ b/GkeHub/samples/V1/GkeHubClient/list_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/list_memberships.php
+++ b/GkeHub/samples/V1/GkeHubClient/list_memberships.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/update_feature.php
+++ b/GkeHub/samples/V1/GkeHubClient/update_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/samples/V1/GkeHubClient/update_membership.php
+++ b/GkeHub/samples/V1/GkeHubClient/update_membership.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/src/V1/Client/GkeHubClient.php
+++ b/GkeHub/src/V1/Client/GkeHubClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/src/V1/resources/gke_hub_descriptor_config.php
+++ b/GkeHub/src/V1/resources/gke_hub_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/src/V1/resources/gke_hub_rest_client_config.php
+++ b/GkeHub/src/V1/resources/gke_hub_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeHub/tests/Unit/V1/Client/GkeHubClientTest.php
+++ b/GkeHub/tests/Unit/V1/Client/GkeHubClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/owlbot.py
+++ b/GkeMultiCloud/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/create_attached_cluster.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/create_attached_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/delete_attached_cluster.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/delete_attached_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/generate_attached_cluster_agent_token.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/generate_attached_cluster_agent_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/generate_attached_cluster_install_manifest.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/generate_attached_cluster_install_manifest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/get_attached_cluster.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/get_attached_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/get_attached_server_config.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/get_attached_server_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/import_attached_cluster.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/import_attached_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/list_attached_clusters.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/list_attached_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AttachedClustersClient/update_attached_cluster.php
+++ b/GkeMultiCloud/samples/V1/AttachedClustersClient/update_attached_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/create_aws_cluster.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/create_aws_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/create_aws_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/create_aws_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/delete_aws_cluster.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/delete_aws_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/delete_aws_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/delete_aws_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/generate_aws_access_token.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/generate_aws_access_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/generate_aws_cluster_agent_token.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/generate_aws_cluster_agent_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_cluster.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_json_web_keys.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_json_web_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_open_id_config.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_open_id_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_server_config.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/get_aws_server_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/list_aws_clusters.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/list_aws_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/list_aws_node_pools.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/list_aws_node_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/rollback_aws_node_pool_update.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/rollback_aws_node_pool_update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/update_aws_cluster.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/update_aws_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AwsClustersClient/update_aws_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AwsClustersClient/update_aws_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_client.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_cluster.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/create_azure_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_client.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_cluster.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/delete_azure_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/generate_azure_access_token.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/generate_azure_access_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/generate_azure_cluster_agent_token.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/generate_azure_cluster_agent_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_client.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_cluster.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_json_web_keys.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_json_web_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_open_id_config.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_open_id_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_server_config.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/get_azure_server_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_clients.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_clients.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_clusters.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_node_pools.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/list_azure_node_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/update_azure_cluster.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/update_azure_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/samples/V1/AzureClustersClient/update_azure_node_pool.php
+++ b/GkeMultiCloud/samples/V1/AzureClustersClient/update_azure_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/Client/AttachedClustersClient.php
+++ b/GkeMultiCloud/src/V1/Client/AttachedClustersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/Client/AwsClustersClient.php
+++ b/GkeMultiCloud/src/V1/Client/AwsClustersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/Client/AzureClustersClient.php
+++ b/GkeMultiCloud/src/V1/Client/AzureClustersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/attached_clusters_descriptor_config.php
+++ b/GkeMultiCloud/src/V1/resources/attached_clusters_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/attached_clusters_rest_client_config.php
+++ b/GkeMultiCloud/src/V1/resources/attached_clusters_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/aws_clusters_descriptor_config.php
+++ b/GkeMultiCloud/src/V1/resources/aws_clusters_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/aws_clusters_rest_client_config.php
+++ b/GkeMultiCloud/src/V1/resources/aws_clusters_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/azure_clusters_descriptor_config.php
+++ b/GkeMultiCloud/src/V1/resources/azure_clusters_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/src/V1/resources/azure_clusters_rest_client_config.php
+++ b/GkeMultiCloud/src/V1/resources/azure_clusters_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/tests/Unit/V1/Client/AttachedClustersClientTest.php
+++ b/GkeMultiCloud/tests/Unit/V1/Client/AttachedClustersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/tests/Unit/V1/Client/AwsClustersClientTest.php
+++ b/GkeMultiCloud/tests/Unit/V1/Client/AwsClustersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeMultiCloud/tests/Unit/V1/Client/AzureClustersClientTest.php
+++ b/GkeMultiCloud/tests/Unit/V1/Client/AzureClustersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GkeRecommender/owlbot.py
+++ b/GkeRecommender/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Grafeas/owlbot.py
+++ b/Grafeas/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/batch_create_notes.php
+++ b/Grafeas/samples/V1/GrafeasClient/batch_create_notes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/batch_create_occurrences.php
+++ b/Grafeas/samples/V1/GrafeasClient/batch_create_occurrences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/create_note.php
+++ b/Grafeas/samples/V1/GrafeasClient/create_note.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/create_occurrence.php
+++ b/Grafeas/samples/V1/GrafeasClient/create_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/delete_note.php
+++ b/Grafeas/samples/V1/GrafeasClient/delete_note.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/delete_occurrence.php
+++ b/Grafeas/samples/V1/GrafeasClient/delete_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/get_note.php
+++ b/Grafeas/samples/V1/GrafeasClient/get_note.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/get_occurrence.php
+++ b/Grafeas/samples/V1/GrafeasClient/get_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/get_occurrence_note.php
+++ b/Grafeas/samples/V1/GrafeasClient/get_occurrence_note.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/list_note_occurrences.php
+++ b/Grafeas/samples/V1/GrafeasClient/list_note_occurrences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/list_notes.php
+++ b/Grafeas/samples/V1/GrafeasClient/list_notes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/list_occurrences.php
+++ b/Grafeas/samples/V1/GrafeasClient/list_occurrences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/update_note.php
+++ b/Grafeas/samples/V1/GrafeasClient/update_note.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/samples/V1/GrafeasClient/update_occurrence.php
+++ b/Grafeas/samples/V1/GrafeasClient/update_occurrence.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/src/V1/Client/GrafeasClient.php
+++ b/Grafeas/src/V1/Client/GrafeasClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/src/V1/resources/grafeas_descriptor_config.php
+++ b/Grafeas/src/V1/resources/grafeas_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/src/V1/resources/grafeas_rest_client_config.php
+++ b/Grafeas/src/V1/resources/grafeas_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Grafeas/tests/Unit/V1/Client/GrafeasClientTest.php
+++ b/Grafeas/tests/Unit/V1/Client/GrafeasClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/owlbot.py
+++ b/HypercomputeCluster/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/create_cluster.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/delete_cluster.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/get_cluster.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/get_location.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/list_clusters.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/list_locations.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/update_cluster.php
+++ b/HypercomputeCluster/samples/V1beta/HypercomputeClusterClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/src/V1beta/Client/HypercomputeClusterClient.php
+++ b/HypercomputeCluster/src/V1beta/Client/HypercomputeClusterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/src/V1beta/resources/hypercompute_cluster_descriptor_config.php
+++ b/HypercomputeCluster/src/V1beta/resources/hypercompute_cluster_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/src/V1beta/resources/hypercompute_cluster_rest_client_config.php
+++ b/HypercomputeCluster/src/V1beta/resources/hypercompute_cluster_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/HypercomputeCluster/tests/Unit/V1beta/Client/HypercomputeClusterClientTest.php
+++ b/HypercomputeCluster/tests/Unit/V1beta/Client/HypercomputeClusterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/owlbot.py
+++ b/Iam/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Iam/samples/V2/PoliciesClient/create_policy.php
+++ b/Iam/samples/V2/PoliciesClient/create_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V2/PoliciesClient/delete_policy.php
+++ b/Iam/samples/V2/PoliciesClient/delete_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V2/PoliciesClient/get_policy.php
+++ b/Iam/samples/V2/PoliciesClient/get_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V2/PoliciesClient/list_policies.php
+++ b/Iam/samples/V2/PoliciesClient/list_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V2/PoliciesClient/update_policy.php
+++ b/Iam/samples/V2/PoliciesClient/update_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/create_policy_binding.php
+++ b/Iam/samples/V3/PolicyBindingsClient/create_policy_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/delete_policy_binding.php
+++ b/Iam/samples/V3/PolicyBindingsClient/delete_policy_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/get_policy_binding.php
+++ b/Iam/samples/V3/PolicyBindingsClient/get_policy_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/list_policy_bindings.php
+++ b/Iam/samples/V3/PolicyBindingsClient/list_policy_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/search_target_policy_bindings.php
+++ b/Iam/samples/V3/PolicyBindingsClient/search_target_policy_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PolicyBindingsClient/update_policy_binding.php
+++ b/Iam/samples/V3/PolicyBindingsClient/update_policy_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/create_principal_access_boundary_policy.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/create_principal_access_boundary_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/delete_principal_access_boundary_policy.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/delete_principal_access_boundary_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/get_principal_access_boundary_policy.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/get_principal_access_boundary_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/list_principal_access_boundary_policies.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/list_principal_access_boundary_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/search_principal_access_boundary_policy_bindings.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/search_principal_access_boundary_policy_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/update_principal_access_boundary_policy.php
+++ b/Iam/samples/V3/PrincipalAccessBoundaryPoliciesClient/update_principal_access_boundary_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V2/Client/PoliciesClient.php
+++ b/Iam/src/V2/Client/PoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V2/resources/policies_descriptor_config.php
+++ b/Iam/src/V2/resources/policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V2/resources/policies_rest_client_config.php
+++ b/Iam/src/V2/resources/policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/Client/PolicyBindingsClient.php
+++ b/Iam/src/V3/Client/PolicyBindingsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/Client/PrincipalAccessBoundaryPoliciesClient.php
+++ b/Iam/src/V3/Client/PrincipalAccessBoundaryPoliciesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/resources/policy_bindings_descriptor_config.php
+++ b/Iam/src/V3/resources/policy_bindings_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/resources/policy_bindings_rest_client_config.php
+++ b/Iam/src/V3/resources/policy_bindings_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/resources/principal_access_boundary_policies_descriptor_config.php
+++ b/Iam/src/V3/resources/principal_access_boundary_policies_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/src/V3/resources/principal_access_boundary_policies_rest_client_config.php
+++ b/Iam/src/V3/resources/principal_access_boundary_policies_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/tests/Unit/V2/Client/PoliciesClientTest.php
+++ b/Iam/tests/Unit/V2/Client/PoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/tests/Unit/V3/Client/PolicyBindingsClientTest.php
+++ b/Iam/tests/Unit/V3/Client/PolicyBindingsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iam/tests/Unit/V3/Client/PrincipalAccessBoundaryPoliciesClientTest.php
+++ b/Iam/tests/Unit/V3/Client/PrincipalAccessBoundaryPoliciesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/owlbot.py
+++ b/IamCredentials/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/IamCredentials/samples/V1/IAMCredentialsClient/generate_access_token.php
+++ b/IamCredentials/samples/V1/IAMCredentialsClient/generate_access_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/samples/V1/IAMCredentialsClient/generate_id_token.php
+++ b/IamCredentials/samples/V1/IAMCredentialsClient/generate_id_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/samples/V1/IAMCredentialsClient/sign_blob.php
+++ b/IamCredentials/samples/V1/IAMCredentialsClient/sign_blob.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/samples/V1/IAMCredentialsClient/sign_jwt.php
+++ b/IamCredentials/samples/V1/IAMCredentialsClient/sign_jwt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/src/V1/Client/IAMCredentialsClient.php
+++ b/IamCredentials/src/V1/Client/IAMCredentialsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/src/V1/resources/iam_credentials_descriptor_config.php
+++ b/IamCredentials/src/V1/resources/iam_credentials_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/src/V1/resources/iam_credentials_rest_client_config.php
+++ b/IamCredentials/src/V1/resources/iam_credentials_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/IamCredentials/tests/Unit/V1/Client/IAMCredentialsClientTest.php
+++ b/IamCredentials/tests/Unit/V1/Client/IAMCredentialsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/owlbot.py
+++ b/Iap/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/create_tunnel_dest_group.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/create_tunnel_dest_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/delete_tunnel_dest_group.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/delete_tunnel_dest_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_iam_policy.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_iap_settings.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_iap_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_tunnel_dest_group.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/get_tunnel_dest_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/list_tunnel_dest_groups.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/list_tunnel_dest_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/set_iam_policy.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/test_iam_permissions.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/update_iap_settings.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/update_iap_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/update_tunnel_dest_group.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/update_tunnel_dest_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/validate_iap_attribute_expression.php
+++ b/Iap/samples/V1/IdentityAwareProxyAdminServiceClient/validate_iap_attribute_expression.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/create_brand.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/create_brand.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/create_identity_aware_proxy_client.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/create_identity_aware_proxy_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/delete_identity_aware_proxy_client.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/delete_identity_aware_proxy_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/get_brand.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/get_brand.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/get_identity_aware_proxy_client.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/get_identity_aware_proxy_client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/list_brands.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/list_brands.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/list_identity_aware_proxy_clients.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/list_identity_aware_proxy_clients.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/reset_identity_aware_proxy_client_secret.php
+++ b/Iap/samples/V1/IdentityAwareProxyOAuthServiceClient/reset_identity_aware_proxy_client_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/Client/IdentityAwareProxyAdminServiceClient.php
+++ b/Iap/src/V1/Client/IdentityAwareProxyAdminServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/Client/IdentityAwareProxyOAuthServiceClient.php
+++ b/Iap/src/V1/Client/IdentityAwareProxyOAuthServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/resources/identity_aware_proxy_admin_service_descriptor_config.php
+++ b/Iap/src/V1/resources/identity_aware_proxy_admin_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/resources/identity_aware_proxy_admin_service_rest_client_config.php
+++ b/Iap/src/V1/resources/identity_aware_proxy_admin_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/resources/identity_aware_proxy_o_auth_service_descriptor_config.php
+++ b/Iap/src/V1/resources/identity_aware_proxy_o_auth_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/src/V1/resources/identity_aware_proxy_o_auth_service_rest_client_config.php
+++ b/Iap/src/V1/resources/identity_aware_proxy_o_auth_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/tests/Unit/V1/Client/IdentityAwareProxyAdminServiceClientTest.php
+++ b/Iap/tests/Unit/V1/Client/IdentityAwareProxyAdminServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Iap/tests/Unit/V1/Client/IdentityAwareProxyOAuthServiceClientTest.php
+++ b/Iap/tests/Unit/V1/Client/IdentityAwareProxyOAuthServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/owlbot.py
+++ b/Ids/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Ids/samples/V1/IDSClient/create_endpoint.php
+++ b/Ids/samples/V1/IDSClient/create_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/samples/V1/IDSClient/delete_endpoint.php
+++ b/Ids/samples/V1/IDSClient/delete_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/samples/V1/IDSClient/get_endpoint.php
+++ b/Ids/samples/V1/IDSClient/get_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/samples/V1/IDSClient/list_endpoints.php
+++ b/Ids/samples/V1/IDSClient/list_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/src/V1/Client/IDSClient.php
+++ b/Ids/src/V1/Client/IDSClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/src/V1/resources/ids_descriptor_config.php
+++ b/Ids/src/V1/resources/ids_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/src/V1/resources/ids_rest_client_config.php
+++ b/Ids/src/V1/resources/ids_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ids/tests/Unit/V1/Client/IDSClientTest.php
+++ b/Ids/tests/Unit/V1/Client/IDSClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/owlbot.py
+++ b/Kms/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/get_autokey_config.php
+++ b/Kms/samples/V1/AutokeyAdminClient/get_autokey_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/get_iam_policy.php
+++ b/Kms/samples/V1/AutokeyAdminClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/get_location.php
+++ b/Kms/samples/V1/AutokeyAdminClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/list_locations.php
+++ b/Kms/samples/V1/AutokeyAdminClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/set_iam_policy.php
+++ b/Kms/samples/V1/AutokeyAdminClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/show_effective_autokey_config.php
+++ b/Kms/samples/V1/AutokeyAdminClient/show_effective_autokey_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/test_iam_permissions.php
+++ b/Kms/samples/V1/AutokeyAdminClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyAdminClient/update_autokey_config.php
+++ b/Kms/samples/V1/AutokeyAdminClient/update_autokey_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/create_key_handle.php
+++ b/Kms/samples/V1/AutokeyClient/create_key_handle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/get_iam_policy.php
+++ b/Kms/samples/V1/AutokeyClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/get_key_handle.php
+++ b/Kms/samples/V1/AutokeyClient/get_key_handle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/get_location.php
+++ b/Kms/samples/V1/AutokeyClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/list_key_handles.php
+++ b/Kms/samples/V1/AutokeyClient/list_key_handles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/list_locations.php
+++ b/Kms/samples/V1/AutokeyClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/set_iam_policy.php
+++ b/Kms/samples/V1/AutokeyClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/AutokeyClient/test_iam_permissions.php
+++ b/Kms/samples/V1/AutokeyClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/create_ekm_connection.php
+++ b/Kms/samples/V1/EkmServiceClient/create_ekm_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/get_ekm_config.php
+++ b/Kms/samples/V1/EkmServiceClient/get_ekm_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/get_ekm_connection.php
+++ b/Kms/samples/V1/EkmServiceClient/get_ekm_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/get_iam_policy.php
+++ b/Kms/samples/V1/EkmServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/get_location.php
+++ b/Kms/samples/V1/EkmServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/list_ekm_connections.php
+++ b/Kms/samples/V1/EkmServiceClient/list_ekm_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/list_locations.php
+++ b/Kms/samples/V1/EkmServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/set_iam_policy.php
+++ b/Kms/samples/V1/EkmServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/test_iam_permissions.php
+++ b/Kms/samples/V1/EkmServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/update_ekm_config.php
+++ b/Kms/samples/V1/EkmServiceClient/update_ekm_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/update_ekm_connection.php
+++ b/Kms/samples/V1/EkmServiceClient/update_ekm_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/EkmServiceClient/verify_connectivity.php
+++ b/Kms/samples/V1/EkmServiceClient/verify_connectivity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/create_import_job.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/create_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/decapsulate.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/decapsulate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/decrypt.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/decrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/encrypt.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/encrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/generate_random_bytes.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/generate_random_bytes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_import_job.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_location.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/get_public_key.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/get_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/list_locations.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/mac_sign.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/mac_sign.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/mac_verify.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/mac_verify.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/raw_decrypt.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/raw_decrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/raw_encrypt.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/raw_encrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
+++ b/Kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/Client/AutokeyAdminClient.php
+++ b/Kms/src/V1/Client/AutokeyAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/Client/AutokeyClient.php
+++ b/Kms/src/V1/Client/AutokeyClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/Client/EkmServiceClient.php
+++ b/Kms/src/V1/Client/EkmServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/Client/KeyManagementServiceClient.php
+++ b/Kms/src/V1/Client/KeyManagementServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/autokey_admin_descriptor_config.php
+++ b/Kms/src/V1/resources/autokey_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/autokey_admin_rest_client_config.php
+++ b/Kms/src/V1/resources/autokey_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/autokey_descriptor_config.php
+++ b/Kms/src/V1/resources/autokey_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/autokey_rest_client_config.php
+++ b/Kms/src/V1/resources/autokey_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/ekm_service_descriptor_config.php
+++ b/Kms/src/V1/resources/ekm_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/ekm_service_rest_client_config.php
+++ b/Kms/src/V1/resources/ekm_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/key_management_service_descriptor_config.php
+++ b/Kms/src/V1/resources/key_management_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/src/V1/resources/key_management_service_rest_client_config.php
+++ b/Kms/src/V1/resources/key_management_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/tests/Unit/V1/Client/AutokeyAdminClientTest.php
+++ b/Kms/tests/Unit/V1/Client/AutokeyAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/tests/Unit/V1/Client/AutokeyClientTest.php
+++ b/Kms/tests/Unit/V1/Client/AutokeyClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/tests/Unit/V1/Client/EkmServiceClientTest.php
+++ b/Kms/tests/Unit/V1/Client/EkmServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Kms/tests/Unit/V1/Client/KeyManagementServiceClientTest.php
+++ b/Kms/tests/Unit/V1/Client/KeyManagementServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/owlbot.py
+++ b/KmsInventory/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/KmsInventory/samples/V1/KeyDashboardServiceClient/list_crypto_keys.php
+++ b/KmsInventory/samples/V1/KeyDashboardServiceClient/list_crypto_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/samples/V1/KeyTrackingServiceClient/get_protected_resources_summary.php
+++ b/KmsInventory/samples/V1/KeyTrackingServiceClient/get_protected_resources_summary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/samples/V1/KeyTrackingServiceClient/search_protected_resources.php
+++ b/KmsInventory/samples/V1/KeyTrackingServiceClient/search_protected_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/Client/KeyDashboardServiceClient.php
+++ b/KmsInventory/src/V1/Client/KeyDashboardServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/Client/KeyTrackingServiceClient.php
+++ b/KmsInventory/src/V1/Client/KeyTrackingServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/resources/key_dashboard_service_descriptor_config.php
+++ b/KmsInventory/src/V1/resources/key_dashboard_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/resources/key_dashboard_service_rest_client_config.php
+++ b/KmsInventory/src/V1/resources/key_dashboard_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/resources/key_tracking_service_descriptor_config.php
+++ b/KmsInventory/src/V1/resources/key_tracking_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/src/V1/resources/key_tracking_service_rest_client_config.php
+++ b/KmsInventory/src/V1/resources/key_tracking_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/tests/Unit/V1/Client/KeyDashboardServiceClientTest.php
+++ b/KmsInventory/tests/Unit/V1/Client/KeyDashboardServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/KmsInventory/tests/Unit/V1/Client/KeyTrackingServiceClientTest.php
+++ b/KmsInventory/tests/Unit/V1/Client/KeyTrackingServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/owlbot.py
+++ b/Language/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/analyze_entities.php
+++ b/Language/samples/V1/LanguageServiceClient/analyze_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/analyze_entity_sentiment.php
+++ b/Language/samples/V1/LanguageServiceClient/analyze_entity_sentiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/analyze_sentiment.php
+++ b/Language/samples/V1/LanguageServiceClient/analyze_sentiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/analyze_syntax.php
+++ b/Language/samples/V1/LanguageServiceClient/analyze_syntax.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/annotate_text.php
+++ b/Language/samples/V1/LanguageServiceClient/annotate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/classify_text.php
+++ b/Language/samples/V1/LanguageServiceClient/classify_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V1/LanguageServiceClient/moderate_text.php
+++ b/Language/samples/V1/LanguageServiceClient/moderate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V2/LanguageServiceClient/analyze_entities.php
+++ b/Language/samples/V2/LanguageServiceClient/analyze_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V2/LanguageServiceClient/analyze_sentiment.php
+++ b/Language/samples/V2/LanguageServiceClient/analyze_sentiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V2/LanguageServiceClient/annotate_text.php
+++ b/Language/samples/V2/LanguageServiceClient/annotate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V2/LanguageServiceClient/classify_text.php
+++ b/Language/samples/V2/LanguageServiceClient/classify_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/samples/V2/LanguageServiceClient/moderate_text.php
+++ b/Language/samples/V2/LanguageServiceClient/moderate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V1/Client/LanguageServiceClient.php
+++ b/Language/src/V1/Client/LanguageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V1/resources/language_service_descriptor_config.php
+++ b/Language/src/V1/resources/language_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V1/resources/language_service_rest_client_config.php
+++ b/Language/src/V1/resources/language_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V2/Client/LanguageServiceClient.php
+++ b/Language/src/V2/Client/LanguageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V2/resources/language_service_descriptor_config.php
+++ b/Language/src/V2/resources/language_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/src/V2/resources/language_service_rest_client_config.php
+++ b/Language/src/V2/resources/language_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/tests/System/AnalyzeTest.php
+++ b/Language/tests/System/AnalyzeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2026 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/tests/System/LanguageTestCase.php
+++ b/Language/tests/System/LanguageTestCase.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/tests/Unit/V1/Client/LanguageServiceClientTest.php
+++ b/Language/tests/Unit/V1/Client/LanguageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Language/tests/Unit/V2/Client/LanguageServiceClientTest.php
+++ b/Language/tests/Unit/V2/Client/LanguageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/owlbot.py
+++ b/LicenseManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/aggregate_usage.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/aggregate_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/create_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/create_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/deactivate_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/deactivate_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/delete_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/delete_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/get_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/get_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/get_instance.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/get_location.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/get_product.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/list_configurations.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/list_configurations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/list_instances.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/list_locations.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/list_products.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/query_configuration_license_usage.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/query_configuration_license_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/reactivate_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/reactivate_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/samples/V1/LicenseManagerClient/update_configuration.php
+++ b/LicenseManager/samples/V1/LicenseManagerClient/update_configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/src/V1/Client/LicenseManagerClient.php
+++ b/LicenseManager/src/V1/Client/LicenseManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/src/V1/resources/license_manager_descriptor_config.php
+++ b/LicenseManager/src/V1/resources/license_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/src/V1/resources/license_manager_rest_client_config.php
+++ b/LicenseManager/src/V1/resources/license_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LicenseManager/tests/Unit/V1/Client/LicenseManagerClientTest.php
+++ b/LicenseManager/tests/Unit/V1/Client/LicenseManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/owlbot.py
+++ b/LifeSciences/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/get_location.php
+++ b/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/list_locations.php
+++ b/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/run_pipeline.php
+++ b/LifeSciences/samples/V2beta/WorkflowsServiceV2BetaClient/run_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/src/V2beta/Client/WorkflowsServiceV2BetaClient.php
+++ b/LifeSciences/src/V2beta/Client/WorkflowsServiceV2BetaClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/src/V2beta/resources/workflows_service_v2_beta_descriptor_config.php
+++ b/LifeSciences/src/V2beta/resources/workflows_service_v2_beta_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/src/V2beta/resources/workflows_service_v2_beta_rest_client_config.php
+++ b/LifeSciences/src/V2beta/resources/workflows_service_v2_beta_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LifeSciences/tests/Unit/V2beta/Client/WorkflowsServiceV2BetaClientTest.php
+++ b/LifeSciences/tests/Unit/V2beta/Client/WorkflowsServiceV2BetaClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/owlbot.py
+++ b/LocationFinder/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LocationFinder/samples/V1/CloudLocationFinderClient/get_cloud_location.php
+++ b/LocationFinder/samples/V1/CloudLocationFinderClient/get_cloud_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/samples/V1/CloudLocationFinderClient/list_cloud_locations.php
+++ b/LocationFinder/samples/V1/CloudLocationFinderClient/list_cloud_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/samples/V1/CloudLocationFinderClient/search_cloud_locations.php
+++ b/LocationFinder/samples/V1/CloudLocationFinderClient/search_cloud_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/src/V1/Client/CloudLocationFinderClient.php
+++ b/LocationFinder/src/V1/Client/CloudLocationFinderClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/src/V1/resources/cloud_location_finder_descriptor_config.php
+++ b/LocationFinder/src/V1/resources/cloud_location_finder_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/src/V1/resources/cloud_location_finder_rest_client_config.php
+++ b/LocationFinder/src/V1/resources/cloud_location_finder_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LocationFinder/tests/Unit/V1/Client/CloudLocationFinderClientTest.php
+++ b/LocationFinder/tests/Unit/V1/Client/CloudLocationFinderClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/copy_log_entries.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/copy_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_bucket.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_bucket_async.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_bucket_async.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_link.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_sink.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/create_view.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/create_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/delete_link.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/delete_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/delete_sink.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/delete_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/delete_view.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/delete_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_bucket.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_link.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_settings.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_sink.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/get_view.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/get_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/list_buckets.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/list_buckets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/list_links.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/list_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/list_sinks.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/list_sinks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/list_views.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/list_views.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_bucket.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_bucket_async.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_bucket_async.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_settings.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_sink.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/ConfigServiceV2Client/update_view.php
+++ b/Logging/samples/V2/ConfigServiceV2Client/update_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/delete_log.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/delete_log.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/list_logs.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/list_logs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
+++ b/Logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
+++ b/Logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
+++ b/Logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
+++ b/Logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
+++ b/Logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
+++ b/Logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Logging/tests/System/V2/LoggingServiceV2SmokeTest.php
+++ b/Logging/tests/System/V2/LoggingServiceV2SmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/owlbot.py
+++ b/LongRunning/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/Client/OperationsClient.php
+++ b/LongRunning/src/LongRunning/Client/OperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/Gapic/OperationsGapicClient.php
+++ b/LongRunning/src/LongRunning/Gapic/OperationsGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/OperationsClient.php
+++ b/LongRunning/src/LongRunning/OperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/OperationsGrpcClient.php
+++ b/LongRunning/src/LongRunning/OperationsGrpcClient.php
@@ -2,7 +2,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 // Original file comments:
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/resources/operations_descriptor_config.php
+++ b/LongRunning/src/LongRunning/resources/operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/src/LongRunning/resources/operations_rest_client_config.php
+++ b/LongRunning/src/LongRunning/resources/operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/tests/Unit/Client/OperationsClientTest.php
+++ b/LongRunning/tests/Unit/Client/OperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LongRunning/tests/Unit/OperationsClientTest.php
+++ b/LongRunning/tests/Unit/OperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/owlbot.py
+++ b/Lustre/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/create_instance.php
+++ b/Lustre/samples/V1/LustreClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/delete_instance.php
+++ b/Lustre/samples/V1/LustreClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/export_data.php
+++ b/Lustre/samples/V1/LustreClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/get_instance.php
+++ b/Lustre/samples/V1/LustreClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/get_location.php
+++ b/Lustre/samples/V1/LustreClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/import_data.php
+++ b/Lustre/samples/V1/LustreClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/list_instances.php
+++ b/Lustre/samples/V1/LustreClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/list_locations.php
+++ b/Lustre/samples/V1/LustreClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/samples/V1/LustreClient/update_instance.php
+++ b/Lustre/samples/V1/LustreClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/src/V1/Client/LustreClient.php
+++ b/Lustre/src/V1/Client/LustreClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/src/V1/resources/lustre_descriptor_config.php
+++ b/Lustre/src/V1/resources/lustre_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/src/V1/resources/lustre_rest_client_config.php
+++ b/Lustre/src/V1/resources/lustre_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Lustre/tests/Unit/V1/Client/LustreClientTest.php
+++ b/Lustre/tests/Unit/V1/Client/LustreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/owlbot.py
+++ b/Maintenance/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1/MaintenanceClient/get_location.php
+++ b/Maintenance/samples/V1/MaintenanceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1/MaintenanceClient/get_resource_maintenance.php
+++ b/Maintenance/samples/V1/MaintenanceClient/get_resource_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1/MaintenanceClient/list_locations.php
+++ b/Maintenance/samples/V1/MaintenanceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1/MaintenanceClient/list_resource_maintenances.php
+++ b/Maintenance/samples/V1/MaintenanceClient/list_resource_maintenances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1/MaintenanceClient/summarize_maintenances.php
+++ b/Maintenance/samples/V1/MaintenanceClient/summarize_maintenances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1beta/MaintenanceClient/get_location.php
+++ b/Maintenance/samples/V1beta/MaintenanceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1beta/MaintenanceClient/get_resource_maintenance.php
+++ b/Maintenance/samples/V1beta/MaintenanceClient/get_resource_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1beta/MaintenanceClient/list_locations.php
+++ b/Maintenance/samples/V1beta/MaintenanceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1beta/MaintenanceClient/list_resource_maintenances.php
+++ b/Maintenance/samples/V1beta/MaintenanceClient/list_resource_maintenances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/samples/V1beta/MaintenanceClient/summarize_maintenances.php
+++ b/Maintenance/samples/V1beta/MaintenanceClient/summarize_maintenances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1/Client/MaintenanceClient.php
+++ b/Maintenance/src/V1/Client/MaintenanceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1/resources/maintenance_descriptor_config.php
+++ b/Maintenance/src/V1/resources/maintenance_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1/resources/maintenance_rest_client_config.php
+++ b/Maintenance/src/V1/resources/maintenance_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1beta/Client/MaintenanceClient.php
+++ b/Maintenance/src/V1beta/Client/MaintenanceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1beta/resources/maintenance_descriptor_config.php
+++ b/Maintenance/src/V1beta/resources/maintenance_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/src/V1beta/resources/maintenance_rest_client_config.php
+++ b/Maintenance/src/V1beta/resources/maintenance_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/tests/Unit/V1/Client/MaintenanceClientTest.php
+++ b/Maintenance/tests/Unit/V1/Client/MaintenanceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Maintenance/tests/Unit/V1beta/Client/MaintenanceClientTest.php
+++ b/Maintenance/tests/Unit/V1beta/Client/MaintenanceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/owlbot.py
+++ b/ManagedIdentities/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/attach_trust.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/attach_trust.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/create_microsoft_ad_domain.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/create_microsoft_ad_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/delete_domain.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/delete_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/detach_trust.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/detach_trust.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/get_domain.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/get_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/list_domains.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/list_domains.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/reconfigure_trust.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/reconfigure_trust.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/reset_admin_password.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/reset_admin_password.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/update_domain.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/update_domain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/validate_trust.php
+++ b/ManagedIdentities/samples/V1/ManagedIdentitiesServiceClient/validate_trust.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/src/V1/Client/ManagedIdentitiesServiceClient.php
+++ b/ManagedIdentities/src/V1/Client/ManagedIdentitiesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/src/V1/resources/managed_identities_service_descriptor_config.php
+++ b/ManagedIdentities/src/V1/resources/managed_identities_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/src/V1/resources/managed_identities_service_rest_client_config.php
+++ b/ManagedIdentities/src/V1/resources/managed_identities_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedIdentities/tests/Unit/V1/Client/ManagedIdentitiesServiceClientTest.php
+++ b/ManagedIdentities/tests/Unit/V1/Client/ManagedIdentitiesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/owlbot.py
+++ b/ManagedKafka/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/add_acl_entry.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/add_acl_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/create_acl.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/create_acl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/create_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/create_topic.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/create_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/delete_acl.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/delete_acl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/delete_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/delete_consumer_group.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/delete_consumer_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/delete_topic.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/delete_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/get_acl.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/get_acl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/get_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/get_consumer_group.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/get_consumer_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/get_location.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/get_topic.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/get_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/list_acls.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/list_acls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/list_clusters.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/list_consumer_groups.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/list_consumer_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/list_locations.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/list_topics.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/list_topics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/remove_acl_entry.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/remove_acl_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/update_acl.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/update_acl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/update_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/update_consumer_group.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/update_consumer_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaClient/update_topic.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaClient/update_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/create_connect_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/create_connect_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/create_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/create_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/delete_connect_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/delete_connect_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/delete_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/delete_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_connect_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_connect_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_location.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_connect_clusters.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_connect_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_connectors.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_connectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_locations.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/pause_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/pause_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/restart_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/restart_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/resume_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/resume_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/stop_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/stop_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/update_connect_cluster.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/update_connect_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/samples/V1/ManagedKafkaConnectClient/update_connector.php
+++ b/ManagedKafka/samples/V1/ManagedKafkaConnectClient/update_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/Client/ManagedKafkaClient.php
+++ b/ManagedKafka/src/V1/Client/ManagedKafkaClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/Client/ManagedKafkaConnectClient.php
+++ b/ManagedKafka/src/V1/Client/ManagedKafkaConnectClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/resources/managed_kafka_connect_descriptor_config.php
+++ b/ManagedKafka/src/V1/resources/managed_kafka_connect_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/resources/managed_kafka_connect_rest_client_config.php
+++ b/ManagedKafka/src/V1/resources/managed_kafka_connect_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/resources/managed_kafka_descriptor_config.php
+++ b/ManagedKafka/src/V1/resources/managed_kafka_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/src/V1/resources/managed_kafka_rest_client_config.php
+++ b/ManagedKafka/src/V1/resources/managed_kafka_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/tests/Unit/V1/Client/ManagedKafkaClientTest.php
+++ b/ManagedKafka/tests/Unit/V1/Client/ManagedKafkaClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafka/tests/Unit/V1/Client/ManagedKafkaConnectClientTest.php
+++ b/ManagedKafka/tests/Unit/V1/Client/ManagedKafkaConnectClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/owlbot.py
+++ b/ManagedKafkaSchemaRegistry/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/check_compatibility.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/check_compatibility.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/create_schema_registry.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/create_schema_registry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/create_version.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/create_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_config.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_mode.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_mode.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_registry.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_schema_registry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_subject.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_subject.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_version.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/delete_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_context.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_location.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_raw_schema.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_raw_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_raw_schema_version.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_raw_schema_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_config.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_mode.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_mode.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_registry.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_schema_registry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_version.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/get_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_contexts.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_locations.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_referenced_schemas.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_referenced_schemas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_registries.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_registries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_types.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_versions.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_schema_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_subjects.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_subjects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_subjects_by_schema_id.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_subjects_by_schema_id.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_versions.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/list_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/lookup_version.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/lookup_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/update_schema_config.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/update_schema_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/update_schema_mode.php
+++ b/ManagedKafkaSchemaRegistry/samples/V1/ManagedSchemaRegistryClient/update_schema_mode.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/src/V1/Client/ManagedSchemaRegistryClient.php
+++ b/ManagedKafkaSchemaRegistry/src/V1/Client/ManagedSchemaRegistryClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/src/V1/resources/managed_schema_registry_descriptor_config.php
+++ b/ManagedKafkaSchemaRegistry/src/V1/resources/managed_schema_registry_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/src/V1/resources/managed_schema_registry_rest_client_config.php
+++ b/ManagedKafkaSchemaRegistry/src/V1/resources/managed_schema_registry_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ManagedKafkaSchemaRegistry/tests/Unit/V1/Client/ManagedSchemaRegistryClientTest.php
+++ b/ManagedKafkaSchemaRegistry/tests/Unit/V1/Client/ManagedSchemaRegistryClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/owlbot.py
+++ b/MapsFleetEngine/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/create_trip.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/create_trip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/delete_trip.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/delete_trip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/get_trip.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/get_trip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/report_billable_trip.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/report_billable_trip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/search_trips.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/search_trips.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/TripServiceClient/update_trip.php
+++ b/MapsFleetEngine/samples/V1/TripServiceClient/update_trip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/create_vehicle.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/create_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/delete_vehicle.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/delete_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/get_vehicle.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/get_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/list_vehicles.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/list_vehicles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/search_vehicles.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/search_vehicles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/update_vehicle.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/update_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/samples/V1/VehicleServiceClient/update_vehicle_attributes.php
+++ b/MapsFleetEngine/samples/V1/VehicleServiceClient/update_vehicle_attributes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/Client/TripServiceClient.php
+++ b/MapsFleetEngine/src/V1/Client/TripServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/Client/VehicleServiceClient.php
+++ b/MapsFleetEngine/src/V1/Client/VehicleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/resources/trip_service_descriptor_config.php
+++ b/MapsFleetEngine/src/V1/resources/trip_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/resources/trip_service_rest_client_config.php
+++ b/MapsFleetEngine/src/V1/resources/trip_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/resources/vehicle_service_descriptor_config.php
+++ b/MapsFleetEngine/src/V1/resources/vehicle_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/src/V1/resources/vehicle_service_rest_client_config.php
+++ b/MapsFleetEngine/src/V1/resources/vehicle_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/tests/Unit/V1/Client/TripServiceClientTest.php
+++ b/MapsFleetEngine/tests/Unit/V1/Client/TripServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngine/tests/Unit/V1/Client/VehicleServiceClientTest.php
+++ b/MapsFleetEngine/tests/Unit/V1/Client/VehicleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/owlbot.py
+++ b/MapsFleetEngineDelivery/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/batch_create_tasks.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/batch_create_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/create_delivery_vehicle.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/create_delivery_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/create_task.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/create_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/delete_delivery_vehicle.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/delete_delivery_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/delete_task.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/delete_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_delivery_vehicle.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_delivery_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_task.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_task_tracking_info.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/get_task_tracking_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/list_delivery_vehicles.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/list_delivery_vehicles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/list_tasks.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/list_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/update_delivery_vehicle.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/update_delivery_vehicle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/update_task.php
+++ b/MapsFleetEngineDelivery/samples/V1/DeliveryServiceClient/update_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/src/V1/Client/DeliveryServiceClient.php
+++ b/MapsFleetEngineDelivery/src/V1/Client/DeliveryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/src/V1/resources/delivery_service_descriptor_config.php
+++ b/MapsFleetEngineDelivery/src/V1/resources/delivery_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/src/V1/resources/delivery_service_rest_client_config.php
+++ b/MapsFleetEngineDelivery/src/V1/resources/delivery_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsFleetEngineDelivery/tests/Unit/V1/Client/DeliveryServiceClientTest.php
+++ b/MapsFleetEngineDelivery/tests/Unit/V1/Client/DeliveryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/owlbot.py
+++ b/MapsRouteOptimization/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/samples/V1/RouteOptimizationClient/batch_optimize_tours.php
+++ b/MapsRouteOptimization/samples/V1/RouteOptimizationClient/batch_optimize_tours.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours.php
+++ b/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours_long_running.php
+++ b/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours_long_running.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours_uri.php
+++ b/MapsRouteOptimization/samples/V1/RouteOptimizationClient/optimize_tours_uri.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/src/V1/Client/RouteOptimizationClient.php
+++ b/MapsRouteOptimization/src/V1/Client/RouteOptimizationClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/src/V1/resources/route_optimization_descriptor_config.php
+++ b/MapsRouteOptimization/src/V1/resources/route_optimization_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/src/V1/resources/route_optimization_rest_client_config.php
+++ b/MapsRouteOptimization/src/V1/resources/route_optimization_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MapsRouteOptimization/tests/Unit/V1/Client/RouteOptimizationClientTest.php
+++ b/MapsRouteOptimization/tests/Unit/V1/Client/RouteOptimizationClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MediaTranslation/owlbot.py
+++ b/MediaTranslation/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MediaTranslation/samples/V1beta1/SpeechTranslationServiceClient/streaming_translate_speech.php
+++ b/MediaTranslation/samples/V1beta1/SpeechTranslationServiceClient/streaming_translate_speech.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MediaTranslation/src/V1beta1/Client/SpeechTranslationServiceClient.php
+++ b/MediaTranslation/src/V1beta1/Client/SpeechTranslationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MediaTranslation/src/V1beta1/resources/speech_translation_service_descriptor_config.php
+++ b/MediaTranslation/src/V1beta1/resources/speech_translation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MediaTranslation/src/V1beta1/resources/speech_translation_service_rest_client_config.php
+++ b/MediaTranslation/src/V1beta1/resources/speech_translation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MediaTranslation/tests/Unit/V1beta1/Client/SpeechTranslationServiceClientTest.php
+++ b/MediaTranslation/tests/Unit/V1beta1/Client/SpeechTranslationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/owlbot.py
+++ b/Memcache/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/apply_parameters.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/apply_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/create_instance.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/delete_instance.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/get_instance.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/get_location.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/list_instances.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/list_locations.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/reschedule_maintenance.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/reschedule_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/update_instance.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/samples/V1/CloudMemcacheClient/update_parameters.php
+++ b/Memcache/samples/V1/CloudMemcacheClient/update_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/src/V1/Client/CloudMemcacheClient.php
+++ b/Memcache/src/V1/Client/CloudMemcacheClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/src/V1/resources/cloud_memcache_descriptor_config.php
+++ b/Memcache/src/V1/resources/cloud_memcache_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/src/V1/resources/cloud_memcache_rest_client_config.php
+++ b/Memcache/src/V1/resources/cloud_memcache_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memcache/tests/Unit/V1/Client/CloudMemcacheClientTest.php
+++ b/Memcache/tests/Unit/V1/Client/CloudMemcacheClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/owlbot.py
+++ b/Memorystore/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/backup_instance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/backup_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/create_instance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/delete_backup.php
+++ b/Memorystore/samples/V1/MemorystoreClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/delete_instance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/export_backup.php
+++ b/Memorystore/samples/V1/MemorystoreClient/export_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/get_backup.php
+++ b/Memorystore/samples/V1/MemorystoreClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/get_backup_collection.php
+++ b/Memorystore/samples/V1/MemorystoreClient/get_backup_collection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/get_certificate_authority.php
+++ b/Memorystore/samples/V1/MemorystoreClient/get_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/get_instance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/get_location.php
+++ b/Memorystore/samples/V1/MemorystoreClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/list_backup_collections.php
+++ b/Memorystore/samples/V1/MemorystoreClient/list_backup_collections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/list_backups.php
+++ b/Memorystore/samples/V1/MemorystoreClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/list_instances.php
+++ b/Memorystore/samples/V1/MemorystoreClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/list_locations.php
+++ b/Memorystore/samples/V1/MemorystoreClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/reschedule_maintenance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/reschedule_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1/MemorystoreClient/update_instance.php
+++ b/Memorystore/samples/V1/MemorystoreClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/create_instance.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/delete_instance.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/get_certificate_authority.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/get_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/get_instance.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/get_location.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/list_instances.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/list_locations.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/samples/V1beta/MemorystoreClient/update_instance.php
+++ b/Memorystore/samples/V1beta/MemorystoreClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1/Client/MemorystoreClient.php
+++ b/Memorystore/src/V1/Client/MemorystoreClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1/resources/memorystore_descriptor_config.php
+++ b/Memorystore/src/V1/resources/memorystore_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1/resources/memorystore_rest_client_config.php
+++ b/Memorystore/src/V1/resources/memorystore_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1beta/Client/MemorystoreClient.php
+++ b/Memorystore/src/V1beta/Client/MemorystoreClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1beta/resources/memorystore_descriptor_config.php
+++ b/Memorystore/src/V1beta/resources/memorystore_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/src/V1beta/resources/memorystore_rest_client_config.php
+++ b/Memorystore/src/V1beta/resources/memorystore_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/tests/Unit/V1/Client/MemorystoreClientTest.php
+++ b/Memorystore/tests/Unit/V1/Client/MemorystoreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Memorystore/tests/Unit/V1beta/Client/MemorystoreClientTest.php
+++ b/Memorystore/tests/Unit/V1beta/Client/MemorystoreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/owlbot.py
+++ b/MigrationCenter/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/add_assets_to_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/add_assets_to_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/aggregate_assets_values.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/aggregate_assets_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/batch_delete_assets.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/batch_delete_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/batch_update_assets.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/batch_update_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_import_data_file.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_import_data_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_preference_set.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_preference_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_report.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_report_config.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/create_source.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/create_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_asset.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_import_data_file.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_import_data_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_preference_set.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_preference_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_report.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_report_config.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/delete_source.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/delete_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_asset.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_error_frame.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_error_frame.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_import_data_file.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_import_data_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_location.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_preference_set.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_preference_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_report.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_report_config.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_settings.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/get_source.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/get_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_assets.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_error_frames.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_error_frames.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_groups.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_import_data_files.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_import_data_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_import_jobs.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_import_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_locations.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_preference_sets.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_preference_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_report_configs.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_report_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_reports.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/list_sources.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/list_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/remove_assets_from_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/remove_assets_from_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/report_asset_frames.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/report_asset_frames.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/run_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/run_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_asset.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_group.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_preference_set.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_preference_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_settings.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/update_source.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/update_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/samples/V1/MigrationCenterClient/validate_import_job.php
+++ b/MigrationCenter/samples/V1/MigrationCenterClient/validate_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/src/V1/Client/MigrationCenterClient.php
+++ b/MigrationCenter/src/V1/Client/MigrationCenterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/src/V1/resources/migration_center_descriptor_config.php
+++ b/MigrationCenter/src/V1/resources/migration_center_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/src/V1/resources/migration_center_rest_client_config.php
+++ b/MigrationCenter/src/V1/resources/migration_center_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MigrationCenter/tests/Unit/V1/Client/MigrationCenterClientTest.php
+++ b/MigrationCenter/tests/Unit/V1/Client/MigrationCenterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/owlbot.py
+++ b/ModelArmor/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/create_template.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/create_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/delete_template.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/delete_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/get_floor_setting.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/get_floor_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/get_location.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/get_template.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/get_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/list_locations.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/list_templates.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/list_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/sanitize_model_response.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/sanitize_model_response.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/sanitize_user_prompt.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/sanitize_user_prompt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/update_floor_setting.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/update_floor_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1/ModelArmorClient/update_template.php
+++ b/ModelArmor/samples/V1/ModelArmorClient/update_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/create_template.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/create_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/delete_template.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/delete_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/get_floor_setting.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/get_floor_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/get_location.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/get_template.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/get_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/list_locations.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/list_templates.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/list_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/sanitize_model_response.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/sanitize_model_response.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/sanitize_user_prompt.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/sanitize_user_prompt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/update_floor_setting.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/update_floor_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/samples/V1beta/ModelArmorClient/update_template.php
+++ b/ModelArmor/samples/V1beta/ModelArmorClient/update_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1/Client/ModelArmorClient.php
+++ b/ModelArmor/src/V1/Client/ModelArmorClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1/resources/model_armor_descriptor_config.php
+++ b/ModelArmor/src/V1/resources/model_armor_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1/resources/model_armor_rest_client_config.php
+++ b/ModelArmor/src/V1/resources/model_armor_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1beta/Client/ModelArmorClient.php
+++ b/ModelArmor/src/V1beta/Client/ModelArmorClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1beta/resources/model_armor_descriptor_config.php
+++ b/ModelArmor/src/V1beta/resources/model_armor_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/src/V1beta/resources/model_armor_rest_client_config.php
+++ b/ModelArmor/src/V1beta/resources/model_armor_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/tests/Unit/V1/Client/ModelArmorClientTest.php
+++ b/ModelArmor/tests/Unit/V1/Client/ModelArmorClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ModelArmor/tests/Unit/V1beta/Client/ModelArmorClientTest.php
+++ b/ModelArmor/tests/Unit/V1beta/Client/ModelArmorClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/owlbot.py
+++ b/Monitoring/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/AlertPolicyServiceClient/create_alert_policy.php
+++ b/Monitoring/samples/V3/AlertPolicyServiceClient/create_alert_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/AlertPolicyServiceClient/delete_alert_policy.php
+++ b/Monitoring/samples/V3/AlertPolicyServiceClient/delete_alert_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/AlertPolicyServiceClient/get_alert_policy.php
+++ b/Monitoring/samples/V3/AlertPolicyServiceClient/get_alert_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/AlertPolicyServiceClient/list_alert_policies.php
+++ b/Monitoring/samples/V3/AlertPolicyServiceClient/list_alert_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/AlertPolicyServiceClient/update_alert_policy.php
+++ b/Monitoring/samples/V3/AlertPolicyServiceClient/update_alert_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/create_group.php
+++ b/Monitoring/samples/V3/GroupServiceClient/create_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/delete_group.php
+++ b/Monitoring/samples/V3/GroupServiceClient/delete_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/get_group.php
+++ b/Monitoring/samples/V3/GroupServiceClient/get_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/list_group_members.php
+++ b/Monitoring/samples/V3/GroupServiceClient/list_group_members.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/list_groups.php
+++ b/Monitoring/samples/V3/GroupServiceClient/list_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/GroupServiceClient/update_group.php
+++ b/Monitoring/samples/V3/GroupServiceClient/update_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/create_metric_descriptor.php
+++ b/Monitoring/samples/V3/MetricServiceClient/create_metric_descriptor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/create_service_time_series.php
+++ b/Monitoring/samples/V3/MetricServiceClient/create_service_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/create_time_series.php
+++ b/Monitoring/samples/V3/MetricServiceClient/create_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/delete_metric_descriptor.php
+++ b/Monitoring/samples/V3/MetricServiceClient/delete_metric_descriptor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/get_metric_descriptor.php
+++ b/Monitoring/samples/V3/MetricServiceClient/get_metric_descriptor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/get_monitored_resource_descriptor.php
+++ b/Monitoring/samples/V3/MetricServiceClient/get_monitored_resource_descriptor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/list_metric_descriptors.php
+++ b/Monitoring/samples/V3/MetricServiceClient/list_metric_descriptors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/list_monitored_resource_descriptors.php
+++ b/Monitoring/samples/V3/MetricServiceClient/list_monitored_resource_descriptors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/MetricServiceClient/list_time_series.php
+++ b/Monitoring/samples/V3/MetricServiceClient/list_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/create_notification_channel.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/create_notification_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/delete_notification_channel.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/delete_notification_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel_descriptor.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel_descriptor.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel_verification_code.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/get_notification_channel_verification_code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/list_notification_channel_descriptors.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/list_notification_channel_descriptors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/list_notification_channels.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/list_notification_channels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/send_notification_channel_verification_code.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/send_notification_channel_verification_code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/update_notification_channel.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/update_notification_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/NotificationChannelServiceClient/verify_notification_channel.php
+++ b/Monitoring/samples/V3/NotificationChannelServiceClient/verify_notification_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/QueryServiceClient/query_time_series.php
+++ b/Monitoring/samples/V3/QueryServiceClient/query_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/create_service.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/create_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/create_service_level_objective.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/create_service_level_objective.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/delete_service.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/delete_service_level_objective.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/delete_service_level_objective.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/get_service.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/get_service_level_objective.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/get_service_level_objective.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/list_service_level_objectives.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/list_service_level_objectives.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/list_services.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/update_service.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/update_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/ServiceMonitoringServiceClient/update_service_level_objective.php
+++ b/Monitoring/samples/V3/ServiceMonitoringServiceClient/update_service_level_objective.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/SnoozeServiceClient/create_snooze.php
+++ b/Monitoring/samples/V3/SnoozeServiceClient/create_snooze.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/SnoozeServiceClient/get_snooze.php
+++ b/Monitoring/samples/V3/SnoozeServiceClient/get_snooze.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/SnoozeServiceClient/list_snoozes.php
+++ b/Monitoring/samples/V3/SnoozeServiceClient/list_snoozes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/SnoozeServiceClient/update_snooze.php
+++ b/Monitoring/samples/V3/SnoozeServiceClient/update_snooze.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/create_uptime_check_config.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/create_uptime_check_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/delete_uptime_check_config.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/delete_uptime_check_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/get_uptime_check_config.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/get_uptime_check_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/list_uptime_check_configs.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/list_uptime_check_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/list_uptime_check_ips.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/list_uptime_check_ips.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/samples/V3/UptimeCheckServiceClient/update_uptime_check_config.php
+++ b/Monitoring/samples/V3/UptimeCheckServiceClient/update_uptime_check_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/AlertPolicyServiceClient.php
+++ b/Monitoring/src/V3/Client/AlertPolicyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/GroupServiceClient.php
+++ b/Monitoring/src/V3/Client/GroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/MetricServiceClient.php
+++ b/Monitoring/src/V3/Client/MetricServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/NotificationChannelServiceClient.php
+++ b/Monitoring/src/V3/Client/NotificationChannelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/QueryServiceClient.php
+++ b/Monitoring/src/V3/Client/QueryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/ServiceMonitoringServiceClient.php
+++ b/Monitoring/src/V3/Client/ServiceMonitoringServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/SnoozeServiceClient.php
+++ b/Monitoring/src/V3/Client/SnoozeServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/Client/UptimeCheckServiceClient.php
+++ b/Monitoring/src/V3/Client/UptimeCheckServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/alert_policy_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/alert_policy_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/alert_policy_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/alert_policy_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/group_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/group_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/group_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/group_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/metric_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/metric_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/metric_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/metric_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/notification_channel_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/notification_channel_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/notification_channel_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/notification_channel_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/query_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/query_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/query_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/query_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/service_monitoring_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/service_monitoring_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/service_monitoring_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/service_monitoring_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/snooze_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/snooze_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/snooze_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/snooze_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/uptime_check_service_descriptor_config.php
+++ b/Monitoring/src/V3/resources/uptime_check_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/src/V3/resources/uptime_check_service_rest_client_config.php
+++ b/Monitoring/src/V3/resources/uptime_check_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/AlertPolicyServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/AlertPolicyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/GroupServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/GroupServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/MetricServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/MetricServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/NotificationChannelServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/NotificationChannelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/QueryServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/QueryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/ServiceMonitoringServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/ServiceMonitoringServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/SnoozeServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/SnoozeServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Monitoring/tests/Unit/V3/Client/UptimeCheckServiceClientTest.php
+++ b/Monitoring/tests/Unit/V3/Client/UptimeCheckServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1033 generated files** in **42 in-scope packages** (Eventarc through Monitoring).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`Eventarc`, `EventarcPublishing`, `Filestore`, `FinancialServices`, `Firestore`, `Functions`, `GSuiteAddOns`, `GeminiDataAnalytics`, `GeoCommonProtos`, `GkeBackup`, `GkeConnectGateway`, `GkeHub`, `GkeMultiCloud`, `GkeRecommender`, `Grafeas`, `HypercomputeCluster`, `Iam`, `IamCredentials`, `Iap`, `Ids`, `Kms`, `KmsInventory`, `Language`, `LicenseManager`, `LifeSciences`, `LocationFinder`, `Logging`, `LongRunning`, `Lustre`, `Maintenance`, `ManagedIdentities`, `ManagedKafka`, `ManagedKafkaSchemaRegistry`, `MapsFleetEngine`, `MapsFleetEngineDelivery`, `MapsRouteOptimization`, `MediaTranslation`, `Memcache`, `Memorystore`, `MigrationCenter`, `ModelArmor`, `Monitoring`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-7
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 7 of 10 in the 2026 copyright update series.
