### PR TITLE
chore: update copyright years to 2026 for generated files (part 8: NetApp to ResourceManager)

### DIFF
--- a/NetApp/owlbot.py
+++ b/NetApp/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_active_directory.php
+++ b/NetApp/samples/V1/NetAppClient/create_active_directory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_backup.php
+++ b/NetApp/samples/V1/NetAppClient/create_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_backup_policy.php
+++ b/NetApp/samples/V1/NetAppClient/create_backup_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_backup_vault.php
+++ b/NetApp/samples/V1/NetAppClient/create_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_kms_config.php
+++ b/NetApp/samples/V1/NetAppClient/create_kms_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_quota_rule.php
+++ b/NetApp/samples/V1/NetAppClient/create_quota_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_replication.php
+++ b/NetApp/samples/V1/NetAppClient/create_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_snapshot.php
+++ b/NetApp/samples/V1/NetAppClient/create_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_storage_pool.php
+++ b/NetApp/samples/V1/NetAppClient/create_storage_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/create_volume.php
+++ b/NetApp/samples/V1/NetAppClient/create_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_active_directory.php
+++ b/NetApp/samples/V1/NetAppClient/delete_active_directory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_backup.php
+++ b/NetApp/samples/V1/NetAppClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_backup_policy.php
+++ b/NetApp/samples/V1/NetAppClient/delete_backup_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_backup_vault.php
+++ b/NetApp/samples/V1/NetAppClient/delete_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_kms_config.php
+++ b/NetApp/samples/V1/NetAppClient/delete_kms_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_quota_rule.php
+++ b/NetApp/samples/V1/NetAppClient/delete_quota_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_replication.php
+++ b/NetApp/samples/V1/NetAppClient/delete_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_snapshot.php
+++ b/NetApp/samples/V1/NetAppClient/delete_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_storage_pool.php
+++ b/NetApp/samples/V1/NetAppClient/delete_storage_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/delete_volume.php
+++ b/NetApp/samples/V1/NetAppClient/delete_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/encrypt_volumes.php
+++ b/NetApp/samples/V1/NetAppClient/encrypt_volumes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/establish_peering.php
+++ b/NetApp/samples/V1/NetAppClient/establish_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_active_directory.php
+++ b/NetApp/samples/V1/NetAppClient/get_active_directory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_backup.php
+++ b/NetApp/samples/V1/NetAppClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_backup_policy.php
+++ b/NetApp/samples/V1/NetAppClient/get_backup_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_backup_vault.php
+++ b/NetApp/samples/V1/NetAppClient/get_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_kms_config.php
+++ b/NetApp/samples/V1/NetAppClient/get_kms_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_location.php
+++ b/NetApp/samples/V1/NetAppClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_quota_rule.php
+++ b/NetApp/samples/V1/NetAppClient/get_quota_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_replication.php
+++ b/NetApp/samples/V1/NetAppClient/get_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_snapshot.php
+++ b/NetApp/samples/V1/NetAppClient/get_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_storage_pool.php
+++ b/NetApp/samples/V1/NetAppClient/get_storage_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/get_volume.php
+++ b/NetApp/samples/V1/NetAppClient/get_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_active_directories.php
+++ b/NetApp/samples/V1/NetAppClient/list_active_directories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_backup_policies.php
+++ b/NetApp/samples/V1/NetAppClient/list_backup_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_backup_vaults.php
+++ b/NetApp/samples/V1/NetAppClient/list_backup_vaults.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_backups.php
+++ b/NetApp/samples/V1/NetAppClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_kms_configs.php
+++ b/NetApp/samples/V1/NetAppClient/list_kms_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_locations.php
+++ b/NetApp/samples/V1/NetAppClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_quota_rules.php
+++ b/NetApp/samples/V1/NetAppClient/list_quota_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_replications.php
+++ b/NetApp/samples/V1/NetAppClient/list_replications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_snapshots.php
+++ b/NetApp/samples/V1/NetAppClient/list_snapshots.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_storage_pools.php
+++ b/NetApp/samples/V1/NetAppClient/list_storage_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/list_volumes.php
+++ b/NetApp/samples/V1/NetAppClient/list_volumes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/resume_replication.php
+++ b/NetApp/samples/V1/NetAppClient/resume_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/reverse_replication_direction.php
+++ b/NetApp/samples/V1/NetAppClient/reverse_replication_direction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/revert_volume.php
+++ b/NetApp/samples/V1/NetAppClient/revert_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/stop_replication.php
+++ b/NetApp/samples/V1/NetAppClient/stop_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/switch_active_replica_zone.php
+++ b/NetApp/samples/V1/NetAppClient/switch_active_replica_zone.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/sync_replication.php
+++ b/NetApp/samples/V1/NetAppClient/sync_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_active_directory.php
+++ b/NetApp/samples/V1/NetAppClient/update_active_directory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_backup.php
+++ b/NetApp/samples/V1/NetAppClient/update_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_backup_policy.php
+++ b/NetApp/samples/V1/NetAppClient/update_backup_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_backup_vault.php
+++ b/NetApp/samples/V1/NetAppClient/update_backup_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_kms_config.php
+++ b/NetApp/samples/V1/NetAppClient/update_kms_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_quota_rule.php
+++ b/NetApp/samples/V1/NetAppClient/update_quota_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_replication.php
+++ b/NetApp/samples/V1/NetAppClient/update_replication.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_snapshot.php
+++ b/NetApp/samples/V1/NetAppClient/update_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_storage_pool.php
+++ b/NetApp/samples/V1/NetAppClient/update_storage_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/update_volume.php
+++ b/NetApp/samples/V1/NetAppClient/update_volume.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/validate_directory_service.php
+++ b/NetApp/samples/V1/NetAppClient/validate_directory_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/samples/V1/NetAppClient/verify_kms_config.php
+++ b/NetApp/samples/V1/NetAppClient/verify_kms_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/src/V1/Client/NetAppClient.php
+++ b/NetApp/src/V1/Client/NetAppClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/src/V1/resources/net_app_descriptor_config.php
+++ b/NetApp/src/V1/resources/net_app_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/src/V1/resources/net_app_rest_client_config.php
+++ b/NetApp/src/V1/resources/net_app_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetApp/tests/Unit/V1/Client/NetAppClientTest.php
+++ b/NetApp/tests/Unit/V1/Client/NetAppClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/owlbot.py
+++ b/NetworkConnectivity/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_map.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_token.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/create_service_connection_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_class.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_map.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_token.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/delete_service_connection_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_location.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_class.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_map.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_token.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/get_service_connection_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_locations.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_classes.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_classes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_maps.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_maps.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_policies.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_tokens.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/list_service_connection_tokens.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/set_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/test_iam_permissions.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_class.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_connection_map.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_connection_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_connection_policy.php
+++ b/NetworkConnectivity/samples/V1/CrossNetworkAutomationServiceClient/update_service_connection_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/create_destination.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/create_destination.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/create_multicloud_data_transfer_config.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/create_multicloud_data_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/delete_destination.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/delete_destination.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/delete_multicloud_data_transfer_config.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/delete_multicloud_data_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_destination.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_destination.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_location.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_multicloud_data_transfer_config.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_multicloud_data_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_multicloud_data_transfer_supported_service.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/get_multicloud_data_transfer_supported_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_destinations.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_destinations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_locations.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_multicloud_data_transfer_configs.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_multicloud_data_transfer_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_multicloud_data_transfer_supported_services.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/list_multicloud_data_transfer_supported_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/set_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/test_iam_permissions.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/update_destination.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/update_destination.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/DataTransferServiceClient/update_multicloud_data_transfer_config.php
+++ b/NetworkConnectivity/samples/V1/DataTransferServiceClient/update_multicloud_data_transfer_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/accept_hub_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/accept_hub_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/accept_spoke_update.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/accept_spoke_update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/create_hub.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/create_hub.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/create_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/create_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/delete_hub.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/delete_hub.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/delete_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/delete_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_group.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_hub.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_hub.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_location.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_route.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_route_table.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_route_table.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/get_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/get_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_groups.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_hub_spokes.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_hub_spokes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_hubs.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_hubs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_locations.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_route_tables.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_route_tables.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_routes.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/list_spokes.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/list_spokes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/query_hub_status.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/query_hub_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/reject_hub_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/reject_hub_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/reject_spoke_update.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/reject_spoke_update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/set_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/test_iam_permissions.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/update_group.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/update_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/update_hub.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/update_hub.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/HubServiceClient/update_spoke.php
+++ b/NetworkConnectivity/samples/V1/HubServiceClient/update_spoke.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/create_internal_range.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/create_internal_range.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/delete_internal_range.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/delete_internal_range.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_internal_range.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_internal_range.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_location.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/list_internal_ranges.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/list_internal_ranges.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/list_locations.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/set_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/test_iam_permissions.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/InternalRangeServiceClient/update_internal_range.php
+++ b/NetworkConnectivity/samples/V1/InternalRangeServiceClient/update_internal_range.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/create_policy_based_route.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/create_policy_based_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/delete_policy_based_route.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/delete_policy_based_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_location.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_policy_based_route.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/get_policy_based_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/list_locations.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/list_policy_based_routes.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/list_policy_based_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/set_iam_policy.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/test_iam_permissions.php
+++ b/NetworkConnectivity/samples/V1/PolicyBasedRoutingServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/Client/CrossNetworkAutomationServiceClient.php
+++ b/NetworkConnectivity/src/V1/Client/CrossNetworkAutomationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/Client/DataTransferServiceClient.php
+++ b/NetworkConnectivity/src/V1/Client/DataTransferServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/Client/HubServiceClient.php
+++ b/NetworkConnectivity/src/V1/Client/HubServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/Client/InternalRangeServiceClient.php
+++ b/NetworkConnectivity/src/V1/Client/InternalRangeServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/Client/PolicyBasedRoutingServiceClient.php
+++ b/NetworkConnectivity/src/V1/Client/PolicyBasedRoutingServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/cross_network_automation_service_descriptor_config.php
+++ b/NetworkConnectivity/src/V1/resources/cross_network_automation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/cross_network_automation_service_rest_client_config.php
+++ b/NetworkConnectivity/src/V1/resources/cross_network_automation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/data_transfer_service_descriptor_config.php
+++ b/NetworkConnectivity/src/V1/resources/data_transfer_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/data_transfer_service_rest_client_config.php
+++ b/NetworkConnectivity/src/V1/resources/data_transfer_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/hub_service_descriptor_config.php
+++ b/NetworkConnectivity/src/V1/resources/hub_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/hub_service_rest_client_config.php
+++ b/NetworkConnectivity/src/V1/resources/hub_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/internal_range_service_descriptor_config.php
+++ b/NetworkConnectivity/src/V1/resources/internal_range_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/internal_range_service_rest_client_config.php
+++ b/NetworkConnectivity/src/V1/resources/internal_range_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/policy_based_routing_service_descriptor_config.php
+++ b/NetworkConnectivity/src/V1/resources/policy_based_routing_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/src/V1/resources/policy_based_routing_service_rest_client_config.php
+++ b/NetworkConnectivity/src/V1/resources/policy_based_routing_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/tests/Unit/V1/Client/CrossNetworkAutomationServiceClientTest.php
+++ b/NetworkConnectivity/tests/Unit/V1/Client/CrossNetworkAutomationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/tests/Unit/V1/Client/DataTransferServiceClientTest.php
+++ b/NetworkConnectivity/tests/Unit/V1/Client/DataTransferServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/tests/Unit/V1/Client/HubServiceClientTest.php
+++ b/NetworkConnectivity/tests/Unit/V1/Client/HubServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/tests/Unit/V1/Client/InternalRangeServiceClientTest.php
+++ b/NetworkConnectivity/tests/Unit/V1/Client/InternalRangeServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkConnectivity/tests/Unit/V1/Client/PolicyBasedRoutingServiceClientTest.php
+++ b/NetworkConnectivity/tests/Unit/V1/Client/PolicyBasedRoutingServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/owlbot.py
+++ b/NetworkManagement/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/create_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/create_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/delete_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/delete_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_iam_policy.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_location.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/get_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/list_locations.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/list_vpc_flow_logs_configs.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/list_vpc_flow_logs_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/set_iam_policy.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/test_iam_permissions.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/update_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/OrganizationVpcFlowLogsServiceClient/update_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/create_connectivity_test.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/create_connectivity_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/delete_connectivity_test.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/delete_connectivity_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/get_connectivity_test.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/get_connectivity_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/get_iam_policy.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/get_location.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/list_connectivity_tests.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/list_connectivity_tests.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/list_locations.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/rerun_connectivity_test.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/rerun_connectivity_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/set_iam_policy.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/test_iam_permissions.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/ReachabilityServiceClient/update_connectivity_test.php
+++ b/NetworkManagement/samples/V1/ReachabilityServiceClient/update_connectivity_test.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/create_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/create_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/delete_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/delete_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_iam_policy.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_location.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/get_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/list_locations.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/list_vpc_flow_logs_configs.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/list_vpc_flow_logs_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/query_org_vpc_flow_logs_configs.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/query_org_vpc_flow_logs_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/set_iam_policy.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/show_effective_flow_logs_configs.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/show_effective_flow_logs_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/test_iam_permissions.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/update_vpc_flow_logs_config.php
+++ b/NetworkManagement/samples/V1/VpcFlowLogsServiceClient/update_vpc_flow_logs_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/Client/OrganizationVpcFlowLogsServiceClient.php
+++ b/NetworkManagement/src/V1/Client/OrganizationVpcFlowLogsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/Client/ReachabilityServiceClient.php
+++ b/NetworkManagement/src/V1/Client/ReachabilityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/Client/VpcFlowLogsServiceClient.php
+++ b/NetworkManagement/src/V1/Client/VpcFlowLogsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/organization_vpc_flow_logs_service_descriptor_config.php
+++ b/NetworkManagement/src/V1/resources/organization_vpc_flow_logs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/organization_vpc_flow_logs_service_rest_client_config.php
+++ b/NetworkManagement/src/V1/resources/organization_vpc_flow_logs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/reachability_service_descriptor_config.php
+++ b/NetworkManagement/src/V1/resources/reachability_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/reachability_service_rest_client_config.php
+++ b/NetworkManagement/src/V1/resources/reachability_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/vpc_flow_logs_service_descriptor_config.php
+++ b/NetworkManagement/src/V1/resources/vpc_flow_logs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/src/V1/resources/vpc_flow_logs_service_rest_client_config.php
+++ b/NetworkManagement/src/V1/resources/vpc_flow_logs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/tests/Unit/V1/Client/OrganizationVpcFlowLogsServiceClientTest.php
+++ b/NetworkManagement/tests/Unit/V1/Client/OrganizationVpcFlowLogsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/tests/Unit/V1/Client/ReachabilityServiceClientTest.php
+++ b/NetworkManagement/tests/Unit/V1/Client/ReachabilityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkManagement/tests/Unit/V1/Client/VpcFlowLogsServiceClientTest.php
+++ b/NetworkManagement/tests/Unit/V1/Client/VpcFlowLogsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/owlbot.py
+++ b/NetworkSecurity/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/add_address_group_items.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/add_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/clone_address_group_items.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/clone_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/create_address_group.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/create_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/delete_address_group.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/delete_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_address_group.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_iam_policy.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_location.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_address_group_references.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_address_group_references.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_address_groups.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_address_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_locations.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/remove_address_group_items.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/remove_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/set_iam_policy.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/test_iam_permissions.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/AddressGroupServiceClient/update_address_group.php
+++ b/NetworkSecurity/samples/V1/AddressGroupServiceClient/update_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/create_authorization_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/create_authorization_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/create_client_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/create_client_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/create_server_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/create_server_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_authorization_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_authorization_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_client_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_client_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_server_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/delete_server_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/get_authorization_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/get_authorization_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/get_client_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/get_client_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/get_iam_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/get_location.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/get_server_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/get_server_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/list_authorization_policies.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/list_authorization_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/list_client_tls_policies.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/list_client_tls_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/list_locations.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/list_server_tls_policies.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/list_server_tls_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/set_iam_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/test_iam_permissions.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/update_authorization_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/update_authorization_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/update_client_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/update_client_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/NetworkSecurityClient/update_server_tls_policy.php
+++ b/NetworkSecurity/samples/V1/NetworkSecurityClient/update_server_tls_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/add_address_group_items.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/add_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/clone_address_group_items.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/clone_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/create_address_group.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/create_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/delete_address_group.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/delete_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_address_group.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_iam_policy.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_location.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_address_group_references.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_address_group_references.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_address_groups.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_address_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_locations.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/remove_address_group_items.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/remove_address_group_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/set_iam_policy.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/test_iam_permissions.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/update_address_group.php
+++ b/NetworkSecurity/samples/V1/OrganizationAddressGroupServiceClient/update_address_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/Client/AddressGroupServiceClient.php
+++ b/NetworkSecurity/src/V1/Client/AddressGroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/Client/NetworkSecurityClient.php
+++ b/NetworkSecurity/src/V1/Client/NetworkSecurityClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/Client/OrganizationAddressGroupServiceClient.php
+++ b/NetworkSecurity/src/V1/Client/OrganizationAddressGroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/address_group_service_descriptor_config.php
+++ b/NetworkSecurity/src/V1/resources/address_group_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/address_group_service_rest_client_config.php
+++ b/NetworkSecurity/src/V1/resources/address_group_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/network_security_descriptor_config.php
+++ b/NetworkSecurity/src/V1/resources/network_security_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/network_security_rest_client_config.php
+++ b/NetworkSecurity/src/V1/resources/network_security_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/organization_address_group_service_descriptor_config.php
+++ b/NetworkSecurity/src/V1/resources/organization_address_group_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/src/V1/resources/organization_address_group_service_rest_client_config.php
+++ b/NetworkSecurity/src/V1/resources/organization_address_group_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/tests/Unit/V1/Client/AddressGroupServiceClientTest.php
+++ b/NetworkSecurity/tests/Unit/V1/Client/AddressGroupServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/tests/Unit/V1/Client/NetworkSecurityClientTest.php
+++ b/NetworkSecurity/tests/Unit/V1/Client/NetworkSecurityClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkSecurity/tests/Unit/V1/Client/OrganizationAddressGroupServiceClientTest.php
+++ b/NetworkSecurity/tests/Unit/V1/Client/OrganizationAddressGroupServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/owlbot.py
+++ b/NetworkServices/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/create_authz_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/create_authz_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/create_lb_edge_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/create_lb_edge_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/create_lb_route_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/create_lb_route_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/create_lb_traffic_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/create_lb_traffic_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/delete_authz_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/delete_authz_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/delete_lb_edge_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/delete_lb_edge_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/delete_lb_route_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/delete_lb_route_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/delete_lb_traffic_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/delete_lb_traffic_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_authz_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_authz_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_iam_policy.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_lb_edge_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_lb_edge_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_lb_route_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_lb_route_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_lb_traffic_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_lb_traffic_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/get_location.php
+++ b/NetworkServices/samples/V1/DepServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/list_authz_extensions.php
+++ b/NetworkServices/samples/V1/DepServiceClient/list_authz_extensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/list_lb_edge_extensions.php
+++ b/NetworkServices/samples/V1/DepServiceClient/list_lb_edge_extensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/list_lb_route_extensions.php
+++ b/NetworkServices/samples/V1/DepServiceClient/list_lb_route_extensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/list_lb_traffic_extensions.php
+++ b/NetworkServices/samples/V1/DepServiceClient/list_lb_traffic_extensions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/list_locations.php
+++ b/NetworkServices/samples/V1/DepServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/set_iam_policy.php
+++ b/NetworkServices/samples/V1/DepServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/test_iam_permissions.php
+++ b/NetworkServices/samples/V1/DepServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/update_authz_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/update_authz_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/update_lb_edge_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/update_lb_edge_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/update_lb_route_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/update_lb_route_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/DepServiceClient/update_lb_traffic_extension.php
+++ b/NetworkServices/samples/V1/DepServiceClient/update_lb_traffic_extension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_endpoint_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_endpoint_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_gateway.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_grpc_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_grpc_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_http_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_http_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_mesh.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_mesh.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_service_binding.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_service_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_service_lb_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_service_lb_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_tcp_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_tcp_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_tls_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_tls_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_wasm_plugin.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_wasm_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/create_wasm_plugin_version.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/create_wasm_plugin_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_endpoint_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_endpoint_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_gateway.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_grpc_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_grpc_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_http_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_http_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_mesh.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_mesh.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_service_binding.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_service_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_service_lb_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_service_lb_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_tcp_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_tcp_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_tls_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_tls_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_wasm_plugin.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_wasm_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/delete_wasm_plugin_version.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/delete_wasm_plugin_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_endpoint_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_endpoint_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_gateway.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_gateway_route_view.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_gateway_route_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_grpc_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_grpc_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_http_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_http_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_iam_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_location.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_mesh.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_mesh.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_mesh_route_view.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_mesh_route_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_service_binding.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_service_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_service_lb_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_service_lb_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_tcp_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_tcp_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_tls_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_tls_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_wasm_plugin.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_wasm_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/get_wasm_plugin_version.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/get_wasm_plugin_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_endpoint_policies.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_endpoint_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_gateway_route_views.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_gateway_route_views.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_gateways.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_gateways.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_grpc_routes.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_grpc_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_http_routes.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_http_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_locations.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_mesh_route_views.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_mesh_route_views.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_meshes.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_meshes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_service_bindings.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_service_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_service_lb_policies.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_service_lb_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_tcp_routes.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_tcp_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_tls_routes.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_tls_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_wasm_plugin_versions.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_wasm_plugin_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/list_wasm_plugins.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/list_wasm_plugins.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/set_iam_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/test_iam_permissions.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_endpoint_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_endpoint_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_gateway.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_gateway.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_grpc_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_grpc_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_http_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_http_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_mesh.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_mesh.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_service_binding.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_service_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_service_lb_policy.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_service_lb_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_tcp_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_tcp_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_tls_route.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_tls_route.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/samples/V1/NetworkServicesClient/update_wasm_plugin.php
+++ b/NetworkServices/samples/V1/NetworkServicesClient/update_wasm_plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/Client/DepServiceClient.php
+++ b/NetworkServices/src/V1/Client/DepServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/Client/NetworkServicesClient.php
+++ b/NetworkServices/src/V1/Client/NetworkServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/resources/dep_service_descriptor_config.php
+++ b/NetworkServices/src/V1/resources/dep_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/resources/dep_service_rest_client_config.php
+++ b/NetworkServices/src/V1/resources/dep_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/resources/network_services_descriptor_config.php
+++ b/NetworkServices/src/V1/resources/network_services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/src/V1/resources/network_services_rest_client_config.php
+++ b/NetworkServices/src/V1/resources/network_services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/tests/Unit/V1/Client/DepServiceClientTest.php
+++ b/NetworkServices/tests/Unit/V1/Client/DepServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/NetworkServices/tests/Unit/V1/Client/NetworkServicesClientTest.php
+++ b/NetworkServices/tests/Unit/V1/Client/NetworkServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/owlbot.py
+++ b/Notebooks/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/create_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/create_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/delete_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/delete_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/diagnose_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/diagnose_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/get_iam_policy.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/get_location.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/get_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/get_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/list_locations.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/list_runtimes.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/list_runtimes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/refresh_runtime_token_internal.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/refresh_runtime_token_internal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/report_runtime_event.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/report_runtime_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/reset_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/reset_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/set_iam_policy.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/start_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/start_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/stop_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/stop_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/switch_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/switch_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/test_iam_permissions.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/update_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/update_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/ManagedNotebookServiceClient/upgrade_runtime.php
+++ b/Notebooks/samples/V1/ManagedNotebookServiceClient/upgrade_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/create_environment.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/create_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/create_execution.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/create_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/create_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/create_schedule.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/create_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/delete_environment.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/delete_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/delete_execution.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/delete_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/delete_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/delete_schedule.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/delete_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/diagnose_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/diagnose_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_environment.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_execution.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_iam_policy.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_instance_health.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_instance_health.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_location.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/get_schedule.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/get_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/is_instance_upgradeable.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/is_instance_upgradeable.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/list_environments.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/list_environments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/list_executions.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/list_executions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/list_instances.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/list_locations.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/list_schedules.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/list_schedules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/register_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/register_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/report_instance_info.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/report_instance_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/reset_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/reset_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/rollback_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/rollback_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/set_iam_policy.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/set_instance_accelerator.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/set_instance_accelerator.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/set_instance_labels.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/set_instance_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/set_instance_machine_type.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/set_instance_machine_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/start_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/start_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/stop_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/stop_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/test_iam_permissions.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/trigger_schedule.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/trigger_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/update_instance_config.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/update_instance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/update_instance_metadata_items.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/update_instance_metadata_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/update_shielded_instance_config.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/update_shielded_instance_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/upgrade_instance.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/upgrade_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V1/NotebookServiceClient/upgrade_instance_internal.php
+++ b/Notebooks/samples/V1/NotebookServiceClient/upgrade_instance_internal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/check_instance_upgradability.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/check_instance_upgradability.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/create_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/delete_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/diagnose_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/diagnose_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/get_iam_policy.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/get_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/get_location.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/list_instances.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/list_locations.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/reset_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/reset_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/rollback_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/rollback_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/set_iam_policy.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/start_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/start_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/stop_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/stop_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/test_iam_permissions.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/update_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/samples/V2/NotebookServiceClient/upgrade_instance.php
+++ b/Notebooks/samples/V2/NotebookServiceClient/upgrade_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/Client/ManagedNotebookServiceClient.php
+++ b/Notebooks/src/V1/Client/ManagedNotebookServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/Client/NotebookServiceClient.php
+++ b/Notebooks/src/V1/Client/NotebookServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/resources/managed_notebook_service_descriptor_config.php
+++ b/Notebooks/src/V1/resources/managed_notebook_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/resources/managed_notebook_service_rest_client_config.php
+++ b/Notebooks/src/V1/resources/managed_notebook_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/resources/notebook_service_descriptor_config.php
+++ b/Notebooks/src/V1/resources/notebook_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V1/resources/notebook_service_rest_client_config.php
+++ b/Notebooks/src/V1/resources/notebook_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V2/Client/NotebookServiceClient.php
+++ b/Notebooks/src/V2/Client/NotebookServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V2/resources/notebook_service_descriptor_config.php
+++ b/Notebooks/src/V2/resources/notebook_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/src/V2/resources/notebook_service_rest_client_config.php
+++ b/Notebooks/src/V2/resources/notebook_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/tests/Unit/V1/Client/ManagedNotebookServiceClientTest.php
+++ b/Notebooks/tests/Unit/V1/Client/ManagedNotebookServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/tests/Unit/V1/Client/NotebookServiceClientTest.php
+++ b/Notebooks/tests/Unit/V1/Client/NotebookServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Notebooks/tests/Unit/V2/Client/NotebookServiceClientTest.php
+++ b/Notebooks/tests/Unit/V2/Client/NotebookServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/owlbot.py
+++ b/Optimization/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Optimization/samples/V1/FleetRoutingClient/batch_optimize_tours.php
+++ b/Optimization/samples/V1/FleetRoutingClient/batch_optimize_tours.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/samples/V1/FleetRoutingClient/optimize_tours.php
+++ b/Optimization/samples/V1/FleetRoutingClient/optimize_tours.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/src/V1/Client/FleetRoutingClient.php
+++ b/Optimization/src/V1/Client/FleetRoutingClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/src/V1/resources/fleet_routing_descriptor_config.php
+++ b/Optimization/src/V1/resources/fleet_routing_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/src/V1/resources/fleet_routing_rest_client_config.php
+++ b/Optimization/src/V1/resources/fleet_routing_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Optimization/tests/Unit/V1/Client/FleetRoutingClientTest.php
+++ b/Optimization/tests/Unit/V1/Client/FleetRoutingClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/owlbot.py
+++ b/OracleDatabase/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_cloud_exadata_infrastructure.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_cloud_exadata_infrastructure.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_cloud_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_cloud_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_db_system.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_db_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_exadb_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_exadb_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_exascale_db_storage_vault.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_exascale_db_storage_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_odb_network.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_odb_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/create_odb_subnet.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/create_odb_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_cloud_exadata_infrastructure.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_cloud_exadata_infrastructure.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_cloud_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_cloud_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_db_system.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_db_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_exadb_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_exadb_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_exascale_db_storage_vault.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_exascale_db_storage_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_odb_network.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_odb_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/delete_odb_subnet.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/delete_odb_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/failover_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/failover_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/generate_autonomous_database_wallet.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/generate_autonomous_database_wallet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_cloud_exadata_infrastructure.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_cloud_exadata_infrastructure.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_cloud_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_cloud_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_db_system.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_db_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_exadb_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_exadb_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_exascale_db_storage_vault.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_exascale_db_storage_vault.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_location.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_odb_network.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_odb_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_odb_subnet.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_odb_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/get_pluggable_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/get_pluggable_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_database_backups.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_database_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_database_character_sets.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_database_character_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_databases.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_databases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_db_versions.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_autonomous_db_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_cloud_exadata_infrastructures.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_cloud_exadata_infrastructures.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_cloud_vm_clusters.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_cloud_vm_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_database_character_sets.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_database_character_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_databases.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_databases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_nodes.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_servers.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_servers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_system_initial_storage_sizes.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_system_initial_storage_sizes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_system_shapes.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_system_shapes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_systems.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_systems.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_versions.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_db_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_entitlements.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_entitlements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_exadb_vm_clusters.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_exadb_vm_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_exascale_db_storage_vaults.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_exascale_db_storage_vaults.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_gi_versions.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_gi_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_locations.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_minor_versions.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_minor_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_odb_networks.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_odb_networks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_odb_subnets.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_odb_subnets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/list_pluggable_databases.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/list_pluggable_databases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/remove_virtual_machine_exadb_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/remove_virtual_machine_exadb_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/restart_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/restart_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/restore_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/restore_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/start_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/start_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/stop_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/stop_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/switchover_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/switchover_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/update_autonomous_database.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/update_autonomous_database.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/samples/V1/OracleDatabaseClient/update_exadb_vm_cluster.php
+++ b/OracleDatabase/samples/V1/OracleDatabaseClient/update_exadb_vm_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/src/V1/Client/OracleDatabaseClient.php
+++ b/OracleDatabase/src/V1/Client/OracleDatabaseClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/src/V1/resources/oracle_database_descriptor_config.php
+++ b/OracleDatabase/src/V1/resources/oracle_database_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/src/V1/resources/oracle_database_rest_client_config.php
+++ b/OracleDatabase/src/V1/resources/oracle_database_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OracleDatabase/tests/Unit/V1/Client/OracleDatabaseClientTest.php
+++ b/OracleDatabase/tests/Unit/V1/Client/OracleDatabaseClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/owlbot.py
+++ b/OrchestrationAirflow/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/check_upgrade.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/check_upgrade.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_environment.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_user_workloads_config_map.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_user_workloads_config_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_user_workloads_secret.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/create_user_workloads_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/database_failover.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/database_failover.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_environment.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_user_workloads_config_map.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_user_workloads_config_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_user_workloads_secret.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/delete_user_workloads_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/execute_airflow_command.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/execute_airflow_command.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/fetch_database_properties.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/fetch_database_properties.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_environment.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_user_workloads_config_map.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_user_workloads_config_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_user_workloads_secret.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/get_user_workloads_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_environments.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_environments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_user_workloads_config_maps.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_user_workloads_config_maps.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_user_workloads_secrets.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_user_workloads_secrets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_workloads.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/list_workloads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/load_snapshot.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/load_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/poll_airflow_command.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/poll_airflow_command.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/save_snapshot.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/save_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/stop_airflow_command.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/stop_airflow_command.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_environment.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_user_workloads_config_map.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_user_workloads_config_map.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_user_workloads_secret.php
+++ b/OrchestrationAirflow/samples/V1/EnvironmentsClient/update_user_workloads_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/samples/V1/ImageVersionsClient/list_image_versions.php
+++ b/OrchestrationAirflow/samples/V1/ImageVersionsClient/list_image_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/Client/EnvironmentsClient.php
+++ b/OrchestrationAirflow/src/V1/Client/EnvironmentsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/Client/ImageVersionsClient.php
+++ b/OrchestrationAirflow/src/V1/Client/ImageVersionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/resources/environments_descriptor_config.php
+++ b/OrchestrationAirflow/src/V1/resources/environments_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/resources/environments_rest_client_config.php
+++ b/OrchestrationAirflow/src/V1/resources/environments_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/resources/image_versions_descriptor_config.php
+++ b/OrchestrationAirflow/src/V1/resources/image_versions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/src/V1/resources/image_versions_rest_client_config.php
+++ b/OrchestrationAirflow/src/V1/resources/image_versions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/tests/Unit/V1/Client/EnvironmentsClientTest.php
+++ b/OrchestrationAirflow/tests/Unit/V1/Client/EnvironmentsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrchestrationAirflow/tests/Unit/V1/Client/ImageVersionsClientTest.php
+++ b/OrchestrationAirflow/tests/Unit/V1/Client/ImageVersionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/owlbot.py
+++ b/OrgPolicy/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/create_custom_constraint.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/create_custom_constraint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/create_policy.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/create_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/delete_custom_constraint.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/delete_custom_constraint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/delete_policy.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/delete_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/get_custom_constraint.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/get_custom_constraint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/get_effective_policy.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/get_effective_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/get_policy.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/get_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/list_constraints.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/list_constraints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/list_custom_constraints.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/list_custom_constraints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/list_policies.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/list_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/update_custom_constraint.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/update_custom_constraint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/samples/V2/OrgPolicyClient/update_policy.php
+++ b/OrgPolicy/samples/V2/OrgPolicyClient/update_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/src/V2/Client/OrgPolicyClient.php
+++ b/OrgPolicy/src/V2/Client/OrgPolicyClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/src/V2/resources/org_policy_descriptor_config.php
+++ b/OrgPolicy/src/V2/resources/org_policy_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/src/V2/resources/org_policy_rest_client_config.php
+++ b/OrgPolicy/src/V2/resources/org_policy_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OrgPolicy/tests/Unit/V2/Client/OrgPolicyClientTest.php
+++ b/OrgPolicy/tests/Unit/V2/Client/OrgPolicyClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/owlbot.py
+++ b/OsConfig/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/cancel_patch_job.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/cancel_patch_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/create_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/create_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/delete_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/delete_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/execute_patch_job.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/execute_patch_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/get_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/get_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/get_patch_job.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/get_patch_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/list_patch_deployments.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/list_patch_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/list_patch_job_instance_details.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/list_patch_job_instance_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/list_patch_jobs.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/list_patch_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/pause_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/pause_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/resume_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/resume_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigServiceClient/update_patch_deployment.php
+++ b/OsConfig/samples/V1/OsConfigServiceClient/update_patch_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/create_os_policy_assignment.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/create_os_policy_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/delete_os_policy_assignment.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/delete_os_policy_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/get_inventory.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/get_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/get_os_policy_assignment.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/get_os_policy_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/get_os_policy_assignment_report.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/get_os_policy_assignment_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/get_vulnerability_report.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/get_vulnerability_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/list_inventories.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/list_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignment_reports.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignment_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignment_revisions.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignment_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignments.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/list_os_policy_assignments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/list_vulnerability_reports.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/list_vulnerability_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/samples/V1/OsConfigZonalServiceClient/update_os_policy_assignment.php
+++ b/OsConfig/samples/V1/OsConfigZonalServiceClient/update_os_policy_assignment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/Client/OsConfigServiceClient.php
+++ b/OsConfig/src/V1/Client/OsConfigServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/Client/OsConfigZonalServiceClient.php
+++ b/OsConfig/src/V1/Client/OsConfigZonalServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/resources/os_config_service_descriptor_config.php
+++ b/OsConfig/src/V1/resources/os_config_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/resources/os_config_service_rest_client_config.php
+++ b/OsConfig/src/V1/resources/os_config_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/resources/os_config_zonal_service_descriptor_config.php
+++ b/OsConfig/src/V1/resources/os_config_zonal_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/src/V1/resources/os_config_zonal_service_rest_client_config.php
+++ b/OsConfig/src/V1/resources/os_config_zonal_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/tests/Unit/V1/Client/OsConfigServiceClientTest.php
+++ b/OsConfig/tests/Unit/V1/Client/OsConfigServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsConfig/tests/Unit/V1/Client/OsConfigZonalServiceClientTest.php
+++ b/OsConfig/tests/Unit/V1/Client/OsConfigZonalServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/owlbot.py
+++ b/OsLogin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/create_ssh_public_key.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/create_ssh_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/delete_posix_account.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/delete_posix_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/delete_ssh_public_key.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/delete_ssh_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/get_login_profile.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/get_login_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/get_ssh_public_key.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/get_ssh_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/import_ssh_public_key.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/import_ssh_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/samples/V1/OsLoginServiceClient/update_ssh_public_key.php
+++ b/OsLogin/samples/V1/OsLoginServiceClient/update_ssh_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/src/V1/Client/OsLoginServiceClient.php
+++ b/OsLogin/src/V1/Client/OsLoginServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/src/V1/resources/os_login_service_descriptor_config.php
+++ b/OsLogin/src/V1/resources/os_login_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/src/V1/resources/os_login_service_rest_client_config.php
+++ b/OsLogin/src/V1/resources/os_login_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OsLogin/tests/Unit/V1/Client/OsLoginServiceClientTest.php
+++ b/OsLogin/tests/Unit/V1/Client/OsLoginServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/owlbot.py
+++ b/Parallelstore/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/create_instance.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/delete_instance.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/export_data.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/get_instance.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/get_location.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/import_data.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/list_instances.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/list_locations.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1/ParallelstoreClient/update_instance.php
+++ b/Parallelstore/samples/V1/ParallelstoreClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/create_instance.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/delete_instance.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/export_data.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/get_instance.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/get_location.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/import_data.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/list_instances.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/list_locations.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/samples/V1beta/ParallelstoreClient/update_instance.php
+++ b/Parallelstore/samples/V1beta/ParallelstoreClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1/Client/ParallelstoreClient.php
+++ b/Parallelstore/src/V1/Client/ParallelstoreClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1/resources/parallelstore_descriptor_config.php
+++ b/Parallelstore/src/V1/resources/parallelstore_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1/resources/parallelstore_rest_client_config.php
+++ b/Parallelstore/src/V1/resources/parallelstore_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1beta/Client/ParallelstoreClient.php
+++ b/Parallelstore/src/V1beta/Client/ParallelstoreClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1beta/resources/parallelstore_descriptor_config.php
+++ b/Parallelstore/src/V1beta/resources/parallelstore_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/src/V1beta/resources/parallelstore_rest_client_config.php
+++ b/Parallelstore/src/V1beta/resources/parallelstore_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/tests/Unit/V1/Client/ParallelstoreClientTest.php
+++ b/Parallelstore/tests/Unit/V1/Client/ParallelstoreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Parallelstore/tests/Unit/V1beta/Client/ParallelstoreClientTest.php
+++ b/Parallelstore/tests/Unit/V1beta/Client/ParallelstoreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/owlbot.py
+++ b/ParameterManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/create_parameter.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/create_parameter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/create_parameter_version.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/create_parameter_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/delete_parameter.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/delete_parameter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/delete_parameter_version.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/delete_parameter_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/get_location.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/get_parameter.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/get_parameter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/get_parameter_version.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/get_parameter_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/list_locations.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/list_parameter_versions.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/list_parameter_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/list_parameters.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/list_parameters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/render_parameter_version.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/render_parameter_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/update_parameter.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/update_parameter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/samples/V1/ParameterManagerClient/update_parameter_version.php
+++ b/ParameterManager/samples/V1/ParameterManagerClient/update_parameter_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/src/V1/Client/ParameterManagerClient.php
+++ b/ParameterManager/src/V1/Client/ParameterManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/src/V1/resources/parameter_manager_descriptor_config.php
+++ b/ParameterManager/src/V1/resources/parameter_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/src/V1/resources/parameter_manager_rest_client_config.php
+++ b/ParameterManager/src/V1/resources/parameter_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ParameterManager/tests/Unit/V1/Client/ParameterManagerClientTest.php
+++ b/ParameterManager/tests/Unit/V1/Client/ParameterManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/owlbot.py
+++ b/PolicySimulator/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/create_org_policy_violations_preview.php
+++ b/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/create_org_policy_violations_preview.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/get_org_policy_violations_preview.php
+++ b/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/get_org_policy_violations_preview.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/list_org_policy_violations.php
+++ b/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/list_org_policy_violations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/list_org_policy_violations_previews.php
+++ b/PolicySimulator/samples/V1/OrgPolicyViolationsPreviewServiceClient/list_org_policy_violations_previews.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/SimulatorClient/create_replay.php
+++ b/PolicySimulator/samples/V1/SimulatorClient/create_replay.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/SimulatorClient/get_replay.php
+++ b/PolicySimulator/samples/V1/SimulatorClient/get_replay.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/samples/V1/SimulatorClient/list_replay_results.php
+++ b/PolicySimulator/samples/V1/SimulatorClient/list_replay_results.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/Client/OrgPolicyViolationsPreviewServiceClient.php
+++ b/PolicySimulator/src/V1/Client/OrgPolicyViolationsPreviewServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/Client/SimulatorClient.php
+++ b/PolicySimulator/src/V1/Client/SimulatorClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/resources/org_policy_violations_preview_service_descriptor_config.php
+++ b/PolicySimulator/src/V1/resources/org_policy_violations_preview_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/resources/org_policy_violations_preview_service_rest_client_config.php
+++ b/PolicySimulator/src/V1/resources/org_policy_violations_preview_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/resources/simulator_descriptor_config.php
+++ b/PolicySimulator/src/V1/resources/simulator_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/src/V1/resources/simulator_rest_client_config.php
+++ b/PolicySimulator/src/V1/resources/simulator_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/tests/Unit/V1/Client/OrgPolicyViolationsPreviewServiceClientTest.php
+++ b/PolicySimulator/tests/Unit/V1/Client/OrgPolicyViolationsPreviewServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicySimulator/tests/Unit/V1/Client/SimulatorClientTest.php
+++ b/PolicySimulator/tests/Unit/V1/Client/SimulatorClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/owlbot.py
+++ b/PolicyTroubleshooter/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/samples/V1/IamCheckerClient/troubleshoot_iam_policy.php
+++ b/PolicyTroubleshooter/samples/V1/IamCheckerClient/troubleshoot_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/src/V1/Client/IamCheckerClient.php
+++ b/PolicyTroubleshooter/src/V1/Client/IamCheckerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/src/V1/resources/iam_checker_descriptor_config.php
+++ b/PolicyTroubleshooter/src/V1/resources/iam_checker_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/src/V1/resources/iam_checker_rest_client_config.php
+++ b/PolicyTroubleshooter/src/V1/resources/iam_checker_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooter/tests/Unit/V1/Client/IamCheckerClientTest.php
+++ b/PolicyTroubleshooter/tests/Unit/V1/Client/IamCheckerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/owlbot.py
+++ b/PolicyTroubleshooterIam/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/samples/V3/PolicyTroubleshooterClient/troubleshoot_iam_policy.php
+++ b/PolicyTroubleshooterIam/samples/V3/PolicyTroubleshooterClient/troubleshoot_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/src/V3/Client/PolicyTroubleshooterClient.php
+++ b/PolicyTroubleshooterIam/src/V3/Client/PolicyTroubleshooterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/src/V3/resources/policy_troubleshooter_descriptor_config.php
+++ b/PolicyTroubleshooterIam/src/V3/resources/policy_troubleshooter_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/src/V3/resources/policy_troubleshooter_rest_client_config.php
+++ b/PolicyTroubleshooterIam/src/V3/resources/policy_troubleshooter_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PolicyTroubleshooterIam/tests/Unit/V3/Client/PolicyTroubleshooterClientTest.php
+++ b/PolicyTroubleshooterIam/tests/Unit/V3/Client/PolicyTroubleshooterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/owlbot.py
+++ b/PrivateCatalog/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_catalogs.php
+++ b/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_catalogs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_products.php
+++ b/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_versions.php
+++ b/PrivateCatalog/samples/V1beta1/PrivateCatalogClient/search_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/src/V1beta1/Client/PrivateCatalogClient.php
+++ b/PrivateCatalog/src/V1beta1/Client/PrivateCatalogClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/src/V1beta1/resources/private_catalog_descriptor_config.php
+++ b/PrivateCatalog/src/V1beta1/resources/private_catalog_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/src/V1beta1/resources/private_catalog_rest_client_config.php
+++ b/PrivateCatalog/src/V1beta1/resources/private_catalog_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivateCatalog/tests/Unit/V1beta1/Client/PrivateCatalogClientTest.php
+++ b/PrivateCatalog/tests/Unit/V1beta1/Client/PrivateCatalogClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/owlbot.py
+++ b/PrivilegedAccessManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/approve_grant.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/approve_grant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/check_onboarding_status.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/check_onboarding_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/create_entitlement.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/create_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/create_grant.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/create_grant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/delete_entitlement.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/delete_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/deny_grant.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/deny_grant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_entitlement.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_grant.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_grant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_location.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_entitlements.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_entitlements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_grants.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_grants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_locations.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/revoke_grant.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/revoke_grant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/search_entitlements.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/search_entitlements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/search_grants.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/search_grants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/update_entitlement.php
+++ b/PrivilegedAccessManager/samples/V1/PrivilegedAccessManagerClient/update_entitlement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/src/V1/Client/PrivilegedAccessManagerClient.php
+++ b/PrivilegedAccessManager/src/V1/Client/PrivilegedAccessManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/src/V1/resources/privileged_access_manager_descriptor_config.php
+++ b/PrivilegedAccessManager/src/V1/resources/privileged_access_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/src/V1/resources/privileged_access_manager_rest_client_config.php
+++ b/PrivilegedAccessManager/src/V1/resources/privileged_access_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PrivilegedAccessManager/tests/Unit/V1/Client/PrivilegedAccessManagerClientTest.php
+++ b/PrivilegedAccessManager/tests/Unit/V1/Client/PrivilegedAccessManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/owlbot.py
+++ b/Profiler/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Profiler/samples/V2/ExportServiceClient/list_profiles.php
+++ b/Profiler/samples/V2/ExportServiceClient/list_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/samples/V2/ProfilerServiceClient/create_offline_profile.php
+++ b/Profiler/samples/V2/ProfilerServiceClient/create_offline_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/samples/V2/ProfilerServiceClient/create_profile.php
+++ b/Profiler/samples/V2/ProfilerServiceClient/create_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/samples/V2/ProfilerServiceClient/update_profile.php
+++ b/Profiler/samples/V2/ProfilerServiceClient/update_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/Client/ExportServiceClient.php
+++ b/Profiler/src/V2/Client/ExportServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/Client/ProfilerServiceClient.php
+++ b/Profiler/src/V2/Client/ProfilerServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/resources/export_service_descriptor_config.php
+++ b/Profiler/src/V2/resources/export_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/resources/export_service_rest_client_config.php
+++ b/Profiler/src/V2/resources/export_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/resources/profiler_service_descriptor_config.php
+++ b/Profiler/src/V2/resources/profiler_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/src/V2/resources/profiler_service_rest_client_config.php
+++ b/Profiler/src/V2/resources/profiler_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/tests/Unit/V2/Client/ExportServiceClientTest.php
+++ b/Profiler/tests/Unit/V2/Client/ExportServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Profiler/tests/Unit/V2/Client/ProfilerServiceClientTest.php
+++ b/Profiler/tests/Unit/V2/Client/ProfilerServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/create_topic.php
+++ b/PubSub/samples/V1/PublisherClient/create_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/delete_topic.php
+++ b/PubSub/samples/V1/PublisherClient/delete_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/detach_subscription.php
+++ b/PubSub/samples/V1/PublisherClient/detach_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/get_iam_policy.php
+++ b/PubSub/samples/V1/PublisherClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/get_topic.php
+++ b/PubSub/samples/V1/PublisherClient/get_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/list_topic_snapshots.php
+++ b/PubSub/samples/V1/PublisherClient/list_topic_snapshots.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/list_topic_subscriptions.php
+++ b/PubSub/samples/V1/PublisherClient/list_topic_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/list_topics.php
+++ b/PubSub/samples/V1/PublisherClient/list_topics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/publish.php
+++ b/PubSub/samples/V1/PublisherClient/publish.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/set_iam_policy.php
+++ b/PubSub/samples/V1/PublisherClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/test_iam_permissions.php
+++ b/PubSub/samples/V1/PublisherClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/PublisherClient/update_topic.php
+++ b/PubSub/samples/V1/PublisherClient/update_topic.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/commit_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/commit_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/create_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/create_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/delete_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/delete_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/delete_schema_revision.php
+++ b/PubSub/samples/V1/SchemaServiceClient/delete_schema_revision.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/get_iam_policy.php
+++ b/PubSub/samples/V1/SchemaServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/get_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/get_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/list_schema_revisions.php
+++ b/PubSub/samples/V1/SchemaServiceClient/list_schema_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/list_schemas.php
+++ b/PubSub/samples/V1/SchemaServiceClient/list_schemas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/rollback_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/rollback_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/set_iam_policy.php
+++ b/PubSub/samples/V1/SchemaServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/test_iam_permissions.php
+++ b/PubSub/samples/V1/SchemaServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/validate_message.php
+++ b/PubSub/samples/V1/SchemaServiceClient/validate_message.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SchemaServiceClient/validate_schema.php
+++ b/PubSub/samples/V1/SchemaServiceClient/validate_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/acknowledge.php
+++ b/PubSub/samples/V1/SubscriberClient/acknowledge.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/create_snapshot.php
+++ b/PubSub/samples/V1/SubscriberClient/create_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/create_subscription.php
+++ b/PubSub/samples/V1/SubscriberClient/create_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/delete_snapshot.php
+++ b/PubSub/samples/V1/SubscriberClient/delete_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/delete_subscription.php
+++ b/PubSub/samples/V1/SubscriberClient/delete_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/get_iam_policy.php
+++ b/PubSub/samples/V1/SubscriberClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/get_snapshot.php
+++ b/PubSub/samples/V1/SubscriberClient/get_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/get_subscription.php
+++ b/PubSub/samples/V1/SubscriberClient/get_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/list_snapshots.php
+++ b/PubSub/samples/V1/SubscriberClient/list_snapshots.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/list_subscriptions.php
+++ b/PubSub/samples/V1/SubscriberClient/list_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/modify_ack_deadline.php
+++ b/PubSub/samples/V1/SubscriberClient/modify_ack_deadline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/modify_push_config.php
+++ b/PubSub/samples/V1/SubscriberClient/modify_push_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/pull.php
+++ b/PubSub/samples/V1/SubscriberClient/pull.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/seek.php
+++ b/PubSub/samples/V1/SubscriberClient/seek.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/set_iam_policy.php
+++ b/PubSub/samples/V1/SubscriberClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/streaming_pull.php
+++ b/PubSub/samples/V1/SubscriberClient/streaming_pull.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/test_iam_permissions.php
+++ b/PubSub/samples/V1/SubscriberClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/update_snapshot.php
+++ b/PubSub/samples/V1/SubscriberClient/update_snapshot.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/samples/V1/SubscriberClient/update_subscription.php
+++ b/PubSub/samples/V1/SubscriberClient/update_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/Client/PublisherClient.php
+++ b/PubSub/src/V1/Client/PublisherClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/Client/SchemaServiceClient.php
+++ b/PubSub/src/V1/Client/SchemaServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/Client/SubscriberClient.php
+++ b/PubSub/src/V1/Client/SubscriberClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/publisher_descriptor_config.php
+++ b/PubSub/src/V1/resources/publisher_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/publisher_rest_client_config.php
+++ b/PubSub/src/V1/resources/publisher_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/schema_service_descriptor_config.php
+++ b/PubSub/src/V1/resources/schema_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/schema_service_rest_client_config.php
+++ b/PubSub/src/V1/resources/schema_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/subscriber_descriptor_config.php
+++ b/PubSub/src/V1/resources/subscriber_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/src/V1/resources/subscriber_rest_client_config.php
+++ b/PubSub/src/V1/resources/subscriber_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/System/V1/PublisherSmokeTest.php
+++ b/PubSub/tests/System/V1/PublisherSmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/Unit/V1/Client/PublisherClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/PublisherClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/Unit/V1/Client/SchemaServiceClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/SchemaServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/PubSub/tests/Unit/V1/Client/SubscriberClientTest.php
+++ b/PubSub/tests/Unit/V1/Client/SubscriberClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/owlbot.py
+++ b/Quotas/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/create_quota_preference.php
+++ b/Quotas/samples/V1/CloudQuotasClient/create_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/get_quota_info.php
+++ b/Quotas/samples/V1/CloudQuotasClient/get_quota_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/get_quota_preference.php
+++ b/Quotas/samples/V1/CloudQuotasClient/get_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/list_quota_infos.php
+++ b/Quotas/samples/V1/CloudQuotasClient/list_quota_infos.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/list_quota_preferences.php
+++ b/Quotas/samples/V1/CloudQuotasClient/list_quota_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1/CloudQuotasClient/update_quota_preference.php
+++ b/Quotas/samples/V1/CloudQuotasClient/update_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/create_quota_preference.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/create_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/get_quota_info.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/get_quota_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/get_quota_preference.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/get_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/list_quota_infos.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/list_quota_infos.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/list_quota_preferences.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/list_quota_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/CloudQuotasClient/update_quota_preference.php
+++ b/Quotas/samples/V1beta/CloudQuotasClient/update_quota_preference.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/QuotaAdjusterSettingsManagerClient/get_quota_adjuster_settings.php
+++ b/Quotas/samples/V1beta/QuotaAdjusterSettingsManagerClient/get_quota_adjuster_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/samples/V1beta/QuotaAdjusterSettingsManagerClient/update_quota_adjuster_settings.php
+++ b/Quotas/samples/V1beta/QuotaAdjusterSettingsManagerClient/update_quota_adjuster_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1/Client/CloudQuotasClient.php
+++ b/Quotas/src/V1/Client/CloudQuotasClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1/resources/cloud_quotas_descriptor_config.php
+++ b/Quotas/src/V1/resources/cloud_quotas_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1/resources/cloud_quotas_rest_client_config.php
+++ b/Quotas/src/V1/resources/cloud_quotas_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/Client/CloudQuotasClient.php
+++ b/Quotas/src/V1beta/Client/CloudQuotasClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/Client/QuotaAdjusterSettingsManagerClient.php
+++ b/Quotas/src/V1beta/Client/QuotaAdjusterSettingsManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/resources/cloud_quotas_descriptor_config.php
+++ b/Quotas/src/V1beta/resources/cloud_quotas_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/resources/cloud_quotas_rest_client_config.php
+++ b/Quotas/src/V1beta/resources/cloud_quotas_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/resources/quota_adjuster_settings_manager_descriptor_config.php
+++ b/Quotas/src/V1beta/resources/quota_adjuster_settings_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/src/V1beta/resources/quota_adjuster_settings_manager_rest_client_config.php
+++ b/Quotas/src/V1beta/resources/quota_adjuster_settings_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/tests/Unit/V1/Client/CloudQuotasClientTest.php
+++ b/Quotas/tests/Unit/V1/Client/CloudQuotasClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/tests/Unit/V1beta/Client/CloudQuotasClientTest.php
+++ b/Quotas/tests/Unit/V1beta/Client/CloudQuotasClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Quotas/tests/Unit/V1beta/Client/QuotaAdjusterSettingsManagerClientTest.php
+++ b/Quotas/tests/Unit/V1beta/Client/QuotaAdjusterSettingsManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/owlbot.py
+++ b/RapidMigrationAssessment/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/create_annotation.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/create_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/create_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/create_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/delete_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/delete_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_annotation.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_annotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_location.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/list_collectors.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/list_collectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/list_locations.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/pause_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/pause_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/register_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/register_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/resume_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/resume_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/update_collector.php
+++ b/RapidMigrationAssessment/samples/V1/RapidMigrationAssessmentClient/update_collector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/src/V1/Client/RapidMigrationAssessmentClient.php
+++ b/RapidMigrationAssessment/src/V1/Client/RapidMigrationAssessmentClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/src/V1/resources/rapid_migration_assessment_descriptor_config.php
+++ b/RapidMigrationAssessment/src/V1/resources/rapid_migration_assessment_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/src/V1/resources/rapid_migration_assessment_rest_client_config.php
+++ b/RapidMigrationAssessment/src/V1/resources/rapid_migration_assessment_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RapidMigrationAssessment/tests/Unit/V1/Client/RapidMigrationAssessmentClientTest.php
+++ b/RapidMigrationAssessment/tests/Unit/V1/Client/RapidMigrationAssessmentClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/owlbot.py
+++ b/RecaptchaEnterprise/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/add_ip_override.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/add_ip_override.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/annotate_assessment.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/annotate_assessment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_assessment.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_assessment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_firewall_policy.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_firewall_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/create_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/delete_firewall_policy.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/delete_firewall_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/delete_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/delete_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_firewall_policy.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_firewall_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_metrics.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/get_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_firewall_policies.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_firewall_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_ip_overrides.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_ip_overrides.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_keys.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_related_account_group_memberships.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_related_account_group_memberships.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_related_account_groups.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/list_related_account_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/migrate_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/migrate_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/remove_ip_override.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/remove_ip_override.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/reorder_firewall_policies.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/reorder_firewall_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/retrieve_legacy_secret_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/retrieve_legacy_secret_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/search_related_account_group_memberships.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/search_related_account_group_memberships.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/update_firewall_policy.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/update_firewall_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/update_key.php
+++ b/RecaptchaEnterprise/samples/V1/RecaptchaEnterpriseServiceClient/update_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/src/V1/Client/RecaptchaEnterpriseServiceClient.php
+++ b/RecaptchaEnterprise/src/V1/Client/RecaptchaEnterpriseServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/src/V1/resources/recaptcha_enterprise_service_descriptor_config.php
+++ b/RecaptchaEnterprise/src/V1/resources/recaptcha_enterprise_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/src/V1/resources/recaptcha_enterprise_service_rest_client_config.php
+++ b/RecaptchaEnterprise/src/V1/resources/recaptcha_enterprise_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecaptchaEnterprise/tests/Unit/V1/Client/RecaptchaEnterpriseServiceClientTest.php
+++ b/RecaptchaEnterprise/tests/Unit/V1/Client/RecaptchaEnterpriseServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/owlbot.py
+++ b/RecommendationEngine/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/create_catalog_item.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/create_catalog_item.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/delete_catalog_item.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/delete_catalog_item.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/get_catalog_item.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/get_catalog_item.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/import_catalog_items.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/import_catalog_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/list_catalog_items.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/list_catalog_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/CatalogServiceClient/update_catalog_item.php
+++ b/RecommendationEngine/samples/V1beta1/CatalogServiceClient/update_catalog_item.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/create_prediction_api_key_registration.php
+++ b/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/create_prediction_api_key_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/delete_prediction_api_key_registration.php
+++ b/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/delete_prediction_api_key_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/list_prediction_api_key_registrations.php
+++ b/RecommendationEngine/samples/V1beta1/PredictionApiKeyRegistryClient/list_prediction_api_key_registrations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/PredictionServiceClient/predict.php
+++ b/RecommendationEngine/samples/V1beta1/PredictionServiceClient/predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/UserEventServiceClient/collect_user_event.php
+++ b/RecommendationEngine/samples/V1beta1/UserEventServiceClient/collect_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/UserEventServiceClient/import_user_events.php
+++ b/RecommendationEngine/samples/V1beta1/UserEventServiceClient/import_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/UserEventServiceClient/list_user_events.php
+++ b/RecommendationEngine/samples/V1beta1/UserEventServiceClient/list_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/UserEventServiceClient/purge_user_events.php
+++ b/RecommendationEngine/samples/V1beta1/UserEventServiceClient/purge_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/samples/V1beta1/UserEventServiceClient/write_user_event.php
+++ b/RecommendationEngine/samples/V1beta1/UserEventServiceClient/write_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/Client/CatalogServiceClient.php
+++ b/RecommendationEngine/src/V1beta1/Client/CatalogServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/Client/PredictionApiKeyRegistryClient.php
+++ b/RecommendationEngine/src/V1beta1/Client/PredictionApiKeyRegistryClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/Client/PredictionServiceClient.php
+++ b/RecommendationEngine/src/V1beta1/Client/PredictionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/Client/UserEventServiceClient.php
+++ b/RecommendationEngine/src/V1beta1/Client/UserEventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/catalog_service_descriptor_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/catalog_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/catalog_service_rest_client_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/catalog_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/prediction_api_key_registry_descriptor_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/prediction_api_key_registry_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/prediction_api_key_registry_rest_client_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/prediction_api_key_registry_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/prediction_service_descriptor_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/prediction_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/prediction_service_rest_client_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/prediction_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/user_event_service_descriptor_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/user_event_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/src/V1beta1/resources/user_event_service_rest_client_config.php
+++ b/RecommendationEngine/src/V1beta1/resources/user_event_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/tests/Unit/V1beta1/Client/CatalogServiceClientTest.php
+++ b/RecommendationEngine/tests/Unit/V1beta1/Client/CatalogServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/tests/Unit/V1beta1/Client/PredictionApiKeyRegistryClientTest.php
+++ b/RecommendationEngine/tests/Unit/V1beta1/Client/PredictionApiKeyRegistryClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/tests/Unit/V1beta1/Client/PredictionServiceClientTest.php
+++ b/RecommendationEngine/tests/Unit/V1beta1/Client/PredictionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RecommendationEngine/tests/Unit/V1beta1/Client/UserEventServiceClientTest.php
+++ b/RecommendationEngine/tests/Unit/V1beta1/Client/UserEventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/owlbot.py
+++ b/Recommender/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/get_insight.php
+++ b/Recommender/samples/V1/RecommenderClient/get_insight.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/get_insight_type_config.php
+++ b/Recommender/samples/V1/RecommenderClient/get_insight_type_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/get_recommendation.php
+++ b/Recommender/samples/V1/RecommenderClient/get_recommendation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/get_recommender_config.php
+++ b/Recommender/samples/V1/RecommenderClient/get_recommender_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/list_insights.php
+++ b/Recommender/samples/V1/RecommenderClient/list_insights.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/list_recommendations.php
+++ b/Recommender/samples/V1/RecommenderClient/list_recommendations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/mark_insight_accepted.php
+++ b/Recommender/samples/V1/RecommenderClient/mark_insight_accepted.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/mark_recommendation_claimed.php
+++ b/Recommender/samples/V1/RecommenderClient/mark_recommendation_claimed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/mark_recommendation_dismissed.php
+++ b/Recommender/samples/V1/RecommenderClient/mark_recommendation_dismissed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/mark_recommendation_failed.php
+++ b/Recommender/samples/V1/RecommenderClient/mark_recommendation_failed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/mark_recommendation_succeeded.php
+++ b/Recommender/samples/V1/RecommenderClient/mark_recommendation_succeeded.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/update_insight_type_config.php
+++ b/Recommender/samples/V1/RecommenderClient/update_insight_type_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/samples/V1/RecommenderClient/update_recommender_config.php
+++ b/Recommender/samples/V1/RecommenderClient/update_recommender_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/src/V1/Client/RecommenderClient.php
+++ b/Recommender/src/V1/Client/RecommenderClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/src/V1/resources/recommender_descriptor_config.php
+++ b/Recommender/src/V1/resources/recommender_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/src/V1/resources/recommender_rest_client_config.php
+++ b/Recommender/src/V1/resources/recommender_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Recommender/tests/Unit/V1/Client/RecommenderClientTest.php
+++ b/Recommender/tests/Unit/V1/Client/RecommenderClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/owlbot.py
+++ b/Redis/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/create_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/delete_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/export_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/export_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/failover_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/failover_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/get_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/get_instance_auth_string.php
+++ b/Redis/samples/V1/CloudRedisClient/get_instance_auth_string.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/get_location.php
+++ b/Redis/samples/V1/CloudRedisClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/import_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/import_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/list_instances.php
+++ b/Redis/samples/V1/CloudRedisClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/list_locations.php
+++ b/Redis/samples/V1/CloudRedisClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/reschedule_maintenance.php
+++ b/Redis/samples/V1/CloudRedisClient/reschedule_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/update_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/samples/V1/CloudRedisClient/upgrade_instance.php
+++ b/Redis/samples/V1/CloudRedisClient/upgrade_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/src/V1/Client/CloudRedisClient.php
+++ b/Redis/src/V1/Client/CloudRedisClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/src/V1/resources/cloud_redis_descriptor_config.php
+++ b/Redis/src/V1/resources/cloud_redis_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/src/V1/resources/cloud_redis_rest_client_config.php
+++ b/Redis/src/V1/resources/cloud_redis_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/tests/System/V1/CloudRedisClientTest.php
+++ b/Redis/tests/System/V1/CloudRedisClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018 Google Inc.
+ * Copyright 2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Redis/tests/Unit/V1/Client/CloudRedisClientTest.php
+++ b/Redis/tests/Unit/V1/Client/CloudRedisClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/owlbot.py
+++ b/RedisCluster/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/backup_cluster.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/backup_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/create_cluster.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/delete_backup.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/delete_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/delete_cluster.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/export_backup.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/export_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/get_backup.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/get_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/get_backup_collection.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/get_backup_collection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/get_cluster.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/get_cluster_certificate_authority.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/get_cluster_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/get_location.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/list_backup_collections.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/list_backup_collections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/list_backups.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/list_backups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/list_clusters.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/list_locations.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/reschedule_cluster_maintenance.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/reschedule_cluster_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/samples/V1/CloudRedisClusterClient/update_cluster.php
+++ b/RedisCluster/samples/V1/CloudRedisClusterClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/src/V1/Client/CloudRedisClusterClient.php
+++ b/RedisCluster/src/V1/Client/CloudRedisClusterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/src/V1/resources/cloud_redis_cluster_descriptor_config.php
+++ b/RedisCluster/src/V1/resources/cloud_redis_cluster_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/src/V1/resources/cloud_redis_cluster_rest_client_config.php
+++ b/RedisCluster/src/V1/resources/cloud_redis_cluster_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/RedisCluster/tests/Unit/V1/Client/CloudRedisClusterClientTest.php
+++ b/RedisCluster/tests/Unit/V1/Client/CloudRedisClusterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/owlbot.py
+++ b/ResourceManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/create_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/create_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/delete_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/delete_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/get_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/get_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/get_iam_policy.php
+++ b/ResourceManager/samples/V3/FoldersClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/list_folders.php
+++ b/ResourceManager/samples/V3/FoldersClient/list_folders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/move_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/move_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/search_folders.php
+++ b/ResourceManager/samples/V3/FoldersClient/search_folders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/set_iam_policy.php
+++ b/ResourceManager/samples/V3/FoldersClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/test_iam_permissions.php
+++ b/ResourceManager/samples/V3/FoldersClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/undelete_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/undelete_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/FoldersClient/update_folder.php
+++ b/ResourceManager/samples/V3/FoldersClient/update_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/OrganizationsClient/get_iam_policy.php
+++ b/ResourceManager/samples/V3/OrganizationsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/OrganizationsClient/get_organization.php
+++ b/ResourceManager/samples/V3/OrganizationsClient/get_organization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/OrganizationsClient/search_organizations.php
+++ b/ResourceManager/samples/V3/OrganizationsClient/search_organizations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/OrganizationsClient/set_iam_policy.php
+++ b/ResourceManager/samples/V3/OrganizationsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/OrganizationsClient/test_iam_permissions.php
+++ b/ResourceManager/samples/V3/OrganizationsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/create_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/create_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/delete_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/delete_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/get_iam_policy.php
+++ b/ResourceManager/samples/V3/ProjectsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/get_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/get_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/list_projects.php
+++ b/ResourceManager/samples/V3/ProjectsClient/list_projects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/move_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/move_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/search_projects.php
+++ b/ResourceManager/samples/V3/ProjectsClient/search_projects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/set_iam_policy.php
+++ b/ResourceManager/samples/V3/ProjectsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/test_iam_permissions.php
+++ b/ResourceManager/samples/V3/ProjectsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/undelete_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/undelete_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/ProjectsClient/update_project.php
+++ b/ResourceManager/samples/V3/ProjectsClient/update_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagBindingsClient/create_tag_binding.php
+++ b/ResourceManager/samples/V3/TagBindingsClient/create_tag_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagBindingsClient/delete_tag_binding.php
+++ b/ResourceManager/samples/V3/TagBindingsClient/delete_tag_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagBindingsClient/list_effective_tags.php
+++ b/ResourceManager/samples/V3/TagBindingsClient/list_effective_tags.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagBindingsClient/list_tag_bindings.php
+++ b/ResourceManager/samples/V3/TagBindingsClient/list_tag_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagHoldsClient/create_tag_hold.php
+++ b/ResourceManager/samples/V3/TagHoldsClient/create_tag_hold.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagHoldsClient/delete_tag_hold.php
+++ b/ResourceManager/samples/V3/TagHoldsClient/delete_tag_hold.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagHoldsClient/list_tag_holds.php
+++ b/ResourceManager/samples/V3/TagHoldsClient/list_tag_holds.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/create_tag_key.php
+++ b/ResourceManager/samples/V3/TagKeysClient/create_tag_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/delete_tag_key.php
+++ b/ResourceManager/samples/V3/TagKeysClient/delete_tag_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/get_iam_policy.php
+++ b/ResourceManager/samples/V3/TagKeysClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/get_namespaced_tag_key.php
+++ b/ResourceManager/samples/V3/TagKeysClient/get_namespaced_tag_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/get_tag_key.php
+++ b/ResourceManager/samples/V3/TagKeysClient/get_tag_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/list_tag_keys.php
+++ b/ResourceManager/samples/V3/TagKeysClient/list_tag_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/set_iam_policy.php
+++ b/ResourceManager/samples/V3/TagKeysClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/test_iam_permissions.php
+++ b/ResourceManager/samples/V3/TagKeysClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagKeysClient/update_tag_key.php
+++ b/ResourceManager/samples/V3/TagKeysClient/update_tag_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/create_tag_value.php
+++ b/ResourceManager/samples/V3/TagValuesClient/create_tag_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/delete_tag_value.php
+++ b/ResourceManager/samples/V3/TagValuesClient/delete_tag_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/get_iam_policy.php
+++ b/ResourceManager/samples/V3/TagValuesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/get_namespaced_tag_value.php
+++ b/ResourceManager/samples/V3/TagValuesClient/get_namespaced_tag_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/get_tag_value.php
+++ b/ResourceManager/samples/V3/TagValuesClient/get_tag_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/list_tag_values.php
+++ b/ResourceManager/samples/V3/TagValuesClient/list_tag_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/set_iam_policy.php
+++ b/ResourceManager/samples/V3/TagValuesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/test_iam_permissions.php
+++ b/ResourceManager/samples/V3/TagValuesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/samples/V3/TagValuesClient/update_tag_value.php
+++ b/ResourceManager/samples/V3/TagValuesClient/update_tag_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/FoldersClient.php
+++ b/ResourceManager/src/V3/Client/FoldersClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/OrganizationsClient.php
+++ b/ResourceManager/src/V3/Client/OrganizationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/ProjectsClient.php
+++ b/ResourceManager/src/V3/Client/ProjectsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/TagBindingsClient.php
+++ b/ResourceManager/src/V3/Client/TagBindingsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/TagHoldsClient.php
+++ b/ResourceManager/src/V3/Client/TagHoldsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/TagKeysClient.php
+++ b/ResourceManager/src/V3/Client/TagKeysClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/Client/TagValuesClient.php
+++ b/ResourceManager/src/V3/Client/TagValuesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/folders_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/folders_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/folders_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/folders_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/organizations_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/organizations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/organizations_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/organizations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/projects_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/projects_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/projects_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/projects_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_bindings_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/tag_bindings_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_bindings_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/tag_bindings_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_holds_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/tag_holds_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_holds_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/tag_holds_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_keys_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/tag_keys_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_keys_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/tag_keys_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_values_descriptor_config.php
+++ b/ResourceManager/src/V3/resources/tag_values_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/src/V3/resources/tag_values_rest_client_config.php
+++ b/ResourceManager/src/V3/resources/tag_values_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/FoldersClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/FoldersClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/OrganizationsClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/OrganizationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/ProjectsClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/ProjectsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/TagBindingsClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/TagBindingsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/TagHoldsClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/TagHoldsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/TagKeysClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/TagKeysClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ResourceManager/tests/Unit/V3/Client/TagValuesClientTest.php
+++ b/ResourceManager/tests/Unit/V3/Client/TagValuesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1048 generated files** in **29 in-scope packages** (NetApp through ResourceManager).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`NetApp`, `NetworkConnectivity`, `NetworkManagement`, `NetworkSecurity`, `NetworkServices`, `Notebooks`, `Optimization`, `OracleDatabase`, `OrchestrationAirflow`, `OrgPolicy`, `OsConfig`, `OsLogin`, `Parallelstore`, `ParameterManager`, `PolicySimulator`, `PolicyTroubleshooter`, `PolicyTroubleshooterIam`, `PrivateCatalog`, `PrivilegedAccessManager`, `Profiler`, `PubSub`, `Quotas`, `RapidMigrationAssessment`, `RecaptchaEnterprise`, `RecommendationEngine`, `Recommender`, `Redis`, `RedisCluster`, `ResourceManager`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-8
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 8 of 10 in the 2026 copyright update series.
