### PR TITLE
fix(pubsub,firestore): update hardcoded owlbot.py copyright year to 2026

### DIFF
--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -73,7 +73,7 @@ yearFixes = [
             "tests/**/V1beta1/*Test.php"
         ]
     }, {
-        "year": "2019",
+        "year": "2026",
         "files": [
             "src/V1/Gapic/*GapicClient.php",
             "src/V1/*Client.php",

--- a/PubSub/owlbot.py
+++ b/PubSub/owlbot.py
@@ -42,7 +42,7 @@ php.owlbot_main(
 s.replace(
     'tests/**/V1/*Test.php',
     r'Copyright \d{4}',
-    'Copyright 2018')
+    'Copyright 2026')
 
 # fix the link to the official doc
 s.replace(


### PR DESCRIPTION
Update the legacy `s.replace()` logic in `owlbot.py` for PubSub and Firestore to set the copyright year to 2026 instead of 2018/2019. This prevents the generator from improperly reverting the current copyright year.

For https://github.com/googleapis/librarian/issues/7456