### PR TITLE
chore: pin pnpm version to ^7.0.0 in generation check workflow

### DIFF
--- a/.github/workflows/generation-check.yaml
+++ b/.github/workflows/generation-check.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: ^11.0.0
+          version: ^7.0.0
       - name: Install tools
         run: librarian install
       - name: Regenerate


### PR DESCRIPTION
Librarian's PHP formatting toolchain expects globally installed pnpm packages (specifically `@prettier/plugin-php`) to be located in `bin/global/5/node_modules/`, which is the layout used by pnpm 7 and 8.

Starting in pnpm 9+, global packages use content-hashed directory paths, which breaks librarian's plugin path resolution during code formatting and causes `librarian generate` to fail in CI.

Restore pnpm to `^7.0.0` to ensure compatibility with librarian.

We will upgrade pnpm once https://github.com/googleapis/librarian/issues/6889 is resovled.
