### PR TITLE
chore: update copyright years to 2026 for generated files (part 1: AccessApproval to AiPlatform)

### DIFF
--- a/AccessApproval/owlbot.py
+++ b/AccessApproval/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/approve_approval_request.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/approve_approval_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/delete_access_approval_settings.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/delete_access_approval_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/dismiss_approval_request.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/dismiss_approval_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/get_access_approval_service_account.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/get_access_approval_service_account.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/get_access_approval_settings.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/get_access_approval_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/get_approval_request.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/get_approval_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/invalidate_approval_request.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/invalidate_approval_request.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/list_approval_requests.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/list_approval_requests.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/samples/V1/AccessApprovalClient/update_access_approval_settings.php
+++ b/AccessApproval/samples/V1/AccessApprovalClient/update_access_approval_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/src/V1/Client/AccessApprovalClient.php
+++ b/AccessApproval/src/V1/Client/AccessApprovalClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/src/V1/resources/access_approval_descriptor_config.php
+++ b/AccessApproval/src/V1/resources/access_approval_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/src/V1/resources/access_approval_rest_client_config.php
+++ b/AccessApproval/src/V1/resources/access_approval_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessApproval/tests/Unit/V1/Client/AccessApprovalClientTest.php
+++ b/AccessApproval/tests/Unit/V1/Client/AccessApprovalClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/owlbot.py
+++ b/AccessContextManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/commit_service_perimeters.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/commit_service_perimeters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/create_access_level.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/create_access_level.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/create_access_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/create_access_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/create_gcp_user_access_binding.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/create_gcp_user_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/create_service_perimeter.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/create_service_perimeter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/delete_access_level.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/delete_access_level.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/delete_access_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/delete_access_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/delete_gcp_user_access_binding.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/delete_gcp_user_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/delete_service_perimeter.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/delete_service_perimeter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/get_access_level.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/get_access_level.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/get_access_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/get_access_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/get_gcp_user_access_binding.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/get_gcp_user_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/get_iam_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/get_service_perimeter.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/get_service_perimeter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/list_access_levels.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/list_access_levels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/list_access_policies.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/list_access_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/list_gcp_user_access_bindings.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/list_gcp_user_access_bindings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/list_service_perimeters.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/list_service_perimeters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/replace_access_levels.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/replace_access_levels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/replace_service_perimeters.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/replace_service_perimeters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/set_iam_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/test_iam_permissions.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/update_access_level.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/update_access_level.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/update_access_policy.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/update_access_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/update_gcp_user_access_binding.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/update_gcp_user_access_binding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/samples/V1/AccessContextManagerClient/update_service_perimeter.php
+++ b/AccessContextManager/samples/V1/AccessContextManagerClient/update_service_perimeter.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/src/V1/Client/AccessContextManagerClient.php
+++ b/AccessContextManager/src/V1/Client/AccessContextManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/src/V1/resources/access_context_manager_descriptor_config.php
+++ b/AccessContextManager/src/V1/resources/access_context_manager_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/src/V1/resources/access_context_manager_rest_client_config.php
+++ b/AccessContextManager/src/V1/resources/access_context_manager_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AccessContextManager/tests/Unit/V1/Client/AccessContextManagerClientTest.php
+++ b/AccessContextManager/tests/Unit/V1/Client/AccessContextManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/owlbot.py
+++ b/AdsAdManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdBreakServiceClient/create_ad_break.php
+++ b/AdsAdManager/samples/V1/AdBreakServiceClient/create_ad_break.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdBreakServiceClient/delete_ad_break.php
+++ b/AdsAdManager/samples/V1/AdBreakServiceClient/delete_ad_break.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdBreakServiceClient/get_ad_break.php
+++ b/AdsAdManager/samples/V1/AdBreakServiceClient/get_ad_break.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdBreakServiceClient/list_ad_breaks.php
+++ b/AdsAdManager/samples/V1/AdBreakServiceClient/list_ad_breaks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdBreakServiceClient/update_ad_break.php
+++ b/AdsAdManager/samples/V1/AdBreakServiceClient/update_ad_break.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/batch_allow_ad_review_center_ads.php
+++ b/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/batch_allow_ad_review_center_ads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/batch_block_ad_review_center_ads.php
+++ b/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/batch_block_ad_review_center_ads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/search_ad_review_center_ads.php
+++ b/AdsAdManager/samples/V1/AdReviewCenterAdServiceClient/search_ad_review_center_ads.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/batch_activate_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/batch_activate_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/batch_archive_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/batch_archive_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/batch_create_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/batch_create_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/batch_deactivate_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/batch_deactivate_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/batch_update_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/batch_update_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/create_ad_unit.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/create_ad_unit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/get_ad_unit.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/get_ad_unit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/list_ad_unit_sizes.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/list_ad_unit_sizes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/list_ad_units.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/list_ad_units.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AdUnitServiceClient/update_ad_unit.php
+++ b/AdsAdManager/samples/V1/AdUnitServiceClient/update_ad_unit.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ApplicationServiceClient/get_application.php
+++ b/AdsAdManager/samples/V1/ApplicationServiceClient/get_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ApplicationServiceClient/list_applications.php
+++ b/AdsAdManager/samples/V1/ApplicationServiceClient/list_applications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AudienceSegmentServiceClient/get_audience_segment.php
+++ b/AdsAdManager/samples/V1/AudienceSegmentServiceClient/get_audience_segment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/AudienceSegmentServiceClient/list_audience_segments.php
+++ b/AdsAdManager/samples/V1/AudienceSegmentServiceClient/list_audience_segments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BandwidthGroupServiceClient/get_bandwidth_group.php
+++ b/AdsAdManager/samples/V1/BandwidthGroupServiceClient/get_bandwidth_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BandwidthGroupServiceClient/list_bandwidth_groups.php
+++ b/AdsAdManager/samples/V1/BandwidthGroupServiceClient/list_bandwidth_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BrowserLanguageServiceClient/get_browser_language.php
+++ b/AdsAdManager/samples/V1/BrowserLanguageServiceClient/get_browser_language.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BrowserLanguageServiceClient/list_browser_languages.php
+++ b/AdsAdManager/samples/V1/BrowserLanguageServiceClient/list_browser_languages.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BrowserServiceClient/get_browser.php
+++ b/AdsAdManager/samples/V1/BrowserServiceClient/get_browser.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/BrowserServiceClient/list_browsers.php
+++ b/AdsAdManager/samples/V1/BrowserServiceClient/list_browsers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CmsMetadataKeyServiceClient/get_cms_metadata_key.php
+++ b/AdsAdManager/samples/V1/CmsMetadataKeyServiceClient/get_cms_metadata_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CmsMetadataKeyServiceClient/list_cms_metadata_keys.php
+++ b/AdsAdManager/samples/V1/CmsMetadataKeyServiceClient/list_cms_metadata_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CmsMetadataValueServiceClient/get_cms_metadata_value.php
+++ b/AdsAdManager/samples/V1/CmsMetadataValueServiceClient/get_cms_metadata_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CmsMetadataValueServiceClient/list_cms_metadata_values.php
+++ b/AdsAdManager/samples/V1/CmsMetadataValueServiceClient/list_cms_metadata_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CompanyServiceClient/get_company.php
+++ b/AdsAdManager/samples/V1/CompanyServiceClient/get_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CompanyServiceClient/list_companies.php
+++ b/AdsAdManager/samples/V1/CompanyServiceClient/list_companies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/batch_create_contacts.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/batch_create_contacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/batch_update_contacts.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/batch_update_contacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/create_contact.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/create_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/get_contact.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/get_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/list_contacts.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/list_contacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContactServiceClient/update_contact.php
+++ b/AdsAdManager/samples/V1/ContactServiceClient/update_contact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentBundleServiceClient/get_content_bundle.php
+++ b/AdsAdManager/samples/V1/ContentBundleServiceClient/get_content_bundle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentBundleServiceClient/list_content_bundles.php
+++ b/AdsAdManager/samples/V1/ContentBundleServiceClient/list_content_bundles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentLabelServiceClient/get_content_label.php
+++ b/AdsAdManager/samples/V1/ContentLabelServiceClient/get_content_label.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentLabelServiceClient/list_content_labels.php
+++ b/AdsAdManager/samples/V1/ContentLabelServiceClient/list_content_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentServiceClient/get_content.php
+++ b/AdsAdManager/samples/V1/ContentServiceClient/get_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ContentServiceClient/list_content.php
+++ b/AdsAdManager/samples/V1/ContentServiceClient/list_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CreativeTemplateServiceClient/get_creative_template.php
+++ b/AdsAdManager/samples/V1/CreativeTemplateServiceClient/get_creative_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CreativeTemplateServiceClient/list_creative_templates.php
+++ b/AdsAdManager/samples/V1/CreativeTemplateServiceClient/list_creative_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_activate_custom_fields.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_activate_custom_fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_create_custom_fields.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_create_custom_fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_deactivate_custom_fields.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_deactivate_custom_fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_update_custom_fields.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/batch_update_custom_fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/create_custom_field.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/create_custom_field.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/get_custom_field.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/get_custom_field.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/list_custom_fields.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/list_custom_fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomFieldServiceClient/update_custom_field.php
+++ b/AdsAdManager/samples/V1/CustomFieldServiceClient/update_custom_field.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_activate_custom_targeting_keys.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_activate_custom_targeting_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_create_custom_targeting_keys.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_create_custom_targeting_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_deactivate_custom_targeting_keys.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_deactivate_custom_targeting_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_update_custom_targeting_keys.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/batch_update_custom_targeting_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/create_custom_targeting_key.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/create_custom_targeting_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/get_custom_targeting_key.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/get_custom_targeting_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/list_custom_targeting_keys.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/list_custom_targeting_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/update_custom_targeting_key.php
+++ b/AdsAdManager/samples/V1/CustomTargetingKeyServiceClient/update_custom_targeting_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingValueServiceClient/get_custom_targeting_value.php
+++ b/AdsAdManager/samples/V1/CustomTargetingValueServiceClient/get_custom_targeting_value.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/CustomTargetingValueServiceClient/list_custom_targeting_values.php
+++ b/AdsAdManager/samples/V1/CustomTargetingValueServiceClient/list_custom_targeting_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceCapabilityServiceClient/get_device_capability.php
+++ b/AdsAdManager/samples/V1/DeviceCapabilityServiceClient/get_device_capability.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceCapabilityServiceClient/list_device_capabilities.php
+++ b/AdsAdManager/samples/V1/DeviceCapabilityServiceClient/list_device_capabilities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceCategoryServiceClient/get_device_category.php
+++ b/AdsAdManager/samples/V1/DeviceCategoryServiceClient/get_device_category.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceCategoryServiceClient/list_device_categories.php
+++ b/AdsAdManager/samples/V1/DeviceCategoryServiceClient/list_device_categories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceManufacturerServiceClient/get_device_manufacturer.php
+++ b/AdsAdManager/samples/V1/DeviceManufacturerServiceClient/get_device_manufacturer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/DeviceManufacturerServiceClient/list_device_manufacturers.php
+++ b/AdsAdManager/samples/V1/DeviceManufacturerServiceClient/list_device_manufacturers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/batch_create_entity_signals_mappings.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/batch_create_entity_signals_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/batch_update_entity_signals_mappings.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/batch_update_entity_signals_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/create_entity_signals_mapping.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/create_entity_signals_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/get_entity_signals_mapping.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/get_entity_signals_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/list_entity_signals_mappings.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/list_entity_signals_mappings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/update_entity_signals_mapping.php
+++ b/AdsAdManager/samples/V1/EntitySignalsMappingServiceClient/update_entity_signals_mapping.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/GeoTargetServiceClient/get_geo_target.php
+++ b/AdsAdManager/samples/V1/GeoTargetServiceClient/get_geo_target.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/GeoTargetServiceClient/list_geo_targets.php
+++ b/AdsAdManager/samples/V1/GeoTargetServiceClient/list_geo_targets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/LineItemServiceClient/get_line_item.php
+++ b/AdsAdManager/samples/V1/LineItemServiceClient/get_line_item.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/LineItemServiceClient/list_line_items.php
+++ b/AdsAdManager/samples/V1/LineItemServiceClient/list_line_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileCarrierServiceClient/get_mobile_carrier.php
+++ b/AdsAdManager/samples/V1/MobileCarrierServiceClient/get_mobile_carrier.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileCarrierServiceClient/list_mobile_carriers.php
+++ b/AdsAdManager/samples/V1/MobileCarrierServiceClient/list_mobile_carriers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileDeviceServiceClient/get_mobile_device.php
+++ b/AdsAdManager/samples/V1/MobileDeviceServiceClient/get_mobile_device.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileDeviceServiceClient/list_mobile_devices.php
+++ b/AdsAdManager/samples/V1/MobileDeviceServiceClient/list_mobile_devices.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileDeviceSubmodelServiceClient/get_mobile_device_submodel.php
+++ b/AdsAdManager/samples/V1/MobileDeviceSubmodelServiceClient/get_mobile_device_submodel.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/MobileDeviceSubmodelServiceClient/list_mobile_device_submodels.php
+++ b/AdsAdManager/samples/V1/MobileDeviceSubmodelServiceClient/list_mobile_device_submodels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/NetworkServiceClient/get_network.php
+++ b/AdsAdManager/samples/V1/NetworkServiceClient/get_network.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/NetworkServiceClient/list_networks.php
+++ b/AdsAdManager/samples/V1/NetworkServiceClient/list_networks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OperatingSystemServiceClient/get_operating_system.php
+++ b/AdsAdManager/samples/V1/OperatingSystemServiceClient/get_operating_system.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OperatingSystemServiceClient/list_operating_systems.php
+++ b/AdsAdManager/samples/V1/OperatingSystemServiceClient/list_operating_systems.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OperatingSystemVersionServiceClient/get_operating_system_version.php
+++ b/AdsAdManager/samples/V1/OperatingSystemVersionServiceClient/get_operating_system_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OperatingSystemVersionServiceClient/list_operating_system_versions.php
+++ b/AdsAdManager/samples/V1/OperatingSystemVersionServiceClient/list_operating_system_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OrderServiceClient/get_order.php
+++ b/AdsAdManager/samples/V1/OrderServiceClient/get_order.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/OrderServiceClient/list_orders.php
+++ b/AdsAdManager/samples/V1/OrderServiceClient/list_orders.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/batch_activate_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/batch_activate_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/batch_archive_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/batch_archive_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/batch_create_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/batch_create_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/batch_deactivate_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/batch_deactivate_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/batch_update_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/batch_update_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/create_placement.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/create_placement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/get_placement.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/get_placement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/list_placements.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/list_placements.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PlacementServiceClient/update_placement.php
+++ b/AdsAdManager/samples/V1/PlacementServiceClient/update_placement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/create_private_auction_deal.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/create_private_auction_deal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/get_private_auction_deal.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/get_private_auction_deal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/list_private_auction_deals.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/list_private_auction_deals.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/update_private_auction_deal.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionDealServiceClient/update_private_auction_deal.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionServiceClient/create_private_auction.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionServiceClient/create_private_auction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionServiceClient/get_private_auction.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionServiceClient/get_private_auction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionServiceClient/list_private_auctions.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionServiceClient/list_private_auctions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/PrivateAuctionServiceClient/update_private_auction.php
+++ b/AdsAdManager/samples/V1/PrivateAuctionServiceClient/update_private_auction.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ProgrammaticBuyerServiceClient/get_programmatic_buyer.php
+++ b/AdsAdManager/samples/V1/ProgrammaticBuyerServiceClient/get_programmatic_buyer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ProgrammaticBuyerServiceClient/list_programmatic_buyers.php
+++ b/AdsAdManager/samples/V1/ProgrammaticBuyerServiceClient/list_programmatic_buyers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/create_report.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/create_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/fetch_report_result_rows.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/fetch_report_result_rows.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/get_report.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/get_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/list_reports.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/list_reports.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/run_report.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/run_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/ReportServiceClient/update_report.php
+++ b/AdsAdManager/samples/V1/ReportServiceClient/update_report.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/RoleServiceClient/get_role.php
+++ b/AdsAdManager/samples/V1/RoleServiceClient/get_role.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/RoleServiceClient/list_roles.php
+++ b/AdsAdManager/samples/V1/RoleServiceClient/list_roles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/batch_create_sites.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/batch_create_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/batch_deactivate_sites.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/batch_deactivate_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/batch_submit_sites_for_approval.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/batch_submit_sites_for_approval.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/batch_update_sites.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/batch_update_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/create_site.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/create_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/get_site.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/get_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/list_sites.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/list_sites.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/SiteServiceClient/update_site.php
+++ b/AdsAdManager/samples/V1/SiteServiceClient/update_site.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TaxonomyCategoryServiceClient/get_taxonomy_category.php
+++ b/AdsAdManager/samples/V1/TaxonomyCategoryServiceClient/get_taxonomy_category.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TaxonomyCategoryServiceClient/list_taxonomy_categories.php
+++ b/AdsAdManager/samples/V1/TaxonomyCategoryServiceClient/list_taxonomy_categories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/batch_activate_teams.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/batch_activate_teams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/batch_create_teams.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/batch_create_teams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/batch_deactivate_teams.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/batch_deactivate_teams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/batch_update_teams.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/batch_update_teams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/create_team.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/create_team.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/get_team.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/get_team.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/list_teams.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/list_teams.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/TeamServiceClient/update_team.php
+++ b/AdsAdManager/samples/V1/TeamServiceClient/update_team.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/samples/V1/UserServiceClient/get_user.php
+++ b/AdsAdManager/samples/V1/UserServiceClient/get_user.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/AdBreakServiceClient.php
+++ b/AdsAdManager/src/V1/Client/AdBreakServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/AdReviewCenterAdServiceClient.php
+++ b/AdsAdManager/src/V1/Client/AdReviewCenterAdServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/AdUnitServiceClient.php
+++ b/AdsAdManager/src/V1/Client/AdUnitServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ApplicationServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ApplicationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/AudienceSegmentServiceClient.php
+++ b/AdsAdManager/src/V1/Client/AudienceSegmentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/BandwidthGroupServiceClient.php
+++ b/AdsAdManager/src/V1/Client/BandwidthGroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/BrowserLanguageServiceClient.php
+++ b/AdsAdManager/src/V1/Client/BrowserLanguageServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/BrowserServiceClient.php
+++ b/AdsAdManager/src/V1/Client/BrowserServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CmsMetadataKeyServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CmsMetadataKeyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CmsMetadataValueServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CmsMetadataValueServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CompanyServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CompanyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ContactServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ContactServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ContentBundleServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ContentBundleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ContentLabelServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ContentLabelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ContentServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ContentServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CreativeTemplateServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CreativeTemplateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CustomFieldServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CustomFieldServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CustomTargetingKeyServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CustomTargetingKeyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/CustomTargetingValueServiceClient.php
+++ b/AdsAdManager/src/V1/Client/CustomTargetingValueServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/DeviceCapabilityServiceClient.php
+++ b/AdsAdManager/src/V1/Client/DeviceCapabilityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/DeviceCategoryServiceClient.php
+++ b/AdsAdManager/src/V1/Client/DeviceCategoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/DeviceManufacturerServiceClient.php
+++ b/AdsAdManager/src/V1/Client/DeviceManufacturerServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/EntitySignalsMappingServiceClient.php
+++ b/AdsAdManager/src/V1/Client/EntitySignalsMappingServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/GeoTargetServiceClient.php
+++ b/AdsAdManager/src/V1/Client/GeoTargetServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/LineItemServiceClient.php
+++ b/AdsAdManager/src/V1/Client/LineItemServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/MobileCarrierServiceClient.php
+++ b/AdsAdManager/src/V1/Client/MobileCarrierServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/MobileDeviceServiceClient.php
+++ b/AdsAdManager/src/V1/Client/MobileDeviceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/MobileDeviceSubmodelServiceClient.php
+++ b/AdsAdManager/src/V1/Client/MobileDeviceSubmodelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/NetworkServiceClient.php
+++ b/AdsAdManager/src/V1/Client/NetworkServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/OperatingSystemServiceClient.php
+++ b/AdsAdManager/src/V1/Client/OperatingSystemServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/OperatingSystemVersionServiceClient.php
+++ b/AdsAdManager/src/V1/Client/OperatingSystemVersionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/OrderServiceClient.php
+++ b/AdsAdManager/src/V1/Client/OrderServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/PlacementServiceClient.php
+++ b/AdsAdManager/src/V1/Client/PlacementServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/PrivateAuctionDealServiceClient.php
+++ b/AdsAdManager/src/V1/Client/PrivateAuctionDealServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/PrivateAuctionServiceClient.php
+++ b/AdsAdManager/src/V1/Client/PrivateAuctionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ProgrammaticBuyerServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ProgrammaticBuyerServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/ReportServiceClient.php
+++ b/AdsAdManager/src/V1/Client/ReportServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/RoleServiceClient.php
+++ b/AdsAdManager/src/V1/Client/RoleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/SiteServiceClient.php
+++ b/AdsAdManager/src/V1/Client/SiteServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/TaxonomyCategoryServiceClient.php
+++ b/AdsAdManager/src/V1/Client/TaxonomyCategoryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/TeamServiceClient.php
+++ b/AdsAdManager/src/V1/Client/TeamServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/Client/UserServiceClient.php
+++ b/AdsAdManager/src/V1/Client/UserServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_break_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/ad_break_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_break_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/ad_break_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_review_center_ad_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/ad_review_center_ad_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_review_center_ad_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/ad_review_center_ad_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_unit_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/ad_unit_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/ad_unit_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/ad_unit_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/application_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/application_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/application_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/application_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/audience_segment_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/audience_segment_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/audience_segment_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/audience_segment_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/bandwidth_group_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/bandwidth_group_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/bandwidth_group_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/bandwidth_group_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/browser_language_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/browser_language_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/browser_language_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/browser_language_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/browser_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/browser_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/browser_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/browser_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/cms_metadata_key_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/cms_metadata_key_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/cms_metadata_key_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/cms_metadata_key_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/cms_metadata_value_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/cms_metadata_value_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/cms_metadata_value_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/cms_metadata_value_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/company_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/company_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/company_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/company_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/contact_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/contact_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/contact_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/contact_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_bundle_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/content_bundle_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_bundle_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/content_bundle_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_label_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/content_label_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_label_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/content_label_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/content_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/content_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/content_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/creative_template_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/creative_template_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/creative_template_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/creative_template_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_field_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/custom_field_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_field_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/custom_field_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_targeting_key_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/custom_targeting_key_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_targeting_key_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/custom_targeting_key_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_targeting_value_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/custom_targeting_value_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/custom_targeting_value_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/custom_targeting_value_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_capability_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/device_capability_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_capability_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/device_capability_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_category_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/device_category_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_category_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/device_category_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_manufacturer_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/device_manufacturer_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/device_manufacturer_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/device_manufacturer_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/entity_signals_mapping_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/entity_signals_mapping_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/entity_signals_mapping_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/entity_signals_mapping_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/geo_target_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/geo_target_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/geo_target_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/geo_target_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/line_item_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/line_item_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/line_item_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/line_item_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_carrier_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_carrier_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_carrier_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_carrier_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_device_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_device_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_device_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_device_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_device_submodel_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_device_submodel_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/mobile_device_submodel_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/mobile_device_submodel_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/network_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/network_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/network_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/network_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/operating_system_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/operating_system_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/operating_system_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/operating_system_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/operating_system_version_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/operating_system_version_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/operating_system_version_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/operating_system_version_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/order_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/order_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/order_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/order_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/placement_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/placement_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/placement_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/placement_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/private_auction_deal_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/private_auction_deal_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/private_auction_deal_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/private_auction_deal_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/private_auction_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/private_auction_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/private_auction_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/private_auction_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/programmatic_buyer_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/programmatic_buyer_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/programmatic_buyer_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/programmatic_buyer_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/report_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/report_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/report_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/report_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/role_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/role_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/role_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/role_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/site_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/site_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/site_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/site_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/taxonomy_category_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/taxonomy_category_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/taxonomy_category_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/taxonomy_category_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/team_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/team_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/team_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/team_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/user_service_descriptor_config.php
+++ b/AdsAdManager/src/V1/resources/user_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/src/V1/resources/user_service_rest_client_config.php
+++ b/AdsAdManager/src/V1/resources/user_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/AdBreakServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/AdBreakServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/AdReviewCenterAdServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/AdReviewCenterAdServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/AdUnitServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/AdUnitServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ApplicationServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ApplicationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/AudienceSegmentServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/AudienceSegmentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/BandwidthGroupServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/BandwidthGroupServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/BrowserLanguageServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/BrowserLanguageServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/BrowserServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/BrowserServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CmsMetadataKeyServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CmsMetadataKeyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CmsMetadataValueServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CmsMetadataValueServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CompanyServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CompanyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ContactServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ContactServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ContentBundleServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ContentBundleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ContentLabelServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ContentLabelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ContentServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ContentServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CreativeTemplateServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CreativeTemplateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CustomFieldServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CustomFieldServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CustomTargetingKeyServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CustomTargetingKeyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/CustomTargetingValueServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/CustomTargetingValueServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/DeviceCapabilityServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/DeviceCapabilityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/DeviceCategoryServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/DeviceCategoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/DeviceManufacturerServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/DeviceManufacturerServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/EntitySignalsMappingServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/EntitySignalsMappingServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/GeoTargetServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/GeoTargetServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/LineItemServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/LineItemServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/MobileCarrierServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/MobileCarrierServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/MobileDeviceServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/MobileDeviceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/MobileDeviceSubmodelServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/MobileDeviceSubmodelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/NetworkServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/NetworkServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/OperatingSystemServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/OperatingSystemServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/OperatingSystemVersionServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/OperatingSystemVersionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/OrderServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/OrderServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/PlacementServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/PlacementServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/PrivateAuctionDealServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/PrivateAuctionDealServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/PrivateAuctionServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/PrivateAuctionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ProgrammaticBuyerServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ProgrammaticBuyerServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/ReportServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/ReportServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/RoleServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/RoleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/SiteServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/SiteServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/TaxonomyCategoryServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/TaxonomyCategoryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/TeamServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/TeamServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsAdManager/tests/Unit/V1/Client/UserServiceClientTest.php
+++ b/AdsAdManager/tests/Unit/V1/Client/UserServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/owlbot.py
+++ b/AdsDataManager/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AdsDataManager/samples/V1/IngestionServiceClient/ingest_audience_members.php
+++ b/AdsDataManager/samples/V1/IngestionServiceClient/ingest_audience_members.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/samples/V1/IngestionServiceClient/ingest_events.php
+++ b/AdsDataManager/samples/V1/IngestionServiceClient/ingest_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/samples/V1/IngestionServiceClient/remove_audience_members.php
+++ b/AdsDataManager/samples/V1/IngestionServiceClient/remove_audience_members.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/samples/V1/IngestionServiceClient/retrieve_request_status.php
+++ b/AdsDataManager/samples/V1/IngestionServiceClient/retrieve_request_status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/src/V1/Client/IngestionServiceClient.php
+++ b/AdsDataManager/src/V1/Client/IngestionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/src/V1/resources/ingestion_service_descriptor_config.php
+++ b/AdsDataManager/src/V1/resources/ingestion_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/src/V1/resources/ingestion_service_rest_client_config.php
+++ b/AdsDataManager/src/V1/resources/ingestion_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsDataManager/tests/Unit/V1/Client/IngestionServiceClientTest.php
+++ b/AdsDataManager/tests/Unit/V1/Client/IngestionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/owlbot.py
+++ b/AdsMarketingPlatformAdmin/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/create_analytics_account_link.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/create_analytics_account_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/delete_analytics_account_link.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/delete_analytics_account_link.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/find_sales_partner_managed_clients.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/find_sales_partner_managed_clients.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/get_organization.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/get_organization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/list_analytics_account_links.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/list_analytics_account_links.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/list_organizations.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/list_organizations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/report_property_usage.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/report_property_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/set_property_service_level.php
+++ b/AdsMarketingPlatformAdmin/samples/V1alpha/MarketingplatformAdminServiceClient/set_property_service_level.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/src/V1alpha/Client/MarketingplatformAdminServiceClient.php
+++ b/AdsMarketingPlatformAdmin/src/V1alpha/Client/MarketingplatformAdminServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/src/V1alpha/resources/marketingplatform_admin_service_descriptor_config.php
+++ b/AdsMarketingPlatformAdmin/src/V1alpha/resources/marketingplatform_admin_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/src/V1alpha/resources/marketingplatform_admin_service_rest_client_config.php
+++ b/AdsMarketingPlatformAdmin/src/V1alpha/resources/marketingplatform_admin_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdsMarketingPlatformAdmin/tests/Unit/V1alpha/Client/MarketingplatformAdminServiceClientTest.php
+++ b/AdsMarketingPlatformAdmin/tests/Unit/V1alpha/Client/MarketingplatformAdminServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/owlbot.py
+++ b/AdvisoryNotifications/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/get_notification.php
+++ b/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/get_notification.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/get_settings.php
+++ b/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/get_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/list_notifications.php
+++ b/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/list_notifications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/update_settings.php
+++ b/AdvisoryNotifications/samples/V1/AdvisoryNotificationsServiceClient/update_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/src/V1/Client/AdvisoryNotificationsServiceClient.php
+++ b/AdvisoryNotifications/src/V1/Client/AdvisoryNotificationsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/src/V1/resources/advisory_notifications_service_descriptor_config.php
+++ b/AdvisoryNotifications/src/V1/resources/advisory_notifications_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/src/V1/resources/advisory_notifications_service_rest_client_config.php
+++ b/AdvisoryNotifications/src/V1/resources/advisory_notifications_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AdvisoryNotifications/tests/Unit/V1/Client/AdvisoryNotificationsServiceClientTest.php
+++ b/AdvisoryNotifications/tests/Unit/V1/Client/AdvisoryNotificationsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/owlbot.py
+++ b/AiPlatform/owlbot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/generate_synthetic_data.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/generate_synthetic_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DataFoundryServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/DataFoundryServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/create_dataset.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/create_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/create_dataset_version.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/create_dataset_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/delete_dataset.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/delete_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/delete_dataset_version.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/delete_dataset_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/delete_saved_query.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/delete_saved_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/export_data.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/export_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/get_annotation_spec.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/get_annotation_spec.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/get_dataset.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/get_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/get_dataset_version.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/get_dataset_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/import_data.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/import_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_annotations.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_annotations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_data_items.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_data_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_dataset_versions.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_dataset_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_datasets.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_datasets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/list_saved_queries.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/list_saved_queries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/restore_dataset_version.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/restore_dataset_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/search_data_items.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/search_data_items.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/update_dataset.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/update_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DatasetServiceClient/update_dataset_version.php
+++ b/AiPlatform/samples/V1/DatasetServiceClient/update_dataset_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/create_deployment_resource_pool.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/create_deployment_resource_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/delete_deployment_resource_pool.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/delete_deployment_resource_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_deployment_resource_pool.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_deployment_resource_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/list_deployment_resource_pools.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/list_deployment_resource_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/query_deployed_models.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/query_deployed_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/update_deployment_resource_pool.php
+++ b/AiPlatform/samples/V1/DeploymentResourcePoolServiceClient/update_deployment_resource_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/create_endpoint.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/create_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/delete_endpoint.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/delete_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/deploy_model.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/deploy_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/get_endpoint.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/get_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/list_endpoints.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/list_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/mutate_deployed_model.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/mutate_deployed_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/undeploy_model.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/undeploy_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/update_endpoint.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/update_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EndpointServiceClient/update_endpoint_long_running.php
+++ b/AiPlatform/samples/V1/EndpointServiceClient/update_endpoint_long_running.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/evaluate_instances.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/evaluate_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/EvaluationServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/EvaluationServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/create_feature_online_store.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/create_feature_online_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/create_feature_view.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/create_feature_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/delete_feature_online_store.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/delete_feature_online_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/delete_feature_view.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/delete_feature_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_online_store.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_online_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_view.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_view_sync.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_feature_view_sync.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_online_stores.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_online_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_view_syncs.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_view_syncs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_views.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_feature_views.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/sync_feature_view.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/sync_feature_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/update_feature_online_store.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/update_feature_online_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/update_feature_view.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreAdminServiceClient/update_feature_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/feature_view_direct_write.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/feature_view_direct_write.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/fetch_feature_values.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/fetch_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/generate_fetch_access_token.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/generate_fetch_access_token.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/search_nearest_entities.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/search_nearest_entities.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/FeatureOnlineStoreServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/batch_create_features.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/batch_create_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/create_feature.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/create_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/create_feature_group.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/create_feature_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/delete_feature.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/delete_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/delete_feature_group.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/delete_feature_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_feature.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_feature_group.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_feature_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_feature_groups.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_feature_groups.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_features.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/update_feature.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/update_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeatureRegistryServiceClient/update_feature_group.php
+++ b/AiPlatform/samples/V1/FeatureRegistryServiceClient/update_feature_group.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/read_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/read_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/streaming_read_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/streaming_read_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/write_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreOnlineServingServiceClient/write_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/batch_create_features.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/batch_create_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/batch_read_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/batch_read_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/create_entity_type.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/create_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/create_feature.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/create_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/create_featurestore.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/create_featurestore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_entity_type.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_feature.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_featurestore.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/delete_featurestore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/export_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/export_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/get_entity_type.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/get_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/get_feature.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/get_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/get_featurestore.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/get_featurestore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/import_feature_values.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/import_feature_values.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/list_entity_types.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/list_entity_types.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/list_features.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/list_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/list_featurestores.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/list_featurestores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/search_features.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/search_features.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/update_entity_type.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/update_entity_type.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/update_feature.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/update_feature.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/FeaturestoreServiceClient/update_featurestore.php
+++ b/AiPlatform/samples/V1/FeaturestoreServiceClient/update_featurestore.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/create_cached_content.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/create_cached_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/delete_cached_content.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/delete_cached_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/get_cached_content.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/get_cached_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/list_cached_contents.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/list_cached_contents.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiCacheServiceClient/update_cached_content.php
+++ b/AiPlatform/samples/V1/GenAiCacheServiceClient/update_cached_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/cancel_tuning_job.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/cancel_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/create_tuning_job.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/create_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/get_tuning_job.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/get_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/list_tuning_jobs.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/list_tuning_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/rebase_tuned_model.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/rebase_tuned_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/GenAiTuningServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/GenAiTuningServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/create_index_endpoint.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/create_index_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/delete_index_endpoint.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/delete_index_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/deploy_index.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/deploy_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/get_index_endpoint.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/get_index_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/list_index_endpoints.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/list_index_endpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/mutate_deployed_index.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/mutate_deployed_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/undeploy_index.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/undeploy_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexEndpointServiceClient/update_index_endpoint.php
+++ b/AiPlatform/samples/V1/IndexEndpointServiceClient/update_index_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/create_index.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/create_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/delete_index.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/delete_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/get_index.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/get_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/list_indexes.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/list_indexes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/remove_datapoints.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/remove_datapoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/update_index.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/update_index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/IndexServiceClient/upsert_datapoints.php
+++ b/AiPlatform/samples/V1/IndexServiceClient/upsert_datapoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/cancel_batch_prediction_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/cancel_batch_prediction_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/cancel_custom_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/cancel_custom_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/cancel_data_labeling_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/cancel_data_labeling_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/cancel_hyperparameter_tuning_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/cancel_hyperparameter_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/cancel_nas_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/cancel_nas_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_batch_prediction_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_batch_prediction_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_custom_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_custom_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_data_labeling_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_data_labeling_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_hyperparameter_tuning_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_hyperparameter_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/create_nas_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/create_nas_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_batch_prediction_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_batch_prediction_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_custom_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_custom_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_data_labeling_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_data_labeling_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_hyperparameter_tuning_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_hyperparameter_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/delete_nas_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/delete_nas_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_batch_prediction_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_batch_prediction_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_custom_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_custom_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_data_labeling_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_data_labeling_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_hyperparameter_tuning_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_hyperparameter_tuning_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_nas_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_nas_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/get_nas_trial_detail.php
+++ b/AiPlatform/samples/V1/JobServiceClient/get_nas_trial_detail.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_batch_prediction_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_batch_prediction_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_custom_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_custom_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_data_labeling_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_data_labeling_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_hyperparameter_tuning_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_hyperparameter_tuning_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_model_deployment_monitoring_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_model_deployment_monitoring_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_nas_jobs.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_nas_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/list_nas_trial_details.php
+++ b/AiPlatform/samples/V1/JobServiceClient/list_nas_trial_details.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/pause_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/pause_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/resume_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/resume_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/search_model_deployment_monitoring_stats_anomalies.php
+++ b/AiPlatform/samples/V1/JobServiceClient/search_model_deployment_monitoring_stats_anomalies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/JobServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/JobServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/JobServiceClient/update_model_deployment_monitoring_job.php
+++ b/AiPlatform/samples/V1/JobServiceClient/update_model_deployment_monitoring_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/compute_tokens.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/compute_tokens.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/count_tokens.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/count_tokens.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/LlmUtilityServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/LlmUtilityServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/find_neighbors.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/find_neighbors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/read_index_datapoints.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/read_index_datapoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MatchServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/MatchServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/add_context_artifacts_and_executions.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/add_context_artifacts_and_executions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/add_context_children.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/add_context_children.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/add_execution_events.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/add_execution_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/create_artifact.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/create_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/create_context.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/create_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/create_execution.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/create_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/create_metadata_schema.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/create_metadata_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/create_metadata_store.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/create_metadata_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/delete_artifact.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/delete_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/delete_context.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/delete_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/delete_execution.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/delete_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/delete_metadata_store.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/delete_metadata_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_artifact.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_context.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_execution.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_metadata_schema.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_metadata_schema.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/get_metadata_store.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/get_metadata_store.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_artifacts.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_artifacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_contexts.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_executions.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_executions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_metadata_schemas.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_metadata_schemas.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/list_metadata_stores.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/list_metadata_stores.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/purge_artifacts.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/purge_artifacts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/purge_contexts.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/purge_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/purge_executions.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/purge_executions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/query_artifact_lineage_subgraph.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/query_artifact_lineage_subgraph.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/query_context_lineage_subgraph.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/query_context_lineage_subgraph.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/query_execution_inputs_and_outputs.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/query_execution_inputs_and_outputs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/remove_context_children.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/remove_context_children.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/update_artifact.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/update_artifact.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/update_context.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/update_context.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MetadataServiceClient/update_execution.php
+++ b/AiPlatform/samples/V1/MetadataServiceClient/update_execution.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/batch_migrate_resources.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/batch_migrate_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/search_migratable_resources.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/search_migratable_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/MigrationServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/MigrationServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/deploy.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/deploy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/get_publisher_model.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/get_publisher_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelGardenServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/ModelGardenServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/batch_import_evaluated_annotations.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/batch_import_evaluated_annotations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/batch_import_model_evaluation_slices.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/batch_import_model_evaluation_slices.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/copy_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/copy_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/delete_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/delete_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/delete_model_version.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/delete_model_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/export_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/export_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/get_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/get_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/get_model_evaluation.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/get_model_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/get_model_evaluation_slice.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/get_model_evaluation_slice.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/import_model_evaluation.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/import_model_evaluation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_model_evaluation_slices.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_model_evaluation_slices.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_model_evaluations.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_model_evaluations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_model_version_checkpoints.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_model_version_checkpoints.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_model_versions.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_model_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/list_models.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/list_models.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/merge_version_aliases.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/merge_version_aliases.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/update_explanation_dataset.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/update_explanation_dataset.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/update_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/update_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ModelServiceClient/upload_model.php
+++ b/AiPlatform/samples/V1/ModelServiceClient/upload_model.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/assign_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/assign_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/create_notebook_execution_job.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/create_notebook_execution_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/create_notebook_runtime_template.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/create_notebook_runtime_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_execution_job.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_execution_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_runtime_template.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/delete_notebook_runtime_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_execution_job.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_execution_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_runtime_template.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/get_notebook_runtime_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_execution_jobs.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_execution_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_runtime_templates.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_runtime_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_runtimes.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/list_notebook_runtimes.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/start_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/start_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/stop_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/stop_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/update_notebook_runtime_template.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/update_notebook_runtime_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/NotebookServiceClient/upgrade_notebook_runtime.php
+++ b/AiPlatform/samples/V1/NotebookServiceClient/upgrade_notebook_runtime.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/create_persistent_resource.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/create_persistent_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/delete_persistent_resource.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/delete_persistent_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/get_persistent_resource.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/get_persistent_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/list_persistent_resources.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/list_persistent_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/reboot_persistent_resource.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/reboot_persistent_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PersistentResourceServiceClient/update_persistent_resource.php
+++ b/AiPlatform/samples/V1/PersistentResourceServiceClient/update_persistent_resource.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/batch_cancel_pipeline_jobs.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/batch_cancel_pipeline_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/batch_delete_pipeline_jobs.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/batch_delete_pipeline_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/cancel_pipeline_job.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/cancel_pipeline_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/cancel_training_pipeline.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/cancel_training_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/create_pipeline_job.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/create_pipeline_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/create_training_pipeline.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/create_training_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/delete_pipeline_job.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/delete_pipeline_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/delete_training_pipeline.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/delete_training_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/get_pipeline_job.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/get_pipeline_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/get_training_pipeline.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/get_training_pipeline.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/list_pipeline_jobs.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/list_pipeline_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/list_training_pipelines.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/list_training_pipelines.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PipelineServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/PipelineServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/direct_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/direct_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/direct_raw_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/direct_raw_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/embed_content.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/embed_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/explain.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/explain.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/generate_content.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/generate_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/raw_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/raw_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/server_streaming_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/server_streaming_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/stream_direct_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/stream_direct_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/stream_direct_raw_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/stream_direct_raw_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/stream_generate_content.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/stream_generate_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/stream_raw_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/stream_raw_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/streaming_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/streaming_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/streaming_raw_predict.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/streaming_raw_predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/PredictionServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/PredictionServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/query_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/query_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/stream_query_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/stream_query_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/ReasoningEngineExecutionServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/create_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/create_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/delete_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/delete_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/get_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/list_reasoning_engines.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/list_reasoning_engines.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ReasoningEngineServiceClient/update_reasoning_engine.php
+++ b/AiPlatform/samples/V1/ReasoningEngineServiceClient/update_reasoning_engine.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/create_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/create_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/delete_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/delete_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/get_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/get_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/list_schedules.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/list_schedules.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/pause_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/pause_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/resume_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/resume_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/ScheduleServiceClient/update_schedule.php
+++ b/AiPlatform/samples/V1/ScheduleServiceClient/update_schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/create_specialist_pool.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/create_specialist_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/delete_specialist_pool.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/delete_specialist_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_specialist_pool.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/get_specialist_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/list_specialist_pools.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/list_specialist_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/SpecialistPoolServiceClient/update_specialist_pool.php
+++ b/AiPlatform/samples/V1/SpecialistPoolServiceClient/update_specialist_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/batch_create_tensorboard_runs.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/batch_create_tensorboard_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/batch_create_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/batch_create_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/batch_read_tensorboard_time_series_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/batch_read_tensorboard_time_series_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_experiment.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_run.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/create_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_experiment.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_run.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/delete_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/export_tensorboard_time_series_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/export_tensorboard_time_series_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_experiment.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_run.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/get_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_experiments.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_experiments.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_runs.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_runs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboards.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/list_tensorboards.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_blob_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_blob_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_size.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_size.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_time_series_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_time_series_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_usage.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/read_tensorboard_usage.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_experiment.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_experiment.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_run.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_run.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_time_series.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/update_tensorboard_time_series.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/write_tensorboard_experiment_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/write_tensorboard_experiment_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/TensorboardServiceClient/write_tensorboard_run_data.php
+++ b/AiPlatform/samples/V1/TensorboardServiceClient/write_tensorboard_run_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/create_rag_corpus.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/create_rag_corpus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/delete_rag_corpus.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/delete_rag_corpus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/delete_rag_file.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/delete_rag_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_corpus.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_corpus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_engine_config.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_file.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/get_rag_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/import_rag_files.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/import_rag_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/list_rag_corpora.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/list_rag_corpora.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/list_rag_files.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/list_rag_files.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/update_rag_corpus.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/update_rag_corpus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/update_rag_engine_config.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/update_rag_engine_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagDataServiceClient/upload_rag_file.php
+++ b/AiPlatform/samples/V1/VertexRagDataServiceClient/upload_rag_file.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/augment_prompt.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/augment_prompt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/corroborate_content.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/corroborate_content.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/retrieve_contexts.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/retrieve_contexts.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VertexRagServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/VertexRagServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/add_trial_measurement.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/add_trial_measurement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/check_trial_early_stopping_state.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/check_trial_early_stopping_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/complete_trial.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/complete_trial.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/create_study.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/create_study.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/create_trial.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/create_trial.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/delete_study.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/delete_study.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/delete_trial.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/delete_trial.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/get_iam_policy.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/get_location.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/get_study.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/get_study.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/get_trial.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/get_trial.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/list_locations.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/list_optimal_trials.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/list_optimal_trials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/list_studies.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/list_studies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/list_trials.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/list_trials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/lookup_study.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/lookup_study.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/set_iam_policy.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/stop_trial.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/stop_trial.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/suggest_trials.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/suggest_trials.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/samples/V1/VizierServiceClient/test_iam_permissions.php
+++ b/AiPlatform/samples/V1/VizierServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/DataFoundryServiceClient.php
+++ b/AiPlatform/src/V1/Client/DataFoundryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/DatasetServiceClient.php
+++ b/AiPlatform/src/V1/Client/DatasetServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/DeploymentResourcePoolServiceClient.php
+++ b/AiPlatform/src/V1/Client/DeploymentResourcePoolServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/EndpointServiceClient.php
+++ b/AiPlatform/src/V1/Client/EndpointServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/EvaluationServiceClient.php
+++ b/AiPlatform/src/V1/Client/EvaluationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/FeatureOnlineStoreAdminServiceClient.php
+++ b/AiPlatform/src/V1/Client/FeatureOnlineStoreAdminServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/FeatureOnlineStoreServiceClient.php
+++ b/AiPlatform/src/V1/Client/FeatureOnlineStoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/FeatureRegistryServiceClient.php
+++ b/AiPlatform/src/V1/Client/FeatureRegistryServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/FeaturestoreOnlineServingServiceClient.php
+++ b/AiPlatform/src/V1/Client/FeaturestoreOnlineServingServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/FeaturestoreServiceClient.php
+++ b/AiPlatform/src/V1/Client/FeaturestoreServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/GenAiCacheServiceClient.php
+++ b/AiPlatform/src/V1/Client/GenAiCacheServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/GenAiTuningServiceClient.php
+++ b/AiPlatform/src/V1/Client/GenAiTuningServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/IndexEndpointServiceClient.php
+++ b/AiPlatform/src/V1/Client/IndexEndpointServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/IndexServiceClient.php
+++ b/AiPlatform/src/V1/Client/IndexServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/JobServiceClient.php
+++ b/AiPlatform/src/V1/Client/JobServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/LlmUtilityServiceClient.php
+++ b/AiPlatform/src/V1/Client/LlmUtilityServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/MatchServiceClient.php
+++ b/AiPlatform/src/V1/Client/MatchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/MetadataServiceClient.php
+++ b/AiPlatform/src/V1/Client/MetadataServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/MigrationServiceClient.php
+++ b/AiPlatform/src/V1/Client/MigrationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/ModelGardenServiceClient.php
+++ b/AiPlatform/src/V1/Client/ModelGardenServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/ModelServiceClient.php
+++ b/AiPlatform/src/V1/Client/ModelServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/NotebookServiceClient.php
+++ b/AiPlatform/src/V1/Client/NotebookServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/PersistentResourceServiceClient.php
+++ b/AiPlatform/src/V1/Client/PersistentResourceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/PipelineServiceClient.php
+++ b/AiPlatform/src/V1/Client/PipelineServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/PredictionServiceClient.php
+++ b/AiPlatform/src/V1/Client/PredictionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/ReasoningEngineExecutionServiceClient.php
+++ b/AiPlatform/src/V1/Client/ReasoningEngineExecutionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/ReasoningEngineServiceClient.php
+++ b/AiPlatform/src/V1/Client/ReasoningEngineServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/ScheduleServiceClient.php
+++ b/AiPlatform/src/V1/Client/ScheduleServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/SpecialistPoolServiceClient.php
+++ b/AiPlatform/src/V1/Client/SpecialistPoolServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/TensorboardServiceClient.php
+++ b/AiPlatform/src/V1/Client/TensorboardServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/VertexRagDataServiceClient.php
+++ b/AiPlatform/src/V1/Client/VertexRagDataServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/VertexRagServiceClient.php
+++ b/AiPlatform/src/V1/Client/VertexRagServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/Client/VizierServiceClient.php
+++ b/AiPlatform/src/V1/Client/VizierServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/data_foundry_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/data_foundry_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/data_foundry_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/data_foundry_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/dataset_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/dataset_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/dataset_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/dataset_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/deployment_resource_pool_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/deployment_resource_pool_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/deployment_resource_pool_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/deployment_resource_pool_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/endpoint_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/endpoint_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/endpoint_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/endpoint_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/evaluation_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/evaluation_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/evaluation_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/evaluation_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_online_store_admin_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/feature_online_store_admin_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_online_store_admin_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/feature_online_store_admin_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_online_store_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/feature_online_store_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_online_store_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/feature_online_store_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_registry_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/feature_registry_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/feature_registry_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/feature_registry_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/featurestore_online_serving_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/featurestore_online_serving_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/featurestore_online_serving_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/featurestore_online_serving_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/featurestore_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/featurestore_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/featurestore_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/featurestore_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/gen_ai_cache_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/gen_ai_cache_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/gen_ai_cache_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/gen_ai_cache_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/gen_ai_tuning_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/gen_ai_tuning_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/gen_ai_tuning_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/gen_ai_tuning_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/index_endpoint_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/index_endpoint_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/index_endpoint_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/index_endpoint_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/index_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/index_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/index_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/index_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/job_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/job_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/job_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/job_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/llm_utility_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/llm_utility_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/llm_utility_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/llm_utility_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/match_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/match_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/match_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/match_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/metadata_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/metadata_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/metadata_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/metadata_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/migration_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/migration_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/migration_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/migration_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/model_garden_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/model_garden_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/model_garden_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/model_garden_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/model_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/model_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/model_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/model_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/notebook_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/notebook_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/notebook_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/notebook_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/persistent_resource_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/persistent_resource_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/persistent_resource_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/persistent_resource_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/pipeline_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/pipeline_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/pipeline_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/pipeline_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/prediction_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/prediction_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/prediction_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/prediction_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/reasoning_engine_execution_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/reasoning_engine_execution_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/reasoning_engine_execution_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/reasoning_engine_execution_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/reasoning_engine_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/reasoning_engine_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/reasoning_engine_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/reasoning_engine_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/schedule_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/schedule_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/schedule_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/schedule_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/specialist_pool_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/specialist_pool_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/specialist_pool_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/specialist_pool_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/tensorboard_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/tensorboard_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/tensorboard_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/tensorboard_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vertex_rag_data_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/vertex_rag_data_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vertex_rag_data_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/vertex_rag_data_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vertex_rag_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/vertex_rag_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vertex_rag_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/vertex_rag_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vizier_service_descriptor_config.php
+++ b/AiPlatform/src/V1/resources/vizier_service_descriptor_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/src/V1/resources/vizier_service_rest_client_config.php
+++ b/AiPlatform/src/V1/resources/vizier_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/DataFoundryServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/DataFoundryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/DatasetServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/DatasetServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/DeploymentResourcePoolServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/DeploymentResourcePoolServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/EndpointServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/EndpointServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/EvaluationServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/EvaluationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/FeatureOnlineStoreAdminServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/FeatureOnlineStoreAdminServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/FeatureOnlineStoreServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/FeatureOnlineStoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/FeatureRegistryServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/FeatureRegistryServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/FeaturestoreOnlineServingServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/FeaturestoreOnlineServingServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/FeaturestoreServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/FeaturestoreServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/GenAiCacheServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/GenAiCacheServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/GenAiTuningServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/GenAiTuningServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/IndexEndpointServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/IndexEndpointServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/IndexServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/IndexServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/JobServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/JobServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/LlmUtilityServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/LlmUtilityServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/MatchServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/MatchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/MetadataServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/MetadataServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/MigrationServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/MigrationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/ModelGardenServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/ModelGardenServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/ModelServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/ModelServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/NotebookServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/NotebookServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/PersistentResourceServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/PersistentResourceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/PipelineServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/PipelineServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/PredictionServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/PredictionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/ReasoningEngineExecutionServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/ReasoningEngineExecutionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/ReasoningEngineServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/ReasoningEngineServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/ScheduleServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/ScheduleServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/SpecialistPoolServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/SpecialistPoolServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/TensorboardServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/TensorboardServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/VertexRagDataServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/VertexRagDataServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/VertexRagServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/VertexRagServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AiPlatform/tests/Unit/V1/Client/VizierServiceClientTest.php
+++ b/AiPlatform/tests/Unit/V1/Client/VizierServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Updates copyright year headers to 2026 across **1019 generated files** in **7 in-scope packages** (AccessApproval through AiPlatform).
All handwritten libraries, non-generated files, and out-of-scope packages have been excluded per the PHP migration tracker.

### Packages Included:
`AccessApproval`, `AccessContextManager`, `AdsAdManager`, `AdsDataManager`, `AdsMarketingPlatformAdmin`, `AdvisoryNotifications`, `AiPlatform`

### Verification
Verifying that this branch contains exclusively copyright year changes (ignoring lines matching `Copyright.*Google` yields no diffs):

**Command:**
```bash
$ git diff -I "Copyright.*Google" main...chore/copyright-2026-part-1
```

**Output:**
```
(empty output - 0 diffs found)
```

Part 1 of 10 in the 2026 copyright update series.
