### PR TITLE
chore: fix gRPC fork deadlock in Ubuntu unit tests

### DIFF
--- a/.github/run-package-tests.sh
+++ b/.github/run-package-tests.sh
@@ -156,6 +156,7 @@ export -f run_package_test_parallel
 export STRICT
 export PREFER_LOWEST
 export FAILED_FILE
+export GRPC_ENABLE_FORK_SUPPORT=1
 
 # Determine optimal parallelism: default to the number of CPU cores on the host runner
 MAX_JOBS=${MAX_JOBS:-$(nproc 2>/dev/null || echo 8)}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,6 +7,10 @@ on:
 
 permissions:
   contents: read
+
+env:
+  GRPC_ENABLE_FORK_SUPPORT: 1
+
 jobs:
   test:
     strategy:

--- a/Auth/phpunit.xml.dist
+++ b/Auth/phpunit.xml.dist
@@ -13,4 +13,7 @@
       <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <env name="GRPC_ENABLE_FORK_SUPPORT" value="1"/>
+  </php>
 </phpunit>

--- a/Auth/tests/Cache/RaceConditionTest.php
+++ b/Auth/tests/Cache/RaceConditionTest.php
@@ -45,6 +45,11 @@ class RaceConditionTest extends TestCase
         if (!function_exists('pcntl_fork')) {
             $this->markTestSkipped('pcntl_fork is not available');
         }
+        if (extension_loaded('grpc') && !getenv('GRPC_ENABLE_FORK_SUPPORT')) {
+            $this->markTestSkipped(
+                'Cannot run fork test with grpc extension unless GRPC_ENABLE_FORK_SUPPORT=1 is set.'
+            );
+        }
         for ($i = 0; $i < 50; $i++) {
             // SysV Cache warmup to prevent segment creation race
             if ($cacheClass === SysVCacheItemPool::class) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,7 @@
   </testsuites>
   <php>
     <ini name="memory_limit" value="2048M"/>
+    <env name="GRPC_ENABLE_FORK_SUPPORT" value="1"/>
   </php>
 
 </phpunit>


### PR DESCRIPTION
## Description

This PR fixes the issue causing the Unit tests in Ubuntu (and Package tests) on PR #9514 to hang and time out after 6 hours.

### Root Cause
1. `Auth/tests/Cache/RaceConditionTest.php` uses `pcntl_fork()` to test concurrency across 4 child processes.
2. In the monorepo CI, the PHP `grpc` extension is installed for Ubuntu runners.
3. When the `grpc` C-core extension is loaded in a PHP process, background threads and mutexes are initialized. When `pcntl_fork()` is called, POSIX `fork()` only clones the calling thread, leaving unreleased locks and absent background worker threads in the child process.
4. When the child process calls `exit(0)`, PHP runs module shutdown, which deadlocks indefinitely on a futex (`futex_do_wait`) waiting on mutexes/threads that do not exist in the child.
5. The parent process is stuck in `pcntl_waitpid()`, and PHPUnit is stuck waiting for the test process to finish, causing the 6-hour timeout in CI.
6. This also hung `run-package-tests.sh` because `Auth` is included in the package test directory loop and run under xargs.
7. This passed on Windows because `pcntl_fork` is unsupported on Windows (test was skipped), and passed on `PHP 8.1 Unit Test (no gRPC)` because `grpc` was not installed.

### Solution
1. Add `GRPC_ENABLE_FORK_SUPPORT=1` to `unit-tests.yaml`, `run-package-tests.sh`, `phpunit.xml.dist`, and `Auth/phpunit.xml.dist`. This enables gRPC's `pthread_atfork` handlers to properly reset C-core state post-fork so child processes exit cleanly.
2. Add a defensive skip check in `Auth/tests/Cache/RaceConditionTest.php` so that if a developer runs PHPUnit locally with `grpc` loaded and without `GRPC_ENABLE_FORK_SUPPORT=1`, the test skips with an informative message instead of hanging.