### PR TITLE
fix(datastore): fix phpstan incorrect case error for Mode

### DIFF
--- a/Datastore/src/Operation.php
+++ b/Datastore/src/Operation.php
@@ -763,8 +763,8 @@ class Operation
 
         $commitRequest->setMode(
             empty($commitRequest->getTransaction())
-            ? MODE::NON_TRANSACTIONAL
-            : MODE::TRANSACTIONAL
+            ? Mode::NON_TRANSACTIONAL
+            : Mode::TRANSACTIONAL
         );
 
         try {


### PR DESCRIPTION
PHPStan currently fails on `main` due to an incorrect casing of `Mode` in `Datastore/src/Operation.php`. This fixes the casing to match the use statement.