### PR TITLE
test(Bigtable): configure per-operation timeout and totalTimeoutMillis for MutateRow in test proxy

### DIFF
--- a/Bigtable/tests/Conformance/proxy/src/ProxyService.php
+++ b/Bigtable/tests/Conformance/proxy/src/ProxyService.php
@@ -275,11 +275,20 @@ class ProxyService implements Testproxy\CloudBigtableV2TestProxyInterface
             'appProfileId' => $config->getAppProfileId(),
         ]);
 
+        $options = [];
+        if ($timeoutMillis = $this->getTimeoutMillis($config->getPerOperationTimeout())) {
+            $options = [
+                'timeoutMillis' => $timeoutMillis,
+                'retrySettings' => [
+                    'totalTimeoutMillis' => $timeoutMillis,
+                ],
+            ];
+        }
         try {
             $table->mutateRow(
                 $request->getRowKey(),
                 $this->protoToMutations($request->getMutations()),
-                ['timeoutMillis' => $this->getTimeoutMillis($config->getPerOperationTimeout())],
+                $options,
             );
         } catch (\Google\ApiCore\ApiException $e) {
             return $out->setStatus(new Status([


### PR DESCRIPTION
In the Bigtable test proxy, `MutateRow` previously passed `timeoutMillis` unconditionally without configuring `retrySettings.totalTimeoutMillis`.

When `MutateRow` has retries enabled (or when `DEADLINE_EXCEEDED` is configured as retryable), failing to set `totalTimeoutMillis` causes GAX to fall back to the default total timeout (60s) and retry upon receiving a deadline timeout. This caused tests like `TestMutateRow_Generic_DeadlineExceeded` to send unexpected retry attempts, crashing the mock test server.

This change:
1. Conditionally checks if `perOperationTimeout` is set to avoid passing `null` values into `RetrySettings`, preventing `ValidationException`.
2. Sets both `timeoutMillis` and `retrySettings.totalTimeoutMillis` so that:
   - On branches where retries are disabled (e.g. `main`), `timeoutMillis` ensures the call times out after the requested deadline.
   - On branches where retries are enabled, `totalTimeoutMillis` ensures GAX bounds the total operation time and stops retrying once the deadline is exceeded.

Fixes https://github.com/googleapis/librarian/issues/7405