### PR TITLE
fix: update the component:new command

### DIFF
--- a/dev/src/Command/ComponentUpdateCommand.php
+++ b/dev/src/Command/ComponentUpdateCommand.php
@@ -192,8 +192,7 @@ class ComponentUpdateCommand extends Command
     private function owlbotPostProcessor(): string
     {
         list($userId, $groupId) = $this->getUserAndGroupId();
-        $owlbotLock = Yaml::parse(file_get_contents($this->rootPath . '/.github/.OwlBot.lock.yaml'));
-        $owlbotPhpImage = sprintf('%s@%s', $owlbotLock['docker']['image'], $owlbotLock['docker']['digest']);
+        $owlbotPhpImage = 'gcr.io/cloud-devrel-public-resources/owlbot-php:latest';
 
         $command = [
             'docker', 'pull', $owlbotPhpImage

--- a/dev/tests/Unit/Command/ComponentUpdateCommandTest.php
+++ b/dev/tests/Unit/Command/ComponentUpdateCommandTest.php
@@ -36,8 +36,6 @@ class ComponentUpdateCommandTest extends TestCase
     private static CommandTester $commandTester;
 
     private const COMPONENT_NAME = 'Storage';
-    private const OWLBOT_PHP_IMAGE = 'gcr.io/fake-owlbot-image/owlbot-php';
-    private const OWLBOT_PHP_DIGEST = 'sha256:12345';
     private const OWLBOT_CLI_IMAGE = 'gcr.io/cloud-devrel-public-resources/owlbot-cli:latest';
     private const DEFAULT_TIMEOUT = 120;
 
@@ -48,12 +46,6 @@ class ComponentUpdateCommandTest extends TestCase
         mkdir($tmpDir . '/.github', 0777, true);
         self::$tmpDir = realpath($tmpDir);
 
-        file_put_contents(self::$tmpDir . '/.github/.OwlBot.lock.yaml', Yaml::dump([
-            'docker' => [
-                'image' => self::OWLBOT_PHP_IMAGE,
-                'digest' => self::OWLBOT_PHP_DIGEST,
-            ],
-        ]));
         $application = new Application();
         $application->add(new ComponentUpdateCommand(self::$tmpDir));
         self::$commandTester = new CommandTester($application->get('component:update'));
@@ -135,7 +127,7 @@ class ComponentUpdateCommandTest extends TestCase
             ->willReturn('/path/to/docker');
 
         list($userId, $groupId) = [posix_getuid(), posix_getgid()];
-        $owlbotPhpImage = self::OWLBOT_PHP_IMAGE . '@' . self::OWLBOT_PHP_DIGEST;
+        $owlbotPhpImage = 'gcr.io/cloud-devrel-public-resources/owlbot-php:latest';
 
         $copyCodeCommand = [
             'docker', 'run', '--rm',


### PR DESCRIPTION
On this PR:
https://github.com/googleapis/google-cloud-php/pull/9621/changes

We got rid of the `.Owlbot.lock.yaml` file, breaking the `component:new` command. This aims to fix this command.