### PR TITLE
chore: fix the run package tests configuration

### DIFF
--- a/.github/run-package-tests.sh
+++ b/.github/run-package-tests.sh
@@ -78,7 +78,7 @@ run_package_test() {
         "PubSub,cloud-pubsub"
         "Storage,cloud-storage,2.100"
         "ShoppingCommonProtos,shopping-common-protos"
-        "GeoCommonProtos,geo-common-protos,0.1",
+        "GeoCommonProtos,geo-common-protos,0.1"
         "Monitoring,cloud-monitoring"
     )
     for i in "${PACKAGE_DEPENDENCIES[@]}"; do


### PR DESCRIPTION
Removed an unnecessary comma from the `run-package-tests.sh` file.