### PR TITLE
chore: remove class_alias removal logic from owlbot

### DIFF
--- a/CloudCommonProtos/owlbot.py
+++ b/CloudCommonProtos/owlbot.py
@@ -16,7 +16,6 @@
 
 import logging
 from pathlib import Path
-from pathlib import PosixPath
 import subprocess
 
 import synthtool as s
@@ -67,17 +66,4 @@ s.replace(
     "src/**/*.php",
     "\$arr->count\(\)",
     "count($arr)")
-
-# remove class_alias code (but keep the existing class aliases)
-sources = list(Path(".").glob("src/**/*.php"))
-sources.remove(PosixPath("src/Audit/ServiceAccountDelegationInfo/FirstPartyPrincipal.php"))
-sources.remove(PosixPath("src/Audit/ServiceAccountDelegationInfo/ThirdPartyPrincipal.php"))
-sources.remove(PosixPath("src/DevTools/Source/V1/AliasContext/Kind.php"))
-s.replace(
-    sources,
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
 

--- a/CommonProtos/owlbot.py
+++ b/CommonProtos/owlbot.py
@@ -62,11 +62,3 @@ for proto in protos:
 s.move("metadata/Google/Iam/V1", "metadata/Iam/V1")
 s.move("metadata/Google/Logging/Type", "metadata/Logging/Type")
 
-s.replace(
-    "src/**/*.php",
-    r"^// Adding a class alias for backwards compatibility with the previous class name.$"
-    + "\n"
-    + r"^class_alias\(.*\);$"
-    + "\n",
-    '')
-

--- a/Firestore/owlbot.py
+++ b/Firestore/owlbot.py
@@ -99,15 +99,6 @@ s.replace(
     r'@group admin',
     '@group firestore-admin')
 
-# remove ReadOnly class_alias code
-s.replace(
-    "src/V*/**/PBReadOnly.php",
-    r"^// Adding a class alias for backwards compatibility with the \"readonly\" keyword.$"
-    + "\n"
-    + r"^class_alias\(PBReadOnly::class, __NAMESPACE__ . '\\ReadOnly'\);$"
-    + "\n",
-    '')
-
 ### [START] protoc backwards compatibility fixes
 
 # roll back to private properties.


### PR DESCRIPTION
Removes the obsolete `class_alias` removal logic from `CloudCommonProtos`, `CommonProtos`, and `Firestore` `owlbot.py` files.

Thanks to upgrading to protobuf >= 4.31, legacy backwards-compatibility `class_alias` calls are no longer generated at the bottom of protobuf message files. This aligns the remaining 3 components with the rest of the repository (#8986) and simplifies Librarian migration.