### PR TITLE
chore: update copyright years to 2026 for generated files (part 9: Retail to ShoppingMerchantDataSources)

### DIFF
--- a/Retail/owlbot.py
+++ b/Retail/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/AnalyticsServiceClient/export_analytics_metrics.php
+++ b/Retail/samples/V2/AnalyticsServiceClient/export_analytics_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/add_catalog_attribute.php
+++ b/Retail/samples/V2/CatalogServiceClient/add_catalog_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/get_attributes_config.php
+++ b/Retail/samples/V2/CatalogServiceClient/get_attributes_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/get_completion_config.php
+++ b/Retail/samples/V2/CatalogServiceClient/get_completion_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/get_default_branch.php
+++ b/Retail/samples/V2/CatalogServiceClient/get_default_branch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/list_catalogs.php
+++ b/Retail/samples/V2/CatalogServiceClient/list_catalogs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/remove_catalog_attribute.php
+++ b/Retail/samples/V2/CatalogServiceClient/remove_catalog_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/replace_catalog_attribute.php
+++ b/Retail/samples/V2/CatalogServiceClient/replace_catalog_attribute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/set_default_branch.php
+++ b/Retail/samples/V2/CatalogServiceClient/set_default_branch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/update_attributes_config.php
+++ b/Retail/samples/V2/CatalogServiceClient/update_attributes_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/update_catalog.php
+++ b/Retail/samples/V2/CatalogServiceClient/update_catalog.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CatalogServiceClient/update_completion_config.php
+++ b/Retail/samples/V2/CatalogServiceClient/update_completion_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CompletionServiceClient/complete_query.php
+++ b/Retail/samples/V2/CompletionServiceClient/complete_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/CompletionServiceClient/import_completion_data.php
+++ b/Retail/samples/V2/CompletionServiceClient/import_completion_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ControlServiceClient/create_control.php
+++ b/Retail/samples/V2/ControlServiceClient/create_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ControlServiceClient/delete_control.php
+++ b/Retail/samples/V2/ControlServiceClient/delete_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ControlServiceClient/get_control.php
+++ b/Retail/samples/V2/ControlServiceClient/get_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ControlServiceClient/list_controls.php
+++ b/Retail/samples/V2/ControlServiceClient/list_controls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ControlServiceClient/update_control.php
+++ b/Retail/samples/V2/ControlServiceClient/update_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ConversationalSearchServiceClient/conversational_search.php
+++ b/Retail/samples/V2/ConversationalSearchServiceClient/conversational_search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/GenerativeQuestionServiceClient/batch_update_generative_question_configs.php
+++ b/Retail/samples/V2/GenerativeQuestionServiceClient/batch_update_generative_question_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/GenerativeQuestionServiceClient/get_generative_questions_feature_config.php
+++ b/Retail/samples/V2/GenerativeQuestionServiceClient/get_generative_questions_feature_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/GenerativeQuestionServiceClient/list_generative_question_configs.php
+++ b/Retail/samples/V2/GenerativeQuestionServiceClient/list_generative_question_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/GenerativeQuestionServiceClient/update_generative_question_config.php
+++ b/Retail/samples/V2/GenerativeQuestionServiceClient/update_generative_question_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/GenerativeQuestionServiceClient/update_generative_questions_feature_config.php
+++ b/Retail/samples/V2/GenerativeQuestionServiceClient/update_generative_questions_feature_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/create_model.php
+++ b/Retail/samples/V2/ModelServiceClient/create_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/delete_model.php
+++ b/Retail/samples/V2/ModelServiceClient/delete_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/get_model.php
+++ b/Retail/samples/V2/ModelServiceClient/get_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/list_models.php
+++ b/Retail/samples/V2/ModelServiceClient/list_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/pause_model.php
+++ b/Retail/samples/V2/ModelServiceClient/pause_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/resume_model.php
+++ b/Retail/samples/V2/ModelServiceClient/resume_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/tune_model.php
+++ b/Retail/samples/V2/ModelServiceClient/tune_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ModelServiceClient/update_model.php
+++ b/Retail/samples/V2/ModelServiceClient/update_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/PredictionServiceClient/predict.php
+++ b/Retail/samples/V2/PredictionServiceClient/predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/add_fulfillment_places.php
+++ b/Retail/samples/V2/ProductServiceClient/add_fulfillment_places.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/add_local_inventories.php
+++ b/Retail/samples/V2/ProductServiceClient/add_local_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/create_product.php
+++ b/Retail/samples/V2/ProductServiceClient/create_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/delete_product.php
+++ b/Retail/samples/V2/ProductServiceClient/delete_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/get_product.php
+++ b/Retail/samples/V2/ProductServiceClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/import_products.php
+++ b/Retail/samples/V2/ProductServiceClient/import_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/list_products.php
+++ b/Retail/samples/V2/ProductServiceClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/purge_products.php
+++ b/Retail/samples/V2/ProductServiceClient/purge_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/remove_fulfillment_places.php
+++ b/Retail/samples/V2/ProductServiceClient/remove_fulfillment_places.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/remove_local_inventories.php
+++ b/Retail/samples/V2/ProductServiceClient/remove_local_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/set_inventory.php
+++ b/Retail/samples/V2/ProductServiceClient/set_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ProductServiceClient/update_product.php
+++ b/Retail/samples/V2/ProductServiceClient/update_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/SearchServiceClient/search.php
+++ b/Retail/samples/V2/SearchServiceClient/search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/add_control.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/add_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/create_serving_config.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/create_serving_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/delete_serving_config.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/delete_serving_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/get_serving_config.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/get_serving_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/list_serving_configs.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/list_serving_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/remove_control.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/remove_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/ServingConfigServiceClient/update_serving_config.php
+++ b/Retail/samples/V2/ServingConfigServiceClient/update_serving_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/UserEventServiceClient/collect_user_event.php
+++ b/Retail/samples/V2/UserEventServiceClient/collect_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/UserEventServiceClient/import_user_events.php
+++ b/Retail/samples/V2/UserEventServiceClient/import_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/UserEventServiceClient/purge_user_events.php
+++ b/Retail/samples/V2/UserEventServiceClient/purge_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/UserEventServiceClient/rejoin_user_events.php
+++ b/Retail/samples/V2/UserEventServiceClient/rejoin_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/samples/V2/UserEventServiceClient/write_user_event.php
+++ b/Retail/samples/V2/UserEventServiceClient/write_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/AnalyticsServiceClient.php
+++ b/Retail/src/V2/Client/AnalyticsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/CatalogServiceClient.php
+++ b/Retail/src/V2/Client/CatalogServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/CompletionServiceClient.php
+++ b/Retail/src/V2/Client/CompletionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/ControlServiceClient.php
+++ b/Retail/src/V2/Client/ControlServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/ConversationalSearchServiceClient.php
+++ b/Retail/src/V2/Client/ConversationalSearchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/GenerativeQuestionServiceClient.php
+++ b/Retail/src/V2/Client/GenerativeQuestionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/ModelServiceClient.php
+++ b/Retail/src/V2/Client/ModelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/PredictionServiceClient.php
+++ b/Retail/src/V2/Client/PredictionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/ProductServiceClient.php
+++ b/Retail/src/V2/Client/ProductServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/SearchServiceClient.php
+++ b/Retail/src/V2/Client/SearchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/ServingConfigServiceClient.php
+++ b/Retail/src/V2/Client/ServingConfigServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/Client/UserEventServiceClient.php
+++ b/Retail/src/V2/Client/UserEventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/analytics_service_descriptor_config.php
+++ b/Retail/src/V2/resources/analytics_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/analytics_service_rest_client_config.php
+++ b/Retail/src/V2/resources/analytics_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/catalog_service_descriptor_config.php
+++ b/Retail/src/V2/resources/catalog_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/catalog_service_rest_client_config.php
+++ b/Retail/src/V2/resources/catalog_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/completion_service_descriptor_config.php
+++ b/Retail/src/V2/resources/completion_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/completion_service_rest_client_config.php
+++ b/Retail/src/V2/resources/completion_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/control_service_descriptor_config.php
+++ b/Retail/src/V2/resources/control_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/control_service_rest_client_config.php
+++ b/Retail/src/V2/resources/control_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/conversational_search_service_descriptor_config.php
+++ b/Retail/src/V2/resources/conversational_search_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/conversational_search_service_rest_client_config.php
+++ b/Retail/src/V2/resources/conversational_search_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/generative_question_service_descriptor_config.php
+++ b/Retail/src/V2/resources/generative_question_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/generative_question_service_rest_client_config.php
+++ b/Retail/src/V2/resources/generative_question_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/model_service_descriptor_config.php
+++ b/Retail/src/V2/resources/model_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/model_service_rest_client_config.php
+++ b/Retail/src/V2/resources/model_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/prediction_service_descriptor_config.php
+++ b/Retail/src/V2/resources/prediction_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/prediction_service_rest_client_config.php
+++ b/Retail/src/V2/resources/prediction_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/product_service_descriptor_config.php
+++ b/Retail/src/V2/resources/product_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/product_service_rest_client_config.php
+++ b/Retail/src/V2/resources/product_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/search_service_descriptor_config.php
+++ b/Retail/src/V2/resources/search_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/search_service_rest_client_config.php
+++ b/Retail/src/V2/resources/search_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/serving_config_service_descriptor_config.php
+++ b/Retail/src/V2/resources/serving_config_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/serving_config_service_rest_client_config.php
+++ b/Retail/src/V2/resources/serving_config_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/user_event_service_descriptor_config.php
+++ b/Retail/src/V2/resources/user_event_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/src/V2/resources/user_event_service_rest_client_config.php
+++ b/Retail/src/V2/resources/user_event_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/AnalyticsServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/AnalyticsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/CatalogServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/CatalogServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/CompletionServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/CompletionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/ControlServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/ControlServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/ConversationalSearchServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/ConversationalSearchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/GenerativeQuestionServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/GenerativeQuestionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/ModelServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/ModelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/PredictionServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/PredictionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/ProductServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/ProductServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/SearchServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/SearchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/ServingConfigServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/ServingConfigServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Retail/tests/Unit/V2/Client/UserEventServiceClientTest.php
+++ b/Retail/tests/Unit/V2/Client/UserEventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/owlbot.py
+++ b/Run/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Run/samples/V2/BuildsClient/submit_build.php
+++ b/Run/samples/V2/BuildsClient/submit_build.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ExecutionsClient/cancel_execution.php
+++ b/Run/samples/V2/ExecutionsClient/cancel_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ExecutionsClient/delete_execution.php
+++ b/Run/samples/V2/ExecutionsClient/delete_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ExecutionsClient/get_execution.php
+++ b/Run/samples/V2/ExecutionsClient/get_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ExecutionsClient/list_executions.php
+++ b/Run/samples/V2/ExecutionsClient/list_executions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/create_job.php
+++ b/Run/samples/V2/JobsClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/delete_job.php
+++ b/Run/samples/V2/JobsClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/get_iam_policy.php
+++ b/Run/samples/V2/JobsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/get_job.php
+++ b/Run/samples/V2/JobsClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/list_jobs.php
+++ b/Run/samples/V2/JobsClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/run_job.php
+++ b/Run/samples/V2/JobsClient/run_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/set_iam_policy.php
+++ b/Run/samples/V2/JobsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/test_iam_permissions.php
+++ b/Run/samples/V2/JobsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/JobsClient/update_job.php
+++ b/Run/samples/V2/JobsClient/update_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/RevisionsClient/delete_revision.php
+++ b/Run/samples/V2/RevisionsClient/delete_revision.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/RevisionsClient/get_revision.php
+++ b/Run/samples/V2/RevisionsClient/get_revision.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/RevisionsClient/list_revisions.php
+++ b/Run/samples/V2/RevisionsClient/list_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/create_service.php
+++ b/Run/samples/V2/ServicesClient/create_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/delete_service.php
+++ b/Run/samples/V2/ServicesClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/get_iam_policy.php
+++ b/Run/samples/V2/ServicesClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/get_service.php
+++ b/Run/samples/V2/ServicesClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/list_services.php
+++ b/Run/samples/V2/ServicesClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/set_iam_policy.php
+++ b/Run/samples/V2/ServicesClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/test_iam_permissions.php
+++ b/Run/samples/V2/ServicesClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/ServicesClient/update_service.php
+++ b/Run/samples/V2/ServicesClient/update_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/TasksClient/get_task.php
+++ b/Run/samples/V2/TasksClient/get_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/TasksClient/list_tasks.php
+++ b/Run/samples/V2/TasksClient/list_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/create_worker_pool.php
+++ b/Run/samples/V2/WorkerPoolsClient/create_worker_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/delete_worker_pool.php
+++ b/Run/samples/V2/WorkerPoolsClient/delete_worker_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/get_iam_policy.php
+++ b/Run/samples/V2/WorkerPoolsClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/get_worker_pool.php
+++ b/Run/samples/V2/WorkerPoolsClient/get_worker_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/list_worker_pools.php
+++ b/Run/samples/V2/WorkerPoolsClient/list_worker_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/set_iam_policy.php
+++ b/Run/samples/V2/WorkerPoolsClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/test_iam_permissions.php
+++ b/Run/samples/V2/WorkerPoolsClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/samples/V2/WorkerPoolsClient/update_worker_pool.php
+++ b/Run/samples/V2/WorkerPoolsClient/update_worker_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/BuildsClient.php
+++ b/Run/src/V2/Client/BuildsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/ExecutionsClient.php
+++ b/Run/src/V2/Client/ExecutionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/JobsClient.php
+++ b/Run/src/V2/Client/JobsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/RevisionsClient.php
+++ b/Run/src/V2/Client/RevisionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/ServicesClient.php
+++ b/Run/src/V2/Client/ServicesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/TasksClient.php
+++ b/Run/src/V2/Client/TasksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/Client/WorkerPoolsClient.php
+++ b/Run/src/V2/Client/WorkerPoolsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/builds_descriptor_config.php
+++ b/Run/src/V2/resources/builds_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/builds_rest_client_config.php
+++ b/Run/src/V2/resources/builds_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/executions_descriptor_config.php
+++ b/Run/src/V2/resources/executions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/executions_rest_client_config.php
+++ b/Run/src/V2/resources/executions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/jobs_descriptor_config.php
+++ b/Run/src/V2/resources/jobs_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/jobs_rest_client_config.php
+++ b/Run/src/V2/resources/jobs_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/revisions_descriptor_config.php
+++ b/Run/src/V2/resources/revisions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/revisions_rest_client_config.php
+++ b/Run/src/V2/resources/revisions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/services_descriptor_config.php
+++ b/Run/src/V2/resources/services_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/services_rest_client_config.php
+++ b/Run/src/V2/resources/services_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/tasks_descriptor_config.php
+++ b/Run/src/V2/resources/tasks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/tasks_rest_client_config.php
+++ b/Run/src/V2/resources/tasks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/worker_pools_descriptor_config.php
+++ b/Run/src/V2/resources/worker_pools_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/src/V2/resources/worker_pools_rest_client_config.php
+++ b/Run/src/V2/resources/worker_pools_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/BuildsClientTest.php
+++ b/Run/tests/Unit/V2/Client/BuildsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/ExecutionsClientTest.php
+++ b/Run/tests/Unit/V2/Client/ExecutionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/JobsClientTest.php
+++ b/Run/tests/Unit/V2/Client/JobsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/RevisionsClientTest.php
+++ b/Run/tests/Unit/V2/Client/RevisionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/ServicesClientTest.php
+++ b/Run/tests/Unit/V2/Client/ServicesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/TasksClientTest.php
+++ b/Run/tests/Unit/V2/Client/TasksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Run/tests/Unit/V2/Client/WorkerPoolsClientTest.php
+++ b/Run/tests/Unit/V2/Client/WorkerPoolsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/owlbot.py
+++ b/Scheduler/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/create_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/delete_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/get_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/get_location.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/list_jobs.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/list_locations.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/pause_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/pause_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/resume_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/resume_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/run_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/run_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/samples/V1/CloudSchedulerClient/update_job.php
+++ b/Scheduler/samples/V1/CloudSchedulerClient/update_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/src/V1/Client/CloudSchedulerClient.php
+++ b/Scheduler/src/V1/Client/CloudSchedulerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/src/V1/resources/cloud_scheduler_descriptor_config.php
+++ b/Scheduler/src/V1/resources/cloud_scheduler_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/src/V1/resources/cloud_scheduler_rest_client_config.php
+++ b/Scheduler/src/V1/resources/cloud_scheduler_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scheduler/tests/Unit/V1/Client/CloudSchedulerClientTest.php
+++ b/Scheduler/tests/Unit/V1/Client/CloudSchedulerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/owlbot.py
+++ b/SecretManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/access_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/access_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/add_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/add_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/create_secret.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/create_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/delete_secret.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/delete_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/destroy_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/destroy_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/disable_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/disable_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/enable_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/enable_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/get_iam_policy.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/get_secret.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/get_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/get_secret_version.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/get_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/list_secret_versions.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/list_secret_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/list_secrets.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/list_secrets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/set_iam_policy.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/test_iam_permissions.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1/SecretManagerServiceClient/update_secret.php
+++ b/SecretManager/samples/V1/SecretManagerServiceClient/update_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/access_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/access_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/add_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/add_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/create_secret.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/create_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/delete_secret.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/delete_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/destroy_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/destroy_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/disable_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/disable_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/enable_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/enable_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_iam_policy.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_location.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_secret.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_secret_version.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/get_secret_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_locations.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_secret_versions.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_secret_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_secrets.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/list_secrets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/set_iam_policy.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/test_iam_permissions.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/samples/V1beta2/SecretManagerServiceClient/update_secret.php
+++ b/SecretManager/samples/V1beta2/SecretManagerServiceClient/update_secret.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1/Client/SecretManagerServiceClient.php
+++ b/SecretManager/src/V1/Client/SecretManagerServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1/resources/secret_manager_service_descriptor_config.php
+++ b/SecretManager/src/V1/resources/secret_manager_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1/resources/secret_manager_service_rest_client_config.php
+++ b/SecretManager/src/V1/resources/secret_manager_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1beta2/Client/SecretManagerServiceClient.php
+++ b/SecretManager/src/V1beta2/Client/SecretManagerServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1beta2/resources/secret_manager_service_descriptor_config.php
+++ b/SecretManager/src/V1beta2/resources/secret_manager_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/src/V1beta2/resources/secret_manager_service_rest_client_config.php
+++ b/SecretManager/src/V1beta2/resources/secret_manager_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/tests/Unit/V1/Client/SecretManagerServiceClientTest.php
+++ b/SecretManager/tests/Unit/V1/Client/SecretManagerServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecretManager/tests/Unit/V1beta2/Client/SecretManagerServiceClientTest.php
+++ b/SecretManager/tests/Unit/V1beta2/Client/SecretManagerServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/owlbot.py
+++ b/SecureSourceManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/batch_create_pull_request_comments.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/batch_create_pull_request_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/close_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/close_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/close_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/close_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_branch_rule.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_branch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_hook.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_hook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_instance.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_issue_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_issue_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_pull_request_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_pull_request_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_repository.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/create_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_branch_rule.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_branch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_hook.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_hook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_instance.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_issue_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_issue_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_pull_request_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_pull_request_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_repository.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/delete_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/fetch_blob.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/fetch_blob.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/fetch_tree.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/fetch_tree.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_branch_rule.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_branch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_hook.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_hook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_iam_policy.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_iam_policy_repo.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_iam_policy_repo.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_instance.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_issue_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_issue_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_location.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_pull_request_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_pull_request_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_repository.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/get_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_branch_rules.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_branch_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_hooks.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_hooks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_instances.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_issue_comments.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_issue_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_issues.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_issues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_locations.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_request_comments.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_request_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_request_file_diffs.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_request_file_diffs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_requests.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_pull_requests.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_repositories.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/list_repositories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/merge_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/merge_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/open_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/open_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/open_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/open_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/resolve_pull_request_comments.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/resolve_pull_request_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/set_iam_policy.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/set_iam_policy_repo.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/set_iam_policy_repo.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/test_iam_permissions.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/test_iam_permissions_repo.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/test_iam_permissions_repo.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/unresolve_pull_request_comments.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/unresolve_pull_request_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_branch_rule.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_branch_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_hook.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_hook.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_issue.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_issue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_issue_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_issue_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_pull_request.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_pull_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_pull_request_comment.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_pull_request_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_repository.php
+++ b/SecureSourceManager/samples/V1/SecureSourceManagerClient/update_repository.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/src/V1/Client/SecureSourceManagerClient.php
+++ b/SecureSourceManager/src/V1/Client/SecureSourceManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/src/V1/resources/secure_source_manager_descriptor_config.php
+++ b/SecureSourceManager/src/V1/resources/secure_source_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/src/V1/resources/secure_source_manager_rest_client_config.php
+++ b/SecureSourceManager/src/V1/resources/secure_source_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecureSourceManager/tests/Unit/V1/Client/SecureSourceManagerClientTest.php
+++ b/SecureSourceManager/tests/Unit/V1/Client/SecureSourceManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/owlbot.py
+++ b/SecurityCenter/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/batch_create_resource_value_configs.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/batch_create_resource_value_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/bulk_mute_findings.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/bulk_mute_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_big_query_export.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_finding.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_mute_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_notification_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/create_source.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/create_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_big_query_export.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_mute_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_notification_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_resource_value_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/delete_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/delete_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_big_query_export.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_effective_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_effective_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_effective_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_effective_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_iam_policy.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_mute_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_notification_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_organization_settings.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_organization_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_resource_value_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_simulation.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_simulation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_source.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/get_valued_resource.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/get_valued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/group_assets.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/group_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/group_findings.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/group_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_assets.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_attack_paths.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_attack_paths.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_big_query_exports.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_big_query_exports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_descendant_event_threat_detection_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_descendant_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_descendant_security_health_analytics_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_descendant_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_effective_event_threat_detection_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_effective_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_effective_security_health_analytics_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_effective_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_event_threat_detection_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_findings.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_mute_configs.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_mute_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_notification_configs.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_notification_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_resource_value_configs.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_resource_value_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_security_health_analytics_custom_modules.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_sources.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/list_valued_resources.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/list_valued_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/set_finding_state.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/set_finding_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/set_iam_policy.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/set_mute.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/set_mute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/simulate_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/simulate_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_big_query_export.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_external_system.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_external_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_finding.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_mute_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_notification_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_organization_settings.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_organization_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_resource_value_config.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_security_health_analytics_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_security_marks.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_security_marks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/update_source.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/update_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V1/SecurityCenterClient/validate_event_threat_detection_custom_module.php
+++ b/SecurityCenter/samples/V1/SecurityCenterClient/validate_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/batch_create_resource_value_configs.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/batch_create_resource_value_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/bulk_mute_findings.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/bulk_mute_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/create_big_query_export.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/create_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/create_finding.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/create_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/create_mute_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/create_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/create_notification_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/create_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/create_source.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/create_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/delete_big_query_export.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/delete_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/delete_mute_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/delete_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/delete_notification_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/delete_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/delete_resource_value_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/delete_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_big_query_export.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_iam_policy.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_mute_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_notification_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_resource_value_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_simulation.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_simulation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_source.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/get_valued_resource.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/get_valued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/group_findings.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/group_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_attack_paths.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_attack_paths.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_big_query_exports.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_big_query_exports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_findings.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_mute_configs.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_mute_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_notification_configs.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_notification_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_resource_value_configs.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_resource_value_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_sources.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/list_valued_resources.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/list_valued_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/set_finding_state.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/set_finding_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/set_iam_policy.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/set_mute.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/set_mute.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/test_iam_permissions.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_big_query_export.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_big_query_export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_external_system.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_external_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_finding.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_mute_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_mute_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_notification_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_resource_value_config.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_resource_value_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_security_marks.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_security_marks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/samples/V2/SecurityCenterClient/update_source.php
+++ b/SecurityCenter/samples/V2/SecurityCenterClient/update_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V1/Client/SecurityCenterClient.php
+++ b/SecurityCenter/src/V1/Client/SecurityCenterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V1/resources/security_center_descriptor_config.php
+++ b/SecurityCenter/src/V1/resources/security_center_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V1/resources/security_center_rest_client_config.php
+++ b/SecurityCenter/src/V1/resources/security_center_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V2/Client/SecurityCenterClient.php
+++ b/SecurityCenter/src/V2/Client/SecurityCenterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V2/resources/security_center_descriptor_config.php
+++ b/SecurityCenter/src/V2/resources/security_center_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/src/V2/resources/security_center_rest_client_config.php
+++ b/SecurityCenter/src/V2/resources/security_center_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/tests/Unit/V1/Client/SecurityCenterClientTest.php
+++ b/SecurityCenter/tests/Unit/V1/Client/SecurityCenterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenter/tests/Unit/V2/Client/SecurityCenterClientTest.php
+++ b/SecurityCenter/tests/Unit/V2/Client/SecurityCenterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/owlbot.py
+++ b/SecurityCenterManagement/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/create_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/create_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/create_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/create_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/delete_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/delete_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/delete_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/delete_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_effective_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_effective_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_effective_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_effective_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_location.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_security_center_service.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_security_center_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/get_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_descendant_event_threat_detection_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_descendant_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_descendant_security_health_analytics_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_descendant_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_effective_event_threat_detection_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_effective_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_effective_security_health_analytics_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_effective_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_event_threat_detection_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_event_threat_detection_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_locations.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_security_center_services.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_security_center_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_security_health_analytics_custom_modules.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/list_security_health_analytics_custom_modules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/simulate_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/simulate_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_security_center_service.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_security_center_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_security_health_analytics_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/update_security_health_analytics_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/validate_event_threat_detection_custom_module.php
+++ b/SecurityCenterManagement/samples/V1/SecurityCenterManagementClient/validate_event_threat_detection_custom_module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/src/V1/Client/SecurityCenterManagementClient.php
+++ b/SecurityCenterManagement/src/V1/Client/SecurityCenterManagementClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/src/V1/resources/security_center_management_descriptor_config.php
+++ b/SecurityCenterManagement/src/V1/resources/security_center_management_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/src/V1/resources/security_center_management_rest_client_config.php
+++ b/SecurityCenterManagement/src/V1/resources/security_center_management_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCenterManagement/tests/Unit/V1/Client/SecurityCenterManagementClientTest.php
+++ b/SecurityCenterManagement/tests/Unit/V1/Client/SecurityCenterManagementClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/owlbot.py
+++ b/SecurityCompliance/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/create_framework_audit.php
+++ b/SecurityCompliance/samples/V1/AuditClient/create_framework_audit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/generate_framework_audit_scope_report.php
+++ b/SecurityCompliance/samples/V1/AuditClient/generate_framework_audit_scope_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/get_framework_audit.php
+++ b/SecurityCompliance/samples/V1/AuditClient/get_framework_audit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/get_location.php
+++ b/SecurityCompliance/samples/V1/AuditClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/list_framework_audits.php
+++ b/SecurityCompliance/samples/V1/AuditClient/list_framework_audits.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/AuditClient/list_locations.php
+++ b/SecurityCompliance/samples/V1/AuditClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/calculate_effective_cm_enrollment.php
+++ b/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/calculate_effective_cm_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/get_location.php
+++ b/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/list_locations.php
+++ b/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/update_cm_enrollment.php
+++ b/SecurityCompliance/samples/V1/CmEnrollmentServiceClient/update_cm_enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/create_cloud_control.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/create_cloud_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/create_framework.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/create_framework.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/delete_cloud_control.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/delete_cloud_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/delete_framework.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/delete_framework.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/get_cloud_control.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/get_cloud_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/get_framework.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/get_framework.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/get_location.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/list_cloud_controls.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/list_cloud_controls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/list_frameworks.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/list_frameworks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/list_locations.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/update_cloud_control.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/update_cloud_control.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/ConfigClient/update_framework.php
+++ b/SecurityCompliance/samples/V1/ConfigClient/update_framework.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/create_framework_deployment.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/create_framework_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/delete_framework_deployment.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/delete_framework_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/get_cloud_control_deployment.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/get_cloud_control_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/get_framework_deployment.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/get_framework_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/get_location.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/list_cloud_control_deployments.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/list_cloud_control_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/list_framework_deployments.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/list_framework_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/DeploymentClient/list_locations.php
+++ b/SecurityCompliance/samples/V1/DeploymentClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/aggregate_framework_compliance_report.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/aggregate_framework_compliance_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/fetch_framework_compliance_report.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/fetch_framework_compliance_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/get_location.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/list_control_compliance_summaries.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/list_control_compliance_summaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/list_finding_summaries.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/list_finding_summaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/list_framework_compliance_summaries.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/list_framework_compliance_summaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/samples/V1/MonitoringClient/list_locations.php
+++ b/SecurityCompliance/samples/V1/MonitoringClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/Client/AuditClient.php
+++ b/SecurityCompliance/src/V1/Client/AuditClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/Client/CmEnrollmentServiceClient.php
+++ b/SecurityCompliance/src/V1/Client/CmEnrollmentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/Client/ConfigClient.php
+++ b/SecurityCompliance/src/V1/Client/ConfigClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/Client/DeploymentClient.php
+++ b/SecurityCompliance/src/V1/Client/DeploymentClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/Client/MonitoringClient.php
+++ b/SecurityCompliance/src/V1/Client/MonitoringClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/audit_descriptor_config.php
+++ b/SecurityCompliance/src/V1/resources/audit_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/audit_rest_client_config.php
+++ b/SecurityCompliance/src/V1/resources/audit_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/cm_enrollment_service_descriptor_config.php
+++ b/SecurityCompliance/src/V1/resources/cm_enrollment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/cm_enrollment_service_rest_client_config.php
+++ b/SecurityCompliance/src/V1/resources/cm_enrollment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/config_descriptor_config.php
+++ b/SecurityCompliance/src/V1/resources/config_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/config_rest_client_config.php
+++ b/SecurityCompliance/src/V1/resources/config_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/deployment_descriptor_config.php
+++ b/SecurityCompliance/src/V1/resources/deployment_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/deployment_rest_client_config.php
+++ b/SecurityCompliance/src/V1/resources/deployment_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/monitoring_descriptor_config.php
+++ b/SecurityCompliance/src/V1/resources/monitoring_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/src/V1/resources/monitoring_rest_client_config.php
+++ b/SecurityCompliance/src/V1/resources/monitoring_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/tests/Unit/V1/Client/AuditClientTest.php
+++ b/SecurityCompliance/tests/Unit/V1/Client/AuditClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/tests/Unit/V1/Client/CmEnrollmentServiceClientTest.php
+++ b/SecurityCompliance/tests/Unit/V1/Client/CmEnrollmentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/tests/Unit/V1/Client/ConfigClientTest.php
+++ b/SecurityCompliance/tests/Unit/V1/Client/ConfigClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/tests/Unit/V1/Client/DeploymentClientTest.php
+++ b/SecurityCompliance/tests/Unit/V1/Client/DeploymentClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityCompliance/tests/Unit/V1/Client/MonitoringClientTest.php
+++ b/SecurityCompliance/tests/Unit/V1/Client/MonitoringClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/owlbot.py
+++ b/SecurityPrivateCa/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/activate_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/activate_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_ca_pool.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_ca_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate_template.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/create_certificate_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_ca_pool.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_ca_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_certificate_template.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/delete_certificate_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/disable_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/disable_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/enable_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/enable_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/fetch_ca_certs.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/fetch_ca_certs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/fetch_certificate_authority_csr.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/fetch_certificate_authority_csr.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_ca_pool.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_ca_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_revocation_list.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_revocation_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_template.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_certificate_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_iam_policy.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_location.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_ca_pools.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_ca_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_authorities.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_authorities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_revocation_lists.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_revocation_lists.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_templates.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificate_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificates.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_certificates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_locations.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/revoke_certificate.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/revoke_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/set_iam_policy.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/test_iam_permissions.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/undelete_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/undelete_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_ca_pool.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_ca_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_authority.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_authority.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_revocation_list.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_revocation_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_template.php
+++ b/SecurityPrivateCa/samples/V1/CertificateAuthorityServiceClient/update_certificate_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/src/V1/Client/CertificateAuthorityServiceClient.php
+++ b/SecurityPrivateCa/src/V1/Client/CertificateAuthorityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/src/V1/resources/certificate_authority_service_descriptor_config.php
+++ b/SecurityPrivateCa/src/V1/resources/certificate_authority_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/src/V1/resources/certificate_authority_service_rest_client_config.php
+++ b/SecurityPrivateCa/src/V1/resources/certificate_authority_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPrivateCa/tests/Unit/V1/Client/CertificateAuthorityServiceClientTest.php
+++ b/SecurityPrivateCa/tests/Unit/V1/Client/CertificateAuthorityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/owlbot.py
+++ b/SecurityPublicCA/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/samples/V1/PublicCertificateAuthorityServiceClient/create_external_account_key.php
+++ b/SecurityPublicCA/samples/V1/PublicCertificateAuthorityServiceClient/create_external_account_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/src/V1/Client/PublicCertificateAuthorityServiceClient.php
+++ b/SecurityPublicCA/src/V1/Client/PublicCertificateAuthorityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/src/V1/resources/public_certificate_authority_service_descriptor_config.php
+++ b/SecurityPublicCA/src/V1/resources/public_certificate_authority_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/src/V1/resources/public_certificate_authority_service_rest_client_config.php
+++ b/SecurityPublicCA/src/V1/resources/public_certificate_authority_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SecurityPublicCA/tests/Unit/V1/Client/PublicCertificateAuthorityServiceClientTest.php
+++ b/SecurityPublicCA/tests/Unit/V1/Client/PublicCertificateAuthorityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/owlbot.py
+++ b/ServiceControl/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ServiceControl/samples/V1/QuotaControllerClient/allocate_quota.php
+++ b/ServiceControl/samples/V1/QuotaControllerClient/allocate_quota.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/samples/V1/ServiceControllerClient/check.php
+++ b/ServiceControl/samples/V1/ServiceControllerClient/check.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/samples/V1/ServiceControllerClient/report.php
+++ b/ServiceControl/samples/V1/ServiceControllerClient/report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/Client/QuotaControllerClient.php
+++ b/ServiceControl/src/V1/Client/QuotaControllerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/Client/ServiceControllerClient.php
+++ b/ServiceControl/src/V1/Client/ServiceControllerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/resources/quota_controller_descriptor_config.php
+++ b/ServiceControl/src/V1/resources/quota_controller_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/resources/quota_controller_rest_client_config.php
+++ b/ServiceControl/src/V1/resources/quota_controller_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/resources/service_controller_descriptor_config.php
+++ b/ServiceControl/src/V1/resources/service_controller_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/src/V1/resources/service_controller_rest_client_config.php
+++ b/ServiceControl/src/V1/resources/service_controller_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/tests/Unit/V1/Client/QuotaControllerClientTest.php
+++ b/ServiceControl/tests/Unit/V1/Client/QuotaControllerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceControl/tests/Unit/V1/Client/ServiceControllerClientTest.php
+++ b/ServiceControl/tests/Unit/V1/Client/ServiceControllerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/owlbot.py
+++ b/ServiceDirectory/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/LookupServiceClient/get_location.php
+++ b/ServiceDirectory/samples/V1/LookupServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/LookupServiceClient/list_locations.php
+++ b/ServiceDirectory/samples/V1/LookupServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/LookupServiceClient/resolve_service.php
+++ b/ServiceDirectory/samples/V1/LookupServiceClient/resolve_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/create_endpoint.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/create_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/create_namespace.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/create_namespace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/create_service.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/create_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_endpoint.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_namespace.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_namespace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_service.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/get_endpoint.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/get_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/get_iam_policy.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/get_location.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/get_namespace.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/get_namespace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/get_service.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/list_endpoints.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/list_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/list_locations.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/list_namespaces.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/list_namespaces.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/list_services.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/set_iam_policy.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/test_iam_permissions.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/update_endpoint.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/update_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/update_namespace.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/update_namespace.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/samples/V1/RegistrationServiceClient/update_service.php
+++ b/ServiceDirectory/samples/V1/RegistrationServiceClient/update_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/Client/LookupServiceClient.php
+++ b/ServiceDirectory/src/V1/Client/LookupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/Client/RegistrationServiceClient.php
+++ b/ServiceDirectory/src/V1/Client/RegistrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/resources/lookup_service_descriptor_config.php
+++ b/ServiceDirectory/src/V1/resources/lookup_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/resources/lookup_service_rest_client_config.php
+++ b/ServiceDirectory/src/V1/resources/lookup_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/resources/registration_service_descriptor_config.php
+++ b/ServiceDirectory/src/V1/resources/registration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/src/V1/resources/registration_service_rest_client_config.php
+++ b/ServiceDirectory/src/V1/resources/registration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/tests/Unit/V1/Client/LookupServiceClientTest.php
+++ b/ServiceDirectory/tests/Unit/V1/Client/LookupServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceDirectory/tests/Unit/V1/Client/RegistrationServiceClientTest.php
+++ b/ServiceDirectory/tests/Unit/V1/Client/RegistrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/owlbot.py
+++ b/ServiceHealth/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/get_event.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/get_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/get_location.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/get_organization_event.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/get_organization_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/get_organization_impact.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/get_organization_impact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/list_events.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/list_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/list_locations.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/list_organization_events.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/list_organization_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/samples/V1/ServiceHealthClient/list_organization_impacts.php
+++ b/ServiceHealth/samples/V1/ServiceHealthClient/list_organization_impacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/src/V1/Client/ServiceHealthClient.php
+++ b/ServiceHealth/src/V1/Client/ServiceHealthClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/src/V1/resources/service_health_descriptor_config.php
+++ b/ServiceHealth/src/V1/resources/service_health_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/src/V1/resources/service_health_rest_client_config.php
+++ b/ServiceHealth/src/V1/resources/service_health_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceHealth/tests/Unit/V1/Client/ServiceHealthClientTest.php
+++ b/ServiceHealth/tests/Unit/V1/Client/ServiceHealthClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/owlbot.py
+++ b/ServiceManagement/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/create_service.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/create_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/create_service_config.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/create_service_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/create_service_rollout.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/create_service_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/delete_service.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/delete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/generate_config_report.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/generate_config_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/get_iam_policy.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/get_service.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/get_service_config.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/get_service_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/get_service_rollout.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/get_service_rollout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/list_service_configs.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/list_service_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/list_service_rollouts.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/list_service_rollouts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/list_services.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/set_iam_policy.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/submit_config_source.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/submit_config_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/test_iam_permissions.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/samples/V1/ServiceManagerClient/undelete_service.php
+++ b/ServiceManagement/samples/V1/ServiceManagerClient/undelete_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/src/V1/Client/ServiceManagerClient.php
+++ b/ServiceManagement/src/V1/Client/ServiceManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/src/V1/resources/service_manager_descriptor_config.php
+++ b/ServiceManagement/src/V1/resources/service_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/src/V1/resources/service_manager_rest_client_config.php
+++ b/ServiceManagement/src/V1/resources/service_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceManagement/tests/Unit/V1/Client/ServiceManagerClientTest.php
+++ b/ServiceManagement/tests/Unit/V1/Client/ServiceManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/owlbot.py
+++ b/ServiceUsage/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/batch_enable_services.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/batch_enable_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/batch_get_services.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/batch_get_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/disable_service.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/disable_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/enable_service.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/enable_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/get_service.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/get_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/samples/V1/ServiceUsageClient/list_services.php
+++ b/ServiceUsage/samples/V1/ServiceUsageClient/list_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/src/V1/Client/ServiceUsageClient.php
+++ b/ServiceUsage/src/V1/Client/ServiceUsageClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/src/V1/resources/service_usage_descriptor_config.php
+++ b/ServiceUsage/src/V1/resources/service_usage_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/src/V1/resources/service_usage_rest_client_config.php
+++ b/ServiceUsage/src/V1/resources/service_usage_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ServiceUsage/tests/Unit/V1/Client/ServiceUsageClientTest.php
+++ b/ServiceUsage/tests/Unit/V1/Client/ServiceUsageClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/owlbot.py
+++ b/Shell/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Shell/samples/V1/CloudShellServiceClient/add_public_key.php
+++ b/Shell/samples/V1/CloudShellServiceClient/add_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/samples/V1/CloudShellServiceClient/authorize_environment.php
+++ b/Shell/samples/V1/CloudShellServiceClient/authorize_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/samples/V1/CloudShellServiceClient/get_environment.php
+++ b/Shell/samples/V1/CloudShellServiceClient/get_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/samples/V1/CloudShellServiceClient/remove_public_key.php
+++ b/Shell/samples/V1/CloudShellServiceClient/remove_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/samples/V1/CloudShellServiceClient/start_environment.php
+++ b/Shell/samples/V1/CloudShellServiceClient/start_environment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/src/V1/Client/CloudShellServiceClient.php
+++ b/Shell/src/V1/Client/CloudShellServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/src/V1/resources/cloud_shell_service_descriptor_config.php
+++ b/Shell/src/V1/resources/cloud_shell_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/src/V1/resources/cloud_shell_service_rest_client_config.php
+++ b/Shell/src/V1/resources/cloud_shell_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Shell/tests/Unit/V1/Client/CloudShellServiceClientTest.php
+++ b/Shell/tests/Unit/V1/Client/CloudShellServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCommonProtos/owlbot.py
+++ b/ShoppingCommonProtos/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingCommonProtos/tests/Unit/InstantiateClassesTest.php
+++ b/ShoppingCommonProtos/tests/Unit/InstantiateClassesTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/owlbot.py
+++ b/ShoppingCss/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountLabelsServiceClient/create_account_label.php
+++ b/ShoppingCss/samples/V1/AccountLabelsServiceClient/create_account_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountLabelsServiceClient/delete_account_label.php
+++ b/ShoppingCss/samples/V1/AccountLabelsServiceClient/delete_account_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountLabelsServiceClient/list_account_labels.php
+++ b/ShoppingCss/samples/V1/AccountLabelsServiceClient/list_account_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountLabelsServiceClient/update_account_label.php
+++ b/ShoppingCss/samples/V1/AccountLabelsServiceClient/update_account_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountsServiceClient/get_account.php
+++ b/ShoppingCss/samples/V1/AccountsServiceClient/get_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountsServiceClient/list_child_accounts.php
+++ b/ShoppingCss/samples/V1/AccountsServiceClient/list_child_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/AccountsServiceClient/update_labels.php
+++ b/ShoppingCss/samples/V1/AccountsServiceClient/update_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/CssProductInputsServiceClient/delete_css_product_input.php
+++ b/ShoppingCss/samples/V1/CssProductInputsServiceClient/delete_css_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/CssProductInputsServiceClient/insert_css_product_input.php
+++ b/ShoppingCss/samples/V1/CssProductInputsServiceClient/insert_css_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/CssProductInputsServiceClient/update_css_product_input.php
+++ b/ShoppingCss/samples/V1/CssProductInputsServiceClient/update_css_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/CssProductsServiceClient/get_css_product.php
+++ b/ShoppingCss/samples/V1/CssProductsServiceClient/get_css_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/CssProductsServiceClient/list_css_products.php
+++ b/ShoppingCss/samples/V1/CssProductsServiceClient/list_css_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/samples/V1/QuotaServiceClient/list_quota_groups.php
+++ b/ShoppingCss/samples/V1/QuotaServiceClient/list_quota_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/Client/AccountLabelsServiceClient.php
+++ b/ShoppingCss/src/V1/Client/AccountLabelsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/Client/AccountsServiceClient.php
+++ b/ShoppingCss/src/V1/Client/AccountsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/Client/CssProductInputsServiceClient.php
+++ b/ShoppingCss/src/V1/Client/CssProductInputsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/Client/CssProductsServiceClient.php
+++ b/ShoppingCss/src/V1/Client/CssProductsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/Client/QuotaServiceClient.php
+++ b/ShoppingCss/src/V1/Client/QuotaServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/account_labels_service_descriptor_config.php
+++ b/ShoppingCss/src/V1/resources/account_labels_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/account_labels_service_rest_client_config.php
+++ b/ShoppingCss/src/V1/resources/account_labels_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/accounts_service_descriptor_config.php
+++ b/ShoppingCss/src/V1/resources/accounts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/accounts_service_rest_client_config.php
+++ b/ShoppingCss/src/V1/resources/accounts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/css_product_inputs_service_descriptor_config.php
+++ b/ShoppingCss/src/V1/resources/css_product_inputs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/css_product_inputs_service_rest_client_config.php
+++ b/ShoppingCss/src/V1/resources/css_product_inputs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/css_products_service_descriptor_config.php
+++ b/ShoppingCss/src/V1/resources/css_products_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/css_products_service_rest_client_config.php
+++ b/ShoppingCss/src/V1/resources/css_products_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/quota_service_descriptor_config.php
+++ b/ShoppingCss/src/V1/resources/quota_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/src/V1/resources/quota_service_rest_client_config.php
+++ b/ShoppingCss/src/V1/resources/quota_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/tests/Unit/V1/Client/AccountLabelsServiceClientTest.php
+++ b/ShoppingCss/tests/Unit/V1/Client/AccountLabelsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/tests/Unit/V1/Client/AccountsServiceClientTest.php
+++ b/ShoppingCss/tests/Unit/V1/Client/AccountsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/tests/Unit/V1/Client/CssProductInputsServiceClientTest.php
+++ b/ShoppingCss/tests/Unit/V1/Client/CssProductInputsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/tests/Unit/V1/Client/CssProductsServiceClientTest.php
+++ b/ShoppingCss/tests/Unit/V1/Client/CssProductsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingCss/tests/Unit/V1/Client/QuotaServiceClientTest.php
+++ b/ShoppingCss/tests/Unit/V1/Client/QuotaServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/owlbot.py
+++ b/ShoppingMerchantAccounts/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountIssueServiceClient/list_account_issues.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountIssueServiceClient/list_account_issues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/get_account_relationship.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/get_account_relationship.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/list_account_relationships.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/list_account_relationships.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/update_account_relationship.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountRelationshipsServiceClient/update_account_relationship.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/approve_account_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/approve_account_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/get_account_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/get_account_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/list_account_services.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/list_account_services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/propose_account_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/propose_account_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/reject_account_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountServicesServiceClient/reject_account_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/create_and_configure_account.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/create_and_configure_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/delete_account.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/delete_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/get_account.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/get_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/list_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/list_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/list_sub_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/list_sub_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/update_account.php
+++ b/ShoppingMerchantAccounts/samples/V1/AccountsServiceClient/update_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AutofeedSettingsServiceClient/get_autofeed_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/AutofeedSettingsServiceClient/get_autofeed_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AutofeedSettingsServiceClient/update_autofeed_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/AutofeedSettingsServiceClient/update_autofeed_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AutomaticImprovementsServiceClient/get_automatic_improvements.php
+++ b/ShoppingMerchantAccounts/samples/V1/AutomaticImprovementsServiceClient/get_automatic_improvements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/AutomaticImprovementsServiceClient/update_automatic_improvements.php
+++ b/ShoppingMerchantAccounts/samples/V1/AutomaticImprovementsServiceClient/update_automatic_improvements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/BusinessIdentityServiceClient/get_business_identity.php
+++ b/ShoppingMerchantAccounts/samples/V1/BusinessIdentityServiceClient/get_business_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/BusinessIdentityServiceClient/update_business_identity.php
+++ b/ShoppingMerchantAccounts/samples/V1/BusinessIdentityServiceClient/update_business_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/BusinessInfoServiceClient/get_business_info.php
+++ b/ShoppingMerchantAccounts/samples/V1/BusinessInfoServiceClient/get_business_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/BusinessInfoServiceClient/update_business_info.php
+++ b/ShoppingMerchantAccounts/samples/V1/BusinessInfoServiceClient/update_business_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/create_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/create_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/delete_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/delete_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/get_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/get_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/update_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/CheckoutSettingsServiceClient/update_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/get_account_for_gcp_registration.php
+++ b/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/get_account_for_gcp_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/get_developer_registration.php
+++ b/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/get_developer_registration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/register_gcp.php
+++ b/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/register_gcp.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/unregister_gcp.php
+++ b/ShoppingMerchantAccounts/samples/V1/DeveloperRegistrationServiceClient/unregister_gcp.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/EmailPreferencesServiceClient/get_email_preferences.php
+++ b/ShoppingMerchantAccounts/samples/V1/EmailPreferencesServiceClient/get_email_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/EmailPreferencesServiceClient/update_email_preferences.php
+++ b/ShoppingMerchantAccounts/samples/V1/EmailPreferencesServiceClient/update_email_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/GbpAccountsServiceClient/link_gbp_account.php
+++ b/ShoppingMerchantAccounts/samples/V1/GbpAccountsServiceClient/link_gbp_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/GbpAccountsServiceClient/list_gbp_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1/GbpAccountsServiceClient/list_gbp_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/claim_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/claim_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/get_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/get_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/unclaim_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/unclaim_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/update_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1/HomepageServiceClient/update_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/LfpProvidersServiceClient/find_lfp_providers.php
+++ b/ShoppingMerchantAccounts/samples/V1/LfpProvidersServiceClient/find_lfp_providers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/LfpProvidersServiceClient/link_lfp_provider.php
+++ b/ShoppingMerchantAccounts/samples/V1/LfpProvidersServiceClient/link_lfp_provider.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/create_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/create_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/get_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/get_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/list_omnichannel_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/list_omnichannel_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/request_inventory_verification.php
+++ b/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/request_inventory_verification.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/update_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1/OmnichannelSettingsServiceClient/update_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/create_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/create_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/delete_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/delete_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/get_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/get_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/list_online_return_policies.php
+++ b/ShoppingMerchantAccounts/samples/V1/OnlineReturnPolicyServiceClient/list_online_return_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/disable_program.php
+++ b/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/disable_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/enable_program.php
+++ b/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/enable_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/get_program.php
+++ b/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/get_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/list_programs.php
+++ b/ShoppingMerchantAccounts/samples/V1/ProgramsServiceClient/list_programs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_create_regions.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_create_regions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_delete_regions.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_delete_regions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_update_regions.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/batch_update_regions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/create_region.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/create_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/delete_region.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/delete_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/get_region.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/get_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/list_regions.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/list_regions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/update_region.php
+++ b/ShoppingMerchantAccounts/samples/V1/RegionsServiceClient/update_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ShippingSettingsServiceClient/get_shipping_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/ShippingSettingsServiceClient/get_shipping_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/ShippingSettingsServiceClient/insert_shipping_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1/ShippingSettingsServiceClient/insert_shipping_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/TermsOfServiceAgreementStateServiceClient/get_terms_of_service_agreement_state.php
+++ b/ShoppingMerchantAccounts/samples/V1/TermsOfServiceAgreementStateServiceClient/get_terms_of_service_agreement_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/TermsOfServiceAgreementStateServiceClient/retrieve_for_application_terms_of_service_agreement_state.php
+++ b/ShoppingMerchantAccounts/samples/V1/TermsOfServiceAgreementStateServiceClient/retrieve_for_application_terms_of_service_agreement_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/accept_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/accept_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/get_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/get_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/retrieve_latest_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1/TermsOfServiceServiceClient/retrieve_latest_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/create_user.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/create_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/delete_user.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/delete_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/get_user.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/get_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/list_users.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/list_users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/update_user.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/update_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1/UserServiceClient/verify_self.php
+++ b/ShoppingMerchantAccounts/samples/V1/UserServiceClient/verify_self.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountIssueServiceClient/list_account_issues.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountIssueServiceClient/list_account_issues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/get_account_tax.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/get_account_tax.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/list_account_tax.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/list_account_tax.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/update_account_tax.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountTaxServiceClient/update_account_tax.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/create_and_configure_account.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/create_and_configure_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/delete_account.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/delete_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/get_account.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/get_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/list_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/list_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/list_sub_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/list_sub_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/update_account.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AccountsServiceClient/update_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AutofeedSettingsServiceClient/get_autofeed_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AutofeedSettingsServiceClient/get_autofeed_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AutofeedSettingsServiceClient/update_autofeed_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AutofeedSettingsServiceClient/update_autofeed_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AutomaticImprovementsServiceClient/get_automatic_improvements.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AutomaticImprovementsServiceClient/get_automatic_improvements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/AutomaticImprovementsServiceClient/update_automatic_improvements.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/AutomaticImprovementsServiceClient/update_automatic_improvements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/BusinessIdentityServiceClient/get_business_identity.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/BusinessIdentityServiceClient/get_business_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/BusinessIdentityServiceClient/update_business_identity.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/BusinessIdentityServiceClient/update_business_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/BusinessInfoServiceClient/get_business_info.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/BusinessInfoServiceClient/get_business_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/BusinessInfoServiceClient/update_business_info.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/BusinessInfoServiceClient/update_business_info.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/create_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/create_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/delete_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/delete_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/get_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/get_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/update_checkout_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/CheckoutSettingsServiceClient/update_checkout_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/EmailPreferencesServiceClient/get_email_preferences.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/EmailPreferencesServiceClient/get_email_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/EmailPreferencesServiceClient/update_email_preferences.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/EmailPreferencesServiceClient/update_email_preferences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/GbpAccountsServiceClient/link_gbp_account.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/GbpAccountsServiceClient/link_gbp_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/GbpAccountsServiceClient/list_gbp_accounts.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/GbpAccountsServiceClient/list_gbp_accounts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/claim_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/claim_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/get_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/get_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/unclaim_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/unclaim_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/update_homepage.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/HomepageServiceClient/update_homepage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/LfpProvidersServiceClient/find_lfp_providers.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/LfpProvidersServiceClient/find_lfp_providers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/LfpProvidersServiceClient/link_lfp_provider.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/LfpProvidersServiceClient/link_lfp_provider.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/create_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/create_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/get_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/get_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/list_omnichannel_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/list_omnichannel_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/request_inventory_verification.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/request_inventory_verification.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/update_omnichannel_setting.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OmnichannelSettingsServiceClient/update_omnichannel_setting.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/create_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/create_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/delete_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/delete_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/get_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/get_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/list_online_return_policies.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/list_online_return_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/update_online_return_policy.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/OnlineReturnPolicyServiceClient/update_online_return_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/disable_program.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/disable_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/enable_program.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/enable_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/get_program.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/get_program.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/list_programs.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ProgramsServiceClient/list_programs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/create_region.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/create_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/delete_region.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/delete_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/get_region.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/get_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/list_regions.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/list_regions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/update_region.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/RegionsServiceClient/update_region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ShippingSettingsServiceClient/get_shipping_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ShippingSettingsServiceClient/get_shipping_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/ShippingSettingsServiceClient/insert_shipping_settings.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/ShippingSettingsServiceClient/insert_shipping_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceAgreementStateServiceClient/get_terms_of_service_agreement_state.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceAgreementStateServiceClient/get_terms_of_service_agreement_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceAgreementStateServiceClient/retrieve_for_application_terms_of_service_agreement_state.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceAgreementStateServiceClient/retrieve_for_application_terms_of_service_agreement_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/accept_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/accept_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/get_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/get_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/retrieve_latest_terms_of_service.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/TermsOfServiceServiceClient/retrieve_latest_terms_of_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/create_user.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/create_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/delete_user.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/delete_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/get_user.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/get_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/list_users.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/list_users.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/update_user.php
+++ b/ShoppingMerchantAccounts/samples/V1beta/UserServiceClient/update_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AccountIssueServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AccountIssueServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AccountRelationshipsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AccountRelationshipsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AccountServicesServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AccountServicesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AccountsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AccountsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AutofeedSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AutofeedSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/AutomaticImprovementsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/AutomaticImprovementsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/BusinessIdentityServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/BusinessIdentityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/BusinessInfoServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/BusinessInfoServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/CheckoutSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/CheckoutSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/DeveloperRegistrationServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/DeveloperRegistrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/EmailPreferencesServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/EmailPreferencesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/GbpAccountsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/GbpAccountsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/HomepageServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/HomepageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/LfpProvidersServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/LfpProvidersServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/OmnichannelSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/OmnichannelSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/OnlineReturnPolicyServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/OnlineReturnPolicyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/ProgramsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/ProgramsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/RegionsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/RegionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/ShippingSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/ShippingSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/TermsOfServiceAgreementStateServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/TermsOfServiceAgreementStateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/TermsOfServiceServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/TermsOfServiceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/Client/UserServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1/Client/UserServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_issue_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_issue_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_issue_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_issue_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_relationships_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_relationships_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_relationships_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_relationships_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_services_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_services_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/account_services_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/account_services_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/accounts_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/accounts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/accounts_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/accounts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/autofeed_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/autofeed_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/autofeed_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/autofeed_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/automatic_improvements_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/automatic_improvements_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/automatic_improvements_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/automatic_improvements_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/business_identity_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/business_identity_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/business_identity_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/business_identity_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/business_info_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/business_info_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/business_info_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/business_info_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/checkout_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/checkout_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/checkout_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/checkout_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/developer_registration_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/developer_registration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/developer_registration_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/developer_registration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/email_preferences_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/email_preferences_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/email_preferences_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/email_preferences_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/gbp_accounts_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/gbp_accounts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/gbp_accounts_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/gbp_accounts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/homepage_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/homepage_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/homepage_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/homepage_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/lfp_providers_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/lfp_providers_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/lfp_providers_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/lfp_providers_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/omnichannel_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/omnichannel_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/omnichannel_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/omnichannel_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/online_return_policy_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/online_return_policy_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/online_return_policy_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/online_return_policy_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/programs_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/programs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/programs_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/programs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/regions_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/regions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/regions_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/regions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/shipping_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/shipping_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/shipping_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/shipping_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_agreement_state_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_agreement_state_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_agreement_state_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_agreement_state_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/terms_of_service_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/user_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/user_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1/resources/user_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1/resources/user_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/AccountIssueServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/AccountIssueServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/AccountTaxServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/AccountTaxServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/AccountsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/AccountsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/AutofeedSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/AutofeedSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/AutomaticImprovementsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/AutomaticImprovementsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/BusinessIdentityServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/BusinessIdentityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/BusinessInfoServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/BusinessInfoServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/CheckoutSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/CheckoutSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/EmailPreferencesServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/EmailPreferencesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/GbpAccountsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/GbpAccountsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/HomepageServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/HomepageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/LfpProvidersServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/LfpProvidersServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/OmnichannelSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/OmnichannelSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/OnlineReturnPolicyServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/OnlineReturnPolicyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/ProgramsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/ProgramsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/RegionsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/RegionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/ShippingSettingsServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/ShippingSettingsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/TermsOfServiceAgreementStateServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/TermsOfServiceAgreementStateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/TermsOfServiceServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/TermsOfServiceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/Client/UserServiceClient.php
+++ b/ShoppingMerchantAccounts/src/V1beta/Client/UserServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/account_issue_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/account_issue_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/account_issue_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/account_issue_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/account_tax_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/account_tax_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/account_tax_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/account_tax_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/accounts_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/accounts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/accounts_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/accounts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/autofeed_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/autofeed_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/autofeed_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/autofeed_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/automatic_improvements_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/automatic_improvements_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/automatic_improvements_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/automatic_improvements_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/business_identity_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/business_identity_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/business_identity_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/business_identity_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/business_info_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/business_info_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/business_info_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/business_info_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/checkout_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/checkout_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/checkout_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/checkout_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/email_preferences_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/email_preferences_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/email_preferences_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/email_preferences_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/gbp_accounts_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/gbp_accounts_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/gbp_accounts_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/gbp_accounts_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/homepage_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/homepage_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/homepage_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/homepage_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/lfp_providers_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/lfp_providers_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/lfp_providers_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/lfp_providers_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/omnichannel_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/omnichannel_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/omnichannel_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/omnichannel_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/online_return_policy_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/online_return_policy_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/online_return_policy_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/online_return_policy_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/programs_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/programs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/programs_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/programs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/regions_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/regions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/regions_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/regions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/shipping_settings_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/shipping_settings_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/shipping_settings_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/shipping_settings_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_agreement_state_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_agreement_state_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_agreement_state_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_agreement_state_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/terms_of_service_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/user_service_descriptor_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/user_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/src/V1beta/resources/user_service_rest_client_config.php
+++ b/ShoppingMerchantAccounts/src/V1beta/resources/user_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountIssueServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountIssueServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountRelationshipsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountRelationshipsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountServicesServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountServicesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AccountsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AutofeedSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AutofeedSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/AutomaticImprovementsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/AutomaticImprovementsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/BusinessIdentityServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/BusinessIdentityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/BusinessInfoServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/BusinessInfoServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/CheckoutSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/CheckoutSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/DeveloperRegistrationServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/DeveloperRegistrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/EmailPreferencesServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/EmailPreferencesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/GbpAccountsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/GbpAccountsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/HomepageServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/HomepageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/LfpProvidersServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/LfpProvidersServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/OmnichannelSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/OmnichannelSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/OnlineReturnPolicyServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/OnlineReturnPolicyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/ProgramsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/ProgramsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/RegionsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/RegionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/ShippingSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/ShippingSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/TermsOfServiceAgreementStateServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/TermsOfServiceAgreementStateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/TermsOfServiceServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/TermsOfServiceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1/Client/UserServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1/Client/UserServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountIssueServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountIssueServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountTaxServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountTaxServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AccountsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AutofeedSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AutofeedSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AutomaticImprovementsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/AutomaticImprovementsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/BusinessIdentityServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/BusinessIdentityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/BusinessInfoServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/BusinessInfoServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/CheckoutSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/CheckoutSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/EmailPreferencesServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/EmailPreferencesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/GbpAccountsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/GbpAccountsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/HomepageServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/HomepageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/LfpProvidersServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/LfpProvidersServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/OmnichannelSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/OmnichannelSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/OnlineReturnPolicyServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/OnlineReturnPolicyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/ProgramsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/ProgramsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/RegionsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/RegionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/ShippingSettingsServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/ShippingSettingsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/TermsOfServiceAgreementStateServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/TermsOfServiceAgreementStateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/TermsOfServiceServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/TermsOfServiceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/UserServiceClientTest.php
+++ b/ShoppingMerchantAccounts/tests/Unit/V1beta/Client/UserServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/owlbot.py
+++ b/ShoppingMerchantConversions/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/create_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/create_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/delete_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/delete_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/get_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/get_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/list_conversion_sources.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/list_conversion_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/undelete_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/undelete_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/update_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1/ConversionSourcesServiceClient/update_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/create_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/create_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/delete_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/delete_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/get_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/get_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/list_conversion_sources.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/list_conversion_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/undelete_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/undelete_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/update_conversion_source.php
+++ b/ShoppingMerchantConversions/samples/V1beta/ConversionSourcesServiceClient/update_conversion_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1/Client/ConversionSourcesServiceClient.php
+++ b/ShoppingMerchantConversions/src/V1/Client/ConversionSourcesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1/resources/conversion_sources_service_descriptor_config.php
+++ b/ShoppingMerchantConversions/src/V1/resources/conversion_sources_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1/resources/conversion_sources_service_rest_client_config.php
+++ b/ShoppingMerchantConversions/src/V1/resources/conversion_sources_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1beta/Client/ConversionSourcesServiceClient.php
+++ b/ShoppingMerchantConversions/src/V1beta/Client/ConversionSourcesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1beta/resources/conversion_sources_service_descriptor_config.php
+++ b/ShoppingMerchantConversions/src/V1beta/resources/conversion_sources_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/src/V1beta/resources/conversion_sources_service_rest_client_config.php
+++ b/ShoppingMerchantConversions/src/V1beta/resources/conversion_sources_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/tests/Unit/V1/Client/ConversionSourcesServiceClientTest.php
+++ b/ShoppingMerchantConversions/tests/Unit/V1/Client/ConversionSourcesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantConversions/tests/Unit/V1beta/Client/ConversionSourcesServiceClientTest.php
+++ b/ShoppingMerchantConversions/tests/Unit/V1beta/Client/ConversionSourcesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/owlbot.py
+++ b/ShoppingMerchantDataSources/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/create_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/create_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/delete_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/delete_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/fetch_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/fetch_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/get_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/get_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/list_data_sources.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/list_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/update_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1/DataSourcesServiceClient/update_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1/FileUploadsServiceClient/get_file_upload.php
+++ b/ShoppingMerchantDataSources/samples/V1/FileUploadsServiceClient/get_file_upload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/create_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/create_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/delete_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/delete_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/fetch_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/fetch_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/get_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/get_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/list_data_sources.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/list_data_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/update_data_source.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/DataSourcesServiceClient/update_data_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/samples/V1beta/FileUploadsServiceClient/get_file_upload.php
+++ b/ShoppingMerchantDataSources/samples/V1beta/FileUploadsServiceClient/get_file_upload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/Client/DataSourcesServiceClient.php
+++ b/ShoppingMerchantDataSources/src/V1/Client/DataSourcesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/Client/FileUploadsServiceClient.php
+++ b/ShoppingMerchantDataSources/src/V1/Client/FileUploadsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/resources/data_sources_service_descriptor_config.php
+++ b/ShoppingMerchantDataSources/src/V1/resources/data_sources_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/resources/data_sources_service_rest_client_config.php
+++ b/ShoppingMerchantDataSources/src/V1/resources/data_sources_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/resources/file_uploads_service_descriptor_config.php
+++ b/ShoppingMerchantDataSources/src/V1/resources/file_uploads_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1/resources/file_uploads_service_rest_client_config.php
+++ b/ShoppingMerchantDataSources/src/V1/resources/file_uploads_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/Client/DataSourcesServiceClient.php
+++ b/ShoppingMerchantDataSources/src/V1beta/Client/DataSourcesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/Client/FileUploadsServiceClient.php
+++ b/ShoppingMerchantDataSources/src/V1beta/Client/FileUploadsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/resources/data_sources_service_descriptor_config.php
+++ b/ShoppingMerchantDataSources/src/V1beta/resources/data_sources_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/resources/data_sources_service_rest_client_config.php
+++ b/ShoppingMerchantDataSources/src/V1beta/resources/data_sources_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/resources/file_uploads_service_descriptor_config.php
+++ b/ShoppingMerchantDataSources/src/V1beta/resources/file_uploads_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/src/V1beta/resources/file_uploads_service_rest_client_config.php
+++ b/ShoppingMerchantDataSources/src/V1beta/resources/file_uploads_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/tests/Unit/V1/Client/DataSourcesServiceClientTest.php
+++ b/ShoppingMerchantDataSources/tests/Unit/V1/Client/DataSourcesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/tests/Unit/V1/Client/FileUploadsServiceClientTest.php
+++ b/ShoppingMerchantDataSources/tests/Unit/V1/Client/FileUploadsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/tests/Unit/V1beta/Client/DataSourcesServiceClientTest.php
+++ b/ShoppingMerchantDataSources/tests/Unit/V1beta/Client/DataSourcesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantDataSources/tests/Unit/V1beta/Client/FileUploadsServiceClientTest.php
+++ b/ShoppingMerchantDataSources/tests/Unit/V1beta/Client/FileUploadsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1027 generated files** in **21 in-scope packages** (Retail through ShoppingMerchantDataSources).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`Retail`, `Run`, `Scheduler`, `SecretManager`, `SecureSourceManager`, `SecurityCenter`, `SecurityCenterManagement`, `SecurityCompliance`, `SecurityPrivateCa`, `SecurityPublicCA`, `ServiceControl`, `ServiceDirectory`, `ServiceHealth`, `ServiceManagement`, `ServiceUsage`, `Shell`, `ShoppingCommonProtos`, `ShoppingCss`, `ShoppingMerchantAccounts`, `ShoppingMerchantConversions`, `ShoppingMerchantDataSources`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-9
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 9 of 10 in the 2026 copyright update series.
