### PR TITLE
chore: update copyright years to 2026 for generated files (part 10: ShoppingMerchantInventories to WorkloadManager)

### DIFF
--- a/ShoppingMerchantInventories/owlbot.py
+++ b/ShoppingMerchantInventories/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/delete_local_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/delete_local_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/insert_local_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/insert_local_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/list_local_inventories.php
+++ b/ShoppingMerchantInventories/samples/V1/LocalInventoryServiceClient/list_local_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/delete_regional_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/delete_regional_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/insert_regional_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/insert_regional_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/list_regional_inventories.php
+++ b/ShoppingMerchantInventories/samples/V1/RegionalInventoryServiceClient/list_regional_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/delete_local_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/delete_local_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/insert_local_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/insert_local_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/list_local_inventories.php
+++ b/ShoppingMerchantInventories/samples/V1beta/LocalInventoryServiceClient/list_local_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/delete_regional_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/delete_regional_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/insert_regional_inventory.php
+++ b/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/insert_regional_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/list_regional_inventories.php
+++ b/ShoppingMerchantInventories/samples/V1beta/RegionalInventoryServiceClient/list_regional_inventories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/Client/LocalInventoryServiceClient.php
+++ b/ShoppingMerchantInventories/src/V1/Client/LocalInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/Client/RegionalInventoryServiceClient.php
+++ b/ShoppingMerchantInventories/src/V1/Client/RegionalInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/resources/local_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantInventories/src/V1/resources/local_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/resources/local_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantInventories/src/V1/resources/local_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/resources/regional_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantInventories/src/V1/resources/regional_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1/resources/regional_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantInventories/src/V1/resources/regional_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/Client/LocalInventoryServiceClient.php
+++ b/ShoppingMerchantInventories/src/V1beta/Client/LocalInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/Client/RegionalInventoryServiceClient.php
+++ b/ShoppingMerchantInventories/src/V1beta/Client/RegionalInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/resources/local_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantInventories/src/V1beta/resources/local_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/resources/local_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantInventories/src/V1beta/resources/local_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/resources/regional_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantInventories/src/V1beta/resources/regional_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/src/V1beta/resources/regional_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantInventories/src/V1beta/resources/regional_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/tests/Unit/V1/Client/LocalInventoryServiceClientTest.php
+++ b/ShoppingMerchantInventories/tests/Unit/V1/Client/LocalInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/tests/Unit/V1/Client/RegionalInventoryServiceClientTest.php
+++ b/ShoppingMerchantInventories/tests/Unit/V1/Client/RegionalInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/tests/Unit/V1beta/Client/LocalInventoryServiceClientTest.php
+++ b/ShoppingMerchantInventories/tests/Unit/V1beta/Client/LocalInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantInventories/tests/Unit/V1beta/Client/RegionalInventoryServiceClientTest.php
+++ b/ShoppingMerchantInventories/tests/Unit/V1beta/Client/RegionalInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/owlbot.py
+++ b/ShoppingMerchantIssueResolution/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/samples/V1/AggregateProductStatusesServiceClient/list_aggregate_product_statuses.php
+++ b/ShoppingMerchantIssueResolution/samples/V1/AggregateProductStatusesServiceClient/list_aggregate_product_statuses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/render_account_issues.php
+++ b/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/render_account_issues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/render_product_issues.php
+++ b/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/render_product_issues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/trigger_action.php
+++ b/ShoppingMerchantIssueResolution/samples/V1/IssueResolutionServiceClient/trigger_action.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/Client/AggregateProductStatusesServiceClient.php
+++ b/ShoppingMerchantIssueResolution/src/V1/Client/AggregateProductStatusesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/Client/IssueResolutionServiceClient.php
+++ b/ShoppingMerchantIssueResolution/src/V1/Client/IssueResolutionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/resources/aggregate_product_statuses_service_descriptor_config.php
+++ b/ShoppingMerchantIssueResolution/src/V1/resources/aggregate_product_statuses_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/resources/aggregate_product_statuses_service_rest_client_config.php
+++ b/ShoppingMerchantIssueResolution/src/V1/resources/aggregate_product_statuses_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/resources/issue_resolution_service_descriptor_config.php
+++ b/ShoppingMerchantIssueResolution/src/V1/resources/issue_resolution_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/src/V1/resources/issue_resolution_service_rest_client_config.php
+++ b/ShoppingMerchantIssueResolution/src/V1/resources/issue_resolution_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/tests/Unit/V1/Client/AggregateProductStatusesServiceClientTest.php
+++ b/ShoppingMerchantIssueResolution/tests/Unit/V1/Client/AggregateProductStatusesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantIssueResolution/tests/Unit/V1/Client/IssueResolutionServiceClientTest.php
+++ b/ShoppingMerchantIssueResolution/tests/Unit/V1/Client/IssueResolutionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/owlbot.py
+++ b/ShoppingMerchantLfp/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpInventoryServiceClient/insert_lfp_inventory.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpInventoryServiceClient/insert_lfp_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpMerchantStateServiceClient/get_lfp_merchant_state.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpMerchantStateServiceClient/get_lfp_merchant_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpSaleServiceClient/insert_lfp_sale.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpSaleServiceClient/insert_lfp_sale.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/delete_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/delete_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/get_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/get_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/insert_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/insert_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/list_lfp_stores.php
+++ b/ShoppingMerchantLfp/samples/V1/LfpStoreServiceClient/list_lfp_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpInventoryServiceClient/insert_lfp_inventory.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpInventoryServiceClient/insert_lfp_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpMerchantStateServiceClient/get_lfp_merchant_state.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpMerchantStateServiceClient/get_lfp_merchant_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpSaleServiceClient/insert_lfp_sale.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpSaleServiceClient/insert_lfp_sale.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/delete_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/delete_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/get_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/get_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/insert_lfp_store.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/insert_lfp_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/list_lfp_stores.php
+++ b/ShoppingMerchantLfp/samples/V1beta/LfpStoreServiceClient/list_lfp_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/Client/LfpInventoryServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1/Client/LfpInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/Client/LfpMerchantStateServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1/Client/LfpMerchantStateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/Client/LfpSaleServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1/Client/LfpSaleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/Client/LfpStoreServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1/Client/LfpStoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_merchant_state_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_merchant_state_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_merchant_state_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_merchant_state_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_sale_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_sale_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_sale_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_sale_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_store_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_store_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1/resources/lfp_store_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1/resources/lfp_store_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/Client/LfpInventoryServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1beta/Client/LfpInventoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/Client/LfpMerchantStateServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1beta/Client/LfpMerchantStateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/Client/LfpSaleServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1beta/Client/LfpSaleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/Client/LfpStoreServiceClient.php
+++ b/ShoppingMerchantLfp/src/V1beta/Client/LfpStoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_inventory_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_inventory_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_inventory_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_inventory_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_merchant_state_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_merchant_state_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_merchant_state_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_merchant_state_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_sale_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_sale_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_sale_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_sale_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_store_service_descriptor_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_store_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/src/V1beta/resources/lfp_store_service_rest_client_config.php
+++ b/ShoppingMerchantLfp/src/V1beta/resources/lfp_store_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpInventoryServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpMerchantStateServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpMerchantStateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpSaleServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpSaleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpStoreServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1/Client/LfpStoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpInventoryServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpInventoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpMerchantStateServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpMerchantStateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpSaleServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpSaleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpStoreServiceClientTest.php
+++ b/ShoppingMerchantLfp/tests/Unit/V1beta/Client/LfpStoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/owlbot.py
+++ b/ShoppingMerchantNotifications/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/create_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/create_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/delete_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/delete_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/get_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/get_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/get_notification_subscription_health_metrics.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/get_notification_subscription_health_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/list_notification_subscriptions.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/list_notification_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/update_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1/NotificationsApiServiceClient/update_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/create_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/create_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/delete_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/delete_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/get_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/get_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/list_notification_subscriptions.php
+++ b/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/list_notification_subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/update_notification_subscription.php
+++ b/ShoppingMerchantNotifications/samples/V1beta/NotificationsApiServiceClient/update_notification_subscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1/Client/NotificationsApiServiceClient.php
+++ b/ShoppingMerchantNotifications/src/V1/Client/NotificationsApiServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1/resources/notifications_api_service_descriptor_config.php
+++ b/ShoppingMerchantNotifications/src/V1/resources/notifications_api_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1/resources/notifications_api_service_rest_client_config.php
+++ b/ShoppingMerchantNotifications/src/V1/resources/notifications_api_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1beta/Client/NotificationsApiServiceClient.php
+++ b/ShoppingMerchantNotifications/src/V1beta/Client/NotificationsApiServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1beta/resources/notifications_api_service_descriptor_config.php
+++ b/ShoppingMerchantNotifications/src/V1beta/resources/notifications_api_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/src/V1beta/resources/notifications_api_service_rest_client_config.php
+++ b/ShoppingMerchantNotifications/src/V1beta/resources/notifications_api_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/tests/Unit/V1/Client/NotificationsApiServiceClientTest.php
+++ b/ShoppingMerchantNotifications/tests/Unit/V1/Client/NotificationsApiServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantNotifications/tests/Unit/V1beta/Client/NotificationsApiServiceClientTest.php
+++ b/ShoppingMerchantNotifications/tests/Unit/V1beta/Client/NotificationsApiServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/owlbot.py
+++ b/ShoppingMerchantOrderTracking/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/samples/V1/OrderTrackingSignalsServiceClient/create_order_tracking_signal.php
+++ b/ShoppingMerchantOrderTracking/samples/V1/OrderTrackingSignalsServiceClient/create_order_tracking_signal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/samples/V1beta/OrderTrackingSignalsServiceClient/create_order_tracking_signal.php
+++ b/ShoppingMerchantOrderTracking/samples/V1beta/OrderTrackingSignalsServiceClient/create_order_tracking_signal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1/Client/OrderTrackingSignalsServiceClient.php
+++ b/ShoppingMerchantOrderTracking/src/V1/Client/OrderTrackingSignalsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1/resources/order_tracking_signals_service_descriptor_config.php
+++ b/ShoppingMerchantOrderTracking/src/V1/resources/order_tracking_signals_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1/resources/order_tracking_signals_service_rest_client_config.php
+++ b/ShoppingMerchantOrderTracking/src/V1/resources/order_tracking_signals_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1beta/Client/OrderTrackingSignalsServiceClient.php
+++ b/ShoppingMerchantOrderTracking/src/V1beta/Client/OrderTrackingSignalsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1beta/resources/order_tracking_signals_service_descriptor_config.php
+++ b/ShoppingMerchantOrderTracking/src/V1beta/resources/order_tracking_signals_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/src/V1beta/resources/order_tracking_signals_service_rest_client_config.php
+++ b/ShoppingMerchantOrderTracking/src/V1beta/resources/order_tracking_signals_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/tests/Unit/V1/Client/OrderTrackingSignalsServiceClientTest.php
+++ b/ShoppingMerchantOrderTracking/tests/Unit/V1/Client/OrderTrackingSignalsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantOrderTracking/tests/Unit/V1beta/Client/OrderTrackingSignalsServiceClientTest.php
+++ b/ShoppingMerchantOrderTracking/tests/Unit/V1beta/Client/OrderTrackingSignalsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/owlbot.py
+++ b/ShoppingMerchantProducts/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/delete_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/delete_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/insert_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/insert_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/update_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1/ProductInputsServiceClient/update_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1/ProductsServiceClient/get_product.php
+++ b/ShoppingMerchantProducts/samples/V1/ProductsServiceClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1/ProductsServiceClient/list_products.php
+++ b/ShoppingMerchantProducts/samples/V1/ProductsServiceClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/delete_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/delete_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/insert_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/insert_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/update_product_input.php
+++ b/ShoppingMerchantProducts/samples/V1beta/ProductInputsServiceClient/update_product_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1beta/ProductsServiceClient/get_product.php
+++ b/ShoppingMerchantProducts/samples/V1beta/ProductsServiceClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/samples/V1beta/ProductsServiceClient/list_products.php
+++ b/ShoppingMerchantProducts/samples/V1beta/ProductsServiceClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/Client/ProductInputsServiceClient.php
+++ b/ShoppingMerchantProducts/src/V1/Client/ProductInputsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/Client/ProductsServiceClient.php
+++ b/ShoppingMerchantProducts/src/V1/Client/ProductsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/resources/product_inputs_service_descriptor_config.php
+++ b/ShoppingMerchantProducts/src/V1/resources/product_inputs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/resources/product_inputs_service_rest_client_config.php
+++ b/ShoppingMerchantProducts/src/V1/resources/product_inputs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/resources/products_service_descriptor_config.php
+++ b/ShoppingMerchantProducts/src/V1/resources/products_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1/resources/products_service_rest_client_config.php
+++ b/ShoppingMerchantProducts/src/V1/resources/products_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/Client/ProductInputsServiceClient.php
+++ b/ShoppingMerchantProducts/src/V1beta/Client/ProductInputsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/Client/ProductsServiceClient.php
+++ b/ShoppingMerchantProducts/src/V1beta/Client/ProductsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/resources/product_inputs_service_descriptor_config.php
+++ b/ShoppingMerchantProducts/src/V1beta/resources/product_inputs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/resources/product_inputs_service_rest_client_config.php
+++ b/ShoppingMerchantProducts/src/V1beta/resources/product_inputs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/resources/products_service_descriptor_config.php
+++ b/ShoppingMerchantProducts/src/V1beta/resources/products_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/src/V1beta/resources/products_service_rest_client_config.php
+++ b/ShoppingMerchantProducts/src/V1beta/resources/products_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/tests/Unit/V1/Client/ProductInputsServiceClientTest.php
+++ b/ShoppingMerchantProducts/tests/Unit/V1/Client/ProductInputsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/tests/Unit/V1/Client/ProductsServiceClientTest.php
+++ b/ShoppingMerchantProducts/tests/Unit/V1/Client/ProductsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/tests/Unit/V1beta/Client/ProductInputsServiceClientTest.php
+++ b/ShoppingMerchantProducts/tests/Unit/V1beta/Client/ProductInputsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantProducts/tests/Unit/V1beta/Client/ProductsServiceClientTest.php
+++ b/ShoppingMerchantProducts/tests/Unit/V1beta/Client/ProductsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/owlbot.py
+++ b/ShoppingMerchantPromotions/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/get_promotion.php
+++ b/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/get_promotion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/insert_promotion.php
+++ b/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/insert_promotion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/list_promotions.php
+++ b/ShoppingMerchantPromotions/samples/V1/PromotionsServiceClient/list_promotions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/get_promotion.php
+++ b/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/get_promotion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/insert_promotion.php
+++ b/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/insert_promotion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/list_promotions.php
+++ b/ShoppingMerchantPromotions/samples/V1beta/PromotionsServiceClient/list_promotions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1/Client/PromotionsServiceClient.php
+++ b/ShoppingMerchantPromotions/src/V1/Client/PromotionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1/resources/promotions_service_descriptor_config.php
+++ b/ShoppingMerchantPromotions/src/V1/resources/promotions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1/resources/promotions_service_rest_client_config.php
+++ b/ShoppingMerchantPromotions/src/V1/resources/promotions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1beta/Client/PromotionsServiceClient.php
+++ b/ShoppingMerchantPromotions/src/V1beta/Client/PromotionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1beta/resources/promotions_service_descriptor_config.php
+++ b/ShoppingMerchantPromotions/src/V1beta/resources/promotions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/src/V1beta/resources/promotions_service_rest_client_config.php
+++ b/ShoppingMerchantPromotions/src/V1beta/resources/promotions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/tests/Unit/V1/Client/PromotionsServiceClientTest.php
+++ b/ShoppingMerchantPromotions/tests/Unit/V1/Client/PromotionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantPromotions/tests/Unit/V1beta/Client/PromotionsServiceClientTest.php
+++ b/ShoppingMerchantPromotions/tests/Unit/V1beta/Client/PromotionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/owlbot.py
+++ b/ShoppingMerchantQuota/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/samples/V1/AccountLimitsServiceClient/get_account_limit.php
+++ b/ShoppingMerchantQuota/samples/V1/AccountLimitsServiceClient/get_account_limit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/samples/V1/AccountLimitsServiceClient/list_account_limits.php
+++ b/ShoppingMerchantQuota/samples/V1/AccountLimitsServiceClient/list_account_limits.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/samples/V1/QuotaServiceClient/list_quota_groups.php
+++ b/ShoppingMerchantQuota/samples/V1/QuotaServiceClient/list_quota_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/samples/V1beta/QuotaServiceClient/list_quota_groups.php
+++ b/ShoppingMerchantQuota/samples/V1beta/QuotaServiceClient/list_quota_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/Client/AccountLimitsServiceClient.php
+++ b/ShoppingMerchantQuota/src/V1/Client/AccountLimitsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/Client/QuotaServiceClient.php
+++ b/ShoppingMerchantQuota/src/V1/Client/QuotaServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/resources/account_limits_service_descriptor_config.php
+++ b/ShoppingMerchantQuota/src/V1/resources/account_limits_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/resources/account_limits_service_rest_client_config.php
+++ b/ShoppingMerchantQuota/src/V1/resources/account_limits_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/resources/quota_service_descriptor_config.php
+++ b/ShoppingMerchantQuota/src/V1/resources/quota_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1/resources/quota_service_rest_client_config.php
+++ b/ShoppingMerchantQuota/src/V1/resources/quota_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1beta/Client/QuotaServiceClient.php
+++ b/ShoppingMerchantQuota/src/V1beta/Client/QuotaServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1beta/resources/quota_service_descriptor_config.php
+++ b/ShoppingMerchantQuota/src/V1beta/resources/quota_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/src/V1beta/resources/quota_service_rest_client_config.php
+++ b/ShoppingMerchantQuota/src/V1beta/resources/quota_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/tests/Unit/V1/Client/AccountLimitsServiceClientTest.php
+++ b/ShoppingMerchantQuota/tests/Unit/V1/Client/AccountLimitsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/tests/Unit/V1/Client/QuotaServiceClientTest.php
+++ b/ShoppingMerchantQuota/tests/Unit/V1/Client/QuotaServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantQuota/tests/Unit/V1beta/Client/QuotaServiceClientTest.php
+++ b/ShoppingMerchantQuota/tests/Unit/V1beta/Client/QuotaServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/owlbot.py
+++ b/ShoppingMerchantReports/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/samples/V1/ReportServiceClient/search.php
+++ b/ShoppingMerchantReports/samples/V1/ReportServiceClient/search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/samples/V1beta/ReportServiceClient/search.php
+++ b/ShoppingMerchantReports/samples/V1beta/ReportServiceClient/search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1/Client/ReportServiceClient.php
+++ b/ShoppingMerchantReports/src/V1/Client/ReportServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1/resources/report_service_descriptor_config.php
+++ b/ShoppingMerchantReports/src/V1/resources/report_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1/resources/report_service_rest_client_config.php
+++ b/ShoppingMerchantReports/src/V1/resources/report_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1beta/Client/ReportServiceClient.php
+++ b/ShoppingMerchantReports/src/V1beta/Client/ReportServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1beta/resources/report_service_descriptor_config.php
+++ b/ShoppingMerchantReports/src/V1beta/resources/report_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/src/V1beta/resources/report_service_rest_client_config.php
+++ b/ShoppingMerchantReports/src/V1beta/resources/report_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/tests/Unit/V1/Client/ReportServiceClientTest.php
+++ b/ShoppingMerchantReports/tests/Unit/V1/Client/ReportServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReports/tests/Unit/V1beta/Client/ReportServiceClientTest.php
+++ b/ShoppingMerchantReports/tests/Unit/V1beta/Client/ReportServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/owlbot.py
+++ b/ShoppingMerchantReviews/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/delete_merchant_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/delete_merchant_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/get_merchant_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/get_merchant_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/insert_merchant_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/insert_merchant_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/list_merchant_reviews.php
+++ b/ShoppingMerchantReviews/samples/V1beta/MerchantReviewsServiceClient/list_merchant_reviews.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/delete_product_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/delete_product_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/get_product_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/get_product_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/insert_product_review.php
+++ b/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/insert_product_review.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/list_product_reviews.php
+++ b/ShoppingMerchantReviews/samples/V1beta/ProductReviewsServiceClient/list_product_reviews.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/Client/MerchantReviewsServiceClient.php
+++ b/ShoppingMerchantReviews/src/V1beta/Client/MerchantReviewsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/Client/ProductReviewsServiceClient.php
+++ b/ShoppingMerchantReviews/src/V1beta/Client/ProductReviewsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/resources/merchant_reviews_service_descriptor_config.php
+++ b/ShoppingMerchantReviews/src/V1beta/resources/merchant_reviews_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/resources/merchant_reviews_service_rest_client_config.php
+++ b/ShoppingMerchantReviews/src/V1beta/resources/merchant_reviews_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/resources/product_reviews_service_descriptor_config.php
+++ b/ShoppingMerchantReviews/src/V1beta/resources/product_reviews_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/src/V1beta/resources/product_reviews_service_rest_client_config.php
+++ b/ShoppingMerchantReviews/src/V1beta/resources/product_reviews_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/tests/Unit/V1beta/Client/MerchantReviewsServiceClientTest.php
+++ b/ShoppingMerchantReviews/tests/Unit/V1beta/Client/MerchantReviewsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ShoppingMerchantReviews/tests/Unit/V1beta/Client/ProductReviewsServiceClientTest.php
+++ b/ShoppingMerchantReviews/tests/Unit/V1beta/Client/ProductReviewsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/batch_create_sessions.php
+++ b/Spanner/samples/V1/SpannerClient/batch_create_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/batch_write.php
+++ b/Spanner/samples/V1/SpannerClient/batch_write.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/begin_transaction.php
+++ b/Spanner/samples/V1/SpannerClient/begin_transaction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/commit.php
+++ b/Spanner/samples/V1/SpannerClient/commit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/create_session.php
+++ b/Spanner/samples/V1/SpannerClient/create_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/delete_session.php
+++ b/Spanner/samples/V1/SpannerClient/delete_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/execute_batch_dml.php
+++ b/Spanner/samples/V1/SpannerClient/execute_batch_dml.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/execute_sql.php
+++ b/Spanner/samples/V1/SpannerClient/execute_sql.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/execute_streaming_sql.php
+++ b/Spanner/samples/V1/SpannerClient/execute_streaming_sql.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/get_session.php
+++ b/Spanner/samples/V1/SpannerClient/get_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/list_sessions.php
+++ b/Spanner/samples/V1/SpannerClient/list_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/partition_query.php
+++ b/Spanner/samples/V1/SpannerClient/partition_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/partition_read.php
+++ b/Spanner/samples/V1/SpannerClient/partition_read.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/read.php
+++ b/Spanner/samples/V1/SpannerClient/read.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/rollback.php
+++ b/Spanner/samples/V1/SpannerClient/rollback.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/samples/V1/SpannerClient/streaming_read.php
+++ b/Spanner/samples/V1/SpannerClient/streaming_read.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Database/V1/Client/DatabaseAdminClient.php
+++ b/Spanner/src/Admin/Database/V1/Client/DatabaseAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Database/V1/resources/database_admin_descriptor_config.php
+++ b/Spanner/src/Admin/Database/V1/resources/database_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Database/V1/resources/database_admin_rest_client_config.php
+++ b/Spanner/src/Admin/Database/V1/resources/database_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Instance/V1/Client/InstanceAdminClient.php
+++ b/Spanner/src/Admin/Instance/V1/Client/InstanceAdminClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Instance/V1/resources/instance_admin_descriptor_config.php
+++ b/Spanner/src/Admin/Instance/V1/resources/instance_admin_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/Admin/Instance/V1/resources/instance_admin_rest_client_config.php
+++ b/Spanner/src/Admin/Instance/V1/resources/instance_admin_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/V1/Client/SpannerClient.php
+++ b/Spanner/src/V1/Client/SpannerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/V1/resources/spanner_descriptor_config.php
+++ b/Spanner/src/V1/resources/spanner_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/src/V1/resources/spanner_rest_client_config.php
+++ b/Spanner/src/V1/resources/spanner_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/tests/Unit/Admin/Database/V1/Client/DatabaseAdminClientTest.php
+++ b/Spanner/tests/Unit/Admin/Database/V1/Client/DatabaseAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/tests/Unit/Admin/Instance/V1/Client/InstanceAdminClientTest.php
+++ b/Spanner/tests/Unit/Admin/Instance/V1/Client/InstanceAdminClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Spanner/tests/Unit/V1/Client/SpannerClientTest.php
+++ b/Spanner/tests/Unit/V1/Client/SpannerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/owlbot.py
+++ b/Speech/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/batch_recognize.php
+++ b/Speech/samples/V2/SpeechClient/batch_recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/create_custom_class.php
+++ b/Speech/samples/V2/SpeechClient/create_custom_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/create_phrase_set.php
+++ b/Speech/samples/V2/SpeechClient/create_phrase_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/create_recognizer.php
+++ b/Speech/samples/V2/SpeechClient/create_recognizer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/delete_custom_class.php
+++ b/Speech/samples/V2/SpeechClient/delete_custom_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/delete_phrase_set.php
+++ b/Speech/samples/V2/SpeechClient/delete_phrase_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/delete_recognizer.php
+++ b/Speech/samples/V2/SpeechClient/delete_recognizer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/get_config.php
+++ b/Speech/samples/V2/SpeechClient/get_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/get_custom_class.php
+++ b/Speech/samples/V2/SpeechClient/get_custom_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/get_location.php
+++ b/Speech/samples/V2/SpeechClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/get_phrase_set.php
+++ b/Speech/samples/V2/SpeechClient/get_phrase_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/get_recognizer.php
+++ b/Speech/samples/V2/SpeechClient/get_recognizer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/list_custom_classes.php
+++ b/Speech/samples/V2/SpeechClient/list_custom_classes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/list_locations.php
+++ b/Speech/samples/V2/SpeechClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/list_phrase_sets.php
+++ b/Speech/samples/V2/SpeechClient/list_phrase_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/list_recognizers.php
+++ b/Speech/samples/V2/SpeechClient/list_recognizers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/recognize.php
+++ b/Speech/samples/V2/SpeechClient/recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/streaming_recognize.php
+++ b/Speech/samples/V2/SpeechClient/streaming_recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/undelete_custom_class.php
+++ b/Speech/samples/V2/SpeechClient/undelete_custom_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/undelete_phrase_set.php
+++ b/Speech/samples/V2/SpeechClient/undelete_phrase_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/undelete_recognizer.php
+++ b/Speech/samples/V2/SpeechClient/undelete_recognizer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/update_config.php
+++ b/Speech/samples/V2/SpeechClient/update_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/update_custom_class.php
+++ b/Speech/samples/V2/SpeechClient/update_custom_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/update_phrase_set.php
+++ b/Speech/samples/V2/SpeechClient/update_phrase_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/samples/V2/SpeechClient/update_recognizer.php
+++ b/Speech/samples/V2/SpeechClient/update_recognizer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/src/V2/Client/SpeechClient.php
+++ b/Speech/src/V2/Client/SpeechClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/src/V2/resources/speech_descriptor_config.php
+++ b/Speech/src/V2/resources/speech_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/src/V2/resources/speech_rest_client_config.php
+++ b/Speech/src/V2/resources/speech_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Speech/tests/Unit/V2/Client/SpeechClientTest.php
+++ b/Speech/tests/Unit/V2/Client/SpeechClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/owlbot.py
+++ b/SqlAdmin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/delete.php
+++ b/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/insert.php
+++ b/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlBackupRunsServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlConnectServiceClient/generate_ephemeral_cert.php
+++ b/SqlAdmin/samples/V1/SqlConnectServiceClient/generate_ephemeral_cert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlConnectServiceClient/get_connect_settings.php
+++ b/SqlAdmin/samples/V1/SqlConnectServiceClient/get_connect_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/delete.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/insert.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/patch.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlDatabasesServiceClient/update.php
+++ b/SqlAdmin/samples/V1/SqlDatabasesServiceClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlFlagsServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlFlagsServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/acquire_ssrs_lease.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/acquire_ssrs_lease.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/add_server_ca.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/add_server_ca.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/clone.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/clone.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/create_ephemeral.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/create_ephemeral.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/delete.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/demote.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/demote.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/demote_master.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/demote_master.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/export.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/export.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/failover.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/failover.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/get_disk_shrink_config.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/get_disk_shrink_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/get_latest_recovery_time.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/get_latest_recovery_time.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/import.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/import.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/insert.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/list_server_cas.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/list_server_cas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/patch.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/patch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/perform_disk_shrink.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/perform_disk_shrink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/promote_replica.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/promote_replica.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/reencrypt.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/reencrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/release_ssrs_lease.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/release_ssrs_lease.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/reschedule_maintenance.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/reschedule_maintenance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/reset_replica_size.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/reset_replica_size.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/reset_ssl_config.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/reset_ssl_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/restart.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/restart.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/restore_backup.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/restore_backup.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/rotate_server_ca.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/rotate_server_ca.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/start_external_sync.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/start_external_sync.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/start_replica.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/start_replica.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/stop_replica.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/stop_replica.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/switchover.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/switchover.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/truncate_log.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/truncate_log.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/update.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlInstancesServiceClient/verify_external_sync_settings.php
+++ b/SqlAdmin/samples/V1/SqlInstancesServiceClient/verify_external_sync_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlOperationsServiceClient/cancel.php
+++ b/SqlAdmin/samples/V1/SqlOperationsServiceClient/cancel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlOperationsServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlOperationsServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlOperationsServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlOperationsServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlSslCertsServiceClient/delete.php
+++ b/SqlAdmin/samples/V1/SqlSslCertsServiceClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlSslCertsServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlSslCertsServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlSslCertsServiceClient/insert.php
+++ b/SqlAdmin/samples/V1/SqlSslCertsServiceClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlSslCertsServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlSslCertsServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlTiersServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlTiersServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlUsersServiceClient/delete.php
+++ b/SqlAdmin/samples/V1/SqlUsersServiceClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlUsersServiceClient/get.php
+++ b/SqlAdmin/samples/V1/SqlUsersServiceClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlUsersServiceClient/insert.php
+++ b/SqlAdmin/samples/V1/SqlUsersServiceClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlUsersServiceClient/list.php
+++ b/SqlAdmin/samples/V1/SqlUsersServiceClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/samples/V1/SqlUsersServiceClient/update.php
+++ b/SqlAdmin/samples/V1/SqlUsersServiceClient/update.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlAvailableDatabaseVersionsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlAvailableDatabaseVersionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlBackupRunsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlBackupRunsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlConnectServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlConnectServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlDatabasesServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlDatabasesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlEventsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlEventsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlFlagsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlFlagsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlIamPoliciesServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlIamPoliciesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlInstanceNamesServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlInstanceNamesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlInstancesServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlInstancesServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlOperationsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlOperationsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlRegionsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlRegionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlSslCertsServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlSslCertsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlTiersServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlTiersServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/Client/SqlUsersServiceClient.php
+++ b/SqlAdmin/src/V1/Client/SqlUsersServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_available_database_versions_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_available_database_versions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_available_database_versions_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_available_database_versions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_backup_runs_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_backup_runs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_backup_runs_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_backup_runs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_connect_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_connect_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_connect_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_connect_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_databases_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_databases_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_databases_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_databases_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_events_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_events_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_events_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_events_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_flags_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_flags_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_flags_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_flags_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_iam_policies_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_iam_policies_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_iam_policies_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_iam_policies_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_instance_names_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_instance_names_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_instance_names_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_instance_names_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_instances_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_instances_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_instances_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_instances_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_operations_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_operations_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_operations_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_operations_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_regions_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_regions_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_regions_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_regions_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_ssl_certs_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_ssl_certs_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_ssl_certs_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_ssl_certs_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_tiers_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_tiers_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_tiers_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_tiers_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_users_service_descriptor_config.php
+++ b/SqlAdmin/src/V1/resources/sql_users_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/src/V1/resources/sql_users_service_rest_client_config.php
+++ b/SqlAdmin/src/V1/resources/sql_users_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlAvailableDatabaseVersionsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlAvailableDatabaseVersionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlBackupRunsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlBackupRunsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlConnectServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlConnectServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlDatabasesServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlDatabasesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlEventsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlEventsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlFlagsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlFlagsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlIamPoliciesServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlIamPoliciesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlInstanceNamesServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlInstanceNamesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlInstancesServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlInstancesServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlOperationsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlOperationsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlRegionsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlRegionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlSslCertsServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlSslCertsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlTiersServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlTiersServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/SqlAdmin/tests/Unit/V1/Client/SqlUsersServiceClientTest.php
+++ b/SqlAdmin/tests/Unit/V1/Client/SqlUsersServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/owlbot.py
+++ b/StorageBatchOperations/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/cancel_job.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/cancel_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/create_job.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/delete_job.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/get_job.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/get_location.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/list_jobs.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/list_locations.php
+++ b/StorageBatchOperations/samples/V1/StorageBatchOperationsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/src/V1/Client/StorageBatchOperationsClient.php
+++ b/StorageBatchOperations/src/V1/Client/StorageBatchOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/src/V1/resources/storage_batch_operations_descriptor_config.php
+++ b/StorageBatchOperations/src/V1/resources/storage_batch_operations_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/src/V1/resources/storage_batch_operations_rest_client_config.php
+++ b/StorageBatchOperations/src/V1/resources/storage_batch_operations_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageBatchOperations/tests/Unit/V1/Client/StorageBatchOperationsClientTest.php
+++ b/StorageBatchOperations/tests/Unit/V1/Client/StorageBatchOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/owlbot.py
+++ b/StorageControl/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/create_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/create_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/create_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/create_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/create_managed_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/create_managed_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/delete_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/delete_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/delete_managed_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/delete_managed_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/disable_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/disable_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_folder_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_folder_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_iam_policy.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_managed_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_managed_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_organization_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_organization_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_project_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_project_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/get_storage_layout.php
+++ b/StorageControl/samples/V2/StorageControlClient/get_storage_layout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/list_anywhere_caches.php
+++ b/StorageControl/samples/V2/StorageControlClient/list_anywhere_caches.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/list_folders.php
+++ b/StorageControl/samples/V2/StorageControlClient/list_folders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/list_managed_folders.php
+++ b/StorageControl/samples/V2/StorageControlClient/list_managed_folders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/pause_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/pause_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/rename_folder.php
+++ b/StorageControl/samples/V2/StorageControlClient/rename_folder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/resume_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/resume_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/set_iam_policy.php
+++ b/StorageControl/samples/V2/StorageControlClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/test_iam_permissions.php
+++ b/StorageControl/samples/V2/StorageControlClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/update_anywhere_cache.php
+++ b/StorageControl/samples/V2/StorageControlClient/update_anywhere_cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/update_folder_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/update_folder_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/update_organization_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/update_organization_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/samples/V2/StorageControlClient/update_project_intelligence_config.php
+++ b/StorageControl/samples/V2/StorageControlClient/update_project_intelligence_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/src/V2/Client/StorageControlClient.php
+++ b/StorageControl/src/V2/Client/StorageControlClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/src/V2/resources/storage_control_descriptor_config.php
+++ b/StorageControl/src/V2/resources/storage_control_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/src/V2/resources/storage_control_rest_client_config.php
+++ b/StorageControl/src/V2/resources/storage_control_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageControl/tests/Unit/V2/Client/StorageControlClientTest.php
+++ b/StorageControl/tests/Unit/V2/Client/StorageControlClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/owlbot.py
+++ b/StorageInsights/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/create_dataset_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/create_dataset_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/create_report_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/create_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/delete_dataset_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/delete_dataset_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/delete_report_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/delete_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/get_dataset_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/get_dataset_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/get_location.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/get_report_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/get_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/get_report_detail.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/get_report_detail.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/link_dataset.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/link_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/list_dataset_configs.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/list_dataset_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/list_locations.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/list_report_configs.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/list_report_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/list_report_details.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/list_report_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/unlink_dataset.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/unlink_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/update_dataset_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/update_dataset_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/samples/V1/StorageInsightsClient/update_report_config.php
+++ b/StorageInsights/samples/V1/StorageInsightsClient/update_report_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/src/V1/Client/StorageInsightsClient.php
+++ b/StorageInsights/src/V1/Client/StorageInsightsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/src/V1/resources/storage_insights_descriptor_config.php
+++ b/StorageInsights/src/V1/resources/storage_insights_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/src/V1/resources/storage_insights_rest_client_config.php
+++ b/StorageInsights/src/V1/resources/storage_insights_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageInsights/tests/Unit/V1/Client/StorageInsightsClientTest.php
+++ b/StorageInsights/tests/Unit/V1/Client/StorageInsightsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/owlbot.py
+++ b/StorageTransfer/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/create_agent_pool.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/create_agent_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/create_transfer_job.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/create_transfer_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/delete_agent_pool.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/delete_agent_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/delete_transfer_job.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/delete_transfer_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/get_agent_pool.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/get_agent_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/get_google_service_account.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/get_google_service_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/get_transfer_job.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/get_transfer_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/list_agent_pools.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/list_agent_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/list_transfer_jobs.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/list_transfer_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/pause_transfer_operation.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/pause_transfer_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/resume_transfer_operation.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/resume_transfer_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/run_transfer_job.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/run_transfer_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/update_agent_pool.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/update_agent_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/samples/V1/StorageTransferServiceClient/update_transfer_job.php
+++ b/StorageTransfer/samples/V1/StorageTransferServiceClient/update_transfer_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/src/V1/Client/StorageTransferServiceClient.php
+++ b/StorageTransfer/src/V1/Client/StorageTransferServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/src/V1/resources/storage_transfer_service_descriptor_config.php
+++ b/StorageTransfer/src/V1/resources/storage_transfer_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/src/V1/resources/storage_transfer_service_rest_client_config.php
+++ b/StorageTransfer/src/V1/resources/storage_transfer_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/StorageTransfer/tests/Unit/V1/Client/StorageTransferServiceClientTest.php
+++ b/StorageTransfer/tests/Unit/V1/Client/StorageTransferServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/owlbot.py
+++ b/Support/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseAttachmentServiceClient/list_attachments.php
+++ b/Support/samples/V2/CaseAttachmentServiceClient/list_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/close_case.php
+++ b/Support/samples/V2/CaseServiceClient/close_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/create_case.php
+++ b/Support/samples/V2/CaseServiceClient/create_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/escalate_case.php
+++ b/Support/samples/V2/CaseServiceClient/escalate_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/get_case.php
+++ b/Support/samples/V2/CaseServiceClient/get_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/list_cases.php
+++ b/Support/samples/V2/CaseServiceClient/list_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/search_case_classifications.php
+++ b/Support/samples/V2/CaseServiceClient/search_case_classifications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/search_cases.php
+++ b/Support/samples/V2/CaseServiceClient/search_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CaseServiceClient/update_case.php
+++ b/Support/samples/V2/CaseServiceClient/update_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CommentServiceClient/create_comment.php
+++ b/Support/samples/V2/CommentServiceClient/create_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2/CommentServiceClient/list_comments.php
+++ b/Support/samples/V2/CommentServiceClient/list_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseAttachmentServiceClient/get_attachment.php
+++ b/Support/samples/V2beta/CaseAttachmentServiceClient/get_attachment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseAttachmentServiceClient/list_attachments.php
+++ b/Support/samples/V2beta/CaseAttachmentServiceClient/list_attachments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/close_case.php
+++ b/Support/samples/V2beta/CaseServiceClient/close_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/create_case.php
+++ b/Support/samples/V2beta/CaseServiceClient/create_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/escalate_case.php
+++ b/Support/samples/V2beta/CaseServiceClient/escalate_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/get_case.php
+++ b/Support/samples/V2beta/CaseServiceClient/get_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/list_cases.php
+++ b/Support/samples/V2beta/CaseServiceClient/list_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/search_case_classifications.php
+++ b/Support/samples/V2beta/CaseServiceClient/search_case_classifications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/search_cases.php
+++ b/Support/samples/V2beta/CaseServiceClient/search_cases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CaseServiceClient/update_case.php
+++ b/Support/samples/V2beta/CaseServiceClient/update_case.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CommentServiceClient/create_comment.php
+++ b/Support/samples/V2beta/CommentServiceClient/create_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CommentServiceClient/get_comment.php
+++ b/Support/samples/V2beta/CommentServiceClient/get_comment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/CommentServiceClient/list_comments.php
+++ b/Support/samples/V2beta/CommentServiceClient/list_comments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/samples/V2beta/FeedServiceClient/show_feed.php
+++ b/Support/samples/V2beta/FeedServiceClient/show_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/Client/CaseAttachmentServiceClient.php
+++ b/Support/src/V2/Client/CaseAttachmentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/Client/CaseServiceClient.php
+++ b/Support/src/V2/Client/CaseServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/Client/CommentServiceClient.php
+++ b/Support/src/V2/Client/CommentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/case_attachment_service_descriptor_config.php
+++ b/Support/src/V2/resources/case_attachment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/case_attachment_service_rest_client_config.php
+++ b/Support/src/V2/resources/case_attachment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/case_service_descriptor_config.php
+++ b/Support/src/V2/resources/case_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/case_service_rest_client_config.php
+++ b/Support/src/V2/resources/case_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/comment_service_descriptor_config.php
+++ b/Support/src/V2/resources/comment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2/resources/comment_service_rest_client_config.php
+++ b/Support/src/V2/resources/comment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/Client/CaseAttachmentServiceClient.php
+++ b/Support/src/V2beta/Client/CaseAttachmentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/Client/CaseServiceClient.php
+++ b/Support/src/V2beta/Client/CaseServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/Client/CommentServiceClient.php
+++ b/Support/src/V2beta/Client/CommentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/Client/FeedServiceClient.php
+++ b/Support/src/V2beta/Client/FeedServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/case_attachment_service_descriptor_config.php
+++ b/Support/src/V2beta/resources/case_attachment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/case_attachment_service_rest_client_config.php
+++ b/Support/src/V2beta/resources/case_attachment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/case_service_descriptor_config.php
+++ b/Support/src/V2beta/resources/case_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/case_service_rest_client_config.php
+++ b/Support/src/V2beta/resources/case_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/comment_service_descriptor_config.php
+++ b/Support/src/V2beta/resources/comment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/comment_service_rest_client_config.php
+++ b/Support/src/V2beta/resources/comment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/feed_service_descriptor_config.php
+++ b/Support/src/V2beta/resources/feed_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/src/V2beta/resources/feed_service_rest_client_config.php
+++ b/Support/src/V2beta/resources/feed_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2/Client/CaseAttachmentServiceClientTest.php
+++ b/Support/tests/Unit/V2/Client/CaseAttachmentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2/Client/CaseServiceClientTest.php
+++ b/Support/tests/Unit/V2/Client/CaseServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2/Client/CommentServiceClientTest.php
+++ b/Support/tests/Unit/V2/Client/CommentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2beta/Client/CaseAttachmentServiceClientTest.php
+++ b/Support/tests/Unit/V2beta/Client/CaseAttachmentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2beta/Client/CaseServiceClientTest.php
+++ b/Support/tests/Unit/V2beta/Client/CaseServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2beta/Client/CommentServiceClientTest.php
+++ b/Support/tests/Unit/V2beta/Client/CommentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Support/tests/Unit/V2beta/Client/FeedServiceClientTest.php
+++ b/Support/tests/Unit/V2beta/Client/FeedServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/owlbot.py
+++ b/Talent/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompanyServiceClient/create_company.php
+++ b/Talent/samples/V4/CompanyServiceClient/create_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompanyServiceClient/delete_company.php
+++ b/Talent/samples/V4/CompanyServiceClient/delete_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompanyServiceClient/get_company.php
+++ b/Talent/samples/V4/CompanyServiceClient/get_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompanyServiceClient/list_companies.php
+++ b/Talent/samples/V4/CompanyServiceClient/list_companies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompanyServiceClient/update_company.php
+++ b/Talent/samples/V4/CompanyServiceClient/update_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/CompletionClient/complete_query.php
+++ b/Talent/samples/V4/CompletionClient/complete_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/EventServiceClient/create_client_event.php
+++ b/Talent/samples/V4/EventServiceClient/create_client_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/batch_create_jobs.php
+++ b/Talent/samples/V4/JobServiceClient/batch_create_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/batch_delete_jobs.php
+++ b/Talent/samples/V4/JobServiceClient/batch_delete_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/batch_update_jobs.php
+++ b/Talent/samples/V4/JobServiceClient/batch_update_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/create_job.php
+++ b/Talent/samples/V4/JobServiceClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/delete_job.php
+++ b/Talent/samples/V4/JobServiceClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/get_job.php
+++ b/Talent/samples/V4/JobServiceClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/list_jobs.php
+++ b/Talent/samples/V4/JobServiceClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/search_jobs.php
+++ b/Talent/samples/V4/JobServiceClient/search_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/search_jobs_for_alert.php
+++ b/Talent/samples/V4/JobServiceClient/search_jobs_for_alert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/JobServiceClient/update_job.php
+++ b/Talent/samples/V4/JobServiceClient/update_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/TenantServiceClient/create_tenant.php
+++ b/Talent/samples/V4/TenantServiceClient/create_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/TenantServiceClient/delete_tenant.php
+++ b/Talent/samples/V4/TenantServiceClient/delete_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/TenantServiceClient/get_tenant.php
+++ b/Talent/samples/V4/TenantServiceClient/get_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/TenantServiceClient/list_tenants.php
+++ b/Talent/samples/V4/TenantServiceClient/list_tenants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/samples/V4/TenantServiceClient/update_tenant.php
+++ b/Talent/samples/V4/TenantServiceClient/update_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/Client/CompanyServiceClient.php
+++ b/Talent/src/V4/Client/CompanyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/Client/CompletionClient.php
+++ b/Talent/src/V4/Client/CompletionClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/Client/EventServiceClient.php
+++ b/Talent/src/V4/Client/EventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/Client/JobServiceClient.php
+++ b/Talent/src/V4/Client/JobServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/Client/TenantServiceClient.php
+++ b/Talent/src/V4/Client/TenantServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/company_service_descriptor_config.php
+++ b/Talent/src/V4/resources/company_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/company_service_rest_client_config.php
+++ b/Talent/src/V4/resources/company_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/completion_descriptor_config.php
+++ b/Talent/src/V4/resources/completion_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/completion_rest_client_config.php
+++ b/Talent/src/V4/resources/completion_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/event_service_descriptor_config.php
+++ b/Talent/src/V4/resources/event_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/event_service_rest_client_config.php
+++ b/Talent/src/V4/resources/event_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/job_service_descriptor_config.php
+++ b/Talent/src/V4/resources/job_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/job_service_rest_client_config.php
+++ b/Talent/src/V4/resources/job_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/tenant_service_descriptor_config.php
+++ b/Talent/src/V4/resources/tenant_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/src/V4/resources/tenant_service_rest_client_config.php
+++ b/Talent/src/V4/resources/tenant_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/tests/Unit/V4/Client/CompanyServiceClientTest.php
+++ b/Talent/tests/Unit/V4/Client/CompanyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/tests/Unit/V4/Client/CompletionClientTest.php
+++ b/Talent/tests/Unit/V4/Client/CompletionClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/tests/Unit/V4/Client/EventServiceClientTest.php
+++ b/Talent/tests/Unit/V4/Client/EventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/tests/Unit/V4/Client/JobServiceClientTest.php
+++ b/Talent/tests/Unit/V4/Client/JobServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Talent/tests/Unit/V4/Client/TenantServiceClientTest.php
+++ b/Talent/tests/Unit/V4/Client/TenantServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/owlbot.py
+++ b/Tasks/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/create_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/create_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/create_task.php
+++ b/Tasks/samples/V2/CloudTasksClient/create_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/delete_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/delete_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/delete_task.php
+++ b/Tasks/samples/V2/CloudTasksClient/delete_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/get_iam_policy.php
+++ b/Tasks/samples/V2/CloudTasksClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/get_location.php
+++ b/Tasks/samples/V2/CloudTasksClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/get_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/get_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/get_task.php
+++ b/Tasks/samples/V2/CloudTasksClient/get_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/list_locations.php
+++ b/Tasks/samples/V2/CloudTasksClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/list_queues.php
+++ b/Tasks/samples/V2/CloudTasksClient/list_queues.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/list_tasks.php
+++ b/Tasks/samples/V2/CloudTasksClient/list_tasks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/pause_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/pause_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/purge_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/purge_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/resume_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/resume_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/run_task.php
+++ b/Tasks/samples/V2/CloudTasksClient/run_task.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/set_iam_policy.php
+++ b/Tasks/samples/V2/CloudTasksClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/test_iam_permissions.php
+++ b/Tasks/samples/V2/CloudTasksClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/samples/V2/CloudTasksClient/update_queue.php
+++ b/Tasks/samples/V2/CloudTasksClient/update_queue.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/src/V2/Client/CloudTasksClient.php
+++ b/Tasks/src/V2/Client/CloudTasksClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/src/V2/resources/cloud_tasks_descriptor_config.php
+++ b/Tasks/src/V2/resources/cloud_tasks_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/src/V2/resources/cloud_tasks_rest_client_config.php
+++ b/Tasks/src/V2/resources/cloud_tasks_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tasks/tests/Unit/V2/Client/CloudTasksClientTest.php
+++ b/Tasks/tests/Unit/V2/Client/CloudTasksClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/owlbot.py
+++ b/TelcoAutomation/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/apply_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/apply_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/apply_hydrated_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/apply_hydrated_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/approve_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/approve_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/compute_deployment_status.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/compute_deployment_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/create_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/create_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/create_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/create_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/create_edge_slm.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/create_edge_slm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/create_orchestration_cluster.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/create_orchestration_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_edge_slm.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_edge_slm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_orchestration_cluster.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/delete_orchestration_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/discard_blueprint_changes.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/discard_blueprint_changes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/discard_deployment_changes.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/discard_deployment_changes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_edge_slm.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_edge_slm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_hydrated_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_hydrated_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_location.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_orchestration_cluster.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_orchestration_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/get_public_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/get_public_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_blueprint_revisions.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_blueprint_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_blueprints.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_blueprints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_deployment_revisions.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_deployment_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_deployments.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_edge_slms.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_edge_slms.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_hydrated_deployments.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_hydrated_deployments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_locations.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_orchestration_clusters.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_orchestration_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/list_public_blueprints.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/list_public_blueprints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/propose_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/propose_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/reject_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/reject_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/remove_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/remove_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/rollback_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/rollback_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/search_blueprint_revisions.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/search_blueprint_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/search_deployment_revisions.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/search_deployment_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/update_blueprint.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/update_blueprint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/update_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/update_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/samples/V1/TelcoAutomationClient/update_hydrated_deployment.php
+++ b/TelcoAutomation/samples/V1/TelcoAutomationClient/update_hydrated_deployment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/src/V1/Client/TelcoAutomationClient.php
+++ b/TelcoAutomation/src/V1/Client/TelcoAutomationClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/src/V1/resources/telco_automation_descriptor_config.php
+++ b/TelcoAutomation/src/V1/resources/telco_automation_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/src/V1/resources/telco_automation_rest_client_config.php
+++ b/TelcoAutomation/src/V1/resources/telco_automation_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TelcoAutomation/tests/Unit/V1/Client/TelcoAutomationClientTest.php
+++ b/TelcoAutomation/tests/Unit/V1/Client/TelcoAutomationClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/owlbot.py
+++ b/TextToSpeech/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/TextToSpeech/samples/V1/TextToSpeechClient/list_voices.php
+++ b/TextToSpeech/samples/V1/TextToSpeechClient/list_voices.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/samples/V1/TextToSpeechClient/streaming_synthesize.php
+++ b/TextToSpeech/samples/V1/TextToSpeechClient/streaming_synthesize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/samples/V1/TextToSpeechClient/synthesize_speech.php
+++ b/TextToSpeech/samples/V1/TextToSpeechClient/synthesize_speech.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/samples/V1/TextToSpeechLongAudioSynthesizeClient/synthesize_long_audio.php
+++ b/TextToSpeech/samples/V1/TextToSpeechLongAudioSynthesizeClient/synthesize_long_audio.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/Client/TextToSpeechClient.php
+++ b/TextToSpeech/src/V1/Client/TextToSpeechClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/Client/TextToSpeechLongAudioSynthesizeClient.php
+++ b/TextToSpeech/src/V1/Client/TextToSpeechLongAudioSynthesizeClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/resources/text_to_speech_descriptor_config.php
+++ b/TextToSpeech/src/V1/resources/text_to_speech_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/resources/text_to_speech_long_audio_synthesize_descriptor_config.php
+++ b/TextToSpeech/src/V1/resources/text_to_speech_long_audio_synthesize_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/resources/text_to_speech_long_audio_synthesize_rest_client_config.php
+++ b/TextToSpeech/src/V1/resources/text_to_speech_long_audio_synthesize_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/src/V1/resources/text_to_speech_rest_client_config.php
+++ b/TextToSpeech/src/V1/resources/text_to_speech_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/tests/Unit/V1/Client/TextToSpeechClientTest.php
+++ b/TextToSpeech/tests/Unit/V1/Client/TextToSpeechClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TextToSpeech/tests/Unit/V1/Client/TextToSpeechLongAudioSynthesizeClientTest.php
+++ b/TextToSpeech/tests/Unit/V1/Client/TextToSpeechLongAudioSynthesizeClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/owlbot.py
+++ b/Tpu/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/create_node.php
+++ b/Tpu/samples/V2/TpuClient/create_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/create_queued_resource.php
+++ b/Tpu/samples/V2/TpuClient/create_queued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/delete_node.php
+++ b/Tpu/samples/V2/TpuClient/delete_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/delete_queued_resource.php
+++ b/Tpu/samples/V2/TpuClient/delete_queued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/generate_service_identity.php
+++ b/Tpu/samples/V2/TpuClient/generate_service_identity.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_accelerator_type.php
+++ b/Tpu/samples/V2/TpuClient/get_accelerator_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_guest_attributes.php
+++ b/Tpu/samples/V2/TpuClient/get_guest_attributes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_location.php
+++ b/Tpu/samples/V2/TpuClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_node.php
+++ b/Tpu/samples/V2/TpuClient/get_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_queued_resource.php
+++ b/Tpu/samples/V2/TpuClient/get_queued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/get_runtime_version.php
+++ b/Tpu/samples/V2/TpuClient/get_runtime_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/list_accelerator_types.php
+++ b/Tpu/samples/V2/TpuClient/list_accelerator_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/list_locations.php
+++ b/Tpu/samples/V2/TpuClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/list_nodes.php
+++ b/Tpu/samples/V2/TpuClient/list_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/list_queued_resources.php
+++ b/Tpu/samples/V2/TpuClient/list_queued_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/list_runtime_versions.php
+++ b/Tpu/samples/V2/TpuClient/list_runtime_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/reset_queued_resource.php
+++ b/Tpu/samples/V2/TpuClient/reset_queued_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/start_node.php
+++ b/Tpu/samples/V2/TpuClient/start_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/stop_node.php
+++ b/Tpu/samples/V2/TpuClient/stop_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/samples/V2/TpuClient/update_node.php
+++ b/Tpu/samples/V2/TpuClient/update_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/src/V2/Client/TpuClient.php
+++ b/Tpu/src/V2/Client/TpuClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/src/V2/resources/tpu_descriptor_config.php
+++ b/Tpu/src/V2/resources/tpu_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/src/V2/resources/tpu_rest_client_config.php
+++ b/Tpu/src/V2/resources/tpu_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tpu/tests/Unit/V2/Client/TpuClientTest.php
+++ b/Tpu/tests/Unit/V2/Client/TpuClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Trace/owlbot.py
+++ b/Trace/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Trace/samples/V2/TraceServiceClient/batch_write_spans.php
+++ b/Trace/samples/V2/TraceServiceClient/batch_write_spans.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Trace/samples/V2/TraceServiceClient/create_span.php
+++ b/Trace/samples/V2/TraceServiceClient/create_span.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Trace/tests/System/TraceServiceSmokeTest.php
+++ b/Trace/tests/System/TraceServiceSmokeTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/owlbot.py
+++ b/Translate/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/adaptive_mt_translate.php
+++ b/Translate/samples/V3/TranslationServiceClient/adaptive_mt_translate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/batch_translate_document.php
+++ b/Translate/samples/V3/TranslationServiceClient/batch_translate_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/batch_translate_text.php
+++ b/Translate/samples/V3/TranslationServiceClient/batch_translate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/create_adaptive_mt_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/create_adaptive_mt_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/create_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/create_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/create_glossary.php
+++ b/Translate/samples/V3/TranslationServiceClient/create_glossary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/create_glossary_entry.php
+++ b/Translate/samples/V3/TranslationServiceClient/create_glossary_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/create_model.php
+++ b/Translate/samples/V3/TranslationServiceClient/create_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_adaptive_mt_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_adaptive_mt_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_adaptive_mt_file.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_adaptive_mt_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_glossary.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_glossary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_glossary_entry.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_glossary_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/delete_model.php
+++ b/Translate/samples/V3/TranslationServiceClient/delete_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/detect_language.php
+++ b/Translate/samples/V3/TranslationServiceClient/detect_language.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/export_data.php
+++ b/Translate/samples/V3/TranslationServiceClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_adaptive_mt_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_adaptive_mt_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_adaptive_mt_file.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_adaptive_mt_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_dataset.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_glossary.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_glossary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_glossary_entry.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_glossary_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_model.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/get_supported_languages.php
+++ b/Translate/samples/V3/TranslationServiceClient/get_supported_languages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/import_adaptive_mt_file.php
+++ b/Translate/samples/V3/TranslationServiceClient/import_adaptive_mt_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/import_data.php
+++ b/Translate/samples/V3/TranslationServiceClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_datasets.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_files.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_sentences.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_adaptive_mt_sentences.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_datasets.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_examples.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_examples.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_glossaries.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_glossaries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_glossary_entries.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_glossary_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/list_models.php
+++ b/Translate/samples/V3/TranslationServiceClient/list_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/romanize_text.php
+++ b/Translate/samples/V3/TranslationServiceClient/romanize_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/translate_document.php
+++ b/Translate/samples/V3/TranslationServiceClient/translate_document.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/translate_text.php
+++ b/Translate/samples/V3/TranslationServiceClient/translate_text.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/update_glossary.php
+++ b/Translate/samples/V3/TranslationServiceClient/update_glossary.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/samples/V3/TranslationServiceClient/update_glossary_entry.php
+++ b/Translate/samples/V3/TranslationServiceClient/update_glossary_entry.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/src/V3/Client/TranslationServiceClient.php
+++ b/Translate/src/V3/Client/TranslationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/src/V3/resources/translation_service_descriptor_config.php
+++ b/Translate/src/V3/resources/translation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/src/V3/resources/translation_service_rest_client_config.php
+++ b/Translate/src/V3/resources/translation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Translate/tests/Unit/V3/Client/TranslationServiceClientTest.php
+++ b/Translate/tests/Unit/V3/Client/TranslationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VectorSearch/owlbot.py
+++ b/VectorSearch/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VideoIntelligence/owlbot.py
+++ b/VideoIntelligence/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VideoIntelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
+++ b/VideoIntelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoIntelligence/src/V1/Client/VideoIntelligenceServiceClient.php
+++ b/VideoIntelligence/src/V1/Client/VideoIntelligenceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoIntelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
+++ b/VideoIntelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoIntelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
+++ b/VideoIntelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoIntelligence/tests/Unit/V1/Client/VideoIntelligenceServiceClientTest.php
+++ b/VideoIntelligence/tests/Unit/V1/Client/VideoIntelligenceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/owlbot.py
+++ b/VideoLiveStream/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_asset.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_clip.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_clip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_dvr_session.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_dvr_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_event.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/create_input.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/create_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_asset.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_clip.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_clip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_dvr_session.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_dvr_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_event.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_input.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/delete_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_asset.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_asset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_clip.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_clip.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_dvr_session.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_dvr_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_event.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_input.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_location.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/get_pool.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/get_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_assets.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_channels.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_channels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_clips.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_clips.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_dvr_sessions.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_dvr_sessions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_events.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_inputs.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_inputs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/list_locations.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/preview_input.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/preview_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/start_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/start_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/start_distribution.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/start_distribution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/stop_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/stop_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/stop_distribution.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/stop_distribution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/update_channel.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/update_channel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/update_dvr_session.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/update_dvr_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/update_input.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/update_input.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/samples/V1/LivestreamServiceClient/update_pool.php
+++ b/VideoLiveStream/samples/V1/LivestreamServiceClient/update_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/src/V1/Client/LivestreamServiceClient.php
+++ b/VideoLiveStream/src/V1/Client/LivestreamServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/src/V1/resources/livestream_service_descriptor_config.php
+++ b/VideoLiveStream/src/V1/resources/livestream_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/src/V1/resources/livestream_service_rest_client_config.php
+++ b/VideoLiveStream/src/V1/resources/livestream_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoLiveStream/tests/Unit/V1/Client/LivestreamServiceClientTest.php
+++ b/VideoLiveStream/tests/Unit/V1/Client/LivestreamServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/owlbot.py
+++ b/VideoStitcher/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_cdn_key.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_cdn_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_live_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_live_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_live_session.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_live_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_slate.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_slate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_vod_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_vod_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_vod_session.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/create_vod_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_cdn_key.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_cdn_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_live_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_live_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_slate.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_slate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_vod_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/delete_vod_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_cdn_key.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_cdn_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_ad_tag_detail.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_ad_tag_detail.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_session.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_live_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_slate.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_slate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_ad_tag_detail.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_ad_tag_detail.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_session.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_session.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_stitch_detail.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/get_vod_stitch_detail.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_cdn_keys.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_cdn_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_live_ad_tag_details.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_live_ad_tag_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_live_configs.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_live_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_slates.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_slates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_ad_tag_details.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_ad_tag_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_configs.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_stitch_details.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/list_vod_stitch_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_cdn_key.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_cdn_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_live_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_live_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_slate.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_slate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_vod_config.php
+++ b/VideoStitcher/samples/V1/VideoStitcherServiceClient/update_vod_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/src/V1/Client/VideoStitcherServiceClient.php
+++ b/VideoStitcher/src/V1/Client/VideoStitcherServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/src/V1/resources/video_stitcher_service_descriptor_config.php
+++ b/VideoStitcher/src/V1/resources/video_stitcher_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/src/V1/resources/video_stitcher_service_rest_client_config.php
+++ b/VideoStitcher/src/V1/resources/video_stitcher_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoStitcher/tests/Unit/V1/Client/VideoStitcherServiceClientTest.php
+++ b/VideoStitcher/tests/Unit/V1/Client/VideoStitcherServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/owlbot.py
+++ b/VideoTranscoder/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/create_job.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/create_job_template.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/create_job_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/delete_job.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/delete_job_template.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/delete_job_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/get_job.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/get_job_template.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/get_job_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/list_job_templates.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/list_job_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/samples/V1/TranscoderServiceClient/list_jobs.php
+++ b/VideoTranscoder/samples/V1/TranscoderServiceClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/src/V1/Client/TranscoderServiceClient.php
+++ b/VideoTranscoder/src/V1/Client/TranscoderServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/src/V1/resources/transcoder_service_descriptor_config.php
+++ b/VideoTranscoder/src/V1/resources/transcoder_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/src/V1/resources/transcoder_service_rest_client_config.php
+++ b/VideoTranscoder/src/V1/resources/transcoder_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VideoTranscoder/tests/Unit/V1/Client/TranscoderServiceClientTest.php
+++ b/VideoTranscoder/tests/Unit/V1/Client/TranscoderServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/owlbot.py
+++ b/Vision/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_files.php
+++ b/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_images.php
+++ b/Vision/samples/V1/ImageAnnotatorClient/async_batch_annotate_images.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_files.php
+++ b/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_images.php
+++ b/Vision/samples/V1/ImageAnnotatorClient/batch_annotate_images.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/add_product_to_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/add_product_to_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/create_product.php
+++ b/Vision/samples/V1/ProductSearchClient/create_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/create_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/create_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/create_reference_image.php
+++ b/Vision/samples/V1/ProductSearchClient/create_reference_image.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/delete_product.php
+++ b/Vision/samples/V1/ProductSearchClient/delete_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/delete_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/delete_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/delete_reference_image.php
+++ b/Vision/samples/V1/ProductSearchClient/delete_reference_image.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/get_product.php
+++ b/Vision/samples/V1/ProductSearchClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/get_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/get_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/get_reference_image.php
+++ b/Vision/samples/V1/ProductSearchClient/get_reference_image.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/import_product_sets.php
+++ b/Vision/samples/V1/ProductSearchClient/import_product_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/list_product_sets.php
+++ b/Vision/samples/V1/ProductSearchClient/list_product_sets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/list_products.php
+++ b/Vision/samples/V1/ProductSearchClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/list_products_in_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/list_products_in_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/list_reference_images.php
+++ b/Vision/samples/V1/ProductSearchClient/list_reference_images.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/purge_products.php
+++ b/Vision/samples/V1/ProductSearchClient/purge_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/remove_product_from_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/remove_product_from_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/update_product.php
+++ b/Vision/samples/V1/ProductSearchClient/update_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/samples/V1/ProductSearchClient/update_product_set.php
+++ b/Vision/samples/V1/ProductSearchClient/update_product_set.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/Client/ImageAnnotatorClient.php
+++ b/Vision/src/V1/Client/ImageAnnotatorClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/Client/ProductSearchClient.php
+++ b/Vision/src/V1/Client/ProductSearchClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/resources/image_annotator_descriptor_config.php
+++ b/Vision/src/V1/resources/image_annotator_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/resources/image_annotator_rest_client_config.php
+++ b/Vision/src/V1/resources/image_annotator_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/resources/product_search_descriptor_config.php
+++ b/Vision/src/V1/resources/product_search_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/src/V1/resources/product_search_rest_client_config.php
+++ b/Vision/src/V1/resources/product_search_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/tests/Unit/V1/Client/ImageAnnotatorClientTest.php
+++ b/Vision/tests/Unit/V1/Client/ImageAnnotatorClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Vision/tests/Unit/V1/Client/ProductSearchClientTest.php
+++ b/Vision/tests/Unit/V1/Client/ProductSearchClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VisionAi/owlbot.py
+++ b/VisionAi/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VmMigration/owlbot.py
+++ b/VmMigration/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/add_group_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/add_group_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/cancel_clone_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/cancel_clone_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/cancel_cutover_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/cancel_cutover_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/cancel_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/cancel_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/cancel_image_import_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/cancel_image_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_clone_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_clone_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_cutover_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_cutover_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_datacenter_connector.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_datacenter_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_group.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_image_import.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_image_import.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_migrating_vm.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_migrating_vm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_source.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_target_project.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_target_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/create_utilization_report.php
+++ b/VmMigration/samples/V1/VmMigrationClient/create_utilization_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_datacenter_connector.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_datacenter_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_group.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_image_import.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_image_import.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_migrating_vm.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_migrating_vm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_source.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_target_project.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_target_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/delete_utilization_report.php
+++ b/VmMigration/samples/V1/VmMigrationClient/delete_utilization_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/extend_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/extend_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/fetch_inventory.php
+++ b/VmMigration/samples/V1/VmMigrationClient/fetch_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/fetch_storage_inventory.php
+++ b/VmMigration/samples/V1/VmMigrationClient/fetch_storage_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/finalize_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/finalize_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_clone_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_clone_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_cutover_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_cutover_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_datacenter_connector.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_datacenter_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_group.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_image_import.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_image_import.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_image_import_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_image_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_location.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_migrating_vm.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_migrating_vm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_replication_cycle.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_replication_cycle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_source.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_target_project.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_target_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/get_utilization_report.php
+++ b/VmMigration/samples/V1/VmMigrationClient/get_utilization_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_clone_jobs.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_clone_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_cutover_jobs.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_cutover_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_datacenter_connectors.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_datacenter_connectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_disk_migration_jobs.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_disk_migration_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_groups.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_image_import_jobs.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_image_import_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_image_imports.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_image_imports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_locations.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_migrating_vms.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_migrating_vms.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_replication_cycles.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_replication_cycles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_sources.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_target_projects.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_target_projects.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/list_utilization_reports.php
+++ b/VmMigration/samples/V1/VmMigrationClient/list_utilization_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/pause_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/pause_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/remove_group_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/remove_group_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/resume_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/resume_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/run_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/run_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/start_migration.php
+++ b/VmMigration/samples/V1/VmMigrationClient/start_migration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/update_disk_migration_job.php
+++ b/VmMigration/samples/V1/VmMigrationClient/update_disk_migration_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/update_group.php
+++ b/VmMigration/samples/V1/VmMigrationClient/update_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/update_migrating_vm.php
+++ b/VmMigration/samples/V1/VmMigrationClient/update_migrating_vm.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/update_source.php
+++ b/VmMigration/samples/V1/VmMigrationClient/update_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/update_target_project.php
+++ b/VmMigration/samples/V1/VmMigrationClient/update_target_project.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/samples/V1/VmMigrationClient/upgrade_appliance.php
+++ b/VmMigration/samples/V1/VmMigrationClient/upgrade_appliance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/src/V1/Client/VmMigrationClient.php
+++ b/VmMigration/src/V1/Client/VmMigrationClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/src/V1/resources/vm_migration_descriptor_config.php
+++ b/VmMigration/src/V1/resources/vm_migration_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/src/V1/resources/vm_migration_rest_client_config.php
+++ b/VmMigration/src/V1/resources/vm_migration_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmMigration/tests/Unit/V1/Client/VmMigrationClientTest.php
+++ b/VmMigration/tests/Unit/V1/Client/VmMigrationClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/owlbot.py
+++ b/VmwareEngine/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_cluster.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_external_access_rule.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_external_access_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_external_address.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_external_address.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_hcx_activation_key.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_hcx_activation_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_logging_server.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_logging_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_management_dns_zone_binding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_management_dns_zone_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_network_peering.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_network_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_network_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_network_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_private_cloud.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_private_cloud.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_private_connection.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/create_vmware_engine_network.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/create_vmware_engine_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_cluster.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_external_access_rule.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_external_access_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_external_address.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_external_address.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_logging_server.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_logging_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_management_dns_zone_binding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_management_dns_zone_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_network_peering.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_network_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_network_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_network_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_private_cloud.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_private_cloud.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_private_connection.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/delete_vmware_engine_network.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/delete_vmware_engine_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/fetch_network_policy_external_addresses.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/fetch_network_policy_external_addresses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_cluster.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_dns_bind_permission.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_dns_bind_permission.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_dns_forwarding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_dns_forwarding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_external_access_rule.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_external_access_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_external_address.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_external_address.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_hcx_activation_key.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_hcx_activation_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_iam_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_location.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_logging_server.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_logging_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_management_dns_zone_binding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_management_dns_zone_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_network_peering.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_network_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_network_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_network_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_node.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_node.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_node_type.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_node_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_private_cloud.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_private_cloud.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_private_connection.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_subnet.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/get_vmware_engine_network.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/get_vmware_engine_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/grant_dns_bind_permission.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/grant_dns_bind_permission.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_clusters.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_external_access_rules.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_external_access_rules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_external_addresses.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_external_addresses.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_hcx_activation_keys.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_hcx_activation_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_locations.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_logging_servers.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_logging_servers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_management_dns_zone_bindings.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_management_dns_zone_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_network_peerings.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_network_peerings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_network_policies.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_network_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_node_types.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_node_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_nodes.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_nodes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_peering_routes.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_peering_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_private_clouds.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_private_clouds.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_private_connection_peering_routes.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_private_connection_peering_routes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_private_connections.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_private_connections.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_subnets.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_subnets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/list_vmware_engine_networks.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/list_vmware_engine_networks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/repair_management_dns_zone_binding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/repair_management_dns_zone_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/reset_nsx_credentials.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/reset_nsx_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/reset_vcenter_credentials.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/reset_vcenter_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/revoke_dns_bind_permission.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/revoke_dns_bind_permission.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/set_iam_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/show_nsx_credentials.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/show_nsx_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/show_vcenter_credentials.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/show_vcenter_credentials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/test_iam_permissions.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/undelete_private_cloud.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/undelete_private_cloud.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_cluster.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_dns_forwarding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_dns_forwarding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_external_access_rule.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_external_access_rule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_external_address.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_external_address.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_logging_server.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_logging_server.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_management_dns_zone_binding.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_management_dns_zone_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_network_peering.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_network_peering.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_network_policy.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_network_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_private_cloud.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_private_cloud.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_private_connection.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_private_connection.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_subnet.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_subnet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/samples/V1/VmwareEngineClient/update_vmware_engine_network.php
+++ b/VmwareEngine/samples/V1/VmwareEngineClient/update_vmware_engine_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/src/V1/Client/VmwareEngineClient.php
+++ b/VmwareEngine/src/V1/Client/VmwareEngineClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/src/V1/resources/vmware_engine_descriptor_config.php
+++ b/VmwareEngine/src/V1/resources/vmware_engine_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/src/V1/resources/vmware_engine_rest_client_config.php
+++ b/VmwareEngine/src/V1/resources/vmware_engine_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VmwareEngine/tests/Unit/V1/Client/VmwareEngineClientTest.php
+++ b/VmwareEngine/tests/Unit/V1/Client/VmwareEngineClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/owlbot.py
+++ b/VpcAccess/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/VpcAccess/samples/V1/VpcAccessServiceClient/create_connector.php
+++ b/VpcAccess/samples/V1/VpcAccessServiceClient/create_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/samples/V1/VpcAccessServiceClient/delete_connector.php
+++ b/VpcAccess/samples/V1/VpcAccessServiceClient/delete_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/samples/V1/VpcAccessServiceClient/get_connector.php
+++ b/VpcAccess/samples/V1/VpcAccessServiceClient/get_connector.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/samples/V1/VpcAccessServiceClient/list_connectors.php
+++ b/VpcAccess/samples/V1/VpcAccessServiceClient/list_connectors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/samples/V1/VpcAccessServiceClient/list_locations.php
+++ b/VpcAccess/samples/V1/VpcAccessServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/src/V1/Client/VpcAccessServiceClient.php
+++ b/VpcAccess/src/V1/Client/VpcAccessServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/src/V1/resources/vpc_access_service_descriptor_config.php
+++ b/VpcAccess/src/V1/resources/vpc_access_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/src/V1/resources/vpc_access_service_rest_client_config.php
+++ b/VpcAccess/src/V1/resources/vpc_access_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/VpcAccess/tests/Unit/V1/Client/VpcAccessServiceClientTest.php
+++ b/VpcAccess/tests/Unit/V1/Client/VpcAccessServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/owlbot.py
+++ b/WebRisk/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WebRisk/samples/V1/WebRiskServiceClient/compute_threat_list_diff.php
+++ b/WebRisk/samples/V1/WebRiskServiceClient/compute_threat_list_diff.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/samples/V1/WebRiskServiceClient/create_submission.php
+++ b/WebRisk/samples/V1/WebRiskServiceClient/create_submission.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/samples/V1/WebRiskServiceClient/search_hashes.php
+++ b/WebRisk/samples/V1/WebRiskServiceClient/search_hashes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/samples/V1/WebRiskServiceClient/search_uris.php
+++ b/WebRisk/samples/V1/WebRiskServiceClient/search_uris.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/samples/V1/WebRiskServiceClient/submit_uri.php
+++ b/WebRisk/samples/V1/WebRiskServiceClient/submit_uri.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/src/V1/Client/WebRiskServiceClient.php
+++ b/WebRisk/src/V1/Client/WebRiskServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/src/V1/resources/web_risk_service_descriptor_config.php
+++ b/WebRisk/src/V1/resources/web_risk_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/src/V1/resources/web_risk_service_rest_client_config.php
+++ b/WebRisk/src/V1/resources/web_risk_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebRisk/tests/Unit/V1/Client/WebRiskServiceClientTest.php
+++ b/WebRisk/tests/Unit/V1/Client/WebRiskServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/owlbot.py
+++ b/WebSecurityScanner/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/create_scan_config.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/create_scan_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/delete_scan_config.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/delete_scan_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_finding.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_scan_config.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_scan_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_scan_run.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/get_scan_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_crawled_urls.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_crawled_urls.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_finding_type_stats.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_finding_type_stats.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_findings.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_scan_configs.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_scan_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_scan_runs.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/list_scan_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/start_scan_run.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/start_scan_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/stop_scan_run.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/stop_scan_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/samples/V1/WebSecurityScannerClient/update_scan_config.php
+++ b/WebSecurityScanner/samples/V1/WebSecurityScannerClient/update_scan_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/src/V1/Client/WebSecurityScannerClient.php
+++ b/WebSecurityScanner/src/V1/Client/WebSecurityScannerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/src/V1/resources/web_security_scanner_descriptor_config.php
+++ b/WebSecurityScanner/src/V1/resources/web_security_scanner_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/src/V1/resources/web_security_scanner_rest_client_config.php
+++ b/WebSecurityScanner/src/V1/resources/web_security_scanner_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WebSecurityScanner/tests/Unit/V1/Client/WebSecurityScannerClientTest.php
+++ b/WebSecurityScanner/tests/Unit/V1/Client/WebSecurityScannerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/owlbot.py
+++ b/Workflows/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/create_workflow.php
+++ b/Workflows/samples/V1/WorkflowsClient/create_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/delete_workflow.php
+++ b/Workflows/samples/V1/WorkflowsClient/delete_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/get_location.php
+++ b/Workflows/samples/V1/WorkflowsClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/get_workflow.php
+++ b/Workflows/samples/V1/WorkflowsClient/get_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/list_locations.php
+++ b/Workflows/samples/V1/WorkflowsClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/list_workflow_revisions.php
+++ b/Workflows/samples/V1/WorkflowsClient/list_workflow_revisions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/list_workflows.php
+++ b/Workflows/samples/V1/WorkflowsClient/list_workflows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/samples/V1/WorkflowsClient/update_workflow.php
+++ b/Workflows/samples/V1/WorkflowsClient/update_workflow.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/Executions/V1/Client/ExecutionsClient.php
+++ b/Workflows/src/Executions/V1/Client/ExecutionsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/Executions/V1/resources/executions_descriptor_config.php
+++ b/Workflows/src/Executions/V1/resources/executions_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/Executions/V1/resources/executions_rest_client_config.php
+++ b/Workflows/src/Executions/V1/resources/executions_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/V1/Client/WorkflowsClient.php
+++ b/Workflows/src/V1/Client/WorkflowsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/V1/resources/workflows_descriptor_config.php
+++ b/Workflows/src/V1/resources/workflows_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/src/V1/resources/workflows_rest_client_config.php
+++ b/Workflows/src/V1/resources/workflows_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/tests/Unit/Executions/V1/Client/ExecutionsClientTest.php
+++ b/Workflows/tests/Unit/Executions/V1/Client/ExecutionsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Workflows/tests/Unit/V1/Client/WorkflowsClientTest.php
+++ b/Workflows/tests/Unit/V1/Client/WorkflowsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WorkloadIdentity/owlbot.py
+++ b/WorkloadIdentity/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WorkloadManager/owlbot.py
+++ b/WorkloadManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1052 generated files** in **40 in-scope packages** (ShoppingMerchantInventories through WorkloadManager).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`ShoppingMerchantInventories`, `ShoppingMerchantIssueResolution`, `ShoppingMerchantLfp`, `ShoppingMerchantNotifications`, `ShoppingMerchantOrderTracking`, `ShoppingMerchantProducts`, `ShoppingMerchantPromotions`, `ShoppingMerchantQuota`, `ShoppingMerchantReports`, `ShoppingMerchantReviews`, `Spanner`, `Speech`, `SqlAdmin`, `StorageBatchOperations`, `StorageControl`, `StorageInsights`, `StorageTransfer`, `Support`, `Talent`, `Tasks`, `TelcoAutomation`, `TextToSpeech`, `Tpu`, `Trace`, `Translate`, `VectorSearch`, `VideoIntelligence`, `VideoLiveStream`, `VideoStitcher`, `VideoTranscoder`, `Vision`, `VisionAi`, `VmMigration`, `VmwareEngine`, `VpcAccess`, `WebRisk`, `WebSecurityScanner`, `Workflows`, `WorkloadIdentity`, `WorkloadManager`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-10
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 10 of 10 in the 2026 copyright update series.
