### PR TITLE
feat: support full-format identity tokens on GCE

### DIFF
--- a/Auth/src/Credentials/GCECredentials.php
+++ b/Auth/src/Credentials/GCECredentials.php
@@ -218,6 +218,10 @@ class GCECredentials extends CredentialsLoader implements
      * @param string|null $universeDomain [optional] Specify a universe domain to use
      *   instead of fetching one from the metadata server.
      * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
+     * @param string|null $idTokenFormat [optional] The format of the identity token requested
+     *   from the metadata server when $targetAudience is set. One of "standard" or "full".
+     *   Use "full" to include the full VM instance details in the token payload (for example,
+     *   the authorized party's email). Defaults to the metadata server's default ("standard").
      */
     public function __construct(
         ?Iam $iam = null,
@@ -226,13 +230,20 @@ class GCECredentials extends CredentialsLoader implements
         $quotaProject = null,
         $serviceAccountIdentity = null,
         ?string $universeDomain = null,
-        bool $enableRegionalAccessBoundary = false
+        bool $enableRegionalAccessBoundary = false,
+        ?string $idTokenFormat = null
     ) {
         $this->iam = $iam;
 
         if ($scope && $targetAudience) {
             throw new InvalidArgumentException(
                 'Scope and targetAudience cannot both be supplied'
+            );
+        }
+
+        if ($idTokenFormat !== null && !in_array($idTokenFormat, ['standard', 'full'], true)) {
+            throw new InvalidArgumentException(
+                'Invalid idTokenFormat, must be one of "standard" or "full"'
             );
         }
 
@@ -248,6 +259,9 @@ class GCECredentials extends CredentialsLoader implements
         } elseif ($targetAudience) {
             $tokenUri = self::getIdTokenUri($serviceAccountIdentity);
             $tokenUri = $tokenUri . '?audience=' . $targetAudience;
+            if ($idTokenFormat !== null) {
+                $tokenUri = $tokenUri . '&format=' . $idTokenFormat;
+            }
             $this->targetAudience = $targetAudience;
         }
 

--- a/Auth/tests/Credentials/GCECredentialsTest.php
+++ b/Auth/tests/Credentials/GCECredentialsTest.php
@@ -321,6 +321,34 @@ class GCECredentialsTest extends BaseTest
         $this->assertEquals(2, $timesCalled);
     }
 
+    public function testFetchAuthTokenAppendsFullFormatToIdTokenRequest()
+    {
+        $expectedToken = ['id_token' => 'idtoken12345'];
+        $timesCalled = 0;
+        $httpHandler = function ($request) use (&$timesCalled, $expectedToken) {
+            $timesCalled++;
+            if ($timesCalled == 1) {
+                return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+            }
+            $this->assertEquals(
+                'audience=a+target+audience&format=full',
+                $request->getUri()->getQuery()
+            );
+            return new Psr7\Response(200, [], Utils::streamFor($expectedToken['id_token']));
+        };
+        $g = new GCECredentials(null, null, 'a+target+audience', null, null, null, false, 'full');
+        $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
+        $this->assertEquals(2, $timesCalled);
+    }
+
+    public function testInvalidIdTokenFormatThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid idTokenFormat, must be one of "standard" or "full"');
+
+        new GCECredentials(null, null, 'a+target+audience', null, null, null, false, 'invalid');
+    }
+
     public function testSettingBothScopeAndTargetAudienceThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Adds an optional $idTokenFormat constructor argument to GCECredentials. When a target audience is set, passing 'full' appends '&format=full' to the metadata server identity request so the returned ID token includes the full VM instance payload (for example, the authorized party's email), matching the behavior of the Python auth library. The value is validated to 'standard' or 'full'.

Fixes googleapis/google-auth-library-php#526

This is a mirror of:
https://github.com/googleapis/google-auth-library-php/pull/681

