### PR TITLE
test(datastore): fix flaky emulator tests by ensuring correct cleanup and avoiding eventual consistency issues

### DIFF
--- a/Datastore/tests/System/DatastoreSessionHandlerTest.php
+++ b/Datastore/tests/System/DatastoreSessionHandlerTest.php
@@ -51,18 +51,23 @@ class DatastoreSessionHandlerTest extends DatastoreMultipleDbTestCase
         $q = $client->query();
         $q->kind('PHPSESSID');
 
-        $res = $client->runQuery($q, [
-            'namespaceId' => $namespace,
-        ]);
-
         $hasEntity = false;
-        $keys = [];
-        foreach ($res as $e) {
-            if (!$hasEntity) {
-                $hasEntity = $e['data'] === $storedValue;
+        for ($i = 0; $i < 10; $i++) {
+            $res = $client->runQuery($q, [
+                'namespaceId' => $namespace,
+            ]);
+
+            foreach ($res as $e) {
+                if ($e['data'] === $storedValue) {
+                    $hasEntity = true;
+                }
+                self::$localDeletionQueue->add($e->key());
             }
 
-            self::$localDeletionQueue->add($e->key());
+            if ($hasEntity) {
+                break;
+            }
+            sleep(1);
         }
 
         $this->assertTrue($hasEntity);
@@ -95,18 +100,24 @@ class DatastoreSessionHandlerTest extends DatastoreMultipleDbTestCase
         $q->kind('PHPSESSID');
 
         // multi db should have data
-        $res = $client->runQuery($q, [
-            'namespaceId' => $namespace,
-            'databaseId' => self::TEST_DB_NAME,
-        ]);
-
         $hasEntity = false;
-        foreach ($res as $e) {
-            if (!$hasEntity) {
-                $hasEntity = $e['data'] === $storedValue;
+        for ($i = 0; $i < 10; $i++) {
+            $res = $client->runQuery($q, [
+                'namespaceId' => $namespace,
+                'databaseId' => self::TEST_DB_NAME,
+            ]);
+
+            foreach ($res as $e) {
+                if ($e['data'] === $storedValue) {
+                    $hasEntity = true;
+                }
+                self::$localDeletionQueue->add($e->key());
             }
 
-            self::$localDeletionQueue->add($e->key());
+            if ($hasEntity) {
+                break;
+            }
+            sleep(1);
         }
 
         $this->assertTrue($hasEntity);

--- a/Datastore/tests/System/DatastoreTestCase.php
+++ b/Datastore/tests/System/DatastoreTestCase.php
@@ -73,13 +73,29 @@ class DatastoreTestCase extends TestCase
         }
 
         $backoff = new ExponentialBackoff(8);
-        $transaction = self::$restClient->transaction();
 
-        self::$localDeletionQueue->process(function ($items) use ($backoff, $transaction) {
-            $backoff->execute(function () use ($items, $transaction) {
-                $transaction->deleteBatch($items);
-            });
+        self::$localDeletionQueue->process(function ($items) use ($backoff) {
+            $keysByDb = [];
+            foreach ($items as $key) {
+                $dbId = '';
+                if ($key instanceof \Google\Cloud\Datastore\Key) {
+                    $keyObj = $key->keyObject();
+                    if (isset($keyObj['partitionId']['databaseId'])) {
+                        $dbId = $keyObj['partitionId']['databaseId'];
+                    }
+                }
+                $keysByDb[$dbId][] = $key;
+            }
+
+            foreach ($keysByDb as $dbId => $dbItems) {
+                foreach (array_chunk($dbItems, 500) as $chunk) {
+                    $backoff->execute(function () use ($chunk, $dbId) {
+                        self::$restClient->deleteBatch($chunk, ['databaseId' => $dbId]);
+                    });
+                }
+            }
         });
+        self::$localDeletionQueue = new DeletionQueue(true);
     }
 
     public function defaultDbClientProvider()


### PR DESCRIPTION
Fixes a bug in Datastore system tests where entities were not being properly cleaned up because the teardown transaction was never committed, leading to test data leaking and flaky aggregation queries. It also addresses flaky assertions in `DatastoreSessionHandlerTest` by replacing hardcoded sleeps with a retry loop to better handle emulator query eventual consistency.